### PR TITLE
Clarify launcher components count

### DIFF
--- a/helix_context/launcher/collector.py
+++ b/helix_context/launcher/collector.py
@@ -354,21 +354,25 @@ class StateCollector:
     # ── models ─────────────────────────────────────────────────────
 
     def _tools_panel(self, components: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Project /admin/components into the launcher tools panel.
+        """Project /admin/components into the launcher components panel.
 
         The launcher already has dedicated Helix health and model panels.
         Hide the ribosome here so Ollama/model activity does not get
         mistaken for a separate operator-facing tool.
         """
+        all_components = components.get("components", [])
         entries = [
             component
-            for component in components.get("components", [])
+            for component in all_components
             if self._is_operator_tool(component)
         ]
         if not entries:
             return None
+        source_count = int(components.get("count", len(all_components)) or 0)
         return {
             "count": len(entries),
+            "source_count": source_count,
+            "hidden_count": max(0, source_count - len(entries)),
             "entries": entries,
             "last_activity_s_ago": components.get("last_activity_s_ago"),
         }

--- a/helix_context/launcher/templates/components/controls.html
+++ b/helix_context/launcher/templates/components/controls.html
@@ -30,7 +30,7 @@
       {% if state.tools %}
         <div class="metric">
           <span class="metric-value">{{ state.tools.count }}</span>
-          <span class="metric-label">tools</span>
+          <span class="metric-label">components</span>
         </div>
       {% endif %}
     </div>

--- a/helix_context/launcher/templates/components/tools_panel.html
+++ b/helix_context/launcher/templates/components/tools_panel.html
@@ -1,18 +1,21 @@
 <section class="panel panel--tools">
   <h2 class="panel-title">
-    Tools <span class="panel-count">{{ state.tools.count }}</span>
+    Components <span class="panel-count">{{ state.tools.count }}</span>
+    {% if state.tools.source_count and state.tools.source_count != state.tools.count %}
+      <span class="panel-count-muted">of {{ state.tools.source_count }} reported</span>
+    {% endif %}
     {% if state.tools.last_activity_s_ago is not none %}
-      <span class="panel-count-muted">· last activity {{ state.tools.last_activity_s_ago }}s ago</span>
+      <span class="panel-count-muted">/ last activity {{ state.tools.last_activity_s_ago }}s ago</span>
     {% endif %}
   </h2>
   <ul class="panel-list">
     {% for t in state.tools.entries %}
       <li class="panel-list__item">
         <span class="chip chip--tool chip--{{ t.kind }}">{{ t.name }}</span>
-        <span class="muted">· {{ t.kind }}</span>
+        <span class="muted">/ {{ t.kind }}</span>
         <span class="tool-status tool-status--{{ t.status }}">{{ t.status }}</span>
         {% if t.backend %}
-          <span class="muted">· {{ t.backend }}</span>
+          <span class="muted">/ {{ t.backend }}</span>
         {% endif %}
       </li>
     {% endfor %}

--- a/tests/test_launcher_collector.py
+++ b/tests/test_launcher_collector.py
@@ -252,6 +252,8 @@ class TestToolsPanel:
                 state = collector.collect()
 
         assert state["tools"]["count"] == 1
+        assert state["tools"]["source_count"] == 2
+        assert state["tools"]["hidden_count"] == 1
         assert state["tools"]["last_activity_s_ago"] == 12.4
         assert len(state["tools"]["entries"]) == 1
         assert state["tools"]["entries"][0]["name"] == "splade"


### PR DESCRIPTION
## Summary
- rename the launcher Tools panel/metric to Components to match `/admin/components`
- track source component count separately from displayed operator-facing components
- show `of N reported` when the dashboard hides internal components like ribosome

## Checks
- live `/admin/components` currently reports 5 components and dashboard state renders 5 entries

## Tests
- python -m pytest tests/test_launcher_collector.py::TestToolsPanel tests/test_launcher_app.py