### PR TITLE
Make launcher dashboard width more fluid

### DIFF
--- a/helix_context/launcher/static/launcher.css
+++ b/helix_context/launcher/static/launcher.css
@@ -27,7 +27,7 @@
   --fs-xl: 1.35rem;
   --radius: 8px;
   --gap: 16px;
-  --max-width: 912px;
+  --max-width: 1180px;
   --motion: 140ms ease-out;
 }
 
@@ -94,7 +94,7 @@ p {
 }
 
 .shell {
-  width: min(var(--max-width), calc(100vw - 32px));
+  width: min(var(--max-width), calc(100vw - clamp(32px, 6vw, 96px)));
   min-height: 100vh;
   margin: 0 auto;
   padding: 22px 0;
@@ -396,6 +396,14 @@ p {
   box-shadow: var(--shadow-panel);
 }
 
+.panel--parties {
+  grid-column: span 5;
+}
+
+.panel--participants {
+  grid-column: span 7;
+}
+
 .panel--genes,
 .panel--tokens,
 .panel--diagnostics,
@@ -550,6 +558,7 @@ p {
   min-width: 0;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 7px;
   padding: 9px 10px;
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- widen the launcher dashboard shell on desktop while keeping responsive side gutters
- give Identities more room than Parties in the overview grid
- allow compact panel rows to wrap instead of crunching labels

## Tests
- python -m pytest tests/test_launcher_app.py