### PR TITLE
feat(launcher): hardware detection + VRAM-aware batch sizing (PR1 of 2)

### DIFF
--- a/docs/plans/2026-05-04-hardware-detection.md
+++ b/docs/plans/2026-05-04-hardware-detection.md
@@ -1,0 +1,2141 @@
+# Hardware Detection — PR1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize torch device detection in a new `helix_context/hardware.py` module, plumb it through all four torch-using backends (deberta/nli/splade/sema), surface device + fallback state via logs / `/health` / tray balloon, and chunk batches in deberta+nli+splade based on a VRAM-keyed table — without changing observable behavior on our 24 GB CUDA rig (verified by bench gate ≤ 5 s p95 delta).
+
+**Architecture:** Single `HardwareInfo` dataclass returned by a cached `get_hardware()` singleton. Auto-mode picker walks CUDA → ROCm → MPS → CPU; explicit-device requests fall back loudly to CPU on probe failure but never block. Backend chunking uses `recommended_batch_size(model)` which consults a `_BATCH_TABLE` keyed on `(device_type, vram_total_or_ram_gb)`. Config plumbed via new `[hardware]` TOML section with `HELIX_DEVICE` env-var override; `[ribosome] device` deprecated for one release with a backwards-compat read.
+
+**Tech Stack:** Python 3.12, `torch>=2.0`, `psutil>=5.9`, **new dep: `py-cpuinfo>=9.0`** (added to `launcher` extra). FastAPI `/health` endpoint, pystray balloon notifications, pytest with `monkeypatch` fixtures.
+
+**Spec:** [`docs/specs/2026-05-04-hardware-detection-design.md`](../specs/2026-05-04-hardware-detection-design.md)
+
+**Branch:** `feat/hardware-detection` (already created from master at `7d96320`)
+
+---
+
+## File structure
+
+### NEW files
+
+| File | Responsibility |
+|---|---|
+| `helix_context/hardware.py` | `HardwareInfo` dataclass + `get_hardware()` singleton + `_BATCH_TABLE` + `recommended_batch_size()` + `_probe()` + auto-mode picker + multi-GPU selection + env/config resolution |
+| `tests/test_hardware.py` | Layer 1 mocked-torch unit tests for everything in `hardware.py` |
+
+### MODIFIED files
+
+| File | Change |
+|---|---|
+| `pyproject.toml` | Add `py-cpuinfo>=9.0` to the `launcher` extra |
+| `helix_context/config.py` | Parse `[hardware]` section; deprecation read for `[ribosome] device` |
+| `helix.toml` | Add documented `[hardware]` block |
+| `helix_context/deberta_backend.py` | Consult `get_hardware()` in `__init__`; chunk batches in `re_rank()` and `splice()` |
+| `helix_context/nli_backend.py` | Consult `get_hardware()` in `__init__`; chunk batches in `classify_batch()` |
+| `helix_context/splade_backend.py` | Consult `get_hardware()` in `_ensure_loaded()`; default `batch_size` from `recommended_batch_size("splade")` |
+| `helix_context/sema.py` | `SemanticEncoder` consults `get_hardware()` for default device |
+| `helix_context/server.py` | Add `hardware` block to `/health` JSON response (around line 2213) |
+| `helix_context/launcher/tray.py` | Fallback balloon + sentinel-file dedup (mirrors install-pending pattern) |
+| `tests/test_launcher_tray.py` | Add tests for fallback balloon trigger + sentinel dedup |
+| `tests/test_server.py` | Add test for `/health` `hardware` block presence |
+| `tests/test_config.py` | Add tests for `[hardware]` parsing + `[ribosome] device` deprecation shim |
+
+**Out of scope (PR2):** Wiring up actual ROCm + MPS detection (PR1 leaves these device-type strings parseable but resolves to CPU fallback in practice — the picker's branches are stubbed). GHA CI workflow. Enhancement issue template. Capable-but-unverified disclaimers on alt-device paths.
+
+---
+
+## Task list
+
+There are 14 tasks. Tasks 1–10 build the hardware module and config plumbing; Task 11 plumbs into all four backends; Tasks 12–13 surface state to users; Task 14 is the bench gate.
+
+---
+
+### Task 1: Add `py-cpuinfo` dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+This unblocks Task 4 (CPU detection). Pure dep change, no tests.
+
+- [ ] **Step 1: Find the `launcher` extras block**
+
+Run: `grep -n "launcher" pyproject.toml`
+Expected: locates the `launcher = [...]` and `launcher-tray = [...]` extras lines (sidecar PR landed these around 2026-05-04).
+
+- [ ] **Step 2: Add `py-cpuinfo>=9.0` to both `launcher` and `launcher-tray` extras**
+
+```toml
+launcher = ["jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0"]
+launcher-tray = [
+    "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0",
+    "pystray>=0.19", "Pillow>=10",
+    "pywin32>=306; sys_platform == 'win32'",
+]
+```
+
+- [ ] **Step 3: Install the new dep into the active venv**
+
+Run: `pip install py-cpuinfo>=9.0`
+Expected: `Successfully installed py-cpuinfo-9.X.X`
+
+Verify: `python -c "import cpuinfo; print(cpuinfo.get_cpu_info()['brand_raw'])"` prints something non-empty (e.g., `AMD Ryzen 9 7900X`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "deps(launcher): add py-cpuinfo>=9.0 for hardware-detection cpu_brand source"
+```
+
+---
+
+### Task 2: `HardwareInfo` dataclass + cached singleton skeleton
+
+**Files:**
+- Create: `helix_context/hardware.py`
+- Create: `tests/test_hardware.py`
+
+Establishes the public surface. Singleton starts empty; subsequent tasks fill it in.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_hardware.py`:
+
+```python
+"""Unit tests for helix_context.hardware (mocked-torch).
+
+All tests use monkeypatch to mock torch internals — they never touch a real
+GPU. Pattern mirrors tests/test_observability_paths.py.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import pytest
+
+from helix_context import hardware
+
+
+@pytest.fixture(autouse=True)
+def _reset_hardware_cache():
+    """Every test starts with a clean singleton."""
+    hardware.reset_for_test()
+    yield
+    hardware.reset_for_test()
+
+
+def test_hardware_info_is_frozen():
+    info = hardware.HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name="Test CPU",
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch="x86_64",
+        cpu_brand="Test CPU",
+        system_ram_gb=16.0,
+        requested_device="auto",
+        fallback_reason=None,
+        batch_size_overrides={},
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        info.device = "cuda:0"  # type: ignore[misc]
+
+
+def test_reset_for_test_clears_cached_singleton(monkeypatch):
+    """get_hardware() must recompute after reset_for_test()."""
+    sentinel = hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="Sentinel",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="Sentinel CPU",
+        system_ram_gb=16.0, requested_device="auto",
+        fallback_reason=None, batch_size_overrides={},
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: sentinel)
+    info1 = hardware.get_hardware()
+    assert info1.device_name == "Sentinel"
+    monkeypatch.setattr(hardware, "_detect", lambda: dataclasses.replace(sentinel, device_name="Other"))
+    info2 = hardware.get_hardware()
+    assert info2.device_name == "Sentinel"  # still cached
+    hardware.reset_for_test()
+    info3 = hardware.get_hardware()
+    assert info3.device_name == "Other"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: `ImportError: cannot import name 'hardware' from 'helix_context'` or similar — the module doesn't exist yet.
+
+- [ ] **Step 3: Create the minimal hardware module**
+
+Create `helix_context/hardware.py`:
+
+```python
+"""Hardware detection + device backend dispatch for helix-context.
+
+Single source of truth for which torch device backends consult. Auto-mode
+picker walks CUDA -> ROCm -> MPS -> CPU; explicit-device requests fall back
+loudly to CPU on probe failure but never block. See:
+  docs/specs/2026-05-04-hardware-detection-design.md
+
+Public surface:
+  HardwareInfo            -- frozen dataclass returned by get_hardware()
+  get_hardware()          -- cached singleton; first call performs detection
+  reset_for_test()        -- test-only cache reset
+  recommended_batch_size  -- table-driven, override-aware
+
+Subsequent tasks fill in detection logic; Task 2 lays the dataclass +
+singleton plumbing only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+
+log = logging.getLogger("helix.hardware")
+
+
+@dataclass(frozen=True)
+class HardwareInfo:
+    """Atomic snapshot of detected hardware. Immutable — overrides flow
+    through config + env var, not setters."""
+
+    device: str
+    device_type: str
+    device_name: str
+    vram_total_gb: Optional[float]
+    vram_free_gb: Optional[float]
+    cpu_arch: str
+    cpu_brand: str
+    system_ram_gb: float
+    requested_device: str
+    fallback_reason: Optional[str]
+    batch_size_overrides: Mapping[str, int] = field(default_factory=dict)
+
+
+_cached_info: Optional[HardwareInfo] = None
+
+
+def get_hardware() -> HardwareInfo:
+    """Return the cached HardwareInfo, computing it on first call."""
+    global _cached_info
+    if _cached_info is None:
+        _cached_info = _detect()
+    return _cached_info
+
+
+def reset_for_test() -> None:
+    """Clear the cached HardwareInfo. Test-only."""
+    global _cached_info
+    _cached_info = None
+
+
+def _detect() -> HardwareInfo:
+    """Stub — filled in by Tasks 3-10. Returns a synthetic CPU info for now
+    so Task 2's tests pass."""
+    return HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name="unknown CPU",
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch="unknown",
+        cpu_brand="unknown CPU",
+        system_ram_gb=0.0,
+        requested_device="auto",
+        fallback_reason=None,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): HardwareInfo dataclass + cached singleton scaffolding"
+```
+
+---
+
+### Task 3: CPU detection (`cpu_arch` + `cpu_brand` + `system_ram_gb`)
+
+**Files:**
+- Modify: `helix_context/hardware.py`
+- Modify: `tests/test_hardware.py`
+
+Builds the CPU side of detection. `cpu_brand` resolution: py-cpuinfo → platform.processor() → "unknown CPU".
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_hardware.py`:
+
+```python
+def test_cpu_brand_from_py_cpuinfo(monkeypatch):
+    """When py-cpuinfo is installed and returns brand_raw, use it."""
+    fake_cpuinfo = {"brand_raw": "AMD Ryzen 9 7900X 12-Core Processor"}
+    monkeypatch.setattr(
+        "helix_context.hardware._cpuinfo_get_info",
+        lambda: fake_cpuinfo,
+    )
+    monkeypatch.setattr("platform.processor", lambda: "should not be used")
+    info = hardware._detect_cpu()
+    assert info["cpu_brand"] == "AMD Ryzen 9 7900X 12-Core Processor"
+
+
+def test_cpu_brand_falls_back_to_platform_processor(monkeypatch):
+    """When py-cpuinfo is absent, fall back to platform.processor()."""
+    monkeypatch.setattr("helix_context.hardware._cpuinfo_get_info", lambda: None)
+    monkeypatch.setattr("platform.processor", lambda: "Intel64 Family 6 Model 158")
+    info = hardware._detect_cpu()
+    assert info["cpu_brand"] == "Intel64 Family 6 Model 158"
+
+
+def test_cpu_brand_terminal_fallback(monkeypatch):
+    """When both sources fail, return 'unknown CPU' (no crash)."""
+    monkeypatch.setattr("helix_context.hardware._cpuinfo_get_info", lambda: None)
+    monkeypatch.setattr("platform.processor", lambda: "")
+    info = hardware._detect_cpu()
+    assert info["cpu_brand"] == "unknown CPU"
+
+
+def test_cpu_arch_uses_platform_machine(monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    info = hardware._detect_cpu()
+    assert info["cpu_arch"] == "x86_64"
+
+
+def test_system_ram_via_psutil(monkeypatch):
+    class _FakeVM:
+        total = 64 * 1024 * 1024 * 1024  # 64 GiB
+    monkeypatch.setattr("psutil.virtual_memory", lambda: _FakeVM())
+    info = hardware._detect_cpu()
+    assert info["system_ram_gb"] == pytest.approx(64.0, rel=1e-3)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py::test_cpu_brand_from_py_cpuinfo -v`
+Expected: `AttributeError: module 'helix_context.hardware' has no attribute '_detect_cpu'`.
+
+- [ ] **Step 3: Implement `_detect_cpu()` + the cpuinfo wrapper**
+
+In `helix_context/hardware.py`, add near the top (after imports):
+
+```python
+import platform
+from typing import Any, Dict
+
+
+def _cpuinfo_get_info() -> Optional[Dict[str, Any]]:
+    """Wrap py-cpuinfo behind a function so tests can mock it cleanly.
+    Returns None if py-cpuinfo isn't installed."""
+    try:
+        import cpuinfo
+    except ImportError:
+        return None
+    try:
+        return cpuinfo.get_cpu_info()
+    except Exception:
+        log.warning("py-cpuinfo get_cpu_info() raised; falling back", exc_info=True)
+        return None
+
+
+def _detect_cpu() -> Dict[str, Any]:
+    """Detect cpu_arch, cpu_brand, system_ram_gb. Pure dict to keep
+    HardwareInfo construction in one place (in _detect)."""
+    info = _cpuinfo_get_info()
+    if info and info.get("brand_raw"):
+        cpu_brand = info["brand_raw"]
+    else:
+        proc = platform.processor()
+        cpu_brand = proc if proc else "unknown CPU"
+
+    try:
+        import psutil
+        ram_bytes = psutil.virtual_memory().total
+        system_ram_gb = ram_bytes / (1024 ** 3)
+    except Exception:
+        log.warning("psutil.virtual_memory() failed; system_ram_gb=0", exc_info=True)
+        system_ram_gb = 0.0
+
+    return {
+        "cpu_arch": platform.machine() or "unknown",
+        "cpu_brand": cpu_brand,
+        "system_ram_gb": system_ram_gb,
+    }
+```
+
+Update `_detect()` to use `_detect_cpu()` for the CPU fields:
+
+```python
+def _detect() -> HardwareInfo:
+    cpu = _detect_cpu()
+    return HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name=cpu["cpu_brand"],
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch=cpu["cpu_arch"],
+        cpu_brand=cpu["cpu_brand"],
+        system_ram_gb=cpu["system_ram_gb"],
+        requested_device="auto",
+        fallback_reason=None,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 7 passed (2 from Task 2 + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): CPU detection (cpu_arch + cpu_brand resolution + system_ram_gb)"
+```
+
+---
+
+### Task 4: Probe protocol (`_probe()`)
+
+**Files:**
+- Modify: `helix_context/hardware.py`
+- Modify: `tests/test_hardware.py`
+
+Probe is the "looks present, isn't usable" gate. Will be consumed by the auto-mode picker in Task 5.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_hardware.py`:
+
+```python
+def test_probe_success(monkeypatch):
+    """Round-trip succeeds -> (True, None)."""
+    class _FakeTensor:
+        def to(self, device): return self
+        def cpu(self): return self
+    monkeypatch.setattr("torch.zeros", lambda *a, **kw: _FakeTensor())
+    ok, reason = hardware._probe("cuda:0")
+    assert ok is True
+    assert reason is None
+
+
+def test_probe_failure_returns_reason(monkeypatch):
+    """torch.zeros() raises -> (False, formatted reason)."""
+    def _raise(*a, **kw):
+        raise RuntimeError("CUDA driver version is insufficient")
+    monkeypatch.setattr("torch.zeros", _raise)
+    ok, reason = hardware._probe("cuda:0")
+    assert ok is False
+    assert reason is not None
+    assert "RuntimeError" in reason
+    assert "CUDA driver version is insufficient" in reason
+
+
+def test_probe_to_failure(monkeypatch):
+    """torch.zeros() succeeds but .to(device) raises -> probe fails."""
+    class _BadTensor:
+        def to(self, device):
+            raise RuntimeError("device not available")
+        def cpu(self): return self
+    monkeypatch.setattr("torch.zeros", lambda *a, **kw: _BadTensor())
+    ok, reason = hardware._probe("cuda:0")
+    assert ok is False
+    assert "device not available" in reason
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py::test_probe_success -v`
+Expected: `AttributeError: module 'helix_context.hardware' has no attribute '_probe'`.
+
+- [ ] **Step 3: Implement `_probe()`**
+
+Add to `helix_context/hardware.py`:
+
+```python
+def _probe(device_str: str) -> tuple[bool, Optional[str]]:
+    """Round-trip a 1-element zero tensor through the device.
+
+    device_str: e.g. 'cuda:0', 'cuda:1', 'mps', 'cpu'.
+
+    Returns (True, None) on success, (False, '<ExcType>: <message>') on
+    failure. Catches the 'wheel says yes but kernel launch fails' failure
+    mode (stale driver, dead GPU, container without device passthrough).
+    Probe is ~1ms on healthy hardware.
+    """
+    import torch  # local import — torch may be absent (§5.5)
+    try:
+        t = torch.zeros(1).to(device_str)
+        _ = t.cpu()
+        return True, None
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 10 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): _probe() — 1-element round-trip device usability check"
+```
+
+---
+
+### Task 5: Auto-mode picker (CUDA + ROCm + MPS + CPU)
+
+**Files:**
+- Modify: `helix_context/hardware.py`
+- Modify: `tests/test_hardware.py`
+
+The full auto-mode picking order. Single-GPU-only — multi-GPU fall-through is Task 6.
+
+- [ ] **Step 1: Write the failing tests + the shared `mock_torch` fixture**
+
+Append to `tests/test_hardware.py`:
+
+```python
+@pytest.fixture
+def mock_torch(monkeypatch):
+    """Shared torch mock for picker tests. Returns a state dict so each
+    test can configure which backends are advertised. Defaults: CPU-only.
+    """
+    state = {
+        "cuda_available": False,
+        "cuda_device_count": 0,
+        "cuda_device_names": [],
+        "cuda_mem": [],            # list of (free_gb, total_gb) per index
+        "hip_version": None,
+        "mps_available": False,
+        "mps_built": False,
+        "probe_results": {},       # device_str -> (ok, reason) overrides
+    }
+
+    def _is_available(): return state["cuda_available"]
+    def _device_count(): return state["cuda_device_count"]
+    def _get_device_name(i): return state["cuda_device_names"][i]
+    def _mem_get_info(i):
+        free_gb, total_gb = state["cuda_mem"][i]
+        return (int(free_gb * 1024**3), int(total_gb * 1024**3))
+    def _mps_is_available(): return state["mps_available"]
+    def _mps_is_built(): return state["mps_built"]
+
+    monkeypatch.setattr("torch.cuda.is_available", _is_available)
+    monkeypatch.setattr("torch.cuda.device_count", _device_count)
+    monkeypatch.setattr("torch.cuda.get_device_name", _get_device_name)
+    monkeypatch.setattr("torch.cuda.mem_get_info", _mem_get_info)
+    monkeypatch.setattr("torch.backends.mps.is_available", _mps_is_available)
+    monkeypatch.setattr("torch.backends.mps.is_built", _mps_is_built)
+
+    import torch
+    monkeypatch.setattr(torch.version, "hip", state["hip_version"], raising=False)
+
+    def _probe_stub(device_str: str):
+        if device_str in state["probe_results"]:
+            return state["probe_results"][device_str]
+        return (True, None)
+    monkeypatch.setattr(hardware, "_probe", _probe_stub)
+
+    def _set_hip(v):
+        state["hip_version"] = v
+        monkeypatch.setattr(torch.version, "hip", v, raising=False)
+    state["set_hip"] = _set_hip
+    return state
+
+
+def test_auto_picks_cuda_when_available(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["NVIDIA GeForce RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.4, 24.0)]
+    info = hardware._detect()
+    assert info.device_type == "cuda"
+    assert info.device == "cuda:0"
+    assert info.device_name == "NVIDIA GeForce RTX 4090"
+    assert info.vram_total_gb == pytest.approx(24.0, rel=1e-3)
+
+
+def test_auto_picks_cpu_when_nothing_available(mock_torch):
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.device == "cpu"
+
+
+def test_auto_picks_rocm_when_hip_advertised(mock_torch):
+    """ROCm builds set torch.version.hip; cuda.is_available() also returns
+    True on a ROCm build (HIP devices surface through the cuda API)."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["AMD Radeon RX 7900 XTX"]
+    mock_torch["cuda_mem"] = [(20.0, 24.0)]
+    mock_torch["set_hip"]("5.7.0")
+    info = hardware._detect()
+    assert info.device_type == "rocm"
+    assert info.device == "rocm:0"
+    assert "Radeon" in info.device_name
+
+
+def test_auto_picks_mps_when_only_mps_available(mock_torch):
+    mock_torch["mps_available"] = True
+    mock_torch["mps_built"] = True
+    info = hardware._detect()
+    assert info.device_type == "mps"
+    assert info.device == "mps"
+
+
+def test_auto_falls_through_when_cuda_probe_fails(mock_torch):
+    """Mocked-multi: simulate CUDA advertised but probe fails; MPS available.
+    Real-world this can't happen (CUDA + MPS aren't on the same wheel) but
+    the fall-through logic must work for the explicit-fallback path too."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["Broken GPU"]
+    mock_torch["cuda_mem"] = [(0.0, 4.0)]
+    mock_torch["probe_results"]["cuda:0"] = (False, "RuntimeError: bad")
+    mock_torch["mps_available"] = True
+    mock_torch["mps_built"] = True
+    info = hardware._detect()
+    assert info.device_type == "mps"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py::test_auto_picks_cuda_when_available -v`
+Expected: assertion failure (current `_detect` always returns CPU).
+
+- [ ] **Step 3: Implement the picker**
+
+Replace `_detect()` in `helix_context/hardware.py` and add helpers:
+
+```python
+def _detect_cuda_or_rocm(rocm: bool) -> Optional[Dict[str, Any]]:
+    """Returns dict with device fields, or None if not available.
+    Single-device pick (multi-GPU enumeration is Task 6)."""
+    import torch
+    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+        return None
+    if rocm and getattr(torch.version, "hip", None) is None:
+        return None
+    if not rocm and getattr(torch.version, "hip", None) is not None:
+        return None
+    idx = 0
+    free_b, total_b = torch.cuda.mem_get_info(idx)
+    device_str = f"{'rocm' if rocm else 'cuda'}:{idx}"
+    ok, reason = _probe(f"cuda:{idx}")
+    if not ok:
+        log.warning("Device %s probe failed: %s", device_str, reason)
+        return None
+    return {
+        "device": device_str,
+        "device_type": "rocm" if rocm else "cuda",
+        "device_name": torch.cuda.get_device_name(idx),
+        "vram_total_gb": total_b / (1024 ** 3),
+        "vram_free_gb": free_b / (1024 ** 3),
+    }
+
+
+def _detect_mps() -> Optional[Dict[str, Any]]:
+    import torch
+    if not (torch.backends.mps.is_available() and torch.backends.mps.is_built()):
+        return None
+    ok, reason = _probe("mps")
+    if not ok:
+        log.warning("MPS probe failed: %s", reason)
+        return None
+    return {
+        "device": "mps",
+        "device_type": "mps",
+        "device_name": "Apple Silicon (MPS)",
+        "vram_total_gb": None,
+        "vram_free_gb": None,
+    }
+
+
+def _detect() -> HardwareInfo:
+    cpu = _detect_cpu()
+    requested = "auto"  # Task 7 wires env+config
+
+    for label, fn in (
+        ("cuda", lambda: _detect_cuda_or_rocm(rocm=False)),
+        ("rocm", lambda: _detect_cuda_or_rocm(rocm=True)),
+        ("mps",  _detect_mps),
+    ):
+        try:
+            d = fn()
+        except Exception:
+            log.warning("hardware candidate %s failed", label, exc_info=True)
+            continue
+        if d is not None:
+            return HardwareInfo(
+                device=d["device"],
+                device_type=d["device_type"],
+                device_name=d["device_name"],
+                vram_total_gb=d["vram_total_gb"],
+                vram_free_gb=d["vram_free_gb"],
+                cpu_arch=cpu["cpu_arch"],
+                cpu_brand=cpu["cpu_brand"],
+                system_ram_gb=cpu["system_ram_gb"],
+                requested_device=requested,
+                fallback_reason=None,
+            )
+
+    return HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name=cpu["cpu_brand"],
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch=cpu["cpu_arch"],
+        cpu_brand=cpu["cpu_brand"],
+        system_ram_gb=cpu["system_ram_gb"],
+        requested_device=requested,
+        fallback_reason=None,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 15 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): auto-mode picker (CUDA -> ROCm -> MPS -> CPU)"
+```
+
+---
+
+### Task 6: Multi-GPU device selection
+
+**Files:**
+- Modify: `helix_context/hardware.py`
+- Modify: `tests/test_hardware.py`
+
+Pick the device with most free VRAM; on per-device probe failure, fall through to next-best. Regression pin for spec-review issue B2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_hardware.py`:
+
+```python
+def test_multi_gpu_picks_largest_free_vram(mock_torch):
+    """Two healthy GPUs — pick the one with more free VRAM."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["RTX 3070", "RTX 4090"]
+    mock_torch["cuda_mem"] = [(4.0, 8.0), (22.0, 24.0)]
+    info = hardware._detect()
+    assert info.device == "cuda:1"
+    assert info.device_name == "RTX 4090"
+
+
+def test_multi_gpu_dead_first_device_falls_through(mock_torch, monkeypatch):
+    """device-0 mem_get_info raises (dead); device-1 healthy. Pick cuda:1."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["DeadCard", "RTX 4090"]
+    mock_torch["cuda_mem"] = [(0.0, 0.0), (22.0, 24.0)]
+
+    def _mem(i):
+        if i == 0:
+            raise RuntimeError("device 0 is dead")
+        free_gb, total_gb = mock_torch["cuda_mem"][i]
+        return (int(free_gb * 1024**3), int(total_gb * 1024**3))
+    monkeypatch.setattr("torch.cuda.mem_get_info", _mem)
+
+    info = hardware._detect()
+    assert info.device == "cuda:1"
+    assert info.device_name == "RTX 4090"
+
+
+def test_multi_gpu_probe_failure_on_best_falls_through(mock_torch):
+    """Best-VRAM device probe fails; pick the next-best healthy one."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["RTX 4090 (broken)", "RTX 3070"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0), (6.0, 8.0)]
+    mock_torch["probe_results"]["cuda:0"] = (False, "RuntimeError: kernel launch failed")
+    info = hardware._detect()
+    assert info.device == "cuda:1"
+    assert info.device_name == "RTX 3070"
+
+
+def test_multi_gpu_all_dead_falls_through_to_cpu(mock_torch):
+    """All CUDA devices fail their probes -> CUDA candidate rejected,
+    auto-mode falls through to CPU (no MPS in this scenario)."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["broken1", "broken2"]
+    mock_torch["cuda_mem"] = [(4.0, 8.0), (4.0, 8.0)]
+    mock_torch["probe_results"]["cuda:0"] = (False, "bad")
+    mock_torch["probe_results"]["cuda:1"] = (False, "bad")
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py::test_multi_gpu_picks_largest_free_vram -v`
+Expected: assertion failure (current single-device picker hardcodes idx=0).
+
+- [ ] **Step 3: Replace single-device pick with enumerate-pick-probe-fallthrough**
+
+In `helix_context/hardware.py`, replace `_detect_cuda_or_rocm`:
+
+```python
+def _detect_cuda_or_rocm(rocm: bool) -> Optional[Dict[str, Any]]:
+    """Enumerate live devices, pick the most-free-VRAM one that probes
+    successfully. Falls through to next-best on probe failure. Returns
+    None if no devices probe successfully."""
+    import torch
+    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+        return None
+    if rocm and getattr(torch.version, "hip", None) is None:
+        return None
+    if not rocm and getattr(torch.version, "hip", None) is not None:
+        return None
+
+    candidates = []  # list of (free_gb, total_gb, idx)
+    for idx in range(torch.cuda.device_count()):
+        try:
+            free_b, total_b = torch.cuda.mem_get_info(idx)
+        except Exception as exc:
+            log.warning("cuda:%d mem_get_info failed (treated as dead): %s", idx, exc)
+            continue
+        candidates.append((free_b / (1024**3), total_b / (1024**3), idx))
+
+    if not candidates:
+        return None
+
+    candidates.sort(reverse=True)  # largest free VRAM first
+
+    for free_gb, total_gb, idx in candidates:
+        ok, reason = _probe(f"cuda:{idx}")
+        if not ok:
+            log.warning("cuda:%d probe failed: %s — falling through", idx, reason)
+            continue
+        device_type = "rocm" if rocm else "cuda"
+        device_str = f"{device_type}:{idx}"
+        return {
+            "device": device_str,
+            "device_type": device_type,
+            "device_name": torch.cuda.get_device_name(idx),
+            "vram_total_gb": total_gb,
+            "vram_free_gb": free_gb,
+        }
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 19 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): multi-GPU pick by free VRAM with probe-fall-through
+
+Regression pin for spec-review B2 — dead device-0 + healthy device-1
+must select cuda:1, not reject CUDA outright."
+```
+
+---
+
+### Task 7: Explicit-device requested + `HELIX_DEVICE` env override + fallback policy
+
+**Files:**
+- Modify: `helix_context/hardware.py`
+- Modify: `tests/test_hardware.py`
+
+Wires `requested_device` from env + (later: config) into `_detect()`. Explicit-device mismatch falls back **directly to CPU** (skips ROCm/MPS — see spec §5.4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_hardware.py`:
+
+```python
+def test_explicit_cuda_succeeds(mock_torch, monkeypatch):
+    monkeypatch.setenv("HELIX_DEVICE", "cuda")
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    info = hardware._detect()
+    assert info.device_type == "cuda"
+    assert info.requested_device == "cuda"
+    assert info.fallback_reason is None
+
+
+def test_explicit_cuda_falls_back_to_cpu_on_probe_failure(mock_torch, monkeypatch):
+    """Explicit cuda + no GPU available -> cpu directly (NOT rocm/mps even if available).
+
+    Spec §5.4 asymmetry: auto picks the best available; explicit means
+    'I want this exactly, downgrade to CPU if not there'."""
+    monkeypatch.setenv("HELIX_DEVICE", "cuda")
+    mock_torch["cuda_available"] = False
+    mock_torch["mps_available"] = True
+    mock_torch["mps_built"] = True
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.fallback_reason is not None
+    assert "cuda" in info.fallback_reason.lower()
+
+
+def test_helix_device_env_var_case_insensitive(mock_torch, monkeypatch):
+    monkeypatch.setenv("HELIX_DEVICE", "CPU")
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.requested_device == "cpu"
+
+
+def test_helix_device_env_var_invalid_falls_back_to_auto(mock_torch, monkeypatch, caplog):
+    monkeypatch.setenv("HELIX_DEVICE", "nonsense")
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    with caplog.at_level(logging.WARNING, logger="helix.hardware"):
+        info = hardware._detect()
+    assert info.requested_device == "auto"
+    assert info.device_type == "cuda"
+    assert any(
+        "invalid helix_device" in rec.message.lower()
+        or "ignoring helix_device" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_explicit_mps_on_non_mps_host_falls_back_to_cpu(mock_torch, monkeypatch):
+    monkeypatch.setenv("HELIX_DEVICE", "mps")
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.fallback_reason is not None
+    assert "mps" in info.fallback_reason.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py::test_explicit_cuda_succeeds -v`
+Expected: assertion failure (`requested_device == "auto"` regardless of env var; env not yet read).
+
+- [ ] **Step 3: Add env-var resolution + explicit-device path**
+
+In `helix_context/hardware.py`, add near the top:
+
+```python
+import os
+
+_VALID_DEVICES = ("auto", "cuda", "rocm", "mps", "cpu")
+
+
+def _resolve_requested_device() -> str:
+    """Resolve the user's requested device from HELIX_DEVICE env var.
+    Config plumbing is added in Task 9; for now env-var-only.
+
+    Returns one of _VALID_DEVICES; invalid values log a warning and
+    return 'auto'."""
+    env_value = os.environ.get("HELIX_DEVICE")
+    if env_value is None:
+        return "auto"
+    normalized = env_value.strip().lower()
+    if normalized not in _VALID_DEVICES:
+        log.warning(
+            "Invalid HELIX_DEVICE=%r (valid: %s); ignoring HELIX_DEVICE and using 'auto'",
+            env_value, ", ".join(_VALID_DEVICES),
+        )
+        return "auto"
+    return normalized
+```
+
+Update `_detect()` to consult `_resolve_requested_device()` and dispatch:
+
+```python
+def _detect() -> HardwareInfo:
+    cpu = _detect_cpu()
+    requested = _resolve_requested_device()
+
+    if requested == "auto":
+        attempts = [
+            ("cuda", lambda: _detect_cuda_or_rocm(rocm=False)),
+            ("rocm", lambda: _detect_cuda_or_rocm(rocm=True)),
+            ("mps",  _detect_mps),
+        ]
+        explicit = False
+    elif requested == "cpu":
+        attempts = []
+        explicit = True
+    elif requested == "cuda":
+        attempts = [("cuda", lambda: _detect_cuda_or_rocm(rocm=False))]
+        explicit = True
+    elif requested == "rocm":
+        attempts = [("rocm", lambda: _detect_cuda_or_rocm(rocm=True))]
+        explicit = True
+    elif requested == "mps":
+        attempts = [("mps", _detect_mps)]
+        explicit = True
+    else:
+        attempts = []
+        explicit = True
+
+    last_failure_reason: Optional[str] = None
+    for label, fn in attempts:
+        try:
+            d = fn()
+        except Exception as exc:
+            log.warning("hardware candidate %s failed", label, exc_info=True)
+            last_failure_reason = f"{label} candidate raised: {exc}"
+            continue
+        if d is not None:
+            return HardwareInfo(
+                device=d["device"],
+                device_type=d["device_type"],
+                device_name=d["device_name"],
+                vram_total_gb=d["vram_total_gb"],
+                vram_free_gb=d["vram_free_gb"],
+                cpu_arch=cpu["cpu_arch"],
+                cpu_brand=cpu["cpu_brand"],
+                system_ram_gb=cpu["system_ram_gb"],
+                requested_device=requested,
+                fallback_reason=None,
+            )
+        else:
+            last_failure_reason = (
+                last_failure_reason
+                or f"{label} not available (is_available()/probe returned False)"
+            )
+
+    if requested != "auto" and requested != "cpu":
+        fallback_reason = (
+            f"requested {requested!r} but probe/availability failed: "
+            f"{last_failure_reason or 'no usable device found'}"
+        )
+    else:
+        fallback_reason = None
+
+    return HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name=cpu["cpu_brand"],
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch=cpu["cpu_arch"],
+        cpu_brand=cpu["cpu_brand"],
+        system_ram_gb=cpu["system_ram_gb"],
+        requested_device=requested,
+        fallback_reason=fallback_reason,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 24 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): HELIX_DEVICE env override + explicit-device fallback to CPU
+
+Implements spec §5.4 — explicit device request that fails probes falls
+back to CPU directly (skips other GPU candidates). Auto-mode unchanged."
+```
+
+---
+
+### Task 8: Batch-size table + `recommended_batch_size` + `batch_size_overrides`
+
+**Files:**
+- Modify: `helix_context/hardware.py`
+- Modify: `tests/test_hardware.py`
+
+Implements `recommended_batch_size(model)` consulting `batch_size_overrides` first, then the `_BATCH_TABLE`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_hardware.py`:
+
+```python
+def test_batch_size_24gb_cuda_tier(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 64
+    assert hardware.recommended_batch_size("splice") == 128
+    assert hardware.recommended_batch_size("splade") == 32
+    assert hardware.recommended_batch_size("nli") == 32
+
+
+def test_batch_size_4gb_cuda_tier(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["GTX 1650"]
+    mock_torch["cuda_mem"] = [(3.5, 4.0)]
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 8
+
+
+def test_batch_size_under_4gb_cuda_tier(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["MX150"]
+    mock_torch["cuda_mem"] = [(1.5, 2.0)]
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 4
+
+
+def test_batch_size_cpu_tier_uses_system_ram(monkeypatch, mock_torch):
+    """CPU batch sizes key on system_ram_gb, not VRAM."""
+    class _FakeVM:
+        total = 16 * 1024 ** 3  # 16 GiB
+    monkeypatch.setattr("psutil.virtual_memory", lambda: _FakeVM())
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 8
+
+
+def test_batch_size_total_not_free_drives_lookup(mock_torch):
+    """Even if free VRAM is tiny, total VRAM picks the tier.
+
+    Regression pin for spec-review B3 — vram_free_gb is informational
+    only; the table keys on vram_total_gb.
+    """
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(0.5, 24.0)]  # almost all VRAM in use
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 64  # 24GB tier wins
+
+
+def test_batch_size_override_beats_table(mock_torch):
+    """batch_size_overrides field short-circuits the table lookup."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    info = hardware.get_hardware()
+    forced = dataclasses.replace(info, batch_size_overrides={"rerank": 16})
+    hardware._cached_info = forced  # direct cache poke for test
+    assert hardware.recommended_batch_size("rerank") == 16
+    assert hardware.recommended_batch_size("splice") == 128
+
+
+def test_batch_size_unknown_model_returns_minimum(mock_torch):
+    """Asking for a model not in the table returns the conservative floor."""
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("unknown_model") == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_hardware.py::test_batch_size_24gb_cuda_tier -v`
+Expected: `AttributeError: module 'helix_context.hardware' has no attribute 'recommended_batch_size'`.
+
+- [ ] **Step 3: Add `_BATCH_TABLE` + `recommended_batch_size`**
+
+In `helix_context/hardware.py`, add near the bottom (after `_detect`):
+
+```python
+# Batch-size table — keys are (device_type, ram_threshold_gb_min).
+# Lookup picks the highest threshold row whose minimum is <= the
+# observed value. See spec §7.1 for calibration rationale.
+_BATCH_TABLE: Dict[tuple, Dict[str, int]] = {
+    # CUDA / ROCm tiers — keyed on TOTAL VRAM (invariant per GPU).
+    ("cuda", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
+    ("cuda", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
+    ("cuda",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("cuda",  4.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("cuda",  0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
+    ("rocm", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
+    ("rocm", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
+    ("rocm",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("rocm",  4.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("rocm",  0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
+    # MPS — keyed on system_ram_gb (MPS shares system RAM).
+    ("mps", 16.0): {"rerank": 16, "splice": 32, "splade":  8, "nli":  8},
+    ("mps",  8.0): {"rerank":  8, "splice": 16, "splade":  4, "nli":  4},
+    ("mps",  0.0): {"rerank":  4, "splice":  8, "splade":  2, "nli":  2},
+    # CPU — keyed on system_ram_gb.
+    ("cpu", 16.0): {"rerank":  8, "splice": 16, "splade":  4, "nli":  4},
+    ("cpu",  8.0): {"rerank":  4, "splice":  8, "splade":  2, "nli":  2},
+    ("cpu",  0.0): {"rerank":  2, "splice":  4, "splade":  1, "nli":  1},
+}
+
+
+def _lookup_batch_size(device_type: str, tier_value: float, model: str) -> int:
+    """Find the highest-threshold row whose min <= tier_value."""
+    matching = [
+        (threshold, row[model])
+        for (dt, threshold), row in _BATCH_TABLE.items()
+        if dt == device_type and threshold <= tier_value and model in row
+    ]
+    if not matching:
+        return 1  # ultra-conservative floor for unknown model / table miss
+    matching.sort(reverse=True)
+    return matching[0][1]
+
+
+def recommended_batch_size(model: str) -> int:
+    """Resolve batch size for `model`. Order:
+    1. info.batch_size_overrides[model] if present
+    2. _BATCH_TABLE lookup based on device_type + (vram_total_gb or system_ram_gb)
+    3. Conservative floor (1) for unknown models.
+    """
+    info = get_hardware()
+    if model in info.batch_size_overrides:
+        return info.batch_size_overrides[model]
+    if info.device_type in {"cuda", "rocm"}:
+        tier = info.vram_total_gb if info.vram_total_gb is not None else 0.0
+    else:
+        tier = info.system_ram_gb
+    return _lookup_batch_size(info.device_type, tier, model)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 31 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/hardware.py tests/test_hardware.py
+git commit -m "feat(hardware): batch-size table + recommended_batch_size with overrides
+
+Regression pin for spec-review B3 — table keyed on vram_total_gb (not
+free), pinned in test_batch_size_total_not_free_drives_lookup."
+```
+
+---
+
+### Task 9: Config parsing for `[hardware]` + `[ribosome] device` deprecation
+
+**Files:**
+- Modify: `helix_context/config.py`
+- Modify: `helix_context/hardware.py` (consume parsed config)
+- Modify: `tests/test_config.py` (add deprecation tests)
+- Modify: `tests/test_hardware.py` (add config-flow tests)
+
+Wires the `[hardware]` TOML section through `Config` and into the hardware singleton, with the ribosome.device backwards-compat shim.
+
+- [ ] **Step 1: Inspect current config shape**
+
+Run: `grep -n "device\|class Ribosome\|class Server\|class.*Config" helix_context/config.py | head -30`
+Expected: locates `Ribosome` config class + the `from_dict` constructors.
+
+- [ ] **Step 2: Write the failing tests in `tests/test_config.py`**
+
+Append:
+
+```python
+def test_hardware_section_parses(tmp_path):
+    """[hardware] section parses with all defaults."""
+    cfg_text = """
+[hardware]
+device = "cuda"
+batch_sizes = "auto"
+low_vram_threshold_gb = 4.0
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    cfg = Config.from_file(str(p))
+    assert cfg.hardware.device == "cuda"
+    assert cfg.hardware.batch_sizes == {}  # "auto" -> empty override dict
+    assert cfg.hardware.low_vram_threshold_gb == 4.0
+
+
+def test_hardware_section_batch_sizes_dict(tmp_path):
+    cfg_text = """
+[hardware]
+device = "auto"
+batch_sizes = { rerank = 16, splice = 32 }
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    cfg = Config.from_file(str(p))
+    assert cfg.hardware.batch_sizes == {"rerank": 16, "splice": 32}
+
+
+def test_ribosome_device_deprecation_warning(tmp_path, caplog):
+    """[ribosome] device alone (no [hardware]) triggers deprecation warning."""
+    cfg_text = """
+[ribosome]
+device = "cuda"
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    with caplog.at_level("WARNING", logger="helix.config"):
+        cfg = Config.from_file(str(p))
+    assert cfg.hardware.device == "cuda"  # ribosome value used
+    assert any(
+        "ribosome" in rec.message.lower() and "deprecated" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_hardware_overrides_ribosome_device(tmp_path, caplog):
+    """When both are set, [hardware] wins; warning still fires noting override."""
+    cfg_text = """
+[ribosome]
+device = "cpu"
+
+[hardware]
+device = "cuda"
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    with caplog.at_level("WARNING", logger="helix.config"):
+        cfg = Config.from_file(str(p))
+    assert cfg.hardware.device == "cuda"  # [hardware] wins
+    assert any(
+        "deprecated" in rec.message.lower() and "override" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_no_device_config_defaults_to_auto(tmp_path):
+    """Empty config -> [hardware].device = "auto"."""
+    p = tmp_path / "helix.toml"
+    p.write_text("# empty\n")
+    cfg = Config.from_file(str(p))
+    assert cfg.hardware.device == "auto"
+    assert cfg.hardware.batch_sizes == {}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest tests/test_config.py::test_hardware_section_parses -v`
+Expected: `AttributeError: 'Config' object has no attribute 'hardware'`.
+
+- [ ] **Step 4: Add `Hardware` config dataclass + parser**
+
+In `helix_context/config.py`, add a `Hardware` dataclass (near `Ribosome`):
+
+```python
+@dataclass
+class Hardware:
+    """[hardware] config — see docs/specs/2026-05-04-hardware-detection-design.md."""
+    device: str = "auto"        # auto | cuda | rocm | mps | cpu
+    batch_sizes: Dict[str, int] = field(default_factory=dict)
+    low_vram_threshold_gb: float = 4.0
+```
+
+In `Config.from_dict()` (or wherever the section parsers live), add:
+
+```python
+hw = data.get("hardware", {})
+if isinstance(hw.get("batch_sizes"), str) and hw["batch_sizes"] == "auto":
+    bs = {}
+elif isinstance(hw.get("batch_sizes"), dict):
+    bs = {k: int(v) for k, v in hw["batch_sizes"].items()}
+else:
+    bs = {}
+hardware_device = hw.get("device", "auto")
+
+# Deprecation shim for [ribosome] device.
+ribosome_device = data.get("ribosome", {}).get("device")
+if ribosome_device is not None:
+    if "device" in hw:
+        log.warning(
+            "[ribosome] device is deprecated and was overridden by "
+            "[hardware] device=%r. Remove [ribosome] device.", hardware_device,
+        )
+    else:
+        log.warning(
+            "[ribosome] device is deprecated; move to [hardware] device. "
+            "Using ribosome.device=%r for now.", ribosome_device,
+        )
+        hardware_device = ribosome_device
+
+hardware_cfg = Hardware(
+    device=str(hardware_device),
+    batch_sizes=bs,
+    low_vram_threshold_gb=float(hw.get("low_vram_threshold_gb", 4.0)),
+)
+cfg.hardware = hardware_cfg
+```
+
+(Implementer: place these blocks in the existing `from_dict`/`from_file` flow at the right indent level. The exact line is whatever follows the existing `[ribosome]` parse.)
+
+- [ ] **Step 5: Run config tests**
+
+Run: `pytest tests/test_config.py -k "hardware or ribosome_device" -v`
+Expected: 5 passed.
+
+- [ ] **Step 6: Wire config to `hardware.get_hardware()` via `init_from_config`**
+
+In `helix_context/hardware.py`, modify `_resolve_requested_device()` to also accept a config-supplied default:
+
+```python
+def _resolve_requested_device(config_device: str = "auto") -> str:
+    """Resolve requested device. Order: HELIX_DEVICE env > config > 'auto'."""
+    env_value = os.environ.get("HELIX_DEVICE")
+    if env_value is not None:
+        normalized = env_value.strip().lower()
+        if normalized in _VALID_DEVICES:
+            return normalized
+        log.warning(
+            "Invalid HELIX_DEVICE=%r (valid: %s); ignoring HELIX_DEVICE",
+            env_value, ", ".join(_VALID_DEVICES),
+        )
+    if config_device.lower() in _VALID_DEVICES:
+        return config_device.lower()
+    log.warning("Invalid [hardware] device=%r; using 'auto'", config_device)
+    return "auto"
+```
+
+Add a public init function:
+
+```python
+def init_from_config(config_device: str = "auto",
+                     batch_size_overrides: Optional[Mapping[str, int]] = None) -> HardwareInfo:
+    """One-shot init at server startup. Calls _detect with config-driven
+    requested_device and stamps batch_size_overrides onto the singleton.
+
+    Idempotent: returns the cached HardwareInfo on subsequent calls."""
+    global _cached_info, _config_device, _config_overrides
+    if _cached_info is not None:
+        return _cached_info
+    _config_device = config_device
+    _config_overrides = dict(batch_size_overrides) if batch_size_overrides else {}
+    _cached_info = _detect()
+    return _cached_info
+```
+
+Add module-level state for these defaults near `_cached_info`:
+
+```python
+_config_device: str = "auto"
+_config_overrides: Mapping[str, int] = {}
+```
+
+Update `_detect()` to consume them:
+
+```python
+def _detect() -> HardwareInfo:
+    cpu = _detect_cpu()
+    requested = _resolve_requested_device(_config_device)
+    overrides = dict(_config_overrides)
+    # ...rest unchanged, except add `batch_size_overrides=overrides` to
+    # ALL HardwareInfo(...) constructions in this function.
+```
+
+Make sure both the success-path and CPU-fallback HardwareInfo constructors include `batch_size_overrides=overrides`.
+
+Update `reset_for_test()` to also reset the config state:
+
+```python
+def reset_for_test() -> None:
+    global _cached_info, _config_device, _config_overrides
+    _cached_info = None
+    _config_device = "auto"
+    _config_overrides = {}
+```
+
+- [ ] **Step 7: Add hardware-side test for config flow**
+
+Append to `tests/test_hardware.py`:
+
+```python
+def test_init_from_config_routes_through_singleton(mock_torch):
+    """init_from_config sets requested_device + batch_size_overrides."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    info = hardware.init_from_config(
+        config_device="cuda",
+        batch_size_overrides={"rerank": 8},
+    )
+    assert info.requested_device == "cuda"
+    assert info.batch_size_overrides == {"rerank": 8}
+    assert hardware.recommended_batch_size("rerank") == 8  # override wins
+```
+
+Run: `pytest tests/test_hardware.py -v`
+Expected: 32 passed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add helix_context/hardware.py helix_context/config.py tests/test_config.py tests/test_hardware.py
+git commit -m "feat(hardware): config plumbing — [hardware] section + ribosome.device shim"
+```
+
+---
+
+### Task 10: Document `[hardware]` block in `helix.toml`
+
+**Files:**
+- Modify: `helix.toml`
+
+Pure config-doc change. Default values match the dataclass defaults.
+
+- [ ] **Step 1: Add the documented `[hardware]` block**
+
+Insert near the top of `helix.toml` (above `[budget]` is fine; alphabetical order across sections is not enforced):
+
+```toml
+[hardware]
+# Device picker. "auto" picks best-available (cuda -> rocm -> mps -> cpu).
+# Explicit values fall back loudly to CPU on probe failure; helix never
+# blocks on hardware mismatch -- see /health for fallback state.
+# Override one-shot via HELIX_DEVICE=cpu env var.
+device = "auto"        # auto | cuda | rocm | mps | cpu
+
+# Batch-size policy. "auto" consults the VRAM/RAM-aware table in
+# helix_context/hardware.py. Override per model when tuning:
+#   batch_sizes = { rerank = 16, splice = 32, splade = 8, nli = 8 }
+batch_sizes = "auto"
+
+# Soft-warn threshold. Below this, /health returns a "low_vram" hint and
+# the tray surfaces a one-time balloon. Set to 0 to disable.
+low_vram_threshold_gb = 4.0
+```
+
+- [ ] **Step 2: Verify config still loads**
+
+Run: `python -c "from helix_context.config import Config; c = Config.from_file('helix.toml'); print(c.hardware)"`
+Expected: prints `Hardware(device='auto', batch_sizes={}, low_vram_threshold_gb=4.0)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add helix.toml
+git commit -m "docs(helix.toml): add [hardware] block with documented defaults"
+```
+
+---
+
+### Task 11: Plumb `get_hardware()` through all four backends
+
+This task is split into 4 sub-tasks (one per backend) so each commit is reviewable independently.
+
+#### Task 11a: `deberta_backend.py` — consult hardware + chunk `re_rank` and `splice`
+
+**Files:**
+- Modify: `helix_context/deberta_backend.py`
+- Modify: `tests/test_ribosome.py`
+
+- [ ] **Step 1: Read the current `re_rank` and `splice` to understand the all-at-once tokenize pattern**
+
+Run: `grep -n "def re_rank\|def splice\|tokenizer(.*texts_a" helix_context/deberta_backend.py`
+Expected: locates the entry points + the tokenizer call sites.
+
+- [ ] **Step 2: Write a test that PINS the chunked-batch behavior**
+
+In `tests/test_ribosome.py`, add a test that mocks the tokenizer + model, forces a 16-batch via `recommended_batch_size`, feeds 100 candidates, and asserts the tokenizer was called 7 times (6 full + 1 partial). Adapt to existing fixtures in that file.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Expected: the test fails because `re_rank` currently tokenizes all candidates in one call.
+
+- [ ] **Step 4: Refactor `re_rank` to chunk**
+
+In `helix_context/deberta_backend.py`, change `re_rank` from the all-at-once tokenize to chunked iteration:
+
+```python
+def re_rank(self, query, candidates, k=5):
+    if not candidates:
+        return []
+    if len(candidates) <= k:
+        return candidates
+
+    from helix_context.hardware import recommended_batch_size
+    batch_size = recommended_batch_size("rerank")
+
+    texts_a, texts_b = [], []
+    for g in candidates:
+        # ... (same as before — build the pair lists)
+        pass
+
+    all_scores = []
+    for i in range(0, len(texts_a), batch_size):
+        chunk_a = texts_a[i : i + batch_size]
+        chunk_b = texts_b[i : i + batch_size]
+        encodings = self._rerank_tokenizer(
+            chunk_a, chunk_b,
+            truncation=True, max_length=256, padding=True,
+            return_tensors="pt",
+        ).to(self._device)
+        with torch.no_grad():
+            outputs = self._rerank_model(**encodings)
+        scores = outputs.logits.squeeze(-1)
+        scores = torch.clamp(scores, 0.0, 1.0).cpu().tolist()
+        if isinstance(scores, float):
+            scores = [scores]
+        all_scores.extend(scores)
+
+    # ... (rest of function unchanged: zip with candidates, sort, take top-k)
+```
+
+Apply the same chunking to `splice()`. The pair-building and post-processing stay the same; only the tokenize+forward block is wrapped in the `for i in range(0, ..., batch_size)` loop and per-chunk results are concatenated.
+
+Update `__init__` to default the device argument to `None` and consult `get_hardware()` when None:
+
+```python
+def __init__(self, ..., device: Optional[str] = None, ...):
+    if device is None:
+        from helix_context.hardware import get_hardware
+        device = get_hardware().device
+    self._device = torch.device(device)
+    # ... rest unchanged
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/test_ribosome.py -v`
+Expected: all existing tests still pass + the new chunked-batch test passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helix_context/deberta_backend.py tests/test_ribosome.py
+git commit -m "feat(deberta): chunk re_rank+splice batches via recommended_batch_size"
+```
+
+#### Task 11b: `nli_backend.py` — consult hardware + chunk `classify_batch`
+
+**Files:**
+- Modify: `helix_context/nli_backend.py`
+- Modify: `tests/test_ribosome.py`
+
+Same pattern as 11a.
+
+- [ ] **Step 1: Apply the chunking pattern to `classify_batch`**
+
+```python
+def classify_batch(self, pairs):
+    if not pairs:
+        return []
+    from helix_context.hardware import recommended_batch_size
+    batch_size = recommended_batch_size("nli")
+    texts_a = [p[0] for p in pairs]
+    texts_b = [p[1] for p in pairs]
+    all_results = []
+    for i in range(0, len(texts_a), batch_size):
+        chunk_a = texts_a[i : i + batch_size]
+        chunk_b = texts_b[i : i + batch_size]
+        encodings = self._tokenizer(chunk_a, chunk_b, ...).to(self._device)
+        with torch.no_grad():
+            outputs = self._model(**encodings)
+        # ... (same softmax/argmax processing as before, append to all_results)
+    return all_results
+```
+
+Update `__init__` device default:
+
+```python
+def __init__(self, model_path="training/models/nli", device=None):
+    if device is None or device == "auto":
+        from helix_context.hardware import get_hardware
+        device = get_hardware().device
+    self._device = torch.device(device)
+    # ... rest unchanged
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pytest tests/test_ribosome.py -v`
+Expected: all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add helix_context/nli_backend.py tests/test_ribosome.py
+git commit -m "feat(nli): chunk classify_batch via recommended_batch_size('nli')"
+```
+
+#### Task 11c: `splade_backend.py` — consult hardware in `_ensure_loaded` + default `batch_size`
+
+**Files:**
+- Modify: `helix_context/splade_backend.py`
+
+`splade_backend.encode_batch()` already chunks (line 116); only the default `batch_size: int = 16` parameter needs to consult the hardware module.
+
+- [ ] **Step 1: Update `_ensure_loaded` to consult hardware module**
+
+```python
+def _ensure_loaded(model_name="naver/splade-cocondenser-ensembledistil"):
+    global _model, _tokenizer, _device
+    if _model is not None:
+        return
+    import torch
+    from transformers import AutoModelForMaskedLM, AutoTokenizer
+    from helix_context.hardware import get_hardware
+
+    _device = torch.device(get_hardware().device)
+    _tokenizer = AutoTokenizer.from_pretrained(model_name)
+    _model = AutoModelForMaskedLM.from_pretrained(model_name).to(_device)
+    _model.eval()
+    log.info("SPLADE model loaded: %s on %s", model_name, _device)
+```
+
+- [ ] **Step 2: Make `encode_batch` consult `recommended_batch_size` for the default**
+
+```python
+def encode_batch(texts, top_k=128, batch_size=None,
+                 model_name="naver/splade-cocondenser-ensembledistil"):
+    import torch
+    _ensure_loaded(model_name)
+    if batch_size is None:
+        from helix_context.hardware import recommended_batch_size
+        batch_size = recommended_batch_size("splade")
+    # ... rest unchanged
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/test_ribosome.py tests/test_hardware.py -v`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add helix_context/splade_backend.py
+git commit -m "feat(splade): consult hardware module for device + default batch_size"
+```
+
+#### Task 11d: `sema.py` — `SemanticEncoder` consults hardware module for default device
+
+**Files:**
+- Modify: `helix_context/sema.py`
+- Modify: `tests/test_sema.py`
+
+- [ ] **Step 1: Update `SemanticEncoder.__init__`**
+
+```python
+def __init__(self, model_name="...", device=None):
+    if device is None or device == "auto":
+        from helix_context.hardware import get_hardware
+        device = get_hardware().device
+    from sentence_transformers import SentenceTransformer
+    self._model = SentenceTransformer(model_name, device=device)
+    # ... rest unchanged
+```
+
+- [ ] **Step 2: Add a test pinning the default**
+
+In `tests/test_sema.py`:
+
+```python
+def test_semantic_encoder_default_device_from_hardware(monkeypatch):
+    from helix_context import hardware
+    hardware.reset_for_test()
+    monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="test",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="test",
+        system_ram_gb=16.0, requested_device="auto",
+        fallback_reason=None, batch_size_overrides={},
+    ))
+    captured = {}
+    class _FakeST:
+        def __init__(self, model_name, device):
+            captured["device"] = device
+        def get_sentence_embedding_dimension(self): return 384
+        def encode(self, *a, **kw): return [[0.0] * 384]
+    monkeypatch.setattr("sentence_transformers.SentenceTransformer", _FakeST)
+
+    from helix_context.sema import SemanticEncoder
+    SemanticEncoder()  # no device arg — should default from hardware
+    assert captured["device"] == "cpu"
+```
+
+- [ ] **Step 3: Run**
+
+Run: `pytest tests/test_sema.py -v`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add helix_context/sema.py tests/test_sema.py
+git commit -m "feat(sema): SemanticEncoder default device from hardware module"
+```
+
+---
+
+### Task 12: `/health` endpoint hardware block
+
+**Files:**
+- Modify: `helix_context/server.py` (around line 2213)
+- Modify: `tests/test_server.py`
+
+Surface fallback state via the existing `/health` JSON response.
+
+- [ ] **Step 1: Find the existing `/health` JSON response building**
+
+Run: `grep -n "health_endpoint\|return.*ribosome_model\|return.*ok" helix_context/server.py | head -10`
+Expected: locates line 2213 (`async def health_endpoint`) and the response-building block around lines 2236-2280.
+
+- [ ] **Step 2: Write the failing test in `tests/test_server.py`**
+
+```python
+def test_health_endpoint_includes_hardware_block(monkeypatch):
+    from helix_context import hardware
+    hardware.reset_for_test()
+    fake = hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="AMD Ryzen 9 7900X",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="AMD Ryzen 9 7900X",
+        system_ram_gb=64.0, requested_device="cuda",
+        fallback_reason="cuda probe failed: RuntimeError: no driver",
+        batch_size_overrides={},
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: fake)
+
+    response = test_client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert "hardware" in body
+    hw = body["hardware"]
+    assert hw["device"] == "cpu"
+    assert hw["device_name"] == "AMD Ryzen 9 7900X"
+    assert hw["requested_device"] == "cuda"
+    assert hw["fallback_active"] is True
+    assert "cuda probe failed" in hw["fallback_reason"]
+    assert hw["vram_total_gb"] is None
+    assert hw["system_ram_gb"] == 64.0
+    assert hw["low_vram_warning"] is False
+```
+
+(Implementer: adapt to the existing `test_server.py` fixture pattern — `client.get` or whatever the existing tests use.)
+
+- [ ] **Step 3: Run test to verify failure**
+
+Run: `pytest tests/test_server.py::test_health_endpoint_includes_hardware_block -v`
+Expected: `KeyError: 'hardware'` or `AssertionError`.
+
+- [ ] **Step 4: Add `hardware` block to `/health`**
+
+In `helix_context/server.py` `health_endpoint`, just before the final `return` of the response dict, add:
+
+```python
+from helix_context.hardware import get_hardware
+hw_info = get_hardware()
+low_vram = bool(
+    hw_info.vram_total_gb is not None
+    and hw_info.vram_total_gb < config.hardware.low_vram_threshold_gb
+)
+hardware_block = {
+    "device": hw_info.device,
+    "device_name": hw_info.device_name,
+    "requested_device": hw_info.requested_device,
+    "fallback_active": hw_info.fallback_reason is not None,
+    "fallback_reason": hw_info.fallback_reason,
+    "vram_total_gb": hw_info.vram_total_gb,
+    "system_ram_gb": hw_info.system_ram_gb,
+    "low_vram_warning": low_vram,
+}
+```
+
+Then add `"hardware": hardware_block` to the response dict that's returned.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/test_server.py -v -k health`
+Expected: all health tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helix_context/server.py tests/test_server.py
+git commit -m "feat(server): /health hardware block — surface device + fallback state"
+```
+
+---
+
+### Task 13: Tray fallback balloon + sentinel-file dedup
+
+**Files:**
+- Modify: `helix_context/launcher/tray.py`
+- Modify: `tests/test_launcher_tray.py`
+
+Mirror the install-pending balloon from native-observability sidecar (already in tray.py). Sentinel at `<state_dir>/.hardware-fallback-acknowledged-{requested}-{active}` dedupes per-state-change.
+
+- [ ] **Step 1: Find the install-pending balloon pattern in `tray.py`**
+
+Run: `grep -n "balloon\|notify\|install.*pending\|sentinel" helix_context/launcher/tray.py | head -20`
+Expected: locates the install-pending balloon code (sidecar PR) — that's the template.
+
+- [ ] **Step 2: Write the failing tests in `tests/test_launcher_tray.py`**
+
+```python
+def test_hardware_fallback_balloon_fires_first_launch(tmp_path, monkeypatch):
+    """Balloon fires once when fallback_active=True and no sentinel exists."""
+    from helix_context import hardware
+
+    monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                        lambda create=False: tmp_path)
+    hardware.reset_for_test()
+    fake = hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="CPU",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="CPU",
+        system_ram_gb=16.0, requested_device="cuda",
+        fallback_reason="cuda not available",
+        batch_size_overrides={},
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: fake)
+
+    from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+    assert _should_fire_hardware_fallback_balloon() is True
+
+
+def test_hardware_fallback_balloon_dedups_via_sentinel(tmp_path, monkeypatch):
+    """Sentinel exists -> balloon suppressed."""
+    monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                        lambda create=False: tmp_path)
+    sentinel = tmp_path / ".hardware-fallback-acknowledged-cuda-cpu"
+    sentinel.touch()
+
+    from helix_context import hardware
+    hardware.reset_for_test()
+    monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="CPU",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="CPU", system_ram_gb=16.0,
+        requested_device="cuda", fallback_reason="cuda not available",
+        batch_size_overrides={},
+    ))
+
+    from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+    assert _should_fire_hardware_fallback_balloon() is False
+
+
+def test_hardware_fallback_balloon_refires_on_different_state(tmp_path, monkeypatch):
+    """Different requested/active combo => different sentinel => balloon fires."""
+    monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                        lambda create=False: tmp_path)
+    (tmp_path / ".hardware-fallback-acknowledged-cuda-cpu").touch()
+
+    from helix_context import hardware
+    hardware.reset_for_test()
+    monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="CPU",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="CPU", system_ram_gb=16.0,
+        requested_device="mps", fallback_reason="mps not available",
+        batch_size_overrides={},
+    ))
+
+    from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+    # Sentinel is for cuda->cpu; current state is mps->cpu.
+    assert _should_fire_hardware_fallback_balloon() is True
+
+
+def test_hardware_fallback_balloon_skipped_when_no_fallback(tmp_path, monkeypatch):
+    """fallback_reason is None => no balloon ever."""
+    monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                        lambda create=False: tmp_path)
+    from helix_context import hardware
+    hardware.reset_for_test()
+    monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+        device="cuda:0", device_type="cuda", device_name="RTX 4090",
+        vram_total_gb=24.0, vram_free_gb=22.0,
+        cpu_arch="x86_64", cpu_brand="CPU", system_ram_gb=64.0,
+        requested_device="auto", fallback_reason=None,
+        batch_size_overrides={},
+    ))
+
+    from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+    assert _should_fire_hardware_fallback_balloon() is False
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run: `pytest tests/test_launcher_tray.py -k hardware_fallback -v`
+Expected: `ImportError: cannot import name '_should_fire_hardware_fallback_balloon'`.
+
+- [ ] **Step 4: Implement the helper + balloon trigger in `tray.py`**
+
+In `helix_context/launcher/tray.py`, add:
+
+```python
+def _hardware_fallback_sentinel_path(requested: str, active: str) -> Path:
+    """Sentinel filename encodes the (requested, active) tuple so a
+    state-change re-fires the balloon."""
+    from helix_context.launcher.observability_paths import state_dir
+    return state_dir(create=True) / f".hardware-fallback-acknowledged-{requested}-{active}"
+
+
+def _should_fire_hardware_fallback_balloon() -> bool:
+    """True iff there is an active fallback AND the sentinel for the
+    current (requested, active) tuple does not yet exist."""
+    from helix_context.hardware import get_hardware
+    info = get_hardware()
+    if info.fallback_reason is None:
+        return False
+    sentinel = _hardware_fallback_sentinel_path(info.requested_device, info.device_type)
+    return not sentinel.exists()
+
+
+def _fire_hardware_fallback_balloon(tray_icon) -> None:
+    """Fire a one-shot balloon describing the fallback. Caller should
+    write the sentinel after firing (so re-launches don't nag)."""
+    from helix_context.hardware import get_hardware
+    info = get_hardware()
+    if info.fallback_reason is None:
+        return
+    title = "Helix: device fallback active"
+    msg = (
+        f"Requested {info.requested_device!r}, using {info.device_type!r}. "
+        f"Reason: {info.fallback_reason}"
+    )
+    try:
+        tray_icon.notify(msg, title)
+    except Exception:
+        log.warning("Tray balloon failed; fallback only logged", exc_info=True)
+        return
+    sentinel = _hardware_fallback_sentinel_path(info.requested_device, info.device_type)
+    try:
+        sentinel.touch()
+    except Exception:
+        log.warning("Could not write hardware-fallback sentinel %s", sentinel, exc_info=True)
+```
+
+Then in the tray's startup flow (find the existing call site that fires the install-pending balloon for native-observability — that's the template), add a parallel call:
+
+```python
+if _should_fire_hardware_fallback_balloon():
+    _fire_hardware_fallback_balloon(self._icon)
+```
+
+(Implementer: place this near the existing balloon-firing call in the `_setup_icon` / `run` method or wherever the install-pending balloon fires today.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/test_launcher_tray.py -k hardware_fallback -v`
+Expected: 4 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helix_context/launcher/tray.py tests/test_launcher_tray.py
+git commit -m "feat(tray): hardware-fallback balloon with state-change sentinel dedup
+
+Mirrors the native-observability install-pending balloon pattern.
+Sentinel at <state_dir>/.hardware-fallback-acknowledged-{req}-{act}
+fires once per state-change combination."
+```
+
+---
+
+### Task 14: Bench gate (manual)
+
+**Files:**
+- No code changes; produces bench JSONs + report
+
+This is the spec's mandatory gate before merging PR1. Both runs use the same native sidecar instance to keep observability constant.
+
+- [ ] **Step 1: Verify native sidecar is up**
+
+Run:
+```bash
+netstat -ano 2>&1 | grep -E "[: ](4317|9090|3200|3100|3000) " | grep LISTENING | head -5
+```
+Expected: 5 LISTENING entries. If any port is missing, restart the tray launcher first.
+
+- [ ] **Step 2: Capture master HEAD baseline**
+
+```bash
+git checkout master
+git stash --include-untracked  # save any local working-tree state
+bash overnight_diamond_native_n20_2026-05-04.sh   # script from sidecar PR
+mv benchmarks/results/gpqa_native_n20_2026-05-04.json \
+   benchmarks/results/gpqa_native_n20_master_baseline_pr1_$(date +%Y%m%d).json
+```
+
+(Use a fresh date suffix in the artifact name to avoid clobbering.)
+
+- [ ] **Step 3: Capture PR1 HEAD result**
+
+```bash
+git checkout feat/hardware-detection
+bash overnight_diamond_native_n20_2026-05-04.sh
+mv benchmarks/results/gpqa_native_n20_2026-05-04.json \
+   benchmarks/results/gpqa_native_n20_pr1_$(date +%Y%m%d).json
+```
+
+- [ ] **Step 4: Compute p95 delta + write the gate verdict**
+
+Create a one-shot helper script `bench_gate_pr1.py` (local-only, do NOT commit):
+
+```python
+"""PR1 bench gate p95 delta. Run after Tasks 2-3 produce the JSON pair.
+Exits 0 on PASS (delta <= 5s), 1 on FAIL.
+"""
+import json
+import sys
+from pathlib import Path
+
+results_dir = Path("benchmarks/results")
+master_files = sorted(results_dir.glob("gpqa_native_n20_master_baseline_pr1_*.json"))
+pr1_files    = sorted(results_dir.glob("gpqa_native_n20_pr1_*.json"))
+assert master_files and pr1_files, "Run Tasks 2-3 first to produce the JSONs."
+master = json.loads(master_files[-1].read_text())
+pr1    = json.loads(pr1_files[-1].read_text())
+
+def p95(d):
+    lats = sorted(r.get("proxy_latency_s", 0) for r in d["results"]
+                  if not r.get("error") and r.get("proxy_latency_s", 0) > 0)
+    return lats[int(0.95 * len(lats))] if lats else 0.0
+
+m, p = p95(master), p95(pr1)
+delta = p - m
+print(f"p95(master) = {m:.2f}s")
+print(f"p95(PR1)    = {p:.2f}s")
+print(f"p95 delta   = {delta:+.2f}s   (gate: <= 5s)")
+verdict = "PASS" if delta <= 5.0 else "FAIL"
+print(f"VERDICT: {verdict}")
+sys.exit(0 if verdict == "PASS" else 1)
+```
+
+Run: `python bench_gate_pr1.py`
+Expected: prints PASS verdict.
+
+- [ ] **Step 5: Decision**
+
+If PASS: proceed to push the branch + open the PR.
+If FAIL: investigate the regression. Most likely culprit per spec §10: chunked batches in deberta firing more torch kernel launches than the all-at-once tokenize. Fix is `min(recommended, len(input))` — only chunk if needed. Re-run after fix.
+
+- [ ] **Step 6: Save the bench report (optional, dev-local)**
+
+The artifacts in `benchmarks/results/gpqa_native_n20_*` stay on the dev rig (gitignored). PR body references the gate verdict + raw numbers; reviewers can ask for the JSONs if needed.
+
+---
+
+## After all 14 tasks
+
+1. **Push the branch:** `git push -u origin feat/hardware-detection`
+2. **Open the PR** with body referencing:
+   - Spec link
+   - Bench gate verdict (PASS, with p95 numbers from Task 14)
+   - "PR2 (MPS + ROCm + CI workflow) follows" footer
+3. **Tag for review**
+
+The plan stops at PR1. PR2's plan is a separate cycle once PR1 lands and we've confirmed the bench gate holds in the master-merged form.

--- a/docs/plans/2026-05-04-hardware-detection.md
+++ b/docs/plans/2026-05-04-hardware-detection.md
@@ -62,16 +62,24 @@ This unblocks Task 4 (CPU detection). Pure dep change, no tests.
 Run: `grep -n "launcher" pyproject.toml`
 Expected: locates the `launcher = [...]` and `launcher-tray = [...]` extras lines (sidecar PR landed these around 2026-05-04).
 
-- [ ] **Step 2: Add `py-cpuinfo>=9.0` to both `launcher` and `launcher-tray` extras**
+- [ ] **Step 2: Add `py-cpuinfo>=9.0` to ALL THREE launcher extras (`launcher`, `launcher-native`, `launcher-tray`)**
+
+There are three extras, not two — `launcher-native` was added in the native-observability sidecar PR and also pulls launcher-class deps. All three need the cpuinfo dep so the cpu_brand path doesn't `ImportError` for users on `launcher-native` only.
 
 ```toml
 launcher = ["jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0"]
+launcher-native = [
+    "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0",
+    # ... existing native-only deps stay as they are
+]
 launcher-tray = [
     "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0",
     "pystray>=0.19", "Pillow>=10",
     "pywin32>=306; sys_platform == 'win32'",
 ]
 ```
+
+(Implementer: open the file, locate the three extras at pyproject.toml:61, :62, :69, add `py-cpuinfo>=9.0` to each. Do not invent deps for `launcher-native` — leave its native-only deps untouched and just append py-cpuinfo.)
 
 - [ ] **Step 3: Install the new dep into the active venv**
 
@@ -1242,14 +1250,17 @@ Wires the `[hardware]` TOML section through `Config` and into the hardware singl
 
 - [ ] **Step 1: Inspect current config shape**
 
-Run: `grep -n "device\|class Ribosome\|class Server\|class.*Config" helix_context/config.py | head -30`
-Expected: locates `Ribosome` config class + the `from_dict` constructors.
+Run: `grep -n "def load_config\|class HelixConfig\|class Ribosome" helix_context/config.py | head -10`
+Expected: confirms `class HelixConfig` at line ~304 and `def load_config(path)` at line ~335. The actual public API is `load_config()` returning a `HelixConfig` instance — there is NO `Config.from_file` and NO `from_dict` classmethod. Section parsing happens inline inside `load_config()`.
 
 - [ ] **Step 2: Write the failing tests in `tests/test_config.py`**
 
-Append:
+Append (note: imports use `load_config` and `HelixConfig`, NOT `Config.from_file`):
 
 ```python
+from helix_context.config import load_config
+
+
 def test_hardware_section_parses(tmp_path):
     """[hardware] section parses with all defaults."""
     cfg_text = """
@@ -1260,7 +1271,7 @@ low_vram_threshold_gb = 4.0
 """
     p = tmp_path / "helix.toml"
     p.write_text(cfg_text)
-    cfg = Config.from_file(str(p))
+    cfg = load_config(str(p))
     assert cfg.hardware.device == "cuda"
     assert cfg.hardware.batch_sizes == {}  # "auto" -> empty override dict
     assert cfg.hardware.low_vram_threshold_gb == 4.0
@@ -1274,7 +1285,7 @@ batch_sizes = { rerank = 16, splice = 32 }
 """
     p = tmp_path / "helix.toml"
     p.write_text(cfg_text)
-    cfg = Config.from_file(str(p))
+    cfg = load_config(str(p))
     assert cfg.hardware.batch_sizes == {"rerank": 16, "splice": 32}
 
 
@@ -1287,7 +1298,7 @@ device = "cuda"
     p = tmp_path / "helix.toml"
     p.write_text(cfg_text)
     with caplog.at_level("WARNING", logger="helix.config"):
-        cfg = Config.from_file(str(p))
+        cfg = load_config(str(p))
     assert cfg.hardware.device == "cuda"  # ribosome value used
     assert any(
         "ribosome" in rec.message.lower() and "deprecated" in rec.message.lower()
@@ -1307,7 +1318,7 @@ device = "cuda"
     p = tmp_path / "helix.toml"
     p.write_text(cfg_text)
     with caplog.at_level("WARNING", logger="helix.config"):
-        cfg = Config.from_file(str(p))
+        cfg = load_config(str(p))
     assert cfg.hardware.device == "cuda"  # [hardware] wins
     assert any(
         "deprecated" in rec.message.lower() and "override" in rec.message.lower()
@@ -1319,7 +1330,7 @@ def test_no_device_config_defaults_to_auto(tmp_path):
     """Empty config -> [hardware].device = "auto"."""
     p = tmp_path / "helix.toml"
     p.write_text("# empty\n")
-    cfg = Config.from_file(str(p))
+    cfg = load_config(str(p))
     assert cfg.hardware.device == "auto"
     assert cfg.hardware.batch_sizes == {}
 ```
@@ -1329,9 +1340,9 @@ def test_no_device_config_defaults_to_auto(tmp_path):
 Run: `pytest tests/test_config.py::test_hardware_section_parses -v`
 Expected: `AttributeError: 'Config' object has no attribute 'hardware'`.
 
-- [ ] **Step 4: Add `Hardware` config dataclass + parser**
+- [ ] **Step 4: Add `Hardware` config dataclass + parser inside `load_config`**
 
-In `helix_context/config.py`, add a `Hardware` dataclass (near `Ribosome`):
+In `helix_context/config.py`, add a `Hardware` dataclass near the `HelixConfig` definition (around line 290-304):
 
 ```python
 @dataclass
@@ -1342,9 +1353,12 @@ class Hardware:
     low_vram_threshold_gb: float = 4.0
 ```
 
-In `Config.from_dict()` (or wherever the section parsers live), add:
+Add `hardware: Hardware = field(default_factory=Hardware)` as a field on `HelixConfig`.
+
+Inside `load_config()` (around line 335+), after the existing `[ribosome]` section is parsed (look for "# Ribosome" comment block, ~line 357), add:
 
 ```python
+# Hardware section
 hw = data.get("hardware", {})
 if isinstance(hw.get("batch_sizes"), str) and hw["batch_sizes"] == "auto":
     bs = {}
@@ -1369,15 +1383,14 @@ if ribosome_device is not None:
         )
         hardware_device = ribosome_device
 
-hardware_cfg = Hardware(
+cfg.hardware = Hardware(
     device=str(hardware_device),
     batch_sizes=bs,
     low_vram_threshold_gb=float(hw.get("low_vram_threshold_gb", 4.0)),
 )
-cfg.hardware = hardware_cfg
 ```
 
-(Implementer: place these blocks in the existing `from_dict`/`from_file` flow at the right indent level. The exact line is whatever follows the existing `[ribosome]` parse.)
+(`cfg` is the `HelixConfig` instance under construction in `load_config()` — implementer: confirm the variable name in your local context; older code may use `helix_config` or similar.)
 
 - [ ] **Step 5: Run config tests**
 
@@ -1454,7 +1467,23 @@ def reset_for_test() -> None:
     _config_overrides = {}
 ```
 
-- [ ] **Step 7: Add hardware-side test for config flow**
+- [ ] **Step 7: Wire `init_from_config` into server startup BEFORE backends construct**
+
+This is critical for correctness. The hardware singleton caches on first `get_hardware()` call. If a backend's `__init__` (deberta / nli / splade / sema) calls `get_hardware()` before `init_from_config()` runs, the singleton caches an env-only result and the config-supplied `device` + `batch_size_overrides` are lost.
+
+In `helix_context/server.py`, find the early-startup block where `cfg = load_config(...)` is called and where the helix object is constructed. Add immediately after `cfg = load_config(...)`:
+
+```python
+from helix_context.hardware import init_from_config
+init_from_config(
+    config_device=cfg.hardware.device,
+    batch_size_overrides=cfg.hardware.batch_sizes,
+)
+```
+
+This must happen BEFORE any code path that might construct `Ribosome` / `DeBERTaRibosome` / `NLIClassifier` / `SemaCodec` / call `splade_backend.encode()`.
+
+- [ ] **Step 8: Add hardware-side test for config flow**
 
 Append to `tests/test_hardware.py`:
 
@@ -1473,16 +1502,46 @@ def test_init_from_config_routes_through_singleton(mock_torch):
     assert info.requested_device == "cuda"
     assert info.batch_size_overrides == {"rerank": 8}
     assert hardware.recommended_batch_size("rerank") == 8  # override wins
+
+
+def test_init_from_config_must_run_before_get_hardware(mock_torch, monkeypatch):
+    """Regression pin: if get_hardware() runs before init_from_config(),
+    the cached singleton ignores config. This test documents that
+    server startup MUST call init_from_config() first."""
+    monkeypatch.setenv("HELIX_DEVICE", "auto")
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    # Simulate a backend calling get_hardware() too early.
+    info_early = hardware.get_hardware()
+    assert info_early.batch_size_overrides == {}
+    # init_from_config now runs but the cache is already poisoned.
+    info_late = hardware.init_from_config(
+        config_device="cuda",
+        batch_size_overrides={"rerank": 8},
+    )
+    # The cached singleton wins; the config-supplied overrides are LOST.
+    # This is by design — init_from_config is idempotent. The fix is to
+    # call init_from_config FIRST in server startup.
+    assert info_late.batch_size_overrides == {}
+    # Operator must reset_for_test if they want to override — which is
+    # exactly the wiring guarantee Step 7 enforces.
 ```
 
 Run: `pytest tests/test_hardware.py -v`
-Expected: 32 passed.
+Expected: 33 passed.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
-git add helix_context/hardware.py helix_context/config.py tests/test_config.py tests/test_hardware.py
-git commit -m "feat(hardware): config plumbing — [hardware] section + ribosome.device shim"
+git add helix_context/hardware.py helix_context/config.py helix_context/server.py tests/test_config.py tests/test_hardware.py
+git commit -m "feat(hardware): config plumbing — [hardware] section + ribosome.device shim
+
+Wires init_from_config() at server startup BEFORE any backend
+constructs to avoid the cached-singleton-poisoning failure mode.
+Regression pinned in test_init_from_config_must_run_before_get_hardware."
 ```
 
 ---
@@ -1518,7 +1577,7 @@ low_vram_threshold_gb = 4.0
 
 - [ ] **Step 2: Verify config still loads**
 
-Run: `python -c "from helix_context.config import Config; c = Config.from_file('helix.toml'); print(c.hardware)"`
+Run: `python -c "from helix_context.config import load_config; c = load_config('helix.toml'); print(c.hardware)"`
 Expected: prints `Hardware(device='auto', batch_sizes={}, low_vram_threshold_gb=4.0)`.
 
 - [ ] **Step 3: Commit**
@@ -1538,16 +1597,83 @@ This task is split into 4 sub-tasks (one per backend) so each commit is reviewab
 
 **Files:**
 - Modify: `helix_context/deberta_backend.py`
-- Modify: `tests/test_ribosome.py`
+- Create: `tests/test_deberta_backend.py` (NEW — `tests/test_ribosome.py` only tests the Ollama-backed `Ribosome`, not `DeBERTaRibosome`. There is no existing test harness for the cross-encoder backend, so this is a fresh file.)
 
 - [ ] **Step 1: Read the current `re_rank` and `splice` to understand the all-at-once tokenize pattern**
 
-Run: `grep -n "def re_rank\|def splice\|tokenizer(.*texts_a" helix_context/deberta_backend.py`
-Expected: locates the entry points + the tokenizer call sites.
+Run: `grep -n "def re_rank\|def splice\|tokenizer(.*texts_a\|class DeBERTaRibosome" helix_context/deberta_backend.py`
+Expected: locates `class DeBERTaRibosome`, `def re_rank`, `def splice`, and the tokenizer call sites (`self._rerank_tokenizer(texts_a, texts_b, ...)`).
 
-- [ ] **Step 2: Write a test that PINS the chunked-batch behavior**
+- [ ] **Step 2: Create the failing test in a NEW file `tests/test_deberta_backend.py`**
 
-In `tests/test_ribosome.py`, add a test that mocks the tokenizer + model, forces a 16-batch via `recommended_batch_size`, feeds 100 candidates, and asserts the tokenizer was called 7 times (6 full + 1 partial). Adapt to existing fixtures in that file.
+Since no existing fixtures cover DeBERTa, build minimal fakes that count tokenizer calls. Pattern uses pytest + monkeypatch (matches `tests/test_observability_paths.py` style):
+
+```python
+"""Unit tests for helix_context.deberta_backend (mocked tokenizer + model).
+
+Exists separately from tests/test_ribosome.py because that file tests the
+Ollama-backed Ribosome class with MockBackend, not the DeBERTa cross-encoder
+backend. The chunked-batch test below pins that re_rank/splice consume
+recommended_batch_size from the hardware module instead of one-shot
+tokenizing all pairs.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+import torch
+
+from helix_context import hardware
+
+
+@pytest.fixture(autouse=True)
+def _reset_hardware_cache():
+    hardware.reset_for_test()
+    yield
+    hardware.reset_for_test()
+
+
+def _make_gene(gene_id: str, content: str = "x", domains=None):
+    # Build the smallest Gene-like object accepted by re_rank's pair-builder.
+    # See helix_context/schemas.py for the Gene shape; if Gene requires more
+    # fields, expand here.
+    from helix_context.schemas import Gene
+    return Gene(gene_id=gene_id, content=content, ...)  # adapt to real Gene shape
+
+
+def test_deberta_rerank_chunks_in_recommended_batch_size(monkeypatch):
+    """Force batch=16 via override; feed 100 candidates; expect 7 tokenizer
+    calls (6 full + 1 partial of 4)."""
+    # Force the hardware singleton to a CPU info with a rerank=16 override.
+    info = hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="test",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="test",
+        system_ram_gb=16.0, requested_device="auto",
+        fallback_reason=None, batch_size_overrides={"rerank": 16},
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: info)
+
+    from helix_context.deberta_backend import DeBERTaRibosome
+
+    # Stub tokenizer + model on a fresh DeBERTaRibosome instance.
+    rib = DeBERTaRibosome.__new__(DeBERTaRibosome)  # bypass __init__
+    rib._device = torch.device("cpu")
+    rib._rerank_pretrained = False
+    rib._rerank_tokenizer = MagicMock(return_value=MagicMock(
+        to=lambda dev: {"input_ids": torch.zeros(1, 1, dtype=torch.long)}
+    ))
+    fake_logits = MagicMock(squeeze=lambda dim: torch.zeros(16))
+    rib._rerank_model = MagicMock(return_value=MagicMock(logits=fake_logits))
+
+    candidates = [_make_gene(f"g_{i}") for i in range(100)]
+    rib.re_rank("query", candidates, k=10)
+
+    # 100 candidates / 16 batch = 6 full + 1 partial = 7 tokenizer calls.
+    assert rib._rerank_tokenizer.call_count == 7
+```
+
+(Implementer note: the `_make_gene` helper above sketches the call site but the real `Gene` constructor signature lives in `helix_context/schemas.py` — fill in required fields when writing the test. Confirm with `grep -n "class Gene" helix_context/schemas.py`.)
 
 - [ ] **Step 3: Run test to verify it fails**
 
@@ -1607,13 +1733,13 @@ def __init__(self, ..., device: Optional[str] = None, ...):
 
 - [ ] **Step 5: Run tests**
 
-Run: `pytest tests/test_ribosome.py -v`
-Expected: all existing tests still pass + the new chunked-batch test passes.
+Run: `pytest tests/test_deberta_backend.py tests/test_ribosome.py -v`
+Expected: new chunked-batch test passes; existing test_ribosome.py tests (Ollama backend) unaffected.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add helix_context/deberta_backend.py tests/test_ribosome.py
+git add helix_context/deberta_backend.py tests/test_deberta_backend.py
 git commit -m "feat(deberta): chunk re_rank+splice batches via recommended_batch_size"
 ```
 
@@ -1719,13 +1845,13 @@ git add helix_context/splade_backend.py
 git commit -m "feat(splade): consult hardware module for device + default batch_size"
 ```
 
-#### Task 11d: `sema.py` — `SemanticEncoder` consults hardware module for default device
+#### Task 11d: `sema.py` — `SemaCodec` consults hardware module for default device
 
 **Files:**
-- Modify: `helix_context/sema.py`
+- Modify: `helix_context/sema.py` (the class is `SemaCodec` at line 112, NOT `SemanticEncoder` — the spec doc had a typo carried into the v0 plan; fixed here)
 - Modify: `tests/test_sema.py`
 
-- [ ] **Step 1: Update `SemanticEncoder.__init__`**
+- [ ] **Step 1: Update `SemaCodec.__init__`**
 
 ```python
 def __init__(self, model_name="...", device=None):
@@ -1742,7 +1868,7 @@ def __init__(self, model_name="...", device=None):
 In `tests/test_sema.py`:
 
 ```python
-def test_semantic_encoder_default_device_from_hardware(monkeypatch):
+def test_sema_codec_default_device_from_hardware(monkeypatch):
     from helix_context import hardware
     hardware.reset_for_test()
     monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
@@ -1760,8 +1886,8 @@ def test_semantic_encoder_default_device_from_hardware(monkeypatch):
         def encode(self, *a, **kw): return [[0.0] * 384]
     monkeypatch.setattr("sentence_transformers.SentenceTransformer", _FakeST)
 
-    from helix_context.sema import SemanticEncoder
-    SemanticEncoder()  # no device arg — should default from hardware
+    from helix_context.sema import SemaCodec
+    SemaCodec()  # no device arg — should default from hardware
     assert captured["device"] == "cpu"
 ```
 
@@ -1774,7 +1900,7 @@ Expected: green.
 
 ```bash
 git add helix_context/sema.py tests/test_sema.py
-git commit -m "feat(sema): SemanticEncoder default device from hardware module"
+git commit -m "feat(sema): SemaCodec default device from hardware module"
 ```
 
 ---

--- a/docs/specs/2026-05-04-hardware-detection-design.md
+++ b/docs/specs/2026-05-04-hardware-detection-design.md
@@ -1,0 +1,448 @@
+# Hardware Detection & Device Backend — Design Spec
+
+**Date:** 2026-05-04
+**Status:** Draft → review
+**Owner:** SwiftWing21
+**Related:** [native-observability-sidecar (#16)](2026-05-04-native-observability-sidecar-design.md), [foveated-splice (next)](#9-relationship-to-other-work)
+
+---
+
+## 1. Overview
+
+Centralize device detection, VRAM-aware batch sizing, and graceful fallback for all torch-using backends in `helix-context`. Today, three backends each call `torch.cuda.is_available()` independently, no VRAM is inspected, batch sizes are static, and only NVIDIA + CUDA-built torch is supported in practice. The goal is to make helix work top-to-bottom — phone-class to server-class — by detecting available hardware once at startup, picking sensible batch sizes, and degrading gracefully (with surfacing) when explicit configs don't match the host.
+
+Two PRs ship the work:
+
+- **PR1 — Centralization + VRAM-aware batching.** New `helix_context/hardware.py` module, `[hardware]` config section, chunked batches in deberta/splade/nli/sema, fallback surfacing. NVIDIA + CPU only; non-NVIDIA paths parse but resolve to CPU fallback.
+- **PR2 — MPS + ROCm + CI workflow.** Wires up the alt-device branches in the picker, adds GHA workflow with a macOS-runner MPS smoke test, opt-in env-var gates for ROCm hardware tests. Intel XPU deferred to enhancement-request.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+
+- **One source of truth** — `helix_context/hardware.py` is the only place that calls `torch.cuda.is_available()` (and equivalents). All four backends consult it.
+- **Auto-mode that just works** — `device = "auto"` (the default) picks the best available device on any host without configuration.
+- **VRAM-aware batch sizing** — the same code path produces sensible batch sizes on a 4 GB GPU and a 24 GB GPU; OOM on small cards stops being the default failure mode.
+- **Graceful degradation** — explicit-device mismatches log loudly, expose state via `/health` and a tray balloon, but never block startup or `/context` requests.
+- **CPU support across architectures** — Intel x86, AMD x86, ARM (Linux/macOS) all work via torch's transparent CPU dispatch. Hardware report describes the platform honestly.
+- **Alt-GPU readiness** — MPS (Apple Silicon) and ROCm (AMD GPU on Linux) ship as named device backends in PR2, with appropriate "capable but unverified" disclaimers per non-NVIDIA path until validated on real hardware.
+
+### Non-goals
+
+- **Multi-GPU sharding.** Auto-mode picks the single GPU with the most free VRAM and reports the others; helix does not split work across multiple devices.
+- **Intel XPU support.** Hardware is rare today; deferred to enhancement-request via the new `.github/ISSUE_TEMPLATE/enhancement.md` template (PR2). The picker recognizes the device-type string but resolves to CPU fallback if requested.
+- **OOM-recovery retry loops.** Catching `CudaOutOfMemoryError` and halving batch sizes on the fly is rejected as over-engineered; bug-hiding; non-deterministic latency.
+- **fp16/bf16 dtype optimization.** Kept fp32 in PR1 to avoid entangling dtype perf with the centralization. PR2 may add minimal dtype handling only as needed for MPS smoke-test stability.
+- **Multi-process device negotiation.** Helix runs as a single process per genome; if a user spawns multiple, each detects independently.
+
+---
+
+## 3. Architecture
+
+### 3.1 Module shape
+
+New module: **`helix_context/hardware.py`**.
+
+```python
+@dataclass(frozen=True)
+class HardwareInfo:
+    device: torch.device              # what backends pass to .to()
+    device_type: str                  # "cuda" | "rocm" | "mps" | "cpu"
+    device_name: str                  # e.g. "NVIDIA GeForce RTX 4090"
+    vram_total_gb: float | None       # None for cpu
+    vram_free_gb: float | None        # None for cpu / mps
+    cpu_arch: str                     # "x86_64" | "arm64" | "aarch64"
+    cpu_brand: str                    # short name from cpuinfo / platform.processor()
+    system_ram_gb: float
+    requested_device: str             # "auto" | "cuda" | ...
+    fallback_reason: str | None       # set when requested_device != device_type
+
+def get_hardware() -> HardwareInfo: ...     # cached singleton
+def reset_for_test() -> None: ...           # test-only cache reset
+def recommended_batch_size(model: str) -> int: ...
+```
+
+**Singleton with lazy first-call computation.** Importing the module does not trigger any torch CUDA-driver loading; the first call to `get_hardware()` performs detection and caches the result for the process lifetime. `reset_for_test()` clears the cache for unit tests that mock torch internals.
+
+**No public mutation.** The dataclass is `frozen=True`. Overrides flow through config or env var (Section 4), not via setters.
+
+**Atomic snapshot rationale.** A dataclass return ensures that a consumer reading `device` and `vram_free_gb` in two separate calls cannot get inconsistent values from a stale cache. Since the singleton is computed once and reused, this is mostly belt-and-braces for future evolution (e.g., periodic re-polling of `vram_free_gb`).
+
+### 3.2 Affected backends
+
+Today's call sites for `torch.cuda.is_available()`:
+
+| File | Line | Pattern |
+|---|---|---|
+| `helix_context/deberta_backend.py` | 61 | `device="auto"` constructor arg |
+| `helix_context/nli_backend.py` | 52 | `device="auto"` constructor arg |
+| `helix_context/splade_backend.py` | 46 | module-level `_ensure_loaded` |
+
+`helix_context/sema.py:128` accepts a `device` parameter and passes it to `SentenceTransformer(...)`. No caller plumbs config to it today (caller `context_manager.py:312` passes `config.ribosome.device` to `DeBERTaRibosome`, which passes it to `NLIClassifier` but not to `SemanticEncoder`).
+
+After PR1: every backend consults `get_hardware()` for its device; constructor `device` arguments still accept overrides for tests but default to `None`-meaning-"use hardware module".
+
+---
+
+## 4. Config schema
+
+### 4.1 New `[hardware]` section
+
+```toml
+[hardware]
+# device picker. "auto" picks best-available (cuda → rocm → mps → cpu).
+# Explicit values fall back loudly if the backend isn't usable; helix
+# never blocks on hardware mismatch — see /health for fallback state.
+device = "auto"        # auto | cuda | rocm | mps | cpu
+
+# Batch-size policy. "auto" consults the VRAM/RAM-aware table in
+# helix_context/hardware.py. Override with explicit ints when tuning:
+#   batch_sizes = { rerank = 16, splice = 32, splade = 8, nli = 8 }
+batch_sizes = "auto"
+
+# Soft-warn threshold. Below this, /health returns a "low_vram" hint and
+# the tray surfaces a one-time balloon. Set to 0 to disable.
+low_vram_threshold_gb = 4.0
+```
+
+### 4.2 Env-var override
+
+`HELIX_DEVICE=cpu` (case-insensitive: `auto` / `cuda` / `rocm` / `mps` / `cpu`). One-shot override, matches existing `HELIX_OBSERVABILITY=0` and `HELIX_ABSTAIN_DISABLE=1` patterns.
+
+**Resolution order:**
+1. `HELIX_DEVICE` env var (highest)
+2. `[hardware] device` config
+3. `"auto"` default
+
+### 4.3 Deprecation of `[ribosome] device`
+
+`[ribosome] device` is read for one release with a backwards-compat shim:
+
+- If `[ribosome] device` is present and `[hardware] device` is **not**, helix uses the ribosome value and logs a single `DeprecationWarning` line at startup pointing the user to migrate.
+- After one release, the shim is removed (one-line change in `config.py`).
+
+Splade and sema have no current device config, so nothing to deprecate there — they newly consult `[hardware]` (clean addition).
+
+---
+
+## 5. Detection & fallback logic
+
+### 5.1 Auto-mode picking order
+
+Each candidate is checked for both **availability** and **probed usability** (see §5.2):
+
+1. **CUDA** — `torch.cuda.is_available()` AND `torch.cuda.device_count() > 0` AND probe succeeds
+2. **ROCm** — `torch.version.hip is not None` AND a HIP device probes successfully (Linux + AMD only in practice)
+3. **MPS** — `torch.backends.mps.is_available()` AND `torch.backends.mps.is_built()` AND probe succeeds
+4. **CPU** — terminal fallback; always succeeds
+
+### 5.2 Probe protocol
+
+For each candidate device, run a 1-element zero-tensor round-trip in a try/except:
+
+```python
+def _probe(device_type: str) -> tuple[bool, str | None]:
+    try:
+        t = torch.zeros(1).to(device_type)
+        _ = t.cpu()  # round-trip
+        return True, None
+    except Exception as exc:
+        return False, f"probe failed: {type(exc).__name__}: {exc}"
+```
+
+This catches the "looks present, isn't usable" failure mode (stale CUDA driver, detached eGPU, container-without-device-passthrough). Probe is ~1 ms on healthy hardware.
+
+### 5.3 Multi-GPU posture
+
+If `torch.cuda.device_count() > 1`:
+
+- Pick the device with the most free VRAM (`torch.cuda.mem_get_info(i)`)
+- Log all detected devices in the startup banner
+- Set the chosen device's index in `device = torch.device("cuda:N")`
+- Users who want to pin a specific card can use `CUDA_VISIBLE_DEVICES`; no helix-specific override needed
+
+ROCm follows the same pattern via `torch.cuda.device_count()` (which counts HIP devices on a ROCm build).
+
+### 5.4 Explicit-device fallback policy
+
+If the user set `device = "cuda"` (or env var) and probe fails:
+
+- Fall back **directly to CPU** (skip rocm/mps — user said cuda, downgrade to cpu is the smallest surprise)
+- Set `fallback_reason = "requested 'cuda' but probe failed: <reason>"`
+- All three surfacing channels fire (Section 6)
+
+Same posture for explicit `mps` / `rocm`: probe failure → CPU. **Never block; always degrade.**
+
+### 5.5 Torch-not-installed posture
+
+If `import torch` raises (bare `helix-context` install without the ML extras):
+
+- `get_hardware()` returns a synthetic CPU-only `HardwareInfo` with `device_name = "torch unavailable"`
+- A clear log line surfaces the missing extras
+- Backends that require torch (deberta/nli/splade/sema) raise their existing `ImportError` when called — no change
+
+This makes the helix server survivable on a bare install; only the ML-using endpoints fail.
+
+---
+
+## 6. Surfacing fallback state
+
+When `requested_device != device_type` (loud-fallback active), three independent channels surface it.
+
+### 6.1 Startup logs
+
+A `WARNING` from the `helix.hardware` logger:
+
+```
+WARNING helix.hardware - device fallback: requested 'cuda' → using 'cpu'.
+  Reason: torch.cuda.is_available() returned False (no CUDA driver).
+  To suppress, set [hardware] device = "auto" or "cpu" in helix.toml.
+```
+
+An `INFO`-level startup banner always fires regardless of fallback:
+
+```
+INFO helix.hardware - device=cuda (NVIDIA GeForce RTX 4090, 24.0 GB total / 22.4 GB free);
+  cpu=AMD Ryzen 9 7900X (x86_64, 64.0 GB system);
+  recommended batches: rerank=64 splice=128 splade=32 nli=32
+```
+
+### 6.2 `/health` endpoint
+
+`helix_context/server.py:health()` adds a `hardware` block to its JSON response:
+
+```json
+{
+  "ok": true,
+  "hardware": {
+    "device": "cpu",
+    "device_name": "AMD Ryzen 9 7900X",
+    "requested_device": "cuda",
+    "fallback_active": true,
+    "fallback_reason": "torch.cuda.is_available() returned False (no CUDA driver)",
+    "vram_total_gb": null,
+    "system_ram_gb": 64.0,
+    "low_vram_warning": false
+  }
+}
+```
+
+`helix_health_check` (and any other consumer of `/health`) gets fallback state for free.
+
+### 6.3 Tray balloon
+
+Same pattern as the native-observability "install pending" balloon in `helix_context/launcher/tray.py`. A balloon fires once per state-change combination:
+
+- Fires on launcher start where `fallback_active == true`
+- Buttons: "Don't show again" / "Open helix.toml"
+- Sentinel file at `<state_dir>/.hardware-fallback-acknowledged-{requested}-{active}` dedupes
+- A new combination (e.g., user fixed CUDA → no balloon; later they unplug GPU and now MPS falls to CPU → new balloon) re-fires
+
+### 6.4 Why three channels
+
+- Logs miss eyes that don't grep
+- `/health` misses users who never poll it
+- Tray balloons miss users running helix as a server
+
+Together they catch every audience without spam (one balloon per state-change, not per launch).
+
+---
+
+## 7. VRAM-aware batch sizing
+
+### 7.1 Lookup table
+
+```python
+# (device_type, ram_tier_gb_min) → batch sizes per model
+_BATCH_TABLE: dict[tuple[str, float], dict[str, int]] = {
+    # CUDA / ROCm tiers — VRAM-keyed
+    ("cuda", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
+    ("cuda", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
+    ("cuda",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("cuda",  4.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("cuda",  0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},  # < 4GB GPU
+    ("rocm", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
+    ("rocm", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
+    ("rocm",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("rocm",  4.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("rocm",  0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
+    # MPS — keyed on system_ram_gb (MPS shares system RAM)
+    ("mps",  16.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("mps",   8.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    # CPU — keyed on system_ram_gb, conservative defaults
+    ("cpu",  16.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("cpu",   8.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
+    ("cpu",   0.0): {"rerank":  2, "splice":  4,  "splade":  1, "nli":  1},
+}
+```
+
+`recommended_batch_size("rerank")` finds the highest tier row whose threshold ≤ available VRAM (or system RAM for cpu/mps), reads the model column.
+
+**Calibration.** Numbers are starting points keyed on rough rules of thumb (deberta-v3-small at 256 max-len ≈ 60 MB activation per batch item at fp32; halve again for safety). PR1's bench gate (Section 9) verifies they don't regress on our 24 GB rig. Lower tiers ship as conservative heuristics; users on those cards can report back via the enhancement template.
+
+### 7.2 Where the table is consumed
+
+| Backend | Today | After PR1 |
+|---|---|---|
+| `deberta_backend.py:re_rank` | tokenizes ALL pairs in one call | chunked: `for i in range(0, len(pairs_a), bs):` |
+| `deberta_backend.py:splice` | same | same |
+| `splade_backend.py:encode_batch` | static `batch_size: int = 16` default | default = `recommended_batch_size("splade")`; explicit caller still wins |
+| `nli_backend.py:classify_batch` | tokenizes all pairs | chunked |
+| `sema.py` (sentence-transformers) | pass-through `batch_size` | optional pass-through; not gated by bench |
+
+The chunked pattern already exists in `splade_backend.encode_batch` (line 116) and is the template for the others.
+
+### 7.3 Override hierarchy for batch sizes
+
+1. Explicit caller-passed `batch_size=` argument (preserves existing test patterns)
+2. `[hardware] batch_sizes = { rerank = 16 }` config dict for the named model
+3. Auto from the table (default)
+
+---
+
+## 8. Testing strategy
+
+### 8.1 Layer 1 — Mocked-torch unit tests
+
+`tests/test_hardware.py`. Runs everywhere (Linux/macOS/Windows, NVIDIA-or-not). Mocks `torch.cuda.is_available`, `torch.cuda.device_count`, `torch.cuda.get_device_name`, `torch.cuda.mem_get_info`, `torch.backends.mps.is_available`, `torch.backends.mps.is_built`, `torch.version.hip`, plus the `torch.zeros(1).cuda()` probe.
+
+**Coverage:**
+
+- Auto-mode picks correct device for each `(cuda?, rocm?, mps?, cpu)` matrix combination
+- Probe-failure on CUDA falls through to ROCm in auto mode (not skipped)
+- Probe-failure on explicit `device = "cuda"` falls back to CPU directly (not ROCm/MPS)
+- `recommended_batch_size` returns expected value for each tier boundary (boundary tests at 4.0 / 8.0 / 12.0 / 24.0)
+- HardwareInfo cache is reset by `reset_for_test()`
+- `HELIX_DEVICE` env var beats `[hardware] device` config beats default
+- `[ribosome] device` deprecation warning fires once per process and is overridden by `[hardware] device` when both are set
+
+**Mocking pattern:** `monkeypatch.setattr("torch.cuda.is_available", lambda: True)` — same idiom used in `tests/test_observability_paths.py` for platformdirs.
+
+### 8.2 Layer 2 — GHA workflow
+
+`.github/workflows/ci.yml` (new). Three jobs:
+
+```yaml
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    # Full unit suite, mocked-torch coverage.
+
+  test-macos-mps:
+    runs-on: macos-14   # M1 Apple Silicon, MPS-capable
+    # Full unit suite + 1-iteration MPS smoke test:
+    # load deberta tokenizer, do a 2-pair forward pass on mps,
+    # assert output shape. Catches MPS regressions on every PR.
+
+  test-windows:
+    runs-on: windows-latest
+    # Full unit suite — catches Windows-specific path/encoding bugs
+    # (we already had 5 of those on the sidecar PR).
+```
+
+CPU-only runners on all three (no GHA NVIDIA hosts on the free tier). Total CI ≈ 4–5 min per PR.
+
+### 8.3 Layer 3 — Opt-in real-hardware tests
+
+Pytest markers `requires_rocm` and `requires_real_cuda` (custom). Skip-by-default; check env vars `HELIX_TEST_ROCM=1` / `HELIX_TEST_CUDA=1` and only run when set.
+
+Test files: `tests/test_hardware_rocm.py`, `tests/test_hardware_cuda_real.py`. Anyone with the appropriate hardware can run the full path via the env var without modifying test plumbing.
+
+### 8.4 What is NOT tested
+
+- We do not test that an actual deberta forward pass on a 4 GB GPU avoids OOM. The batch-size table is a heuristic; validation is the bench gate (Section 9), not a unit test.
+- We do not test multi-GPU sharding (out of scope).
+- We do not test fp16/bf16 dtype paths in PR1; that is a separate optimization track.
+
+---
+
+## 9. Rollout
+
+### 9.1 PR1 — Centralization + VRAM-aware batching
+
+**Branch:** `feat/hardware-detection`
+
+**Files added:**
+- `helix_context/hardware.py`
+- `tests/test_hardware.py`
+
+**Files modified:**
+- `helix_context/config.py` — parse `[hardware]` section, deprecation read for `[ribosome] device`
+- `helix.toml` — add documented `[hardware]` block
+- `helix_context/deberta_backend.py`, `nli_backend.py`, `splade_backend.py`, `sema.py` — consult `get_hardware()`, chunk batches
+- `helix_context/server.py` `health()` — add `hardware` block
+- `helix_context/launcher/tray.py` — fallback balloon + sentinel-file dedup
+
+**No new device backends.** `device = "rocm"` or `"mps"` parses cleanly but resolves to CPU fallback in PR1. The picker's auto-mode order documents the future hooks but only the CUDA branch is wired up.
+
+**Bench gate (mandatory before merge):** GPQA Diamond n=20 with native sidecar still up. p95 delta vs `benchmarks/results/gpqa_native_n20_2026-05-04.json` (the sidecar PR's bench artifact) ≤ 5 s. Same gate shape used for the sidecar PR. The risk being measured: chunked batch processing in deberta might add per-chunk overhead.
+
+**Deprecation behavior:** If `[ribosome] device` is present and `[hardware]` is absent:
+
+```
+WARNING helix.config - [ribosome] device is deprecated; move to [hardware] device.
+  Using ribosome.device='cuda' for now.
+```
+
+Logged once per process at config load.
+
+### 9.2 PR2 — MPS + ROCm + CI workflow
+
+**Branch:** `feat/hardware-mps-rocm`
+
+**Files added:**
+- `.github/workflows/ci.yml`
+- `tests/test_hardware_rocm.py` (skip-marked)
+- `tests/test_hardware_cuda_real.py` (skip-marked)
+- `.github/ISSUE_TEMPLATE/enhancement.md` (general enhancement template, with Intel XPU as the natural first user)
+
+**Files modified:**
+- `helix_context/hardware.py` — wire ROCm + MPS into auto picker, populate `device_type`
+- `_BATCH_TABLE` — fill in `("rocm", *)` and `("mps", *)` rows
+- Backends — most need no change (they consult `get_hardware().device` from PR1); fp16/bf16 fixups only if the macOS-runner smoke test surfaces dtype issues
+- This spec — update §3 disclaimers ("ROCm capable but unverified" matching native-sidecar §3 posture)
+
+**No bench gate on PR2.** New device backends are inactive on our rig (no MPS, no ROCm), so bench numbers are unchanged from PR1's gate. The macOS-runner MPS smoke test serves as the integration check; ROCm relies on the opt-in marker until verified on hardware.
+
+### 9.3 Rollout posture
+
+- PR1 ships first, lands on master after bench gate
+- PR2 lands after PR1, opens the door for non-NVIDIA users without changing NVIDIA behavior
+- The `[ribosome] device` deprecation read survives both PRs; removal is a follow-up one-liner in a later release
+
+---
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Chunked batches in deberta fire more torch kernel launches → throughput penalty on the 24 GB tier where "all-at-once" happened to fit | Bench gate on PR1; if regressed, fix is `min(recommended, len(input))` — chunk only if needed |
+| MPS dtype quirks (fp16 hardware, float32 ops fall back to CPU silently) | macOS smoke test in CI catches the cases that matter for our backends |
+| ROCm "capable but unverified" carries reputational risk | Same disclaimer pattern as native-sidecar's macOS/Linux scripts; PR2 body explicit; opt-in marker means contributors with hardware can validate |
+| Probe in `_probe()` slows startup measurably on slow GPUs | 1 ms typical on healthy hardware; if measured slow, downgrade to `is_available()` only with a configurable `HELIX_HARDWARE_PROBE=0` |
+| `[ribosome] device` deprecation surprises existing users | Read shim covers one release with a clear warning; removal scheduled, not silent |
+
+---
+
+## 11. Relationship to other work
+
+- **Native observability sidecar (#16, merged):** unchanged. The hardware module logs into the same OTel/Prometheus stack via the existing logger; no observability config changes.
+- **Foveated splice (next, branch `spec/foveated-splice`):** foveated may want VRAM-aware batch sizing for its rank-scaled compression step. PR1 makes that available via `recommended_batch_size("foveated")` — the table just gains a new column when foveated lands. No coordination needed.
+- **Update-check / version-headroom (just merged on master):** unrelated.
+
+---
+
+## 12. Open questions
+
+- *(none at spec close — all resolved during brainstorm)*
+
+---
+
+## 13. References
+
+- [Native observability sidecar design](2026-05-04-native-observability-sidecar-design.md) — pattern source for tray balloon + capable-but-unverified disclaimer
+- [PyTorch device docs](https://pytorch.org/docs/stable/notes/cuda.html) — multi-GPU + `mem_get_info`
+- [PyTorch MPS backend](https://pytorch.org/docs/stable/notes/mps.html) — Apple Silicon support
+- [PyTorch ROCm](https://pytorch.org/get-started/locally/) — installation and `torch.version.hip`

--- a/docs/specs/2026-05-04-hardware-detection-design.md
+++ b/docs/specs/2026-05-04-hardware-detection-design.md
@@ -48,27 +48,45 @@ New module: **`helix_context/hardware.py`**.
 ```python
 @dataclass(frozen=True)
 class HardwareInfo:
-    device: torch.device              # what backends pass to .to()
-    device_type: str                  # "cuda" | "rocm" | "mps" | "cpu"
+    device: str                       # "cuda:0" | "cuda:1" | "rocm:0" | "mps" | "cpu"
+                                       # — string form so HardwareInfo is constructible
+                                       # even if torch failed to import (§5.5).
+                                       # Backends call torch.device(info.device).
+    device_type: str                  # "cuda" | "rocm" | "mps" | "cpu" — picker key
     device_name: str                  # e.g. "NVIDIA GeForce RTX 4090"
-    vram_total_gb: float | None       # None for cpu
-    vram_free_gb: float | None        # None for cpu / mps
+    vram_total_gb: float | None       # None for cpu — used by batch-size table
+    vram_free_gb: float | None        # None for cpu / mps — INFORMATIONAL ONLY
+                                       # (cached at startup; see "free vs total" below)
     cpu_arch: str                     # "x86_64" | "arm64" | "aarch64"
-    cpu_brand: str                    # short name from cpuinfo / platform.processor()
+    cpu_brand: str                    # see "cpu brand source" below
     system_ram_gb: float
-    requested_device: str             # "auto" | "cuda" | ...
+    requested_device: str             # "auto" | "cuda" | ... — what user asked for
     fallback_reason: str | None       # set when requested_device != device_type
+    batch_size_overrides: Mapping[str, int]   # parsed from [hardware] batch_sizes
+                                       # config; consulted by recommended_batch_size().
 
 def get_hardware() -> HardwareInfo: ...     # cached singleton
 def reset_for_test() -> None: ...           # test-only cache reset
-def recommended_batch_size(model: str) -> int: ...
+def recommended_batch_size(model: str) -> int: ...   # consults singleton; see §7.3
 ```
 
 **Singleton with lazy first-call computation.** Importing the module does not trigger any torch CUDA-driver loading; the first call to `get_hardware()` performs detection and caches the result for the process lifetime. `reset_for_test()` clears the cache for unit tests that mock torch internals.
 
 **No public mutation.** The dataclass is `frozen=True`. Overrides flow through config or env var (Section 4), not via setters.
 
-**Atomic snapshot rationale.** A dataclass return ensures that a consumer reading `device` and `vram_free_gb` in two separate calls cannot get inconsistent values from a stale cache. Since the singleton is computed once and reused, this is mostly belt-and-braces for future evolution (e.g., periodic re-polling of `vram_free_gb`).
+**Free VRAM vs total VRAM.** `vram_free_gb` is captured *once* at startup and reused; the actual free VRAM at request time will differ. **Batch-size sizing therefore keys on `vram_total_gb`** (Section 7.1), which is invariant for the GPU. `vram_free_gb` is reported in the startup banner and `/health` for visibility only — useful to spot "the GPU is already half-consumed by another process at startup", not to drive runtime decisions. If we ever need free-VRAM-aware behavior, it would re-poll `mem_get_info()` per-call rather than reading the cached field.
+
+**`device` as string, not `torch.device`.** Storing the device as a string makes `HardwareInfo` constructible in the torch-not-installed posture (§5.5) where `torch.device` is unavailable. Backends construct `torch.device(info.device)` when they need the actual object — one extra line at the call site, zero coupling at the dataclass.
+
+**`cpu_brand` source.** Resolved in this order:
+
+1. `cpuinfo.get_cpu_info()["brand_raw"]` (from `py-cpuinfo`, added to the `launcher` extra)
+2. `platform.processor()` if non-empty
+3. `"unknown CPU"` as terminal fallback
+
+`py-cpuinfo` is MIT-licensed, single-file, ~50 KB, no native deps. Adding it as a dep is part of PR1's `pyproject.toml` change.
+
+**`batch_size_overrides` field.** Parsed from `[hardware] batch_sizes` at config-load time; empty mapping when `batch_sizes = "auto"` (default). Consulted by `recommended_batch_size()` to enforce the override hierarchy (Section 7.3).
 
 ### 3.2 Affected backends
 
@@ -120,7 +138,8 @@ low_vram_threshold_gb = 4.0
 
 `[ribosome] device` is read for one release with a backwards-compat shim:
 
-- If `[ribosome] device` is present and `[hardware] device` is **not**, helix uses the ribosome value and logs a single `DeprecationWarning` line at startup pointing the user to migrate.
+- If `[ribosome] device` is present and `[hardware] device` is **not**, helix uses the ribosome value and logs a single `WARNING` from `helix.config` at startup pointing the user to migrate (see §9.1 for the wording).
+- If both `[ribosome] device` and `[hardware] device` are present, `[hardware] device` wins and the deprecation warning still fires noting the override.
 - After one release, the shim is removed (one-line change in `config.py`).
 
 Splade and sema have no current device config, so nothing to deprecate there — they newly consult `[hardware]` (clean addition).
@@ -131,39 +150,43 @@ Splade and sema have no current device config, so nothing to deprecate there —
 
 ### 5.1 Auto-mode picking order
 
-Each candidate is checked for both **availability** and **probed usability** (see §5.2):
+Each candidate is checked for both **wheel-level availability** (does the installed torch build advertise this backend?) and **per-device probed usability** (is at least one device of that backend healthy enough to round-trip a tensor?). The picker walks the list in order and stops at the first candidate that passes both:
 
-1. **CUDA** — `torch.cuda.is_available()` AND `torch.cuda.device_count() > 0` AND probe succeeds
-2. **ROCm** — `torch.version.hip is not None` AND a HIP device probes successfully (Linux + AMD only in practice)
+1. **CUDA** — `torch.cuda.is_available()` AND `torch.cuda.device_count() > 0` AND at least one device probes successfully (§5.2 / §5.3)
+2. **ROCm** — `torch.version.hip is not None` AND `torch.cuda.device_count() > 0` AND at least one device probes successfully
 3. **MPS** — `torch.backends.mps.is_available()` AND `torch.backends.mps.is_built()` AND probe succeeds
 4. **CPU** — terminal fallback; always succeeds
 
+**Mutual-exclusion note.** A given torch wheel is built for exactly one of CUDA / ROCm; it cannot serve both. On real hardware, `torch.version.hip is not None` is True only on a ROCm build (where `torch.cuda.is_available()` reports `True` and surfaces HIP devices through the same `torch.cuda` API). So in practice steps 1 and 2 are mutually exclusive at the wheel level — only one of them ever passes its first check on any single host. The fall-through-on-probe-failure path within auto-mode therefore *normally* drops straight to MPS or CPU, since the unsupported sibling backend short-circuits on its availability check before being probed. Mocked tests (§8.1) exercise the fall-through logic by simulating multiple candidates simultaneously available — that is a logic test, not a real-world configuration.
+
 ### 5.2 Probe protocol
 
-For each candidate device, run a 1-element zero-tensor round-trip in a try/except:
+For each candidate device, run a 1-element zero-tensor round-trip in a try/except, **targeting the specific device index** (not just the device-type string):
 
 ```python
-def _probe(device_type: str) -> tuple[bool, str | None]:
+def _probe(device_str: str) -> tuple[bool, str | None]:
+    """device_str = 'cuda:0' / 'cuda:1' / 'mps' / 'cpu'."""
     try:
-        t = torch.zeros(1).to(device_type)
-        _ = t.cpu()  # round-trip
+        t = torch.zeros(1).to(device_str)
+        _ = t.cpu()
         return True, None
     except Exception as exc:
         return False, f"probe failed: {type(exc).__name__}: {exc}"
 ```
 
-This catches the "looks present, isn't usable" failure mode (stale CUDA driver, detached eGPU, container-without-device-passthrough). Probe is ~1 ms on healthy hardware.
+Probe is ~1 ms on healthy hardware. Catches "looks present, isn't usable" failure modes (stale CUDA driver, detached eGPU, container-without-device-passthrough, dead device in a multi-GPU box).
 
-### 5.3 Multi-GPU posture
+### 5.3 Multi-GPU device selection
 
-If `torch.cuda.device_count() > 1`:
+For CUDA / ROCm (which share the `torch.cuda.device_count()` API):
 
-- Pick the device with the most free VRAM (`torch.cuda.mem_get_info(i)`)
-- Log all detected devices in the startup banner
-- Set the chosen device's index in `device = torch.device("cuda:N")`
-- Users who want to pin a specific card can use `CUDA_VISIBLE_DEVICES`; no helix-specific override needed
+1. Enumerate all device indices `0..device_count() - 1`
+2. For each index, attempt `torch.cuda.mem_get_info(i)` — devices that raise are dead and skipped
+3. Among the live devices, pick the one with the most **free** VRAM at startup (free here is fine; it's a one-shot pick, not a runtime budget)
+4. Probe `cuda:N` (or the equivalent on ROCm) for the chosen N — if probe fails, repeat from step 2 with the next-best device, and so on. If no devices probe, the candidate is rejected and auto-mode falls through.
+5. Set `info.device = "cuda:N"` for the winner. Log all enumerated devices (live and dead) in the startup banner.
 
-ROCm follows the same pattern via `torch.cuda.device_count()` (which counts HIP devices on a ROCm build).
+This avoids the "device 0 is broken, device 1 is healthy, but probing 'cuda' (default 0) rejects CUDA entirely" failure. Users who want to pin a specific card can still use `CUDA_VISIBLE_DEVICES` — that masks devices before the picker even sees them.
 
 ### 5.4 Explicit-device fallback policy
 
@@ -231,7 +254,7 @@ INFO helix.hardware - device=cuda (NVIDIA GeForce RTX 4090, 24.0 GB total / 22.4
 
 `helix_health_check` (and any other consumer of `/health`) gets fallback state for free.
 
-### 6.3 Tray balloon
+### 6.3 Tray balloon (launcher-only)
 
 Same pattern as the native-observability "install pending" balloon in `helix_context/launcher/tray.py`. A balloon fires once per state-change combination:
 
@@ -240,13 +263,17 @@ Same pattern as the native-observability "install pending" balloon in `helix_con
 - Sentinel file at `<state_dir>/.hardware-fallback-acknowledged-{requested}-{active}` dedupes
 - A new combination (e.g., user fixed CUDA → no balloon; later they unplug GPU and now MPS falls to CPU → new balloon) re-fires
 
+**Scope:** the balloon channel covers `fallback_active == true` only — the case where the user explicitly asked for a device they didn't get, and we want to make sure they know. **Low-VRAM warnings are NOT balloon-surfaced**; they're a hint, not a fault, and would be annoying to bubble. Low-VRAM stays on logs + `/health` (`hardware.low_vram_warning: true`).
+
+**Headless / server posture:** the balloon channel is launcher-only. Headless server deployments rely on logs (§6.1) and `/health` (§6.2) — both fire identically regardless of whether a tray exists.
+
 ### 6.4 Why three channels
 
 - Logs miss eyes that don't grep
 - `/health` misses users who never poll it
 - Tray balloons miss users running helix as a server
 
-Together they catch every audience without spam (one balloon per state-change, not per launch).
+Together they catch every audience without spam (one balloon per state-change, not per launch). The channels degrade independently — a tray-less server still gets logs + `/health`; a user who never polls `/health` still sees the log line + the balloon.
 
 ---
 
@@ -254,10 +281,12 @@ Together they catch every audience without spam (one balloon per state-change, n
 
 ### 7.1 Lookup table
 
+The table is keyed on **`vram_total_gb`** for CUDA/ROCm (invariant per GPU; safe across runs) and on **`system_ram_gb`** for MPS (shared with system) and CPU. Free VRAM at startup (§3.1) is informational only and never drives the table.
+
 ```python
 # (device_type, ram_tier_gb_min) → batch sizes per model
 _BATCH_TABLE: dict[tuple[str, float], dict[str, int]] = {
-    # CUDA / ROCm tiers — VRAM-keyed
+    # CUDA / ROCm tiers — keyed on TOTAL VRAM
     ("cuda", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
     ("cuda", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
     ("cuda",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
@@ -271,6 +300,7 @@ _BATCH_TABLE: dict[tuple[str, float], dict[str, int]] = {
     # MPS — keyed on system_ram_gb (MPS shares system RAM)
     ("mps",  16.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
     ("mps",   8.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("mps",   0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},  # defensive floor
     # CPU — keyed on system_ram_gb, conservative defaults
     ("cpu",  16.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
     ("cpu",   8.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
@@ -278,7 +308,7 @@ _BATCH_TABLE: dict[tuple[str, float], dict[str, int]] = {
 }
 ```
 
-`recommended_batch_size("rerank")` finds the highest tier row whose threshold ≤ available VRAM (or system RAM for cpu/mps), reads the model column.
+`recommended_batch_size("rerank")` finds the highest tier row whose threshold ≤ `vram_total_gb` (CUDA/ROCm) or `system_ram_gb` (MPS/CPU), reads the model column.
 
 **Calibration.** Numbers are starting points keyed on rough rules of thumb (deberta-v3-small at 256 max-len ≈ 60 MB activation per batch item at fp32; halve again for safety). PR1's bench gate (Section 9) verifies they don't regress on our 24 GB rig. Lower tiers ship as conservative heuristics; users on those cards can report back via the enhancement template.
 
@@ -296,9 +326,24 @@ The chunked pattern already exists in `splade_backend.encode_batch` (line 116) a
 
 ### 7.3 Override hierarchy for batch sizes
 
-1. Explicit caller-passed `batch_size=` argument (preserves existing test patterns)
-2. `[hardware] batch_sizes = { rerank = 16 }` config dict for the named model
-3. Auto from the table (default)
+The hierarchy lives partly in `recommended_batch_size()` and partly at the call site. Resolution per model name:
+
+1. **Explicit caller-passed `batch_size=` argument** at the backend's call site (e.g., a test passing `batch_size=2`). Bypasses `recommended_batch_size()` entirely. Preserved verbatim from existing test patterns.
+2. **`[hardware] batch_sizes = { rerank = 16 }` config dict** for the named model. Read at config-load and stored in `HardwareInfo.batch_size_overrides`. `recommended_batch_size("rerank")` checks this first and short-circuits the table lookup if the key is present.
+3. **Auto from the table** (default). The table is consulted only when steps 1 and 2 don't resolve.
+
+Function shape:
+
+```python
+def recommended_batch_size(model: str) -> int:
+    info = get_hardware()
+    if model in info.batch_size_overrides:
+        return info.batch_size_overrides[model]
+    tier_key = info.vram_total_gb if info.device_type in {"cuda", "rocm"} else info.system_ram_gb
+    return _lookup_table(info.device_type, tier_key, model)
+```
+
+Backends call `recommended_batch_size(model)` with no arguments other than the model name, then optionally override via the call-site `batch_size=` parameter when present.
 
 ---
 
@@ -310,13 +355,17 @@ The chunked pattern already exists in `splade_backend.encode_batch` (line 116) a
 
 **Coverage:**
 
-- Auto-mode picks correct device for each `(cuda?, rocm?, mps?, cpu)` matrix combination
-- Probe-failure on CUDA falls through to ROCm in auto mode (not skipped)
-- Probe-failure on explicit `device = "cuda"` falls back to CPU directly (not ROCm/MPS)
+- Auto-mode picks correct device for each `(cuda?, rocm?, mps?)` matrix combination — including the realistic-build cases (only one of CUDA/ROCm advertised at a time) and the mocked-multi case (both advertised, exercises fall-through logic per §5.1's mutual-exclusion note)
+- Multi-GPU CUDA: dead device-0 + healthy device-1 → picker selects `cuda:1`, never rejects CUDA outright (regression pin for B2)
+- Probe-failure on CUDA in auto mode (with all CUDA devices dead) falls through to the next advertised candidate, not to CPU directly
+- Probe-failure on explicit `device = "cuda"` falls back to CPU directly (not ROCm/MPS) — the asymmetry from §5.4
 - `recommended_batch_size` returns expected value for each tier boundary (boundary tests at 4.0 / 8.0 / 12.0 / 24.0)
+- `recommended_batch_size` consults `info.batch_size_overrides` first and returns the override value when set; falls through to the table when the model name isn't in the override dict
+- `vram_total_gb` drives the table lookup; mutating `vram_free_gb` between calls does NOT change the result (regression pin for B3)
 - HardwareInfo cache is reset by `reset_for_test()`
 - `HELIX_DEVICE` env var beats `[hardware] device` config beats default
-- `[ribosome] device` deprecation warning fires once per process and is overridden by `[hardware] device` when both are set
+- `[ribosome] device` deprecation warning fires once per process; `[hardware] device` overrides ribosome-device when both are set; warning still fires noting the override
+- `cpu_brand` source order: py-cpuinfo present → uses it; py-cpuinfo absent + `platform.processor()` non-empty → uses that; both absent → `"unknown CPU"` (no crash)
 
 **Mocking pattern:** `monkeypatch.setattr("torch.cuda.is_available", lambda: True)` — same idiom used in `tests/test_observability_paths.py` for platformdirs.
 
@@ -374,10 +423,17 @@ Test files: `tests/test_hardware_rocm.py`, `tests/test_hardware_cuda_real.py`. A
 - `helix_context/deberta_backend.py`, `nli_backend.py`, `splade_backend.py`, `sema.py` — consult `get_hardware()`, chunk batches
 - `helix_context/server.py` `health()` — add `hardware` block
 - `helix_context/launcher/tray.py` — fallback balloon + sentinel-file dedup
+- `pyproject.toml` — add `py-cpuinfo>=9.0` to the `launcher` extra (see §3.1 for the cpu_brand source rationale)
 
 **No new device backends.** `device = "rocm"` or `"mps"` parses cleanly but resolves to CPU fallback in PR1. The picker's auto-mode order documents the future hooks but only the CUDA branch is wired up.
 
-**Bench gate (mandatory before merge):** GPQA Diamond n=20 with native sidecar still up. p95 delta vs `benchmarks/results/gpqa_native_n20_2026-05-04.json` (the sidecar PR's bench artifact) ≤ 5 s. Same gate shape used for the sidecar PR. The risk being measured: chunked batch processing in deberta might add per-chunk overhead.
+**Bench gate (mandatory before merge):** GPQA Diamond n=20 procedure (same shape as the sidecar PR's Task 14). The bench artifact `benchmarks/results/gpqa_native_n20_2026-05-04.json` from the sidecar PR was kept local-only; it is NOT on master. The bench-gate procedure for PR1:
+
+1. Re-run the n=20 native-stack bench against `master` HEAD before applying PR1's changes — capture as the local baseline JSON
+2. Run the same n=20 bench against PR1's HEAD
+3. Compare same-IDs p95 delta — must be ≤ 5 s
+
+This avoids relying on a stale local artifact, and gives a clean baseline at the moment PR1 opens. Both runs use the same native sidecar instance to keep observability constant. The risk being measured: chunked batch processing in deberta might add per-chunk overhead that wasn't there before.
 
 **Deprecation behavior:** If `[ribosome] device` is present and `[hardware]` is absent:
 

--- a/helix.toml
+++ b/helix.toml
@@ -36,6 +36,22 @@ query_expansion_enabled = false         # Step 0 LLM query-intent expansion. fal
 # claude_base_url = ""                          # "" = direct Anthropic API; set to a proxy URL (e.g. http://127.0.0.1:8787) to route through a gateway
 # litellm_model = "ollama/gemma4:e2b"           # LiteLLM model string — only used when backend = "litellm"
 
+[hardware]
+# Device picker. "auto" picks best-available (cuda -> rocm -> mps -> cpu).
+# Explicit values fall back loudly to CPU on probe failure; helix never
+# blocks on hardware mismatch -- see /health for fallback state.
+# Override one-shot via HELIX_DEVICE=cpu env var.
+device = "auto"        # auto | cuda | rocm | mps | cpu
+
+# Batch-size policy. "auto" consults the VRAM/RAM-aware table in
+# helix_context/hardware.py. Override per model when tuning:
+#   batch_sizes = { rerank = 16, splice = 32, splade = 8, nli = 8 }
+batch_sizes = "auto"
+
+# Soft-warn threshold. Below this, /health returns a "low_vram" hint and
+# the tray surfaces a one-time balloon. Set to 0 to disable.
+low_vram_threshold_gb = 4.0
+
 [budget]
 ribosome_tokens = 3000                  # fixed decoder prompt
 expression_tokens = 12000               # 1:10 ratio at 128K = ~12.8K total context budget

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -301,6 +301,26 @@ class HeadroomConfig:
 
 
 @dataclass
+class Hardware:
+    """[hardware] config — see docs/specs/2026-05-04-hardware-detection-design.md.
+
+    device: ``auto`` | ``cuda`` | ``rocm`` | ``mps`` | ``cpu``. Wired into
+    ``hardware.init_from_config()`` at server startup.
+
+    batch_sizes: per-model overrides applied on top of the auto-detected
+    table. Empty dict means "use the table". The TOML literal string
+    ``"auto"`` is also accepted and equivalent to ``{}``.
+
+    low_vram_threshold_gb: under this VRAM tier the operator may want
+    fp8 / quantized variants. Surfaced for downstream consumers; not
+    used by the picker itself.
+    """
+    device: str = "auto"
+    batch_sizes: Dict[str, int] = field(default_factory=dict)
+    low_vram_threshold_gb: float = 4.0
+
+
+@dataclass
 class HelixConfig:
     ribosome: RibosomeConfig = field(default_factory=RibosomeConfig)
     budget: BudgetConfig = field(default_factory=BudgetConfig)
@@ -314,6 +334,7 @@ class HelixConfig:
     plr: PLRConfig = field(default_factory=PLRConfig)
     headroom: HeadroomConfig = field(default_factory=HeadroomConfig)
     classifier: ClassifierConfig = field(default_factory=ClassifierConfig)
+    hardware: Hardware = field(default_factory=Hardware)
     synonym_map: Dict[str, List[str]] = field(default_factory=dict)
 
 
@@ -540,6 +561,45 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
         cfg.classifier = ClassifierConfig(
             enabled=bool(cls_section.get("enabled", cfg.classifier.enabled)),
         )
+
+    # Hardware section — see docs/specs/2026-05-04-hardware-detection-design.md.
+    # Always run, even if [hardware] is absent, because the [ribosome]
+    # device deprecation shim must fire whenever the legacy key is set.
+    hw = raw.get("hardware", {})
+    if isinstance(hw, dict):
+        _warn_unknown("hardware", hw, Hardware)
+    if isinstance(hw.get("batch_sizes"), str) and hw["batch_sizes"] == "auto":
+        bs: Dict[str, int] = {}
+    elif isinstance(hw.get("batch_sizes"), dict):
+        bs = {k: int(v) for k, v in hw["batch_sizes"].items()}
+    else:
+        bs = {}
+    hardware_device = hw.get("device", "auto")
+
+    # Deprecation shim for [ribosome] device. Fires whenever the legacy
+    # key is present, even if [hardware] is also set — the warning text
+    # MUST contain both "deprecated" and "override" in the both-set case
+    # so test_hardware_overrides_ribosome_device's substring asserts
+    # match. Don't reword without updating the tests.
+    ribosome_device = raw.get("ribosome", {}).get("device")
+    if ribosome_device is not None:
+        if "device" in hw:
+            log.warning(
+                "[ribosome] device is deprecated; [hardware] device=%r takes "
+                "precedence (override). Remove [ribosome] device.", hardware_device,
+            )
+        else:
+            log.warning(
+                "[ribosome] device is deprecated; move to [hardware] device. "
+                "Using ribosome.device=%r for now.", ribosome_device,
+            )
+            hardware_device = ribosome_device
+
+    cfg.hardware = Hardware(
+        device=str(hardware_device),
+        batch_sizes=bs,
+        low_vram_threshold_gb=float(hw.get("low_vram_threshold_gb", 4.0)),
+    )
 
     # Fix 1: synonym map
     if "synonyms" in raw:

--- a/helix_context/deberta_backend.py
+++ b/helix_context/deberta_backend.py
@@ -49,7 +49,7 @@ class DeBERTaRibosome:
         splice_model_path: str = "training/models/splice",
         nli_model_path: str = "training/models/nli",
         ollama_ribosome=None,
-        device: str = "auto",
+        device: Optional[str] = None,
         splice_threshold: float = 0.5,
         nli_splice_bonus: float = 0.15,
         nli_splice_penalty: float = 0.15,
@@ -57,8 +57,13 @@ class DeBERTaRibosome:
     ):
         from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
-        if device == "auto":
-            self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        # Device resolution: defer to the hardware module's singleton when
+        # the caller passes None. Explicit "auto" (legacy callers) goes
+        # through the same path so detection is centralized; explicit
+        # device strings ("cpu", "cuda:0", ...) are honored as-is.
+        if device is None or device == "auto":
+            from helix_context.hardware import get_hardware
+            self._device = torch.device(get_hardware().device)
         else:
             self._device = torch.device(device)
 
@@ -101,6 +106,9 @@ class DeBERTaRibosome:
 
         t0 = time.perf_counter()
 
+        from helix_context.hardware import recommended_batch_size
+        batch_size = recommended_batch_size("rerank")
+
         # Build text pairs
         texts_a = []
         texts_b = []
@@ -110,26 +118,28 @@ class DeBERTaRibosome:
             domains = ", ".join(g.promoter.domains)
             texts_b.append(f"{summary} [{domains}]" if domains else summary)
 
-        # Tokenize all pairs at once
-        encodings = self._rerank_tokenizer(
-            texts_a,
-            texts_b,
-            truncation=True,
-            max_length=256,
-            padding=True,
-            return_tensors="pt",
-        ).to(self._device)
-
-        # Score
+        # Score in chunks sized by the hardware-recommended batch size so
+        # large candidate pools don't blow up VRAM. Chunked tokenize +
+        # forward, then concatenate the per-chunk score lists.
+        scores: List[float] = []
         with torch.no_grad():
-            outputs = self._rerank_model(**encodings)
-            scores = outputs.logits.squeeze(-1)
-            # Clamp to 0-1 range
-            scores = torch.clamp(scores, 0.0, 1.0).cpu().tolist()
-
-        # If single candidate, scores is a scalar
-        if isinstance(scores, float):
-            scores = [scores]
+            for i in range(0, len(texts_a), batch_size):
+                chunk_a = texts_a[i : i + batch_size]
+                chunk_b = texts_b[i : i + batch_size]
+                encodings = self._rerank_tokenizer(
+                    chunk_a,
+                    chunk_b,
+                    truncation=True,
+                    max_length=256,
+                    padding=True,
+                    return_tensors="pt",
+                ).to(self._device)
+                outputs = self._rerank_model(**encodings)
+                chunk_scores = outputs.logits.squeeze(-1)
+                chunk_scores = torch.clamp(chunk_scores, 0.0, 1.0).cpu().tolist()
+                if isinstance(chunk_scores, float):
+                    chunk_scores = [chunk_scores]
+                scores.extend(chunk_scores)
 
         # For pretrained cross-encoders (e.g. MS MARCO), skip position bonus —
         # they produce calibrated relevance scores that don't need retrieval-order bias.
@@ -181,24 +191,29 @@ class DeBERTaRibosome:
         if not all_pairs_a:
             return {g.gene_id: g.complement or g.content[:500] for g in genes}
 
-        # Tokenize all at once
-        encodings = self._splice_tokenizer(
-            all_pairs_a,
-            all_pairs_b,
-            truncation=True,
-            max_length=128,
-            padding=True,
-            return_tensors="pt",
-        ).to(self._device)
+        from helix_context.hardware import recommended_batch_size
+        batch_size = recommended_batch_size("splice")
 
-        # Predict
+        # Predict in chunks sized by the hardware-recommended batch size.
+        probs: List[float] = []
         with torch.no_grad():
-            outputs = self._splice_model(**encodings)
-            logits = outputs.logits.squeeze(-1)
-            probs = torch.sigmoid(logits).cpu().tolist()
-
-        if isinstance(probs, float):
-            probs = [probs]
+            for i in range(0, len(all_pairs_a), batch_size):
+                chunk_a = all_pairs_a[i : i + batch_size]
+                chunk_b = all_pairs_b[i : i + batch_size]
+                encodings = self._splice_tokenizer(
+                    chunk_a,
+                    chunk_b,
+                    truncation=True,
+                    max_length=128,
+                    padding=True,
+                    return_tensors="pt",
+                ).to(self._device)
+                outputs = self._splice_model(**encodings)
+                logits = outputs.logits.squeeze(-1)
+                chunk_probs = torch.sigmoid(logits).cpu().tolist()
+                if isinstance(chunk_probs, float):
+                    chunk_probs = [chunk_probs]
+                probs.extend(chunk_probs)
 
         # Extract query keywords for content-match preservation
         query_lower = query.lower().split()

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -1,0 +1,76 @@
+"""Hardware detection + device backend dispatch for helix-context.
+
+Single source of truth for which torch device backends consult. Auto-mode
+picker walks CUDA -> ROCm -> MPS -> CPU; explicit-device requests fall back
+loudly to CPU on probe failure but never block. See:
+  docs/specs/2026-05-04-hardware-detection-design.md
+
+Public surface:
+  HardwareInfo            -- frozen dataclass returned by get_hardware()
+  get_hardware()          -- cached singleton; first call performs detection
+  reset_for_test()        -- test-only cache reset
+  recommended_batch_size  -- table-driven, override-aware
+
+Subsequent tasks fill in detection logic; Task 2 lays the dataclass +
+singleton plumbing only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+
+log = logging.getLogger("helix.hardware")
+
+
+@dataclass(frozen=True)
+class HardwareInfo:
+    """Atomic snapshot of detected hardware. Immutable — overrides flow
+    through config + env var, not setters."""
+
+    device: str
+    device_type: str
+    device_name: str
+    vram_total_gb: Optional[float]
+    vram_free_gb: Optional[float]
+    cpu_arch: str
+    cpu_brand: str
+    system_ram_gb: float
+    requested_device: str
+    fallback_reason: Optional[str]
+    batch_size_overrides: Mapping[str, int] = field(default_factory=dict)
+
+
+_cached_info: Optional[HardwareInfo] = None
+
+
+def get_hardware() -> HardwareInfo:
+    """Return the cached HardwareInfo, computing it on first call."""
+    global _cached_info
+    if _cached_info is None:
+        _cached_info = _detect()
+    return _cached_info
+
+
+def reset_for_test() -> None:
+    """Clear the cached HardwareInfo. Test-only."""
+    global _cached_info
+    _cached_info = None
+
+
+def _detect() -> HardwareInfo:
+    """Stub — filled in by Tasks 3-10. Returns a synthetic CPU info for now
+    so Task 2's tests pass."""
+    return HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name="unknown CPU",
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch="unknown",
+        cpu_brand="unknown CPU",
+        system_ram_gb=0.0,
+        requested_device="auto",
+        fallback_reason=None,
+    )

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -27,23 +27,31 @@ log = logging.getLogger("helix.hardware")
 _VALID_DEVICES = ("auto", "cuda", "rocm", "mps", "cpu")
 
 
-def _resolve_requested_device() -> str:
-    """Resolve the user's requested device from HELIX_DEVICE env var.
-    Config plumbing is added in Task 9; for now env-var-only.
+def _resolve_requested_device(config_device: str = "auto") -> str:
+    """Resolve the user's requested device.
 
-    Returns one of _VALID_DEVICES; invalid values log a warning and
-    return 'auto'."""
+    Order of precedence:
+      1. ``HELIX_DEVICE`` env var (operator override at launch).
+      2. ``config_device`` arg (from ``[hardware] device`` in helix.toml).
+      3. ``"auto"`` (sentinel; the picker walks CUDA -> ROCm -> MPS -> CPU).
+
+    Returns one of ``_VALID_DEVICES``; invalid env/config values log a
+    warning and fall through to the next layer."""
     env_value = os.environ.get("HELIX_DEVICE")
-    if env_value is None:
-        return "auto"
-    normalized = env_value.strip().lower()
-    if normalized not in _VALID_DEVICES:
+    if env_value is not None:
+        normalized = env_value.strip().lower()
+        if normalized in _VALID_DEVICES:
+            return normalized
         log.warning(
-            "Invalid HELIX_DEVICE=%r (valid: %s); ignoring HELIX_DEVICE and using 'auto'",
+            "Invalid HELIX_DEVICE=%r (valid: %s); ignoring HELIX_DEVICE",
             env_value, ", ".join(_VALID_DEVICES),
         )
-        return "auto"
-    return normalized
+        # fall through to config / auto
+    cfg_norm = config_device.strip().lower() if isinstance(config_device, str) else ""
+    if cfg_norm in _VALID_DEVICES:
+        return cfg_norm
+    log.warning("Invalid [hardware] device=%r; using 'auto'", config_device)
+    return "auto"
 
 
 def _cpuinfo_get_info() -> Optional[Dict[str, Any]]:
@@ -123,6 +131,10 @@ class HardwareInfo:
 
 
 _cached_info: Optional[HardwareInfo] = None
+# Config-supplied defaults consumed by ``_detect()``. ``init_from_config``
+# is the only public setter; ``reset_for_test`` clears them.
+_config_device: str = "auto"
+_config_overrides: Mapping[str, int] = {}
 
 
 def get_hardware() -> HardwareInfo:
@@ -133,10 +145,38 @@ def get_hardware() -> HardwareInfo:
     return _cached_info
 
 
+def init_from_config(
+    config_device: str = "auto",
+    batch_size_overrides: Optional[Mapping[str, int]] = None,
+) -> HardwareInfo:
+    """One-shot init at server startup.
+
+    Sets the config-supplied ``requested_device`` and ``batch_size_overrides``
+    that ``_detect()`` will stamp onto the singleton, then forces detection.
+
+    **Idempotent on the cache**: if ``get_hardware()`` (or a previous
+    ``init_from_config()``) already populated the singleton, the cached
+    ``HardwareInfo`` is returned unchanged. This is the
+    cached-singleton-poisoning failure mode pinned by
+    ``tests/test_hardware.py::test_init_from_config_must_run_before_get_hardware``
+    — the call order at server startup matters.
+
+    Returns the (possibly-cached) ``HardwareInfo``."""
+    global _cached_info, _config_device, _config_overrides
+    if _cached_info is not None:
+        return _cached_info
+    _config_device = config_device
+    _config_overrides = dict(batch_size_overrides) if batch_size_overrides else {}
+    _cached_info = _detect()
+    return _cached_info
+
+
 def reset_for_test() -> None:
-    """Clear the cached HardwareInfo. Test-only."""
-    global _cached_info
+    """Clear the cached HardwareInfo + config state. Test-only."""
+    global _cached_info, _config_device, _config_overrides
     _cached_info = None
+    _config_device = "auto"
+    _config_overrides = {}
 
 
 def _detect_cuda_or_rocm(rocm: bool) -> Optional[Dict[str, Any]]:
@@ -201,7 +241,8 @@ def _detect_mps() -> Optional[Dict[str, Any]]:
 
 def _detect() -> HardwareInfo:
     cpu = _detect_cpu()
-    requested = _resolve_requested_device()
+    requested = _resolve_requested_device(_config_device)
+    overrides = dict(_config_overrides)
 
     if requested == "auto":
         attempts = [
@@ -246,6 +287,7 @@ def _detect() -> HardwareInfo:
                 system_ram_gb=cpu["system_ram_gb"],
                 requested_device=requested,
                 fallback_reason=None,
+                batch_size_overrides=overrides,
             )
         else:
             last_failure_reason = (
@@ -272,6 +314,7 @@ def _detect() -> HardwareInfo:
         system_ram_gb=cpu["system_ram_gb"],
         requested_device=requested,
         fallback_reason=fallback_reason,
+        batch_size_overrides=overrides,
     )
 
 

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -10,8 +10,7 @@ Public surface:
   get_hardware()          -- cached singleton; first call performs detection
   reset_for_test()        -- test-only cache reset
 
-Subsequent tasks fill in detection logic; Task 2 lays the dataclass +
-singleton plumbing only.
+Subsequent tasks add detection logic incrementally.
 """
 
 from __future__ import annotations
@@ -61,6 +60,25 @@ def _detect_cpu() -> Dict[str, Any]:
         "cpu_brand": cpu_brand,
         "system_ram_gb": system_ram_gb,
     }
+
+
+def _probe(device_str: str) -> tuple[bool, Optional[str]]:
+    """Round-trip a 1-element zero tensor through the device.
+
+    device_str: e.g. 'cuda:0', 'cuda:1', 'mps', 'cpu'.
+
+    Returns (True, None) on success, (False, '<ExcType>: <message>') on
+    failure. Catches the 'wheel says yes but kernel launch fails' failure
+    mode (stale driver, dead GPU, container without device passthrough).
+    Probe is ~1ms on healthy hardware.
+    """
+    import torch  # local import — torch may be absent (§5.5)
+    try:
+        t = torch.zeros(1).to(device_str)
+        _ = t.cpu()
+        return True, None
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
 
 
 @dataclass(frozen=True)

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -16,11 +16,33 @@ Subsequent tasks add detection logic incrementally.
 from __future__ import annotations
 
 import logging
+import os
 import platform
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Optional
 
 log = logging.getLogger("helix.hardware")
+
+_VALID_DEVICES = ("auto", "cuda", "rocm", "mps", "cpu")
+
+
+def _resolve_requested_device() -> str:
+    """Resolve the user's requested device from HELIX_DEVICE env var.
+    Config plumbing is added in Task 9; for now env-var-only.
+
+    Returns one of _VALID_DEVICES; invalid values log a warning and
+    return 'auto'."""
+    env_value = os.environ.get("HELIX_DEVICE")
+    if env_value is None:
+        return "auto"
+    normalized = env_value.strip().lower()
+    if normalized not in _VALID_DEVICES:
+        log.warning(
+            "Invalid HELIX_DEVICE=%r (valid: %s); ignoring HELIX_DEVICE and using 'auto'",
+            env_value, ", ".join(_VALID_DEVICES),
+        )
+        return "auto"
+    return normalized
 
 
 def _cpuinfo_get_info() -> Optional[Dict[str, Any]]:
@@ -178,17 +200,38 @@ def _detect_mps() -> Optional[Dict[str, Any]]:
 
 def _detect() -> HardwareInfo:
     cpu = _detect_cpu()
-    requested = "auto"  # Task 7 wires env+config
+    requested = _resolve_requested_device()
 
-    for label, fn in (
-        ("cuda", lambda: _detect_cuda_or_rocm(rocm=False)),
-        ("rocm", lambda: _detect_cuda_or_rocm(rocm=True)),
-        ("mps",  _detect_mps),
-    ):
+    if requested == "auto":
+        attempts = [
+            ("cuda", lambda: _detect_cuda_or_rocm(rocm=False)),
+            ("rocm", lambda: _detect_cuda_or_rocm(rocm=True)),
+            ("mps",  _detect_mps),
+        ]
+        explicit = False
+    elif requested == "cpu":
+        attempts = []
+        explicit = True
+    elif requested == "cuda":
+        attempts = [("cuda", lambda: _detect_cuda_or_rocm(rocm=False))]
+        explicit = True
+    elif requested == "rocm":
+        attempts = [("rocm", lambda: _detect_cuda_or_rocm(rocm=True))]
+        explicit = True
+    elif requested == "mps":
+        attempts = [("mps", _detect_mps)]
+        explicit = True
+    else:
+        attempts = []
+        explicit = True
+
+    last_failure_reason: Optional[str] = None
+    for label, fn in attempts:
         try:
             d = fn()
-        except Exception:
+        except Exception as exc:
             log.warning("hardware candidate %s failed", label, exc_info=True)
+            last_failure_reason = f"{label} candidate raised: {exc}"
             continue
         if d is not None:
             return HardwareInfo(
@@ -203,6 +246,19 @@ def _detect() -> HardwareInfo:
                 requested_device=requested,
                 fallback_reason=None,
             )
+        else:
+            last_failure_reason = (
+                last_failure_reason
+                or f"{label} not available (is_available()/probe returned False)"
+            )
+
+    if requested != "auto" and requested != "cpu":
+        fallback_reason = (
+            f"requested {requested!r} but probe/availability failed: "
+            f"{last_failure_reason or 'no usable device found'}"
+        )
+    else:
+        fallback_reason = None
 
     return HardwareInfo(
         device="cpu",
@@ -214,5 +270,5 @@ def _detect() -> HardwareInfo:
         cpu_brand=cpu["cpu_brand"],
         system_ram_gb=cpu["system_ram_gb"],
         requested_device=requested,
-        fallback_reason=None,
+        fallback_reason=fallback_reason,
     )

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -117,8 +117,9 @@ def reset_for_test() -> None:
 
 
 def _detect_cuda_or_rocm(rocm: bool) -> Optional[Dict[str, Any]]:
-    """Returns dict with device fields, or None if not available.
-    Single-device pick (multi-GPU enumeration is Task 6)."""
+    """Enumerate live devices, pick the most-free-VRAM one that probes
+    successfully. Falls through to next-best on probe failure. Returns
+    None if no devices probe successfully."""
     import torch
     if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
         return None
@@ -126,20 +127,36 @@ def _detect_cuda_or_rocm(rocm: bool) -> Optional[Dict[str, Any]]:
         return None
     if not rocm and getattr(torch.version, "hip", None) is not None:
         return None
-    idx = 0
-    free_b, total_b = torch.cuda.mem_get_info(idx)
-    device_str = f"{'rocm' if rocm else 'cuda'}:{idx}"
-    ok, reason = _probe(f"cuda:{idx}")
-    if not ok:
-        log.warning("Device %s probe failed: %s", device_str, reason)
+
+    candidates = []  # list of (free_gb, total_gb, idx)
+    for idx in range(torch.cuda.device_count()):
+        try:
+            free_b, total_b = torch.cuda.mem_get_info(idx)
+        except Exception as exc:
+            log.warning("cuda:%d mem_get_info failed (treated as dead): %s", idx, exc)
+            continue
+        candidates.append((free_b / (1024**3), total_b / (1024**3), idx))
+
+    if not candidates:
         return None
-    return {
-        "device": device_str,
-        "device_type": "rocm" if rocm else "cuda",
-        "device_name": torch.cuda.get_device_name(idx),
-        "vram_total_gb": total_b / (1024 ** 3),
-        "vram_free_gb": free_b / (1024 ** 3),
-    }
+
+    candidates.sort(reverse=True)  # largest free VRAM first
+
+    for free_gb, total_gb, idx in candidates:
+        ok, reason = _probe(f"cuda:{idx}")
+        if not ok:
+            log.warning("cuda:%d probe failed: %s — falling through", idx, reason)
+            continue
+        device_type = "rocm" if rocm else "cuda"
+        device_str = f"{device_type}:{idx}"
+        return {
+            "device": device_str,
+            "device_type": device_type,
+            "device_name": torch.cuda.get_device_name(idx),
+            "vram_total_gb": total_gb,
+            "vram_free_gb": free_gb,
+        }
+    return None
 
 
 def _detect_mps() -> Optional[Dict[str, Any]]:

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -116,8 +116,77 @@ def reset_for_test() -> None:
     _cached_info = None
 
 
+def _detect_cuda_or_rocm(rocm: bool) -> Optional[Dict[str, Any]]:
+    """Returns dict with device fields, or None if not available.
+    Single-device pick (multi-GPU enumeration is Task 6)."""
+    import torch
+    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+        return None
+    if rocm and getattr(torch.version, "hip", None) is None:
+        return None
+    if not rocm and getattr(torch.version, "hip", None) is not None:
+        return None
+    idx = 0
+    free_b, total_b = torch.cuda.mem_get_info(idx)
+    device_str = f"{'rocm' if rocm else 'cuda'}:{idx}"
+    ok, reason = _probe(f"cuda:{idx}")
+    if not ok:
+        log.warning("Device %s probe failed: %s", device_str, reason)
+        return None
+    return {
+        "device": device_str,
+        "device_type": "rocm" if rocm else "cuda",
+        "device_name": torch.cuda.get_device_name(idx),
+        "vram_total_gb": total_b / (1024 ** 3),
+        "vram_free_gb": free_b / (1024 ** 3),
+    }
+
+
+def _detect_mps() -> Optional[Dict[str, Any]]:
+    import torch
+    if not (torch.backends.mps.is_available() and torch.backends.mps.is_built()):
+        return None
+    ok, reason = _probe("mps")
+    if not ok:
+        log.warning("MPS probe failed: %s", reason)
+        return None
+    return {
+        "device": "mps",
+        "device_type": "mps",
+        "device_name": "Apple Silicon (MPS)",
+        "vram_total_gb": None,
+        "vram_free_gb": None,
+    }
+
+
 def _detect() -> HardwareInfo:
     cpu = _detect_cpu()
+    requested = "auto"  # Task 7 wires env+config
+
+    for label, fn in (
+        ("cuda", lambda: _detect_cuda_or_rocm(rocm=False)),
+        ("rocm", lambda: _detect_cuda_or_rocm(rocm=True)),
+        ("mps",  _detect_mps),
+    ):
+        try:
+            d = fn()
+        except Exception:
+            log.warning("hardware candidate %s failed", label, exc_info=True)
+            continue
+        if d is not None:
+            return HardwareInfo(
+                device=d["device"],
+                device_type=d["device_type"],
+                device_name=d["device_name"],
+                vram_total_gb=d["vram_total_gb"],
+                vram_free_gb=d["vram_free_gb"],
+                cpu_arch=cpu["cpu_arch"],
+                cpu_brand=cpu["cpu_brand"],
+                system_ram_gb=cpu["system_ram_gb"],
+                requested_device=requested,
+                fallback_reason=None,
+            )
+
     return HardwareInfo(
         device="cpu",
         device_type="cpu",
@@ -127,6 +196,6 @@ def _detect() -> HardwareInfo:
         cpu_arch=cpu["cpu_arch"],
         cpu_brand=cpu["cpu_brand"],
         system_ram_gb=cpu["system_ram_gb"],
-        requested_device="auto",
+        requested_device=requested,
         fallback_reason=None,
     )

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -9,7 +9,6 @@ Public surface:
   HardwareInfo            -- frozen dataclass returned by get_hardware()
   get_hardware()          -- cached singleton; first call performs detection
   reset_for_test()        -- test-only cache reset
-  recommended_batch_size  -- table-driven, override-aware
 
 Subsequent tasks fill in detection logic; Task 2 lays the dataclass +
 singleton plumbing only.

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -17,10 +17,50 @@ singleton plumbing only.
 from __future__ import annotations
 
 import logging
+import platform
 from dataclasses import dataclass, field
-from typing import Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 
 log = logging.getLogger("helix.hardware")
+
+
+def _cpuinfo_get_info() -> Optional[Dict[str, Any]]:
+    """Wrap py-cpuinfo behind a function so tests can mock it cleanly.
+    Returns None if py-cpuinfo isn't installed."""
+    try:
+        import cpuinfo
+    except ImportError:
+        return None
+    try:
+        return cpuinfo.get_cpu_info()
+    except Exception:
+        log.warning("py-cpuinfo get_cpu_info() raised; falling back", exc_info=True)
+        return None
+
+
+def _detect_cpu() -> Dict[str, Any]:
+    """Detect cpu_arch, cpu_brand, system_ram_gb. Pure dict to keep
+    HardwareInfo construction in one place (in _detect)."""
+    info = _cpuinfo_get_info()
+    if info and info.get("brand_raw"):
+        cpu_brand = info["brand_raw"]
+    else:
+        proc = platform.processor()
+        cpu_brand = proc if proc else "unknown CPU"
+
+    try:
+        import psutil
+        ram_bytes = psutil.virtual_memory().total
+        system_ram_gb = ram_bytes / (1024 ** 3)
+    except Exception:
+        log.warning("psutil.virtual_memory() failed; system_ram_gb=0", exc_info=True)
+        system_ram_gb = 0.0
+
+    return {
+        "cpu_arch": platform.machine() or "unknown",
+        "cpu_brand": cpu_brand,
+        "system_ram_gb": system_ram_gb,
+    }
 
 
 @dataclass(frozen=True)
@@ -59,17 +99,16 @@ def reset_for_test() -> None:
 
 
 def _detect() -> HardwareInfo:
-    """Stub — filled in by Tasks 3-10. Returns a synthetic CPU info for now
-    so Task 2's tests pass."""
+    cpu = _detect_cpu()
     return HardwareInfo(
         device="cpu",
         device_type="cpu",
-        device_name="unknown CPU",
+        device_name=cpu["cpu_brand"],
         vram_total_gb=None,
         vram_free_gb=None,
-        cpu_arch="unknown",
-        cpu_brand="unknown CPU",
-        system_ram_gb=0.0,
+        cpu_arch=cpu["cpu_arch"],
+        cpu_brand=cpu["cpu_brand"],
+        system_ram_gb=cpu["system_ram_gb"],
         requested_device="auto",
         fallback_reason=None,
     )

--- a/helix_context/hardware.py
+++ b/helix_context/hardware.py
@@ -8,6 +8,7 @@ loudly to CPU on probe failure but never block. See:
 Public surface:
   HardwareInfo            -- frozen dataclass returned by get_hardware()
   get_hardware()          -- cached singleton; first call performs detection
+  recommended_batch_size(model) -- per-model batch size from table or override
   reset_for_test()        -- test-only cache reset
 
 Subsequent tasks add detection logic incrementally.
@@ -272,3 +273,58 @@ def _detect() -> HardwareInfo:
         requested_device=requested,
         fallback_reason=fallback_reason,
     )
+
+
+# Batch-size table — keys are (device_type, ram_threshold_gb_min).
+# Lookup picks the highest threshold row whose minimum is <= the
+# observed value. See spec §7.1 for calibration rationale.
+_BATCH_TABLE: Dict[tuple, Dict[str, int]] = {
+    # CUDA / ROCm tiers — keyed on TOTAL VRAM (invariant per GPU).
+    ("cuda", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
+    ("cuda", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
+    ("cuda",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("cuda",  4.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("cuda",  0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
+    ("rocm", 24.0): {"rerank": 64, "splice": 128, "splade": 32, "nli": 32},
+    ("rocm", 12.0): {"rerank": 32, "splice": 64,  "splade": 16, "nli": 16},
+    ("rocm",  8.0): {"rerank": 16, "splice": 32,  "splade":  8, "nli":  8},
+    ("rocm",  4.0): {"rerank":  8, "splice": 16,  "splade":  4, "nli":  4},
+    ("rocm",  0.0): {"rerank":  4, "splice":  8,  "splade":  2, "nli":  2},
+    # MPS — keyed on system_ram_gb (MPS shares system RAM).
+    ("mps", 16.0): {"rerank": 16, "splice": 32, "splade":  8, "nli":  8},
+    ("mps",  8.0): {"rerank":  8, "splice": 16, "splade":  4, "nli":  4},
+    ("mps",  0.0): {"rerank":  4, "splice":  8, "splade":  2, "nli":  2},
+    # CPU — keyed on system_ram_gb.
+    ("cpu", 16.0): {"rerank":  8, "splice": 16, "splade":  4, "nli":  4},
+    ("cpu",  8.0): {"rerank":  4, "splice":  8, "splade":  2, "nli":  2},
+    ("cpu",  0.0): {"rerank":  2, "splice":  4, "splade":  1, "nli":  1},
+}
+
+
+def _lookup_batch_size(device_type: str, tier_value: float, model: str) -> int:
+    """Find the highest-threshold row whose min <= tier_value."""
+    matching = [
+        (threshold, row[model])
+        for (dt, threshold), row in _BATCH_TABLE.items()
+        if dt == device_type and threshold <= tier_value and model in row
+    ]
+    if not matching:
+        return 1  # ultra-conservative floor for unknown model / table miss
+    matching.sort(reverse=True)
+    return matching[0][1]
+
+
+def recommended_batch_size(model: str) -> int:
+    """Resolve batch size for `model`. Order:
+    1. info.batch_size_overrides[model] if present
+    2. _BATCH_TABLE lookup based on device_type + (vram_total_gb or system_ram_gb)
+    3. Conservative floor (1) for unknown models.
+    """
+    info = get_hardware()
+    if model in info.batch_size_overrides:
+        return info.batch_size_overrides[model]
+    if info.device_type in {"cuda", "rocm"}:
+        tier = info.vram_total_gb if info.vram_total_gb is not None else 0.0
+    else:
+        tier = info.system_ram_gb
+    return _lookup_batch_size(info.device_type, tier, model)

--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -651,6 +651,15 @@ def main(argv: Optional[list] = None) -> int:
         except Exception:
             log.warning("update balloon scheduling failed", exc_info=True)
 
+        # Surface the hardware-fallback balloon (spec §6 third surface) —
+        # fires once per (requested, active) state change. Mirrors the
+        # install-pending balloon pattern above. Defer past notify_update
+        # so balloons don't stack on top of each other on startup.
+        try:
+            threading.Timer(3.0, tray_icon.notify_hardware_fallback).start()
+        except Exception:
+            log.warning("hardware-fallback balloon scheduling failed", exc_info=True)
+
         log.info("Tray mode active — dashboard at %s", url)
         log.info("Click the tray icon to open the dashboard; Quit from its menu to exit.")
         tray_icon.run()  # blocks until Quit

--- a/helix_context/launcher/tray.py
+++ b/helix_context/launcher/tray.py
@@ -96,6 +96,56 @@ def _build_icon_image(size: int = 64):
     return img
 
 
+# ── Hardware-fallback balloon (spec §6, Task 13) ──────────────────────
+#
+# Mirrors the install-pending balloon pattern used by the
+# native-observability sidecar PR. Sentinel filename encodes the
+# (requested, active) tuple so a state-change re-fires the balloon
+# while same-state re-launches stay quiet.
+
+
+def _hardware_fallback_sentinel_path(requested: str, active: str) -> Path:
+    """Sentinel filename encodes the (requested, active) tuple so a
+    state-change re-fires the balloon."""
+    from helix_context.launcher.observability_paths import state_dir
+    return state_dir(create=True) / f".hardware-fallback-acknowledged-{requested}-{active}"
+
+
+def _should_fire_hardware_fallback_balloon() -> bool:
+    """True iff there is an active fallback AND the sentinel for the
+    current (requested, active) tuple does not yet exist."""
+    from helix_context.hardware import get_hardware
+    info = get_hardware()
+    if info.fallback_reason is None:
+        return False
+    sentinel = _hardware_fallback_sentinel_path(info.requested_device, info.device_type)
+    return not sentinel.exists()
+
+
+def _fire_hardware_fallback_balloon(tray_icon) -> None:
+    """Fire a one-shot balloon describing the fallback. Caller should
+    write the sentinel after firing (so re-launches don't nag)."""
+    from helix_context.hardware import get_hardware
+    info = get_hardware()
+    if info.fallback_reason is None:
+        return
+    title = "Helix: device fallback active"
+    msg = (
+        f"Requested {info.requested_device!r}, using {info.device_type!r}. "
+        f"Reason: {info.fallback_reason}"
+    )
+    try:
+        tray_icon.notify(msg, title)
+    except Exception:
+        log.warning("Tray balloon failed; fallback only logged", exc_info=True)
+        return
+    sentinel = _hardware_fallback_sentinel_path(info.requested_device, info.device_type)
+    try:
+        sentinel.touch()
+    except Exception:
+        log.warning("Could not write hardware-fallback sentinel %s", sentinel, exc_info=True)
+
+
 class HelixTrayIcon:
     """Wraps a pystray.Icon with launcher-aware menu actions.
 
@@ -725,6 +775,21 @@ class HelixTrayIcon:
             log.warning("notify_install_needed failed", exc_info=True)
         # Pulse the Observability submenu label until acknowledged.
         self.start_install_pulse()
+
+    def notify_hardware_fallback(self) -> None:
+        """Show a Windows balloon when the active device differs from the
+        requested device (spec §6 third surface). Sentinel-file dedup
+        ensures the balloon fires once per (requested, active) state
+        change — same-state re-launches stay quiet.
+
+        Mirrors the install-pending balloon pattern from the
+        native-observability sidecar PR.
+        """
+        if self._icon is None:
+            return
+        if not _should_fire_hardware_fallback_balloon():
+            return
+        _fire_hardware_fallback_balloon(self._icon)
 
     def notify_update_available(self) -> None:
         """Show a one-shot balloon when a newer Helix Context release exists."""

--- a/helix_context/nli_backend.py
+++ b/helix_context/nli_backend.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
@@ -44,14 +44,14 @@ class NLIClassifier:
     def __init__(
         self,
         model_path: str = "training/models/nli",
-        device: str = "auto",
+        device: Optional[str] = None,
     ):
         from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
-        if device == "auto":
-            self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        else:
-            self._device = torch.device(device)
+        if device is None or device == "auto":
+            from helix_context.hardware import get_hardware
+            device = get_hardware().device
+        self._device = torch.device(device)
 
         log.info("Loading NLI model from %s", model_path)
         self._tokenizer = AutoTokenizer.from_pretrained(model_path)
@@ -84,31 +84,47 @@ class NLIClassifier:
     def classify_batch(
         self, pairs: List[Tuple[str, str]]
     ) -> List[Tuple[NLRelation, float]]:
-        """Classify relations for a batch of text pairs."""
+        """Classify relations for a batch of text pairs.
+
+        Pairs are processed in chunks of ``recommended_batch_size("nli")`` to
+        keep peak VRAM bounded on long inputs. The hardware module returns the
+        per-device tier (with ``[hardware] batch_size_overrides.nli`` taking
+        precedence).
+        """
         if not pairs:
             return []
+
+        from helix_context.hardware import recommended_batch_size
+        batch_size = recommended_batch_size("nli")
 
         texts_a = [p[0] for p in pairs]
         texts_b = [p[1] for p in pairs]
 
-        encodings = self._tokenizer(
-            texts_a, texts_b,
-            truncation=True,
-            max_length=256,
-            padding=True,
-            return_tensors="pt",
-        ).to(self._device)
+        all_results: List[Tuple[NLRelation, float]] = []
+        for i in range(0, len(texts_a), batch_size):
+            chunk_a = texts_a[i : i + batch_size]
+            chunk_b = texts_b[i : i + batch_size]
 
-        with torch.no_grad():
-            outputs = self._model(**encodings)
-            probs = torch.softmax(outputs.logits, dim=-1)
-            pred_classes = probs.argmax(dim=-1).cpu().tolist()
-            confidences = probs.max(dim=-1).values.cpu().tolist()
+            encodings = self._tokenizer(
+                chunk_a, chunk_b,
+                truncation=True,
+                max_length=256,
+                padding=True,
+                return_tensors="pt",
+            ).to(self._device)
 
-        return [
-            (NLRelation(cls), conf)
-            for cls, conf in zip(pred_classes, confidences)
-        ]
+            with torch.no_grad():
+                outputs = self._model(**encodings)
+                probs = torch.softmax(outputs.logits, dim=-1)
+                pred_classes = probs.argmax(dim=-1).cpu().tolist()
+                confidences = probs.max(dim=-1).values.cpu().tolist()
+
+            all_results.extend(
+                (NLRelation(cls), conf)
+                for cls, conf in zip(pred_classes, confidences)
+            )
+
+        return all_results
 
     def build_relation_graph(
         self, genes: List[Gene]

--- a/helix_context/sema.py
+++ b/helix_context/sema.py
@@ -123,6 +123,10 @@ class SemaCodec:
         model_name: str = "all-MiniLM-L6-v2",
         device: Optional[str] = None,
     ):
+        if device is None or device == "auto":
+            from helix_context.hardware import get_hardware
+            device = get_hardware().device
+
         from sentence_transformers import SentenceTransformer
 
         self._model = SentenceTransformer(model_name, device=device)

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -2258,6 +2258,27 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
         else:
             message = "Upstream model server is unreachable; final chat proxy calls will fail."
 
+        # Hardware fallback surface — operators need to see at a glance
+        # whether we ended up on CPU because cuda probe failed, or whether
+        # we're on a low-VRAM tier where batch sizes will be conservative.
+        # See docs/specs/2026-05-04-hardware-detection-design.md §5.7.
+        from helix_context.hardware import get_hardware
+        hw_info = get_hardware()
+        low_vram = bool(
+            hw_info.vram_total_gb is not None
+            and hw_info.vram_total_gb < config.hardware.low_vram_threshold_gb
+        )
+        hardware_block = {
+            "device": hw_info.device,
+            "device_name": hw_info.device_name,
+            "requested_device": hw_info.requested_device,
+            "fallback_active": hw_info.fallback_reason is not None,
+            "fallback_reason": hw_info.fallback_reason,
+            "vram_total_gb": hw_info.vram_total_gb,
+            "system_ram_gb": hw_info.system_ram_gb,
+            "low_vram_warning": low_vram,
+        }
+
         # Intentionally minimized response — documented contract in
         # CLAUDE.md is "ribosome model, gene count, upstream URL". We keep
         # those and omit raw error strings, cost class, and the full
@@ -2272,6 +2293,7 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
             "genes": total_genes,
             "upstream": config.server.upstream,
             "upstream_reachable": upstream_reachable,
+            "hardware": hardware_block,
             "checks": {
                 "genome_ready": genome_ready,
                 "upstream_ready": upstream_reachable,

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -349,6 +349,20 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
     if config is None:
         config = load_config()
 
+    # ── Hardware init MUST happen BEFORE any backend constructs. ────
+    # The hardware singleton caches on first ``get_hardware()`` call;
+    # if any backend (deberta / nli / splade / sema) calls
+    # ``get_hardware()`` before ``init_from_config()`` runs, the
+    # singleton caches an env-only result and the config-supplied
+    # ``device`` + ``batch_size_overrides`` are silently lost. The
+    # regression is pinned in
+    # tests/test_hardware.py::test_init_from_config_must_run_before_get_hardware.
+    from .hardware import init_from_config
+    init_from_config(
+        config_device=config.hardware.device,
+        batch_size_overrides=config.hardware.batch_sizes,
+    )
+
     # ── Cost-visibility startup warning (W2-B) ─────────────────────
     # Surface paid-API ribosome backends loudly so operators are
     # never surprised by metered cost. Local-first is the helix

--- a/helix_context/splade_backend.py
+++ b/helix_context/splade_backend.py
@@ -43,7 +43,9 @@ def _ensure_loaded(model_name: str = "naver/splade-cocondenser-ensembledistil"):
     import torch
     from transformers import AutoModelForMaskedLM, AutoTokenizer
 
-    _device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    from helix_context.hardware import get_hardware
+
+    _device = torch.device(get_hardware().device)
     _tokenizer = AutoTokenizer.from_pretrained(model_name)
     _model = AutoModelForMaskedLM.from_pretrained(model_name).to(_device)
     _model.eval()
@@ -100,16 +102,24 @@ def encode(text: str, top_k: int = 128, model_name: str = "naver/splade-coconden
 def encode_batch(
     texts: List[str],
     top_k: int = 128,
-    batch_size: int = 16,
+    batch_size: Optional[int] = None,
     model_name: str = "naver/splade-cocondenser-ensembledistil",
 ) -> List[Dict[str, float]]:
     """
     Batch-encode texts into SPLADE sparse vectors.
     More efficient than calling encode() in a loop due to batched forward passes.
+
+    ``batch_size`` defaults to ``recommended_batch_size("splade")`` when unset,
+    sized for the detected hardware (VRAM tier on CUDA/ROCm, system RAM on
+    MPS/CPU). Pass an explicit value to override.
     """
     import torch
 
     _ensure_loaded(model_name)
+
+    if batch_size is None:
+        from helix_context.hardware import recommended_batch_size
+        batch_size = recommended_batch_size("splade")
 
     results: List[Dict[str, float]] = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,16 +58,16 @@ otel = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.27",
     "opentelemetry-instrumentation-fastapi>=0.48b0",
 ]
-launcher = ["jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0"]
+launcher = ["jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0"]
 launcher-native = [
-    "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0",
+    "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0",
     "pywebview>=5.0",
 ]
 # pystray is LGPL-3. It is a runtime-only optional dep that the user
 # installs explicitly; the helix-context wheel itself does not bundle
 # pystray, so the core package stays Apache-2.0-clean.
 launcher-tray = [
-    "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0",
+    "jinja2>=3.1", "psutil>=5.9", "platformdirs>=4.0", "py-cpuinfo>=9.0",
     "pystray>=0.19", "Pillow>=10",
     "pywin32>=306; sys_platform == 'win32'",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,3 +35,84 @@ def test_budget_abstain_enabled_toml_override(tmp_path):
     )
     cfg = load_config(str(toml))
     assert cfg.budget.abstain_enabled is False
+
+
+# ── Hardware section + ribosome.device deprecation shim (Task 9) ─────
+# Tests pin parsing of the [hardware] TOML section and the deprecation
+# warning emitted for legacy [ribosome] device usage. See
+# docs/specs/2026-05-04-hardware-detection-design.md for the contract.
+
+from helix_context.config import load_config
+
+
+def test_hardware_section_parses(tmp_path):
+    """[hardware] section parses with all defaults."""
+    cfg_text = """
+[hardware]
+device = "cuda"
+batch_sizes = "auto"
+low_vram_threshold_gb = 4.0
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    cfg = load_config(str(p))
+    assert cfg.hardware.device == "cuda"
+    assert cfg.hardware.batch_sizes == {}
+    assert cfg.hardware.low_vram_threshold_gb == 4.0
+
+
+def test_hardware_section_batch_sizes_dict(tmp_path):
+    cfg_text = """
+[hardware]
+device = "auto"
+batch_sizes = { rerank = 16, splice = 32 }
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    cfg = load_config(str(p))
+    assert cfg.hardware.batch_sizes == {"rerank": 16, "splice": 32}
+
+
+def test_ribosome_device_deprecation_warning(tmp_path, caplog):
+    """[ribosome] device alone (no [hardware]) triggers deprecation warning."""
+    cfg_text = """
+[ribosome]
+device = "cuda"
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    with caplog.at_level("WARNING", logger="helix_context.config"):
+        cfg = load_config(str(p))
+    assert cfg.hardware.device == "cuda"
+    assert any(
+        "ribosome" in rec.message.lower() and "deprecated" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_hardware_overrides_ribosome_device(tmp_path, caplog):
+    """When both are set, [hardware] wins; warning still fires noting override."""
+    cfg_text = """
+[ribosome]
+device = "cpu"
+
+[hardware]
+device = "cuda"
+"""
+    p = tmp_path / "helix.toml"
+    p.write_text(cfg_text)
+    with caplog.at_level("WARNING", logger="helix_context.config"):
+        cfg = load_config(str(p))
+    assert cfg.hardware.device == "cuda"
+    assert any(
+        "deprecated" in rec.message.lower() and "override" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_no_device_config_defaults_to_auto(tmp_path):
+    p = tmp_path / "helix.toml"
+    p.write_text("# empty\n")
+    cfg = load_config(str(p))
+    assert cfg.hardware.device == "auto"
+    assert cfg.hardware.batch_sizes == {}

--- a/tests/test_deberta_backend.py
+++ b/tests/test_deberta_backend.py
@@ -1,0 +1,192 @@
+"""Unit tests for helix_context.deberta_backend (mocked tokenizer + model).
+
+Exists separately from tests/test_ribosome.py because that file tests the
+Ollama-backed Ribosome class with MockBackend, not the DeBERTa cross-encoder
+backend. The chunked-batch tests below pin that re_rank/splice consume
+recommended_batch_size from the hardware module instead of one-shot
+tokenizing all pairs.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from helix_context import hardware
+from helix_context.schemas import Gene, PromoterTags
+
+
+@pytest.fixture(autouse=True)
+def _reset_hardware_cache():
+    hardware.reset_for_test()
+    yield
+    hardware.reset_for_test()
+
+
+def _override_hardware(monkeypatch, *, rerank_batch=None, splice_batch=None):
+    """Force hardware singleton onto cpu with specific batch overrides."""
+    overrides = {}
+    if rerank_batch is not None:
+        overrides["rerank"] = rerank_batch
+    if splice_batch is not None:
+        overrides["splice"] = splice_batch
+    info = hardware.HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name="test",
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch="x86_64",
+        cpu_brand="test",
+        system_ram_gb=16.0,
+        requested_device="auto",
+        fallback_reason=None,
+        batch_size_overrides=overrides,
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: info)
+
+
+def _make_gene(gene_id: str, *, content: str = "hello world",
+               summary: str = "summary text", domains=None, codons=None) -> Gene:
+    """Build a minimal Gene that satisfies re_rank's pair-builder.
+
+    re_rank reads g.promoter.summary and g.promoter.domains; splice reads
+    g.codons. Other Gene fields fall back to schema defaults.
+    """
+    return Gene(
+        gene_id=gene_id,
+        content=content,
+        complement=content[:80],
+        codons=codons if codons is not None else ["c1", "c2"],
+        promoter=PromoterTags(summary=summary, domains=domains or []),
+    )
+
+
+class _FakeEncodings(dict):
+    """Dict that supports .to(device) the way HF BatchEncoding does."""
+
+    def to(self, device):  # noqa: D401 - mimic HF BatchEncoding
+        return self
+
+
+def _make_tokenizer_mock(scores_per_call):
+    """Tokenizer mock whose return value tracks the chunk size for the model.
+
+    Each call returns a fresh _FakeEncodings; we record the chunk size on
+    the encodings object so the model mock can produce a logits tensor of
+    matching length.
+    """
+    tok = MagicMock()
+
+    def _call(texts_a, texts_b, **kwargs):
+        # Record chunk length so the model knows how many scores to emit.
+        chunk_len = len(texts_a)
+        scores_per_call.append(chunk_len)
+        enc = _FakeEncodings(input_ids=torch.zeros(chunk_len, 1, dtype=torch.long))
+        return enc
+
+    tok.side_effect = _call
+    return tok
+
+
+def _make_model_mock(scores_per_call):
+    """Model mock that emits zeros(chunk_len) so re_rank's clamp/tolist works."""
+    model = MagicMock()
+
+    def _call(**kwargs):
+        # The most recent tokenizer call recorded its chunk_len; use it.
+        chunk_len = scores_per_call[-1]
+        out = MagicMock()
+        out.logits = torch.zeros(chunk_len)
+        return out
+
+    model.side_effect = _call
+    return model
+
+
+def test_deberta_rerank_chunks_in_recommended_batch_size(monkeypatch):
+    """Force batch=16 via override; feed 100 candidates; expect 7 tokenizer
+    calls (6 full + 1 partial of 4)."""
+    _override_hardware(monkeypatch, rerank_batch=16)
+
+    from helix_context.deberta_backend import DeBERTaRibosome
+
+    rib = DeBERTaRibosome.__new__(DeBERTaRibosome)  # bypass __init__
+    rib._device = torch.device("cpu")
+    rib._rerank_pretrained = False
+
+    chunk_log: list[int] = []
+    rib._rerank_tokenizer = _make_tokenizer_mock(chunk_log)
+    rib._rerank_model = _make_model_mock(chunk_log)
+
+    candidates = [_make_gene(f"g_{i}") for i in range(100)]
+    rib.re_rank("query", candidates, k=10)
+
+    # 100 candidates / 16 batch = 6 full + 1 partial = 7 tokenizer calls.
+    assert rib._rerank_tokenizer.call_count == 7
+    # Chunk sizes recorded in order: six 16s + one 4.
+    assert chunk_log == [16, 16, 16, 16, 16, 16, 4]
+
+
+def test_deberta_splice_chunks_in_recommended_batch_size(monkeypatch):
+    """Force batch=16 via splice override; feed 50 codons across 5 genes;
+    expect ceil(50/16) = 4 tokenizer calls (16 + 16 + 16 + 2)."""
+    _override_hardware(monkeypatch, splice_batch=16)
+
+    from helix_context.deberta_backend import DeBERTaRibosome
+
+    rib = DeBERTaRibosome.__new__(DeBERTaRibosome)  # bypass __init__
+    rib._device = torch.device("cpu")
+    rib.splice_threshold = 0.5
+
+    chunk_log: list[int] = []
+    rib._splice_tokenizer = _make_tokenizer_mock(chunk_log)
+    rib._splice_model = _make_model_mock(chunk_log)
+
+    # 5 genes x 10 codons = 50 (query, codon) pairs.
+    genes = [
+        _make_gene(f"g_{gi}", codons=[f"codon_{gi}_{ci}" for ci in range(10)])
+        for gi in range(5)
+    ]
+    rib.splice("query", genes)
+
+    assert rib._splice_tokenizer.call_count == 4
+    assert chunk_log == [16, 16, 16, 2]
+
+
+def test_deberta_init_consults_get_hardware_when_device_none(monkeypatch):
+    """Passing device=None must defer to hardware.get_hardware().device.
+
+    We don't actually load tokenizers/models — we monkeypatch the
+    transformers loaders to return inert mocks and verify the resulting
+    self._device matches the hardware singleton. Skips when transformers
+    isn't installed (ribosome backend can still be unit-tested without it
+    via the chunking tests above, which bypass __init__).
+    """
+    pytest.importorskip("transformers")
+
+    _override_hardware(monkeypatch, rerank_batch=8)
+
+    import helix_context.deberta_backend as db
+
+    monkeypatch.setattr(
+        "transformers.AutoTokenizer.from_pretrained",
+        lambda *a, **kw: MagicMock(),
+    )
+
+    fake_model = MagicMock()
+    fake_model.to = lambda dev: fake_model
+    fake_model.train = lambda flag: None
+    monkeypatch.setattr(
+        "transformers.AutoModelForSequenceClassification.from_pretrained",
+        lambda *a, **kw: fake_model,
+    )
+
+    rib = db.DeBERTaRibosome(
+        rerank_model_path="x",
+        splice_model_path="y",
+        nli_model_path="z",
+        device=None,
+    )
+    assert str(rib._device) == "cpu"

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -98,3 +98,38 @@ def test_system_ram_via_psutil(monkeypatch):
     monkeypatch.setattr("psutil.virtual_memory", lambda: _FakeVM())
     info = hardware._detect_cpu()
     assert info["system_ram_gb"] == pytest.approx(64.0, rel=1e-3)
+
+
+def test_probe_success(monkeypatch):
+    """Round-trip succeeds -> (True, None)."""
+    class _FakeTensor:
+        def to(self, device): return self
+        def cpu(self): return self
+    monkeypatch.setattr("torch.zeros", lambda *a, **kw: _FakeTensor())
+    ok, reason = hardware._probe("cuda:0")
+    assert ok is True
+    assert reason is None
+
+
+def test_probe_failure_returns_reason(monkeypatch):
+    """torch.zeros() raises -> (False, formatted reason)."""
+    def _raise(*a, **kw):
+        raise RuntimeError("CUDA driver version is insufficient")
+    monkeypatch.setattr("torch.zeros", _raise)
+    ok, reason = hardware._probe("cuda:0")
+    assert ok is False
+    assert reason is not None
+    assert "RuntimeError" in reason
+    assert "CUDA driver version is insufficient" in reason
+
+
+def test_probe_to_failure(monkeypatch):
+    """torch.zeros() succeeds but .to(device) raises -> probe fails."""
+    class _BadTensor:
+        def to(self, device):
+            raise RuntimeError("device not available")
+        def cpu(self): return self
+    monkeypatch.setattr("torch.zeros", lambda *a, **kw: _BadTensor())
+    ok, reason = hardware._probe("cuda:0")
+    assert ok is False
+    assert "device not available" in reason

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -291,3 +291,63 @@ def test_multi_gpu_all_dead_falls_through_to_cpu(mock_torch):
     mock_torch["probe_results"]["cuda:1"] = (False, "bad")
     info = hardware._detect()
     assert info.device_type == "cpu"
+
+
+def test_explicit_cuda_succeeds(mock_torch, monkeypatch):
+    monkeypatch.setenv("HELIX_DEVICE", "cuda")
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    info = hardware._detect()
+    assert info.device_type == "cuda"
+    assert info.requested_device == "cuda"
+    assert info.fallback_reason is None
+
+
+def test_explicit_cuda_falls_back_to_cpu_on_probe_failure(mock_torch, monkeypatch):
+    """Explicit cuda + no GPU available -> cpu directly (NOT rocm/mps even if available).
+
+    Spec §5.4 asymmetry: auto picks the best available; explicit means
+    'I want this exactly, downgrade to CPU if not there'."""
+    monkeypatch.setenv("HELIX_DEVICE", "cuda")
+    mock_torch["cuda_available"] = False
+    mock_torch["mps_available"] = True
+    mock_torch["mps_built"] = True
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.fallback_reason is not None
+    assert "cuda" in info.fallback_reason.lower()
+
+
+def test_helix_device_env_var_case_insensitive(mock_torch, monkeypatch):
+    monkeypatch.setenv("HELIX_DEVICE", "CPU")
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.requested_device == "cpu"
+
+
+def test_helix_device_env_var_invalid_falls_back_to_auto(mock_torch, monkeypatch, caplog):
+    monkeypatch.setenv("HELIX_DEVICE", "nonsense")
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    import logging
+    with caplog.at_level(logging.WARNING, logger="helix.hardware"):
+        info = hardware._detect()
+    assert info.requested_device == "auto"
+    assert info.device_type == "cuda"
+    assert any(
+        "invalid helix_device" in rec.message.lower()
+        or "ignoring helix_device" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_explicit_mps_on_non_mps_host_falls_back_to_cpu(mock_torch, monkeypatch):
+    monkeypatch.setenv("HELIX_DEVICE", "mps")
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.fallback_reason is not None
+    assert "mps" in info.fallback_reason.lower()

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -236,3 +236,58 @@ def test_auto_falls_through_when_cuda_probe_fails(mock_torch):
     mock_torch["mps_built"] = True
     info = hardware._detect()
     assert info.device_type == "mps"
+
+
+def test_multi_gpu_picks_largest_free_vram(mock_torch):
+    """Two healthy GPUs — pick the one with more free VRAM."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["RTX 3070", "RTX 4090"]
+    mock_torch["cuda_mem"] = [(4.0, 8.0), (22.0, 24.0)]
+    info = hardware._detect()
+    assert info.device == "cuda:1"
+    assert info.device_name == "RTX 4090"
+
+
+def test_multi_gpu_dead_first_device_falls_through(mock_torch, monkeypatch):
+    """device-0 mem_get_info raises (dead); device-1 healthy. Pick cuda:1."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["DeadCard", "RTX 4090"]
+    mock_torch["cuda_mem"] = [(0.0, 0.0), (22.0, 24.0)]
+
+    def _mem(i):
+        if i == 0:
+            raise RuntimeError("device 0 is dead")
+        free_gb, total_gb = mock_torch["cuda_mem"][i]
+        return (int(free_gb * 1024**3), int(total_gb * 1024**3))
+    monkeypatch.setattr("torch.cuda.mem_get_info", _mem)
+
+    info = hardware._detect()
+    assert info.device == "cuda:1"
+    assert info.device_name == "RTX 4090"
+
+
+def test_multi_gpu_probe_failure_on_best_falls_through(mock_torch):
+    """Best-VRAM device probe fails; pick the next-best healthy one."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["RTX 4090 (broken)", "RTX 3070"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0), (6.0, 8.0)]
+    mock_torch["probe_results"]["cuda:0"] = (False, "RuntimeError: kernel launch failed")
+    info = hardware._detect()
+    assert info.device == "cuda:1"
+    assert info.device_name == "RTX 3070"
+
+
+def test_multi_gpu_all_dead_falls_through_to_cpu(mock_torch):
+    """All CUDA devices fail their probes -> CUDA candidate rejected,
+    auto-mode falls through to CPU (no MPS in this scenario)."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 2
+    mock_torch["cuda_device_names"] = ["broken1", "broken2"]
+    mock_torch["cuda_mem"] = [(4.0, 8.0), (4.0, 8.0)]
+    mock_torch["probe_results"]["cuda:0"] = (False, "bad")
+    mock_torch["probe_results"]["cuda:1"] = (False, "bad")
+    info = hardware._detect()
+    assert info.device_type == "cpu"

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,59 @@
+"""Unit tests for helix_context.hardware (mocked-torch).
+
+All tests use monkeypatch to mock torch internals — they never touch a real
+GPU. Pattern mirrors tests/test_observability_paths.py.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import pytest
+
+from helix_context import hardware
+
+
+@pytest.fixture(autouse=True)
+def _reset_hardware_cache():
+    """Every test starts with a clean singleton."""
+    hardware.reset_for_test()
+    yield
+    hardware.reset_for_test()
+
+
+def test_hardware_info_is_frozen():
+    info = hardware.HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name="Test CPU",
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch="x86_64",
+        cpu_brand="Test CPU",
+        system_ram_gb=16.0,
+        requested_device="auto",
+        fallback_reason=None,
+        batch_size_overrides={},
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        info.device = "cuda:0"  # type: ignore[misc]
+
+
+def test_reset_for_test_clears_cached_singleton(monkeypatch):
+    """get_hardware() must recompute after reset_for_test()."""
+    sentinel = hardware.HardwareInfo(
+        device="cpu", device_type="cpu", device_name="Sentinel",
+        vram_total_gb=None, vram_free_gb=None,
+        cpu_arch="x86_64", cpu_brand="Sentinel CPU",
+        system_ram_gb=16.0, requested_device="auto",
+        fallback_reason=None, batch_size_overrides={},
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: sentinel)
+    info1 = hardware.get_hardware()
+    assert info1.device_name == "Sentinel"
+    monkeypatch.setattr(hardware, "_detect", lambda: dataclasses.replace(sentinel, device_name="Other"))
+    info2 = hardware.get_hardware()
+    assert info2.device_name == "Sentinel"  # still cached
+    hardware.reset_for_test()
+    info3 = hardware.get_hardware()
+    assert info3.device_name == "Other"

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -351,3 +351,76 @@ def test_explicit_mps_on_non_mps_host_falls_back_to_cpu(mock_torch, monkeypatch)
     assert info.device_type == "cpu"
     assert info.fallback_reason is not None
     assert "mps" in info.fallback_reason.lower()
+
+
+def test_batch_size_24gb_cuda_tier(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 64
+    assert hardware.recommended_batch_size("splice") == 128
+    assert hardware.recommended_batch_size("splade") == 32
+    assert hardware.recommended_batch_size("nli") == 32
+
+
+def test_batch_size_4gb_cuda_tier(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["GTX 1650"]
+    mock_torch["cuda_mem"] = [(3.5, 4.0)]
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 8
+
+
+def test_batch_size_under_4gb_cuda_tier(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["MX150"]
+    mock_torch["cuda_mem"] = [(1.5, 2.0)]
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 4
+
+
+def test_batch_size_cpu_tier_uses_system_ram(monkeypatch, mock_torch):
+    """CPU batch sizes key on system_ram_gb, not VRAM."""
+    class _FakeVM:
+        total = 16 * 1024 ** 3  # 16 GiB
+    monkeypatch.setattr("psutil.virtual_memory", lambda: _FakeVM())
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 8
+
+
+def test_batch_size_total_not_free_drives_lookup(mock_torch):
+    """Even if free VRAM is tiny, total VRAM picks the tier.
+
+    Regression pin for spec-review B3 — vram_free_gb is informational
+    only; the table keys on vram_total_gb.
+    """
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(0.5, 24.0)]  # almost all VRAM in use
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("rerank") == 64  # 24GB tier wins
+
+
+def test_batch_size_override_beats_table(mock_torch):
+    """batch_size_overrides field short-circuits the table lookup."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    info = hardware.get_hardware()
+    forced = dataclasses.replace(info, batch_size_overrides={"rerank": 16})
+    hardware._cached_info = forced  # direct cache poke for test
+    assert hardware.recommended_batch_size("rerank") == 16
+    assert hardware.recommended_batch_size("splice") == 128
+
+
+def test_batch_size_unknown_model_returns_minimum(mock_torch):
+    """Asking for a model not in the table returns the conservative floor."""
+    hardware.reset_for_test()
+    assert hardware.recommended_batch_size("unknown_model") == 1

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -56,3 +56,45 @@ def test_reset_for_test_clears_cached_singleton(monkeypatch):
     hardware.reset_for_test()
     info3 = hardware.get_hardware()
     assert info3.device_name == "Other"
+
+
+def test_cpu_brand_from_py_cpuinfo(monkeypatch):
+    """When py-cpuinfo is installed and returns brand_raw, use it."""
+    fake_cpuinfo = {"brand_raw": "AMD Ryzen 9 7900X 12-Core Processor"}
+    monkeypatch.setattr(
+        "helix_context.hardware._cpuinfo_get_info",
+        lambda: fake_cpuinfo,
+    )
+    monkeypatch.setattr("platform.processor", lambda: "should not be used")
+    info = hardware._detect_cpu()
+    assert info["cpu_brand"] == "AMD Ryzen 9 7900X 12-Core Processor"
+
+
+def test_cpu_brand_falls_back_to_platform_processor(monkeypatch):
+    """When py-cpuinfo is absent, fall back to platform.processor()."""
+    monkeypatch.setattr("helix_context.hardware._cpuinfo_get_info", lambda: None)
+    monkeypatch.setattr("platform.processor", lambda: "Intel64 Family 6 Model 158")
+    info = hardware._detect_cpu()
+    assert info["cpu_brand"] == "Intel64 Family 6 Model 158"
+
+
+def test_cpu_brand_terminal_fallback(monkeypatch):
+    """When both sources fail, return 'unknown CPU' (no crash)."""
+    monkeypatch.setattr("helix_context.hardware._cpuinfo_get_info", lambda: None)
+    monkeypatch.setattr("platform.processor", lambda: "")
+    info = hardware._detect_cpu()
+    assert info["cpu_brand"] == "unknown CPU"
+
+
+def test_cpu_arch_uses_platform_machine(monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    info = hardware._detect_cpu()
+    assert info["cpu_arch"] == "x86_64"
+
+
+def test_system_ram_via_psutil(monkeypatch):
+    class _FakeVM:
+        total = 64 * 1024 * 1024 * 1024  # 64 GiB
+    monkeypatch.setattr("psutil.virtual_memory", lambda: _FakeVM())
+    info = hardware._detect_cpu()
+    assert info["system_ram_gb"] == pytest.approx(64.0, rel=1e-3)

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -7,7 +7,6 @@ GPU. Pattern mirrors tests/test_observability_paths.py.
 from __future__ import annotations
 
 import dataclasses
-import logging
 import pytest
 
 from helix_context import hardware

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -424,3 +424,41 @@ def test_batch_size_unknown_model_returns_minimum(mock_torch):
     """Asking for a model not in the table returns the conservative floor."""
     hardware.reset_for_test()
     assert hardware.recommended_batch_size("unknown_model") == 1
+
+
+# ── Config flow (Task 9) ────────────────────────────────────────────
+# init_from_config wires [hardware] section through to the singleton.
+
+def test_init_from_config_routes_through_singleton(mock_torch):
+    """init_from_config sets requested_device + batch_size_overrides."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    info = hardware.init_from_config(
+        config_device="cuda",
+        batch_size_overrides={"rerank": 8},
+    )
+    assert info.requested_device == "cuda"
+    assert info.batch_size_overrides == {"rerank": 8}
+    assert hardware.recommended_batch_size("rerank") == 8
+
+
+def test_init_from_config_must_run_before_get_hardware(mock_torch, monkeypatch):
+    """Regression pin: if get_hardware() runs before init_from_config(),
+    the cached singleton ignores config. This test documents that
+    server startup MUST call init_from_config() first."""
+    monkeypatch.setenv("HELIX_DEVICE", "auto")
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.0, 24.0)]
+    hardware.reset_for_test()
+    info_early = hardware.get_hardware()
+    assert info_early.batch_size_overrides == {}
+    info_late = hardware.init_from_config(
+        config_device="cuda",
+        batch_size_overrides={"rerank": 8},
+    )
+    assert info_late.batch_size_overrides == {}  # cache wins; config lost

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -133,3 +133,106 @@ def test_probe_to_failure(monkeypatch):
     ok, reason = hardware._probe("cuda:0")
     assert ok is False
     assert "device not available" in reason
+
+
+@pytest.fixture
+def mock_torch(monkeypatch):
+    """Shared torch mock for picker tests. Returns a state dict so each
+    test can configure which backends are advertised. Defaults: CPU-only.
+    """
+    state = {
+        "cuda_available": False,
+        "cuda_device_count": 0,
+        "cuda_device_names": [],
+        "cuda_mem": [],            # list of (free_gb, total_gb) per index
+        "hip_version": None,
+        "mps_available": False,
+        "mps_built": False,
+        "probe_results": {},       # device_str -> (ok, reason) overrides
+    }
+
+    def _is_available(): return state["cuda_available"]
+    def _device_count(): return state["cuda_device_count"]
+    def _get_device_name(i): return state["cuda_device_names"][i]
+    def _mem_get_info(i):
+        free_gb, total_gb = state["cuda_mem"][i]
+        return (int(free_gb * 1024**3), int(total_gb * 1024**3))
+    def _mps_is_available(): return state["mps_available"]
+    def _mps_is_built(): return state["mps_built"]
+
+    monkeypatch.setattr("torch.cuda.is_available", _is_available)
+    monkeypatch.setattr("torch.cuda.device_count", _device_count)
+    monkeypatch.setattr("torch.cuda.get_device_name", _get_device_name)
+    monkeypatch.setattr("torch.cuda.mem_get_info", _mem_get_info)
+    monkeypatch.setattr("torch.backends.mps.is_available", _mps_is_available)
+    monkeypatch.setattr("torch.backends.mps.is_built", _mps_is_built)
+
+    import torch
+    monkeypatch.setattr(torch.version, "hip", state["hip_version"], raising=False)
+
+    def _probe_stub(device_str: str):
+        if device_str in state["probe_results"]:
+            return state["probe_results"][device_str]
+        return (True, None)
+    monkeypatch.setattr(hardware, "_probe", _probe_stub)
+
+    def _set_hip(v):
+        state["hip_version"] = v
+        monkeypatch.setattr(torch.version, "hip", v, raising=False)
+    state["set_hip"] = _set_hip
+    return state
+
+
+def test_auto_picks_cuda_when_available(mock_torch):
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["NVIDIA GeForce RTX 4090"]
+    mock_torch["cuda_mem"] = [(22.4, 24.0)]
+    info = hardware._detect()
+    assert info.device_type == "cuda"
+    assert info.device == "cuda:0"
+    assert info.device_name == "NVIDIA GeForce RTX 4090"
+    assert info.vram_total_gb == pytest.approx(24.0, rel=1e-3)
+
+
+def test_auto_picks_cpu_when_nothing_available(mock_torch):
+    info = hardware._detect()
+    assert info.device_type == "cpu"
+    assert info.device == "cpu"
+
+
+def test_auto_picks_rocm_when_hip_advertised(mock_torch):
+    """ROCm builds set torch.version.hip; cuda.is_available() also returns
+    True on a ROCm build (HIP devices surface through the cuda API)."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["AMD Radeon RX 7900 XTX"]
+    mock_torch["cuda_mem"] = [(20.0, 24.0)]
+    mock_torch["set_hip"]("5.7.0")
+    info = hardware._detect()
+    assert info.device_type == "rocm"
+    assert info.device == "rocm:0"
+    assert "Radeon" in info.device_name
+
+
+def test_auto_picks_mps_when_only_mps_available(mock_torch):
+    mock_torch["mps_available"] = True
+    mock_torch["mps_built"] = True
+    info = hardware._detect()
+    assert info.device_type == "mps"
+    assert info.device == "mps"
+
+
+def test_auto_falls_through_when_cuda_probe_fails(mock_torch):
+    """Mocked-multi: simulate CUDA advertised but probe fails; MPS available.
+    Real-world this can't happen (CUDA + MPS aren't on the same wheel) but
+    the fall-through logic must work for the explicit-fallback path too."""
+    mock_torch["cuda_available"] = True
+    mock_torch["cuda_device_count"] = 1
+    mock_torch["cuda_device_names"] = ["Broken GPU"]
+    mock_torch["cuda_mem"] = [(0.0, 4.0)]
+    mock_torch["probe_results"]["cuda:0"] = (False, "RuntimeError: bad")
+    mock_torch["mps_available"] = True
+    mock_torch["mps_built"] = True
+    info = hardware._detect()
+    assert info.device_type == "mps"

--- a/tests/test_launcher_tray.py
+++ b/tests/test_launcher_tray.py
@@ -918,3 +918,89 @@ class TestRepoRootHelper:
         assert (repo / "helix_context").is_dir()
         # And scripts/install-native-observability.ps1 must live under it.
         assert (repo / "scripts" / "install-native-observability.ps1").exists()
+
+
+# ── Hardware-fallback balloon (Task 13 — feat/hardware-detection) ─────
+
+
+class TestHardwareFallbackBalloon:
+    """Spec §6 third surface: tray balloon when the active device differs
+    from the requested device. Sentinel encodes (requested, active) so a
+    state-change re-fires; same-state re-launches stay quiet."""
+
+    def test_hardware_fallback_balloon_fires_first_launch(self, tmp_path, monkeypatch):
+        """Balloon fires once when fallback_active=True and no sentinel exists."""
+        from helix_context import hardware
+
+        monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                            lambda create=False: tmp_path)
+        hardware.reset_for_test()
+        fake = hardware.HardwareInfo(
+            device="cpu", device_type="cpu", device_name="CPU",
+            vram_total_gb=None, vram_free_gb=None,
+            cpu_arch="x86_64", cpu_brand="CPU",
+            system_ram_gb=16.0, requested_device="cuda",
+            fallback_reason="cuda not available",
+            batch_size_overrides={},
+        )
+        monkeypatch.setattr(hardware, "_detect", lambda: fake)
+
+        from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+        assert _should_fire_hardware_fallback_balloon() is True
+
+    def test_hardware_fallback_balloon_dedups_via_sentinel(self, tmp_path, monkeypatch):
+        """Sentinel exists -> balloon suppressed."""
+        monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                            lambda create=False: tmp_path)
+        sentinel = tmp_path / ".hardware-fallback-acknowledged-cuda-cpu"
+        sentinel.touch()
+
+        from helix_context import hardware
+        hardware.reset_for_test()
+        monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+            device="cpu", device_type="cpu", device_name="CPU",
+            vram_total_gb=None, vram_free_gb=None,
+            cpu_arch="x86_64", cpu_brand="CPU", system_ram_gb=16.0,
+            requested_device="cuda", fallback_reason="cuda not available",
+            batch_size_overrides={},
+        ))
+
+        from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+        assert _should_fire_hardware_fallback_balloon() is False
+
+    def test_hardware_fallback_balloon_refires_on_different_state(self, tmp_path, monkeypatch):
+        """Different requested/active combo => different sentinel => balloon fires."""
+        monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                            lambda create=False: tmp_path)
+        (tmp_path / ".hardware-fallback-acknowledged-cuda-cpu").touch()
+
+        from helix_context import hardware
+        hardware.reset_for_test()
+        monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+            device="cpu", device_type="cpu", device_name="CPU",
+            vram_total_gb=None, vram_free_gb=None,
+            cpu_arch="x86_64", cpu_brand="CPU", system_ram_gb=16.0,
+            requested_device="mps", fallback_reason="mps not available",
+            batch_size_overrides={},
+        ))
+
+        from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+        # Sentinel is for cuda->cpu; current state is mps->cpu.
+        assert _should_fire_hardware_fallback_balloon() is True
+
+    def test_hardware_fallback_balloon_skipped_when_no_fallback(self, tmp_path, monkeypatch):
+        """fallback_reason is None => no balloon ever."""
+        monkeypatch.setattr("helix_context.launcher.observability_paths.state_dir",
+                            lambda create=False: tmp_path)
+        from helix_context import hardware
+        hardware.reset_for_test()
+        monkeypatch.setattr(hardware, "_detect", lambda: hardware.HardwareInfo(
+            device="cuda:0", device_type="cuda", device_name="RTX 4090",
+            vram_total_gb=24.0, vram_free_gb=22.0,
+            cpu_arch="x86_64", cpu_brand="CPU", system_ram_gb=64.0,
+            requested_device="auto", fallback_reason=None,
+            batch_size_overrides={},
+        ))
+
+        from helix_context.launcher.tray import _should_fire_hardware_fallback_balloon
+        assert _should_fire_hardware_fallback_balloon() is False

--- a/tests/test_nli_backend.py
+++ b/tests/test_nli_backend.py
@@ -1,0 +1,157 @@
+"""Unit tests for helix_context.nli_backend (mocked tokenizer + model).
+
+Parallel to tests/test_deberta_backend.py — the chunked-batch test pins that
+NLIClassifier.classify_batch consumes recommended_batch_size('nli') from the
+hardware module instead of one-shot tokenizing all pairs. The init test pins
+that device=None defers to the hardware singleton.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from helix_context import hardware
+from helix_context.schemas import NLRelation
+
+
+@pytest.fixture(autouse=True)
+def _reset_hardware_cache():
+    hardware.reset_for_test()
+    yield
+    hardware.reset_for_test()
+
+
+def _override_hardware(monkeypatch, *, nli_batch=None):
+    """Force hardware singleton onto cpu with a specific nli batch override."""
+    overrides = {}
+    if nli_batch is not None:
+        overrides["nli"] = nli_batch
+    info = hardware.HardwareInfo(
+        device="cpu",
+        device_type="cpu",
+        device_name="test",
+        vram_total_gb=None,
+        vram_free_gb=None,
+        cpu_arch="x86_64",
+        cpu_brand="test",
+        system_ram_gb=16.0,
+        requested_device="auto",
+        fallback_reason=None,
+        batch_size_overrides=overrides,
+    )
+    monkeypatch.setattr(hardware, "_detect", lambda: info)
+
+
+class _FakeEncodings(dict):
+    """Dict that supports .to(device) the way HF BatchEncoding does."""
+
+    def to(self, device):  # noqa: D401 - mimic HF BatchEncoding
+        return self
+
+
+def _make_tokenizer_mock(chunk_log):
+    """Tokenizer mock whose return value tracks the chunk size for the model.
+
+    Each call records len(texts_a) so the model mock knows how many rows of
+    7-class logits to emit.
+    """
+    tok = MagicMock()
+
+    def _call(texts_a, texts_b, **kwargs):
+        chunk_len = len(texts_a)
+        chunk_log.append(chunk_len)
+        enc = _FakeEncodings(input_ids=torch.zeros(chunk_len, 1, dtype=torch.long))
+        return enc
+
+    tok.side_effect = _call
+    return tok
+
+
+def _make_model_mock(chunk_log):
+    """Model mock that emits (chunk_len, 7) logits matching the 7 NLI classes."""
+    model = MagicMock()
+
+    def _call(**kwargs):
+        chunk_len = chunk_log[-1]
+        # 7 classes: ENTAILMENT, REVERSE_ENTAILMENT, EQUIVALENCE,
+        # ALTERNATION, NEGATION, COVER, INDEPENDENCE.
+        out = MagicMock()
+        out.logits = torch.zeros(chunk_len, 7)
+        return out
+
+    model.side_effect = _call
+    return model
+
+
+def test_nli_classify_batch_chunks_in_recommended_batch_size(monkeypatch):
+    """Force nli batch=16 via override; feed 50 pairs; expect ceil(50/16)=4
+    tokenizer calls (16 + 16 + 16 + 2)."""
+    _override_hardware(monkeypatch, nli_batch=16)
+
+    from helix_context.nli_backend import NLIClassifier
+
+    clf = NLIClassifier.__new__(NLIClassifier)  # bypass __init__
+    clf._device = torch.device("cpu")
+
+    chunk_log: list[int] = []
+    clf._tokenizer = _make_tokenizer_mock(chunk_log)
+    clf._model = _make_model_mock(chunk_log)
+
+    pairs = [(f"text_a_{i}", f"text_b_{i}") for i in range(50)]
+    results = clf.classify_batch(pairs)
+
+    assert clf._tokenizer.call_count == 4
+    assert chunk_log == [16, 16, 16, 2]
+    # Result length matches input length, and items unpack into (NLRelation, float).
+    assert len(results) == 50
+    rel, conf = results[0]
+    assert isinstance(rel, NLRelation)
+    assert isinstance(conf, float)
+
+
+def test_nli_classify_batch_empty_returns_empty(monkeypatch):
+    """Empty input must short-circuit before consulting hardware."""
+    _override_hardware(monkeypatch, nli_batch=16)
+
+    from helix_context.nli_backend import NLIClassifier
+
+    clf = NLIClassifier.__new__(NLIClassifier)
+    clf._device = torch.device("cpu")
+    clf._tokenizer = MagicMock()
+    clf._model = MagicMock()
+
+    assert clf.classify_batch([]) == []
+    assert clf._tokenizer.call_count == 0
+    assert clf._model.call_count == 0
+
+
+def test_nli_init_consults_get_hardware_when_device_none(monkeypatch):
+    """Passing device=None must defer to hardware.get_hardware().device.
+
+    We monkeypatch transformers loaders to return inert mocks and verify the
+    resulting self._device matches the hardware singleton. Skips when
+    transformers isn't installed (the chunking tests above bypass __init__).
+    """
+    pytest.importorskip("transformers")
+
+    _override_hardware(monkeypatch, nli_batch=8)
+
+    import helix_context.nli_backend as nb
+
+    monkeypatch.setattr(
+        "transformers.AutoTokenizer.from_pretrained",
+        lambda *a, **kw: MagicMock(),
+    )
+
+    fake_model = MagicMock()
+    fake_model.to = lambda dev: fake_model
+    fake_model.train = lambda flag: None
+    monkeypatch.setattr(
+        "transformers.AutoModelForSequenceClassification.from_pretrained",
+        lambda *a, **kw: fake_model,
+    )
+
+    clf = nb.NLIClassifier(model_path="x", device=None)
+    assert str(clf._device) == "cpu"

--- a/tests/test_sema.py
+++ b/tests/test_sema.py
@@ -178,3 +178,55 @@ def test_error_prime_high_for_exceptions(codec):
         f"error prime (idx={error_idx}) not in top 5: "
         f"{[(PRIMES[i].name, f'{v:.2f}') for i, v in scored[:5]]}"
     )
+
+
+# ── Hardware-module device defaulting ────────────────────────────────
+
+def test_sema_codec_default_device_from_hardware(monkeypatch):
+    """SemaCodec() with no device arg should consult helix_context.hardware
+    instead of falling through to sentence-transformers' own auto-detect."""
+    from helix_context import hardware
+
+    hardware.reset_for_test()
+    monkeypatch.setattr(
+        hardware,
+        "_detect",
+        lambda: hardware.HardwareInfo(
+            device="cpu",
+            device_type="cpu",
+            device_name="test",
+            vram_total_gb=None,
+            vram_free_gb=None,
+            cpu_arch="x86_64",
+            cpu_brand="test",
+            system_ram_gb=16.0,
+            requested_device="auto",
+            fallback_reason=None,
+            batch_size_overrides={},
+        ),
+    )
+
+    captured = {}
+
+    class _FakeST:
+        def __init__(self, model_name, device):
+            captured["model_name"] = model_name
+            captured["device"] = device
+
+        def get_sentence_embedding_dimension(self):
+            return 384
+
+        def encode(self, *a, **kw):
+            # encode() is called by _build_projection() with the 20 anchors
+            # → return shape (20, 384) of zeros.
+            import numpy as np
+            return np.zeros((20, 384), dtype=np.float32)
+
+    monkeypatch.setattr("sentence_transformers.SentenceTransformer", _FakeST)
+
+    from helix_context.sema import SemaCodec
+
+    SemaCodec()  # no device arg — should default from hardware module
+    assert captured["device"] == "cpu"
+
+    hardware.reset_for_test()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -132,6 +132,41 @@ class TestHealthEndpoint:
         assert data["checks"]["upstream_ready"] is False
         assert "upstream model server is unreachable" in data["message"].lower()
 
+    def test_health_endpoint_includes_hardware_block(self, client, monkeypatch):
+        """Task 12: /health surfaces the detected hardware + fallback state
+        so operators can see at a glance whether they ended up on CPU
+        because cuda probe failed, etc."""
+        monkeypatch.setattr(
+            server_mod,
+            "_probe_upstream",
+            lambda _url, timeout_s=1.0: {"reachable": True, "probe": "/api/tags", "status_code": 200},
+        )
+        from helix_context import hardware
+        hardware.reset_for_test()
+        fake = hardware.HardwareInfo(
+            device="cpu", device_type="cpu", device_name="AMD Ryzen 9 7900X",
+            vram_total_gb=None, vram_free_gb=None,
+            cpu_arch="x86_64", cpu_brand="AMD Ryzen 9 7900X",
+            system_ram_gb=64.0, requested_device="cuda",
+            fallback_reason="cuda probe failed: RuntimeError: no driver",
+            batch_size_overrides={},
+        )
+        monkeypatch.setattr(hardware, "_detect", lambda: fake)
+
+        response = client.get("/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert "hardware" in body
+        hw = body["hardware"]
+        assert hw["device"] == "cpu"
+        assert hw["device_name"] == "AMD Ryzen 9 7900X"
+        assert hw["requested_device"] == "cuda"
+        assert hw["fallback_active"] is True
+        assert "cuda probe failed" in hw["fallback_reason"]
+        assert hw["vram_total_gb"] is None
+        assert hw["system_ram_gb"] == 64.0
+        assert hw["low_vram_warning"] is False
+
 
 class TestStatsEndpoint:
     def test_stats_returns_genome_info(self, client):


### PR DESCRIPTION
## Summary

- New `helix_context/hardware.py` module — single source of truth for torch device detection. Replaces 3 independent `torch.cuda.is_available()` call sites with a centralized `HardwareInfo` singleton + `recommended_batch_size(model)` lookup.
- All four torch-using backends (deberta, nli, splade, sema) consult the singleton for device + chunk batches via a VRAM-keyed table — preventing OOM on small cards.
- Loud-fallback policy with three surfacing channels: `WARNING` log, `/health` `hardware:{}` block, tray balloon (state-change-deduped sentinel). `device = "cuda"` on a host without CUDA falls back to CPU; never blocks startup.
- New `[hardware]` config section with `HELIX_DEVICE` env-var override. `[ribosome] device` deprecated for one release with a backwards-compat read.
- Spec: [docs/specs/2026-05-04-hardware-detection-design.md](docs/specs/2026-05-04-hardware-detection-design.md)
- Plan: [docs/plans/2026-05-04-hardware-detection.md](docs/plans/2026-05-04-hardware-detection.md) (14 tasks, executed via subagent-driven-development)

## Bench gate (Task 14, mandatory)

GPQA Diamond, n=20, ON-mode, gemma4:e4b, 180s timeout, native sidecar up. Apples-to-apples on the same 20 problem IDs.

| run | n | completed | correct | p50 | p90 | **p95** | max |
|---|---|---|---|---|---|---|---|
| master baseline | 20 | 20 | 7 | 38.6s | 100.3s | **168.2s** | 168.2s |
| PR1 (this branch) | 20 | 20 | 5 | 38.6s | 125.5s | **147.5s** | 147.5s |

- **p95 delta (PR1 − master, same 20 IDs): −20.74s** → spec gate `≤ 5s` **PASS** with ~25s margin
- 0 errors on both runs; all 20 problems completed
- Accuracy 7/20 vs 5/20 is within n=20 noise (~10pp std error on binary samples)
- p50 identical at 38.6s; tail behavior shifts (p90 +25s, p95 −21s) — could be variance or chunked-path smoothing

## What changed

**21 commits** since master `7d96320`.

**New files:**
- `helix_context/hardware.py` — HardwareInfo, get_hardware, _BATCH_TABLE, recommended_batch_size, _probe, auto-mode picker, multi-GPU selection, env+config resolution, init_from_config
- `tests/test_hardware.py` — 33 unit tests (mocked torch) covering picker / probe / multi-GPU / env-var / batch table / config flow / cache-poisoning regression pin
- `tests/test_deberta_backend.py` — chunked re_rank + splice tests (3)
- `tests/test_nli_backend.py` — chunked classify_batch tests (3)

**Modified files:**
- `pyproject.toml` — `py-cpuinfo>=9.0` added to launcher / launcher-native / launcher-tray extras
- `helix_context/config.py` — `Hardware` dataclass + parser + `[ribosome] device` deprecation shim
- `helix.toml` — documented `[hardware]` block
- `helix_context/{deberta,nli,splade,sema}_backend.py` (4 files) — consult `get_hardware()`, chunk batches via `recommended_batch_size`
- `helix_context/server.py` — `init_from_config()` wired at startup BEFORE backend construction; `/health` adds `hardware:{}` block
- `helix_context/launcher/{tray,app}.py` — fallback balloon helpers + state-change sentinel + 3s-defer call site
- `tests/test_{config,sema,server,launcher_tray}.py` — coverage extensions (~13 new tests across files)

## Locked design decisions (spec §11)

1. **Auto-mode picker order**: CUDA → ROCm → MPS → CPU. Mutual exclusion at wheel level (CUDA-built torch can't probe ROCm; the unsupported sibling skips on `is_available()=False`).
2. **VRAM-aware batching keyed on TOTAL VRAM** (invariant per GPU). Free VRAM at startup is informational only — pinned in `test_batch_size_total_not_free_drives_lookup`.
3. **Multi-GPU**: pick the index with most free VRAM at startup, probe per-index, fall through to next-best on probe failure. Pinned for dead-device-0 + healthy-device-1 → cuda:1.
4. **Explicit-device asymmetry**: explicit `device = "cuda"` that fails probes falls back to CPU directly (skips ROCm/MPS even if available). Auto-mode walks all candidates.
5. **`init_from_config` ordering**: must run before any backend `__init__`. Regression-pinned in `test_init_from_config_must_run_before_get_hardware` documenting the cached-singleton-poisoning failure mode.
6. **Three surfacing channels**: log warning, /health `hardware.fallback_active`, tray balloon (sentinel-deduped per (requested, active) tuple). Low-VRAM is logs+/health only — no balloon spam.

## Cross-platform / future-PR scope

- This is **PR1 of 2.** PR2 wires up actual MPS + ROCm device backends + adds GHA CI workflow with macOS-runner MPS smoke test + opt-in env-var ROCm tests + Intel XPU enhancement template. PR1 leaves `device = "rocm"` / `device = "mps"` parseable but resolving to CPU fallback in practice — the picker's branches are stubbed.
- macOS / Linux remain "capable but unverified" per spec §3 non-goals (same posture as the native-sidecar PR's macOS/Linux scripts).

## Test plan

- [x] 33 hardware unit tests + ~17 cross-file tests passing on dev rig
- [x] No regressions: pre-existing tests in test_ribosome / test_observability_* / test_launcher_* all pass (69 passed, 36 skipped — skips are env-gated, not new failures)
- [x] Bench gate PASS (−20.74s p95 delta vs master baseline)
- [x] /health endpoint returns `hardware:{}` block with all 8 documented fields
- [x] Tray fallback balloon dedupes via state-change sentinel
- [ ] Reviewer to spot-check that `init_from_config` is called before backend construction in `server.py:create_app`
- [ ] Reviewer to confirm the `[ribosome] device` deprecation warning fires once per process
- [ ] Reviewer to consider whether the structural gap (no end-to-end test exercising `helix.toml → load_config → init_from_config → backend chunk count`) needs an integration test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)