### PR TITLE
Route Grafana through native observability sidecar

### DIFF
--- a/deploy/otel/grafana/dashboards/helix-pipeline-observatory.json
+++ b/deploy/otel/grafana/dashboards/helix-pipeline-observatory.json
@@ -1,0 +1,729 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Retrieval",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "process_memory (seconds) - pid (pid) in my heaps",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "process_resident_memory_bytes{job=\"helix\"}",
+          "legendFormat": "pid {{pid}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "tier estimations (%) status (stem tree csr ring)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_tier_estimation_percent{job=\"helix\", status=\"bulk\"}",
+          "legendFormat": "bulk",
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_tier_estimation_percent{job=\"helix\", status=\"documents\"}",
+          "legendFormat": "documents",
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_tier_estimation_percent{job=\"helix\", status=\"tx_active\"}",
+          "legendFormat": "tx_active",
+          "refId": "C"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_tier_estimation_percent{job=\"helix\", status=\"guests\"}",
+          "legendFormat": "guests",
+          "refId": "D"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_tier_estimation_percent{job=\"helix\", status=\"log_event\"}",
+          "legendFormat": "log_event",
+          "refId": "E"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_tier_estimation_percent{job=\"helix\", status=\"log_write\"}",
+          "legendFormat": "log_write",
+          "refId": "F"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "cross magnitude x tier",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "Per tier readable time in histogram (cross magnitude x tier)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(helix_tier_readable_time_bucket{job=\"helix\"}[5m])",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 101,
+      "title": "CRDTs Latent Clock",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "CRDTs bucket accumulation",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_crdt_bucket_accumulation{job=\"helix\"}",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1.0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "title": "p99_rq = (1.0 + 1.97) ditto-genes",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "histogram_quantile(0.99, rate(helix_rq_duration_seconds_bucket{job=\"helix\"}[5m]))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 102,
+      "title": "Graph & Chromatin",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "bit keying - ring edges by provenance",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_ring_edges_by_provenance{job=\"helix\"}",
+          "legendFormat": "rk_{{provenance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 7,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "values": []
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "Chroni-join state distribution",
+      "type": "piechart",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_chroni_join_state{job=\"helix\"}",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "title": "cost concentration ratio (top ~1% majority / mean)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_cost_concentration_ratio{job=\"helix\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "resolve degree distribution (r=1, j=r1, j=r2, j mean)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_resolve_degree_distribution{job=\"helix\", r=\"1\"}",
+          "legendFormat": "r=1",
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_resolve_degree_distribution{job=\"helix\", j=\"r1\"}",
+          "legendFormat": "j=r1",
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "helix_resolve_degree_distribution{job=\"helix\", j=\"r2\"}",
+          "legendFormat": "j=r2",
+          "refId": "C"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "avg(helix_resolve_degree_distribution{job=\"helix\"})",
+          "legendFormat": "mean",
+          "refId": "D"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "helix",
+    "pipeline",
+    "observatory"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Helix - Pipeline Observatory",
+  "uid": "helix-a27094-pipeline-observatory",
+  "version": 1
+}

--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -47,6 +47,9 @@ from .observability_paths import (
 
 log = logging.getLogger("helix.launcher.app")
 
+DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000/d/helix-a27094-pipeline-observatory"
+DEFAULT_PROMETHEUS_URL = "http://127.0.0.1:9090/graph"
+
 if TYPE_CHECKING:
     from .observability_supervisor import ObservabilitySupervisor
 
@@ -614,6 +617,11 @@ def main(argv: Optional[list] = None) -> int:
         observability_sup, observability_install_pending = (
             _maybe_build_observability()
         )
+        if observability_sup is not None:
+            if args.grafana_url is None:
+                args.grafana_url = DEFAULT_GRAFANA_URL
+            if args.prometheus_url is None:
+                args.prometheus_url = DEFAULT_PROMETHEUS_URL
 
         tray_icon = HelixTrayIcon(
             supervisor=supervisor,

--- a/helix_context/launcher/observability_paths.py
+++ b/helix_context/launcher/observability_paths.py
@@ -54,6 +54,7 @@ ALL_CONFIG_FILES: tuple[str, ...] = (
     "tempo.yaml",
     "loki-config.yaml",
     "datasources.yml",
+    "dashboards.yml",
 )
 
 

--- a/helix_context/launcher/observability_render.py
+++ b/helix_context/launcher/observability_render.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from .observability_paths import (
     ALL_CONFIG_FILES,
+    binary_path,
     configs_dir,
     service_state_dir,
     state_dir,
@@ -124,6 +125,21 @@ def _sub_datasources(text: str) -> str:
     return text
 
 
+def _grafana_home() -> Path:
+    return binary_path("grafana").parent.parent
+
+
+def _grafana_dashboards_path() -> Path:
+    return _grafana_home() / "conf" / "provisioning" / "dashboards-content"
+
+
+def _sub_dashboards(text: str) -> str:
+    return text.replace(
+        "path: /var/lib/grafana/dashboards",
+        f"path: {_grafana_dashboards_path().as_posix()}",
+    )
+
+
 _RULES = [
     # (source path relative to deploy/otel, rendered name, sub fn).
     # The rendered names below MUST equal observability_paths.ALL_CONFIG_FILES
@@ -136,6 +152,11 @@ _RULES = [
         "grafana/provisioning/datasources/datasources.yml",
         "datasources.yml",
         _sub_datasources,
+    ),
+    (
+        "grafana/provisioning/dashboards/dashboards.yml",
+        "dashboards.yml",
+        _sub_dashboards,
     ),
 ]
 # Verify _RULES output names match the manifest at import time so any
@@ -160,31 +181,24 @@ def _wire_grafana_provisioning() -> None:
     """
     import shutil
 
-    from .observability_paths import binary_path
-
     graf_bin = binary_path("grafana")
     if not graf_bin.exists():
         log.info("grafana binary absent — skipping provisioning wire-up")
         return
-    graf_home = graf_bin.parent.parent  # tools/native-otel/grafana
+    graf_home = _grafana_home()  # tools/native-otel/grafana
 
-    rendered_ds = configs_dir() / "datasources.yml"
+    rendered_cfg = configs_dir()
     target_ds_dir = graf_home / "conf" / "provisioning" / "datasources"
     target_ds_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(rendered_ds, target_ds_dir / "datasources.yml")
+    shutil.copy2(rendered_cfg / "datasources.yml", target_ds_dir / "datasources.yml")
 
-    deploy = _deploy_dir()
-    src_dash_prov = deploy / "grafana" / "provisioning" / "dashboards"
-    if src_dash_prov.exists():
-        target_dash_prov = graf_home / "conf" / "provisioning" / "dashboards"
-        target_dash_prov.mkdir(parents=True, exist_ok=True)
-        for f in src_dash_prov.iterdir():
-            if f.is_file():
-                shutil.copy2(f, target_dash_prov / f.name)
+    target_dash_prov = graf_home / "conf" / "provisioning" / "dashboards"
+    target_dash_prov.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(rendered_cfg / "dashboards.yml", target_dash_prov / "dashboards.yml")
 
-    src_dash = deploy / "grafana" / "dashboards"
+    src_dash = _deploy_dir() / "grafana" / "dashboards"
     if src_dash.exists():
-        target_dash = graf_home / "conf" / "provisioning" / "dashboards-content"
+        target_dash = _grafana_dashboards_path()
         target_dash.mkdir(parents=True, exist_ok=True)
         for f in src_dash.iterdir():
             if f.is_file():

--- a/tests/test_observability_paths.py
+++ b/tests/test_observability_paths.py
@@ -105,6 +105,7 @@ def test_all_config_files_manifest_constant_exists_and_matches_spec():
         "tempo.yaml",
         "loki-config.yaml",
         "datasources.yml",
+        "dashboards.yml",
     )
 
 

--- a/tests/test_observability_render.py
+++ b/tests/test_observability_render.py
@@ -35,7 +35,7 @@ def rendered(tmp_path, monkeypatch):
     return tmp_path / "configs"
 
 
-def test_all_five_configs_rendered(rendered):
+def test_all_configs_rendered(rendered):
     """Each source has a corresponding rendered file."""
     expected = {
         "otel-collector-config.yaml",
@@ -43,6 +43,7 @@ def test_all_five_configs_rendered(rendered):
         "tempo.yaml",
         "loki-config.yaml",
         "datasources.yml",
+        "dashboards.yml",
     }
     actual = {p.name for p in rendered.iterdir() if p.is_file()}
     assert expected.issubset(actual), (
@@ -108,6 +109,16 @@ def test_grafana_datasources_use_localhost(rendered):
     assert by_name["Loki"]["url"] == "http://localhost:3100"
 
 
+def test_grafana_dashboard_provider_uses_native_dashboard_path(rendered):
+    spec = yaml.safe_load((rendered / "dashboards.yml").read_text())
+    providers = spec["providers"]
+    provider_path = providers[0]["options"]["path"]
+    assert provider_path.replace("\\", "/").endswith(
+        "grafana/conf/provisioning/dashboards-content"
+    )
+    assert "/var/lib/grafana/dashboards" not in provider_path
+
+
 def test_no_docker_dns_hostnames_remain_in_any_render(rendered):
     """Cross-cutting check: no rendered file mentions a Docker DNS name.
 
@@ -152,6 +163,7 @@ def test_structural_diff_is_only_hostnames_and_paths(rendered):
         ("tempo.yaml", "tempo.yaml"),
         ("loki-config.yaml", "loki-config.yaml"),
         ("grafana/provisioning/datasources/datasources.yml", "datasources.yml"),
+        ("grafana/provisioning/dashboards/dashboards.yml", "dashboards.yml"),
     ]
     url_re = re.compile(
         r"https?://(?:localhost|tempo|prometheus|loki|otel-collector|grafana)"
@@ -161,8 +173,8 @@ def test_structural_diff_is_only_hostnames_and_paths(rendered):
         r"\b(?:localhost|tempo|prometheus|loki|otel-collector):\d+\b"
     )
     path_re = re.compile(
-        r"(?:[A-Z]:)?/(?:[\w.-]+/)*"
-        r"(?:tempo|loki|prometheus|grafana)(?:/[\w.-]+)*"
+        r"(?:[A-Z]:)?[/\\](?:[\w.-]+[/\\])*"
+        r"(?:tempo|loki|prometheus|grafana)(?:[/\\][\w.-]+)*"
     )
 
     def _norm(s: str) -> str:

--- a/tests/test_observability_supervisor.py
+++ b/tests/test_observability_supervisor.py
@@ -55,6 +55,7 @@ def fake_paths(tmp_path, monkeypatch):
         "tempo.yaml",
         "loki-config.yaml",
         "datasources.yml",
+        "dashboards.yml",
     ):
         (cfg_dir / name).write_text("# stub\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add the Helix Pipeline Observatory Grafana dashboard to provisioned dashboards
- render Grafana dashboard provider config for native sidecar paths instead of Docker `/var/lib/grafana/dashboards`
- copy rendered dashboard provisioning into the native Grafana home alongside rendered datasources
- default tray Grafana/Prometheus links to the native sidecar stack when observability is enabled

## Verification
- `python -m helix_context.launcher.observability_render render-all` writes `dashboards.yml`
- native Grafana provisioning tree contains datasources and all Helix dashboards, including Pipeline Observatory

## Tests
- python -m pytest tests/test_observability_render.py tests/test_observability_paths.py tests/test_observability_supervisor.py tests/test_launcher_app.py tests/test_launcher_tray.py