### PR TITLE
Bust launcher dashboard static cache

### DIFF
--- a/helix_context/launcher/templates/layout.html
+++ b/helix_context/launcher/templates/layout.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Helix Dashboard{% endblock %}</title>
-  <link rel="stylesheet" href="/static/launcher.css">
+  <link rel="stylesheet" href="/static/launcher.css?v=dashboard-ui-20260505">
 </head>
 <body>
   <div class="shell">
@@ -41,6 +41,6 @@
     </footer>
   </div>
 
-  <script src="/static/launcher.js" defer></script>
+  <script src="/static/launcher.js?v=dashboard-ui-20260505" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add version query strings to launcher dashboard CSS/JS asset URLs
- prevents browsers from combining new dashboard HTML with stale cached static assets

## Tests
- python -m pytest tests/test_launcher_app.py