### PR TITLE
chore(gitignore): silence regenerable benchmark outputs and runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ helix.db-wal
 helix.log
 metrics.json
 overnight_logs/
+logs/
 genomes/
 
 # Benchmark incremental traces (one line per needle)
@@ -45,6 +46,12 @@ benchmarks/docs_tidy_diff.md
 benchmarks/docs_tidy_*.json
 benchmarks/*error*.json
 benchmarks/snow/results/*error*.json
+# Benchmark run outputs — regenerable, large, per-run timestamps. If a JSON
+# *should* be tracked (curated fixture, etc.) commit it with `git add -f`.
+benchmarks/*.json
+benchmarks/results/
+benchmarks/*_report.txt
+benchmarks/*_report_utf8.txt
 
 # IDE
 .vscode/
@@ -65,6 +72,8 @@ core_ingest.log
 
 # Server runtime log (redirected stdout when starting via `python -m helix_context.server > helix_server.log`)
 helix_server.log
+# Catches sharded_server.log, helix_mcpo_server.log, etc. — any *_server.log shape.
+*_server.log
 
 # cwola_log export staging area (scripts/export_cwola_log.py writes here before rclone upload)
 cwola_export/
@@ -72,6 +81,11 @@ cwola_export/
 # Upload tarballs built for R2 delivery (see scripts/ + docs/collab/)
 helix-collab-bundle*.tar.gz
 helix-code-bundle*.tar.gz
+
+# Local scratch + benchmark backups (e.g. helix.toml.bench-backup written by
+# overnight orchestrators while temporarily tuning config for a run).
+temp_*.md
+*.bench-backup
 
 # OS
 Thumbs.db


### PR DESCRIPTION
## Summary

Silences ~40+ untracked files that were cluttering \`git status\` and risking accidental inclusion in feature PRs. PRs #9 and #10 stayed clean by careful staging, but the next slip is one \`git add -A\` away.

## What's added

- \`benchmarks/*.json\` + \`benchmarks/results/\` + \`benchmarks/*_report.txt\` (and \`_utf8.txt\`) — per-run timestamped outputs, regenerable from bench scripts. Aggressive on purpose. If a specific JSON should ever be tracked (curated fixture etc.), use \`git add -f\`.
- \`*_server.log\` — catches \`sharded_server.log\`, \`helix_mcpo_server.log\`, etc. alongside the existing exact-match \`helix_server.log\`.
- \`logs/\` — ephemeral bench log root (companion to the already-ignored \`overnight_logs/\`).
- \`temp_*.md\` + \`*.bench-backup\` — local scratch and the \`helix.toml.bench-backup\` written by overnight orchestrators while temporarily tuning config.

## Impact

Untracked file count drops from ~50 to 9. The 9 remaining items are intentional:
- \`overnight_run.sh\`, \`overnight_diamond.sh\` — my orchestrator scripts (decision pending: ignore or move to \`benchmarks/scripts/\`)
- \`run_full_suite.ps1\`, \`run_overnight_bench.ps1\`, \`run_pr9_sweep.ps1\` — gemini's orchestrator scripts (same decision)
- \`tests/test_telemetry.py\` — gemini's; tests \`emit_gauges_snapshot\`; passes; should be committed (separate PR)
- \`docs/specs/2026-05-01-convergence-paper-design.md\` — uncertain provenance; pending review
- \`docs/superpowers/\` — superpowers skill output; pending review

## Test plan

- [x] \`git status\` reduces from ~50 untracked to 9
- [x] No tracked files become ignored (no \`git rm --cached\` needed)
- [x] Existing patterns still match (no regressions in coverage)

## Tests for tests/test_telemetry.py provenance (per separate ask)

Created Apr 24 22:09, gemini-era. Tests \`helix_context.telemetry.emit_gauges_snapshot\` reading registered shards without warning. Single test, passes cleanly. Same telemetry sprint commits exist in master (\`c91a9b9 feat(telemetry): add 4 meters\`, \`32fcde1 feat(w2-b): backend cost-class visibility\`, etc.). Recommend a small follow-up PR to commit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)