### PR TITLE
fix(server): bump default upstream_timeout from 120s to 180s

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -90,6 +90,7 @@ replica_sync_interval = 100             # sync replicas every N inserts
 host = "127.0.0.1"
 port = 11437
 upstream = "http://localhost:11434"     # Ollama
+# upstream_timeout = 180                # Per-request timeout for proxied calls to Ollama. Default in config.py is 180s. Raise to 240+ for very slow models or large prompts; lower if you want fail-fast.
 
 # ──────────────────────────────────────────────────────────────────────
 # [headroom] — OPTIONAL PROXY LIFECYCLE (launcher only).

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -148,7 +148,7 @@ class ServerConfig:
     host: str = "127.0.0.1"
     port: int = 11437
     upstream: str = "http://localhost:11434"
-    upstream_timeout: float = 120.0     # Timeout for proxied requests to Ollama
+    upstream_timeout: float = 180.0     # Timeout for proxied requests to Ollama. Bumped from 120s on 2026-05-02 — observed Proxy 500s on slow gemma4:e4b GPQA queries at ~125s; 180s gives long-tail generation room without letting truly stuck requests hang. Override per-deployment via [server] in helix.toml.
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+def test_upstream_timeout_default_is_180s():
+    """Regression test for the 2026-05-02 default bump.
+
+    Helix's default of 120s was observed to silently return Proxy 500s
+    on slow gemma4:e4b GPQA queries at ~125s (full breakdown in the
+    2026-05-01 overnight report). 180s is the shipping default; 120s
+    is a regression.
+    """
+    from helix_context.config import HelixConfig
+    cfg = HelixConfig()
+    assert cfg.server.upstream_timeout == 180.0


### PR DESCRIPTION
## Summary

- `helix_context/config.py` default `upstream_timeout` 120.0 → 180.0
- `helix.toml` adds a commented-out `[server] upstream_timeout` knob for deployment overrides
- `tests/test_config.py` pins the new default with a regression test

## Why

The 2026-04-29 GPQA Diamond overnight run hit "Proxy HTTP 500" errors at ~120-128s on slow generations. Root cause: helix's own httpx client to Ollama defaulted to 120s; `helix.toml` did not override it, so any Ollama generation running >120s caused helix to time out and return 500 to the caller — silently dropping correct answers.

Tonight's full Diamond run (n=198) bumped `upstream_timeout=240` in `helix.toml` for the run, and Proxy 500s went from ~10/17 in a retry sample to 0/198. Full breakdown in `overnight_logs/diamond_2026-05-01_report.md`.

180s (not 240s) is the right shipping default: gives long-tail generation room without letting truly stuck requests hang. 240s was a per-run override; deployments running heavier models can override per-deployment via `[server] upstream_timeout = N` in `helix.toml`.

## Surface impact

None. This is a default-value change. No public API, no config schema, no behavior change for any deployment that already overrides `upstream_timeout` in `helix.toml`. Deployments wanting fail-fast (e.g. CI) can set the value lower; deployments running very slow models can raise it.

## Test plan

- [x] `py -3 -m pytest tests/test_config.py -v` — new regression test passes
- [x] `py -3 -m pytest tests/test_query_classifier.py tests/test_pipeline.py -q` — 52/52 pass, no regressions
- [ ] Reviewer: spot-check `helix_context/config.py` line 151 docstring renders the rationale clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)