### PR TITLE
foveated-splice: rank-scaled BROAD compression + reverse-rank placement (off by default)

### DIFF
--- a/docs/plans/2026-05-05-foveated-splice.md
+++ b/docs/plans/2026-05-05-foveated-splice.md
@@ -1,0 +1,766 @@
+# Foveated-Splice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement rank-scaled per-gene compression + reverse-rank placement for the BROAD tier of `build_context`, off by default, gated by `foveated_enabled` config flag. Per-gene byte cap follows `c_i = max(c_min, c_max · i^(-α))` and feeds the existing Step 4 `compress_text(target_chars=...)` call so each gene gets a rank-proportional slice of the BROAD char budget.
+
+**Architecture:** Three integration points inside `helix_context/context_manager.py`:
+1. **After tier resolves (post line ~843):** compute `caps[]` and reverse `(candidates, caps)` together when foveated is active on BROAD. Stash on `self._last_foveated_caps`.
+2. **Step 4 compression loop (around line 965):** swap the hardcoded `target_chars=1000` for `int(caps[i] * foveated_base_chars)` when caps are stashed; otherwise keep `1000`.
+3. **`_assemble` (line 1716):** add a `respect_caller_order: bool = False` parameter. When True, skip the score-DESC and sequence-index re-sorts so the reversed BROAD ordering survives all the way to the prompt.
+
+Compression schedule lives in a pure helper (`_compute_foveated_caps`) for ease of testing. Telemetry adds two `metadata["foveated_*"]` keys when the path fires.
+
+**Tech Stack:** Python 3.13, pytest, dataclasses (config), OpenTelemetry counters (already present, no new metrics).
+
+**Spec:** `docs/specs/2026-05-03-foveated-splice-design.md` (NOTE: §7 names `_build_item(max_item_chars=...)` as the seam, but on master that function lives only in `context_packet.py` and is not reachable from `build_context`. The actual seam is `compress_text(target_chars=...)` at `context_manager.py:965`. The plan codifies this; a follow-up commit can patch the spec.)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `helix_context/config.py` | Modify | Add 4 fields to `BudgetConfig` (`foveated_enabled`, `foveated_alpha`, `foveated_c_min`, `foveated_base_chars`) + matching loader entries in `load_config`. |
+| `helix.toml` | Modify | Add the four `[budget]` keys with comment block referencing the spec §6. |
+| `helix_context/context_manager.py` | Modify | Add `_compute_foveated_caps` helper, foveated block after BROAD resolves, Step 4 cap lookup, `_assemble` `respect_caller_order` parameter, telemetry stash. |
+| `tests/test_foveated_splice.py` | Create | All eight cases from spec §10 + helper unit tests + the `_assemble` ordering regression. |
+| `tests/test_config.py` | Modify | Default + toml-override regression tests for the four new keys. |
+
+**Files explicitly NOT touched:**
+- `helix_context/context_packet.py` — `_build_item` / `_DEFAULT_MAX_ITEM_CHARS = 280` belong to the `/context` packet path, not `build_context`. Foveated does not run there.
+- `helix_context/telemetry.py` — `budget_tier_counter` already labels `"broad"`; no new counter needed (per spec §8).
+- `helix_context/headroom_bridge.py` — `compress_text` already accepts `target_chars`; no signature change.
+
+---
+
+## Task 1: Add the four `foveated_*` config fields
+
+**Files:**
+- Modify: `helix_context/config.py` — `BudgetConfig` dataclass (around the existing `abstain_enabled` field) and `load_config` (around the existing `abstain_enabled` loader line).
+- Modify: `helix.toml` — `[budget]` section.
+- Modify: `tests/test_config.py` — extend with new regression tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_budget_foveated_defaults_off_with_alpha_one():
+    """Regression: foveated ships off-by-default with alpha=1.0, c_min=0.15.
+
+    The 2026-05-03 foveated-splice spec (docs/specs/2026-05-03-foveated-
+    splice-design.md §6.3) ships off-by-default for a measurement period.
+    A bench α-sweep is required before flipping on. Bumping any default
+    here without bench evidence would silently change BROAD-tier
+    compression on every install.
+    """
+    from helix_context.config import HelixConfig
+    cfg = HelixConfig()
+    assert cfg.budget.foveated_enabled is False
+    assert cfg.budget.foveated_alpha == 1.0
+    assert cfg.budget.foveated_c_min == 0.15
+    assert cfg.budget.foveated_base_chars == 1000
+
+
+def test_budget_foveated_toml_override(tmp_path):
+    """Regression: helix.toml [budget] foveated_* keys are honored."""
+    import tomli_w
+    from helix_context.config import load_config
+    p = tmp_path / "helix.toml"
+    p.write_bytes(tomli_w.dumps({
+        "budget": {
+            "foveated_enabled": True,
+            "foveated_alpha": 2.0,
+            "foveated_c_min": 0.20,
+            "foveated_base_chars": 1500,
+        }
+    }).encode())
+    cfg = load_config(str(p))
+    assert cfg.budget.foveated_enabled is True
+    assert cfg.budget.foveated_alpha == 2.0
+    assert cfg.budget.foveated_c_min == 0.20
+    assert cfg.budget.foveated_base_chars == 1500
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `py -3 -m pytest tests/test_config.py::test_budget_foveated_defaults_off_with_alpha_one tests/test_config.py::test_budget_foveated_toml_override -v`
+
+Expected: FAIL with `AttributeError: 'BudgetConfig' object has no attribute 'foveated_enabled'`
+
+- [ ] **Step 3: Add the four fields to `BudgetConfig`**
+
+In `helix_context/config.py`, locate the `abstain_enabled: bool = True` line in `BudgetConfig` and append below it:
+
+```python
+    # Foveated-splice (BROAD tier only). Off by default for the measurement
+    # period — see docs/specs/2026-05-03-foveated-splice-design.md §6.3 and
+    # docs/plans/2026-05-05-foveated-splice.md. Flip to True only after the
+    # phased α-sweep bench (§9) identifies a winning configuration.
+    foveated_enabled: bool = False
+    # Power-law exponent for c_i = max(c_min, c_max · i^(-α)). α=0.5 = gentle
+    # decay, α=1.0 = harmonic-ish, α=2.0 = aggressive top-bias.
+    foveated_alpha: float = 1.0
+    # Rank-N floor compression ratio. Pinned at 0.15 by spec §4.1.
+    foveated_c_min: float = 0.15
+    # Per-gene char-budget multiplier. Each gene's target_chars =
+    # int(c_i · foveated_base_chars). Default 1000 matches the current
+    # uniform behavior at c_i = 1.0. The Step 4 compression loop in
+    # context_manager.py uses 1000 today; keeping this configurable lets
+    # bench cells (and a future on-by-default ship) tune the top-1 ceiling
+    # without touching code.
+    foveated_base_chars: int = 1000
+```
+
+- [ ] **Step 4: Add the loader entries**
+
+In `helix_context/config.py` `load_config`, locate the `abstain_enabled=bool(b.get(...))` line and append below it:
+
+```python
+            foveated_enabled=bool(b.get("foveated_enabled", cfg.budget.foveated_enabled)),
+            foveated_alpha=float(b.get("foveated_alpha", cfg.budget.foveated_alpha)),
+            foveated_c_min=float(b.get("foveated_c_min", cfg.budget.foveated_c_min)),
+            foveated_base_chars=int(b.get("foveated_base_chars", cfg.budget.foveated_base_chars)),
+```
+
+- [ ] **Step 5: Add the `[budget]` keys to `helix.toml`**
+
+Append to the `[budget]` section in `helix.toml`:
+
+```toml
+# Foveated-splice (BROAD tier only). When True, the BROAD branch of the
+# dynamic-budget tier replaces uniform per-gene compression with a rank-
+# scaled power-law schedule and reverses the assembly order so the top-
+# ranked gene lands immediately before the user query. Off by default for
+# the measurement period — see docs/specs/2026-05-03-foveated-splice-
+# design.md §6.3.
+foveated_enabled = false
+
+# Power-law exponent: c_i = max(c_min, c_max · i^(-α)). α=0.5 = gentle
+# decay, α=1.0 (default) = harmonic-ish, α=2.0 = aggressive top-bias.
+# Bench Phase 2 sweeps {0.5, 1.0, 2.0}; ship the winner.
+foveated_alpha = 1.0
+
+# Rank-N (bottom of BROAD) compression floor. Each gene's effective char
+# cap = max(foveated_c_min · base, c_i · base) where c_i = c_max · i^(-α).
+foveated_c_min = 0.15
+
+# Per-gene char-budget multiplier. target_chars per gene = int(c_i · base).
+# Default 1000 matches current uniform Step 4 behavior at c_i = 1.0.
+foveated_base_chars = 1000
+```
+
+- [ ] **Step 6: Run config tests — expect PASS**
+
+Run: `py -3 -m pytest tests/test_config.py -v`
+
+Expected: all green, including the two new tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add helix_context/config.py helix.toml tests/test_config.py
+git commit -m "feat(config): add foveated-splice config fields
+
+Adds foveated_enabled, foveated_alpha, foveated_c_min, foveated_base_chars
+to BudgetConfig + helix.toml [budget]. All four ship off-by-default.
+
+Spec: docs/specs/2026-05-03-foveated-splice-design.md §6
+Plan: docs/plans/2026-05-05-foveated-splice.md Task 1
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add `_compute_foveated_caps` pure helper
+
+**Files:**
+- Modify: `helix_context/context_manager.py` — add module-level helper near the top of the file (after imports, before the class definition). A pure function makes the schedule shape trivially testable.
+- Create: `tests/test_foveated_splice.py` — start the file, add helper unit tests.
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `tests/test_foveated_splice.py`:
+
+```python
+"""Tests for foveated-splice — rank-scaled BROAD compression schedule.
+
+Spec: docs/specs/2026-05-03-foveated-splice-design.md
+Plan: docs/plans/2026-05-05-foveated-splice.md
+"""
+import pytest
+
+from helix_context.context_manager import _compute_foveated_caps
+
+
+class TestComputeFoveatedCaps:
+    """Pure-function tests for the schedule-shape helper (spec §4.1)."""
+
+    def test_alpha_one_n_twelve_matches_spec_table(self):
+        """Spec §10 Test 6: caps[0]=1.0, caps[1]=0.5, caps[5]≈1/6, caps[11]=c_min."""
+        caps = _compute_foveated_caps(n=12, alpha=1.0, c_min=0.15, c_max=1.0)
+        assert len(caps) == 12
+        assert caps[0] == 1.0
+        assert caps[1] == 0.5
+        assert caps[5] == pytest.approx(1 / 6, abs=1e-9)
+        # rank-12 → 1/12 ≈ 0.083 < c_min=0.15, so floor wins
+        assert caps[11] == 0.15
+
+    def test_alpha_two_collapses_to_floor_by_rank_three(self):
+        """Spec §10 Test 8: α=2 floors caps[5..11] at c_min."""
+        caps = _compute_foveated_caps(n=12, alpha=2.0, c_min=0.15, c_max=1.0)
+        # 1/3^2 = 0.111 < 0.15 → already floored at rank 3
+        for i in range(2, 12):
+            assert caps[i] == 0.15, f"caps[{i}]={caps[i]} expected 0.15"
+
+    def test_alpha_half_gentle_decay(self):
+        """Spec §4.2 table: α=0.5 caps[1] ≈ 0.71."""
+        caps = _compute_foveated_caps(n=12, alpha=0.5, c_min=0.15, c_max=1.0)
+        assert caps[0] == 1.0
+        assert caps[1] == pytest.approx(1 / (2 ** 0.5), abs=1e-9)  # ≈ 0.7071
+        assert caps[2] == pytest.approx(1 / (3 ** 0.5), abs=1e-9)  # ≈ 0.5774
+
+    def test_c_min_floor_is_inclusive_lower_bound(self):
+        """A custom c_min raises the floor for low-rank genes."""
+        caps = _compute_foveated_caps(n=12, alpha=1.0, c_min=0.30, c_max=1.0)
+        assert caps[0] == 1.0
+        # rank-4 → 0.25 < c_min=0.30, floors at 0.30
+        for i in range(3, 12):
+            assert caps[i] == 0.30
+
+    def test_n_one_returns_single_c_max(self):
+        """Edge case: a single-candidate BROAD set returns [c_max]."""
+        assert _compute_foveated_caps(n=1, alpha=1.0, c_min=0.15) == [1.0]
+
+    def test_n_zero_returns_empty(self):
+        """Edge case: empty input → empty output, never raises."""
+        assert _compute_foveated_caps(n=0, alpha=1.0, c_min=0.15) == []
+```
+
+- [ ] **Step 2: Run tests — expect ImportError**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py -v`
+
+Expected: FAIL with `ImportError: cannot import name '_compute_foveated_caps' from 'helix_context.context_manager'`
+
+- [ ] **Step 3: Add the helper**
+
+In `helix_context/context_manager.py`, after the existing imports and before the `class HelixContextManager:` line (search for the first `class ` definition; the helper goes immediately above it):
+
+```python
+def _compute_foveated_caps(
+    n: int,
+    alpha: float,
+    c_min: float,
+    c_max: float = 1.0,
+) -> list[float]:
+    """Power-law per-gene compression caps for foveated-splice.
+
+    c_i = max(c_min, c_max · i^(-α))    for i ∈ [1, N]
+
+    Returns a list of N floats in forward-rank order (caps[0] = rank-1 cap,
+    caps[N-1] = rank-N cap). Caller reverses to pair with reverse-rank
+    candidate placement.
+
+    Spec: docs/specs/2026-05-03-foveated-splice-design.md §4.1
+    """
+    if n <= 0:
+        return []
+    return [max(c_min, c_max * ((i + 1) ** -alpha)) for i in range(n)]
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py -v`
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/context_manager.py tests/test_foveated_splice.py
+git commit -m "feat(context): add _compute_foveated_caps schedule helper
+
+Pure function computing power-law per-gene compression caps for
+foveated-splice. Tests cover α∈{0.5,1.0,2.0}, c_min floor, edge cases
+(N=0, N=1).
+
+Spec: docs/specs/2026-05-03-foveated-splice-design.md §4.1
+Plan: docs/plans/2026-05-05-foveated-splice.md Task 2
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `respect_caller_order` parameter to `_assemble`
+
+**Files:**
+- Modify: `helix_context/context_manager.py` — `_assemble` signature (around line 1716) + the use_slate sort block (around lines 1740-1752).
+- Modify: `tests/test_foveated_splice.py` — add ordering test (covers spec §10 Test 7).
+
+**Why this task is separate:** `_assemble` re-sorts candidates internally (line 1745: `sorted(candidates, key=score, reverse=True)` on the slate path; line 1752: `sorted(by sequence_index)` on the dense path). A naïve `list.reverse()` before the call gets clobbered. We need to opt out of the re-sort when foveated is driving placement.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_foveated_splice.py`:
+
+```python
+class TestAssembleRespectsCallerOrder:
+    """When respect_caller_order=True, _assemble preserves the candidates list
+    order verbatim — no score-desc or sequence-index re-sort. This is what
+    makes reverse-rank placement actually reach the prompt (spec §5)."""
+
+    def test_assemble_default_resorts_by_score_for_slate(self, helix_manager_with_three_genes):
+        """Sanity: default (use_slate=True) re-sorts by score DESC."""
+        m, g_low, g_mid, g_high = helix_manager_with_three_genes
+        # Pass in low→high; default behavior should re-emit high→low
+        window = m._assemble(
+            query="q",
+            candidates=[g_low, g_mid, g_high],
+            spliced_map={
+                g_low.gene_id: "<G>L</G>",
+                g_mid.gene_id: "<G>M</G>",
+                g_high.gene_id: "<G>H</G>",
+            },
+            relation_graph={},
+            answer_slate=["k=v"],  # forces use_slate=True
+        )
+        # Top-score gene (g_high) should appear first in the rendered text.
+        assert window.text.find("H") < window.text.find("L")
+
+    def test_assemble_respects_caller_order_when_flagged(self, helix_manager_with_three_genes):
+        """With respect_caller_order=True, the input order is preserved."""
+        m, g_low, g_mid, g_high = helix_manager_with_three_genes
+        # Pass in reverse-rank order (low→high → bottom-rank first, top-rank last)
+        window = m._assemble(
+            query="q",
+            candidates=[g_low, g_mid, g_high],
+            spliced_map={
+                g_low.gene_id: "<G>L</G>",
+                g_mid.gene_id: "<G>M</G>",
+                g_high.gene_id: "<G>H</G>",
+            },
+            relation_graph={},
+            answer_slate=["k=v"],
+            respect_caller_order=True,
+        )
+        # L came first in input → stays first in text. H last in input → last.
+        assert window.text.find("L") < window.text.find("M") < window.text.find("H")
+```
+
+Add the fixture at the top of the test file (or in `conftest.py` if one exists in `tests/`):
+
+```python
+@pytest.fixture
+def helix_manager_with_three_genes(tmp_path):
+    """In-memory genome + a HelixContextManager with 3 genes of distinct scores.
+
+    Mirrors the tests/test_abstain_tier.py fixture pattern. The three genes
+    have score 1.0 (g_low), 5.0 (g_mid), 9.0 (g_high) so any sort by score
+    is observable.
+    """
+    from helix_context.config import HelixConfig
+    from helix_context.context_manager import HelixContextManager
+    from helix_context.genome import Genome
+    # Replicate the abstain-tier fixture's exact construction:
+    # see tests/test_abstain_tier.py for the canonical pattern.
+    raise NotImplementedError(
+        "Copy the fixture from tests/test_abstain_tier.py and adapt to "
+        "produce three genes with scores 1.0, 5.0, 9.0. See spec §10 "
+        "preamble: 'Test fixtures mirror the tests/test_abstain_tier.py "
+        "pattern (in-memory genome, mock backend, controllable scores via "
+        "_stub_express).'"
+    )
+```
+
+> **Note for the implementer:** Read `tests/test_abstain_tier.py` first to copy the existing fixture pattern. The placeholder above intentionally raises so you don't skip this step. The three genes need stable `gene_id`s and the `last_query_scores` map needs to contain {g_low: 1.0, g_mid: 5.0, g_high: 9.0} so the slate-path sort has something to sort by.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py::TestAssembleRespectsCallerOrder -v`
+
+Expected: FAIL — either `TypeError: _assemble() got an unexpected keyword argument 'respect_caller_order'` or, after adding the param without wiring, the order test fails because the slate sort still runs.
+
+- [ ] **Step 3: Add the parameter and gate the re-sort**
+
+In `helix_context/context_manager.py` `_assemble` (around line 1716), add `respect_caller_order: bool = False` to the signature. Then around lines 1740-1752, gate the existing sort:
+
+```python
+        if respect_caller_order:
+            # Foveated-splice path (spec §5): the caller has already arranged
+            # candidates in the desired emission order (e.g., reverse-rank
+            # for BROAD). Skip the re-sort so reverse-rank actually reaches
+            # the prompt instead of being clobbered back to score-DESC.
+            sorted_genes = list(candidates)
+        elif use_slate:
+            # MoE/small-model: relevance-first ordering — best gene at position 0
+            # so it's within every sliding-window attention layer
+            scores = self.genome.last_query_scores or {}
+            sorted_genes = sorted(
+                candidates,
+                key=lambda g: scores.get(g.gene_id, 0),
+                reverse=True,
+            )
+        else:
+            # Dense: sequence ordering for narrative coherence
+            sorted_genes = sorted(candidates, key=lambda g: g.promoter.sequence_index or 0)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py::TestAssembleRespectsCallerOrder -v`
+
+Expected: 2 tests PASS.
+
+- [ ] **Step 5: Run the full assembled-related regression suite**
+
+Run: `py -3 -m pytest tests/test_abstain_tier.py tests/test_context_manager_classifier.py -q`
+
+Expected: all green. The new parameter defaults to False, so existing call sites are unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helix_context/context_manager.py tests/test_foveated_splice.py
+git commit -m "feat(context): add respect_caller_order to _assemble
+
+Lets foveated-splice's reverse-rank placement survive _assemble's
+internal re-sort. Default False = no behavior change for existing
+callers. The slate-path sort (line 1745) and sequence-index sort
+(line 1752) only run when the flag is False.
+
+Spec: docs/specs/2026-05-03-foveated-splice-design.md §5
+Plan: docs/plans/2026-05-05-foveated-splice.md Task 3
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire foveated into `build_context` BROAD branch
+
+**Files:**
+- Modify: `helix_context/context_manager.py` — three insert/edit sites:
+  - After line 843 (BROAD-tier resolution): compute caps + reverse.
+  - Around line 940-970 (Step 4 compress loop): use foveated caps when stashed.
+  - Around line 974 (`_assemble` call): pass `respect_caller_order=foveated_active`.
+  - After line 985 (window metadata): stash `foveated_caps` + `foveated_alpha` when active.
+- Modify: `tests/test_foveated_splice.py` — add tier-gating + metadata + reverse-rank-end-to-end tests (spec §10 Tests 1, 2, 3, 4, 5, 7).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_foveated_splice.py`:
+
+```python
+class TestFoveatedTierGating:
+    """Foveated only fires on BROAD (spec §3, §10 Tests 1-5)."""
+
+    def test_disabled_broad_no_metadata(self, helix_manager_broad_with_twelve_genes):
+        """Test 1: foveated_enabled=False on BROAD → no metadata key, uniform compression."""
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = False
+        window = m.build_context("a query that lands in BROAD")
+        assert window.metadata.get("budget_tier") == "broad"
+        assert "foveated_caps" not in window.metadata
+
+    def test_enabled_broad_metadata_present(self, helix_manager_broad_with_twelve_genes):
+        """Test 2: foveated_enabled=True on BROAD → metadata['foveated_caps'] is a list, len = N."""
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in BROAD")
+        assert window.metadata.get("budget_tier") == "broad"
+        caps = window.metadata.get("foveated_caps")
+        assert isinstance(caps, list)
+        assert len(caps) == 12
+        assert window.metadata.get("foveated_alpha") == 1.0
+
+    def test_enabled_tight_no_metadata(self, helix_manager_tight):
+        """Test 3: foveated_enabled=True but tier=tight → no metadata key."""
+        m = helix_manager_tight
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in TIGHT")
+        assert window.metadata.get("budget_tier") == "tight"
+        assert "foveated_caps" not in window.metadata
+
+    def test_enabled_focused_no_metadata(self, helix_manager_focused):
+        """Test 4: foveated_enabled=True but tier=focused → no metadata key."""
+        m = helix_manager_focused
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in FOCUSED")
+        assert window.metadata.get("budget_tier") == "focused"
+        assert "foveated_caps" not in window.metadata
+
+    def test_enabled_abstain_no_metadata(self, helix_manager_abstain):
+        """Test 5: foveated_enabled=True but ABSTAIN gate fired first → no metadata key."""
+        m = helix_manager_abstain
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a weak query that triggers ABSTAIN")
+        assert window.metadata.get("budget_tier") == "abstain"
+        assert "foveated_caps" not in window.metadata
+
+
+class TestFoveatedReverseRankEndToEnd:
+    """Top-rank gene lands LAST in the assembled prompt (spec §10 Test 7)."""
+
+    def test_top_rank_gene_appears_last_in_window_text(
+        self, helix_manager_broad_with_twelve_genes,
+    ):
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in BROAD")
+        # The fixture seeds gene_0..gene_11 with descending scores. With
+        # foveated on, gene_0 (highest score) should be reversed to LAST.
+        # Verify by index of the gene_id strings in window.text.
+        idx_top = window.text.find("gene_0")
+        idx_bottom = window.text.find("gene_11")
+        assert idx_top != -1 and idx_bottom != -1
+        assert idx_top > idx_bottom, (
+            "Reverse-rank failed: top-score gene should appear AFTER "
+            "bottom-rank gene in the assembled window."
+        )
+```
+
+> **Implementer note on fixtures:** The four `helix_manager_*` fixtures (`_broad_with_twelve_genes`, `_tight`, `_focused`, `_abstain`) need to seed scores that land in the right tier per the existing logic at `context_manager.py:829-843`:
+> - **BROAD:** 12 genes, top_score < 5.0 (below TIGHT_SCORE_FLOOR) — e.g. all scores in [1.0, 3.0] — so the tier resolves to `broad`.
+> - **TIGHT:** ratio ≥ 3.0 AND top ≥ 5.0 AND ≥ 3 candidates — e.g. top=10, others=2.0.
+> - **FOCUSED:** ratio ≥ 1.8 AND top ≥ 2.5 AND ≥ 6 candidates, but not TIGHT — e.g. top=4.5, mean=2.0.
+> - **ABSTAIN:** trigger via `tests/test_abstain_tier.py`'s existing weak-retrieval pattern.
+> Read `tests/test_abstain_tier.py` end-to-end before writing these — copy its fixture machinery rather than re-deriving it.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py -v`
+
+Expected: the tier-gating and reverse-rank tests FAIL because the foveated block doesn't exist yet in `build_context`.
+
+- [ ] **Step 3: Add the foveated block after BROAD tier resolves**
+
+In `helix_context/context_manager.py`, immediately after the `# else: broad — keep current up-to-max_genes set` comment (around line 843, BEFORE the `# Stash shadow pool for Lagrange check` line), insert:
+
+```python
+                # Foveated-splice (spec §4-5): for BROAD only, replace uniform
+                # per-gene compression with a rank-scaled power-law schedule
+                # AND reverse the assembly order so top-rank lands nearest
+                # the user query (lost-in-the-middle exploit). Off by default;
+                # see docs/specs/2026-05-03-foveated-splice-design.md §6.3.
+                # No env override in v1 — when foveated flips on by default
+                # later, add HELIX_FOVEATED_DISABLE via _env_truthy at that
+                # point (spec §6.3).
+                foveated_active = (
+                    budget_tier == "broad"
+                    and self.config.budget.foveated_enabled
+                    and len(candidates) > 1
+                )
+                if foveated_active:
+                    caps = _compute_foveated_caps(
+                        n=len(candidates),
+                        alpha=self.config.budget.foveated_alpha,
+                        c_min=self.config.budget.foveated_c_min,
+                        c_max=1.0,
+                    )
+                    # Reverse together so caps[i] still pairs with candidates[i]
+                    candidates = list(reversed(candidates))
+                    caps = list(reversed(caps))
+                    self._last_foveated_caps = caps
+                    self._last_foveated_active = True
+                else:
+                    self._last_foveated_caps = None
+                    self._last_foveated_active = False
+```
+
+- [ ] **Step 4: Wire foveated caps into the Step 4 compression loop**
+
+In `helix_context/context_manager.py` around line 940-970, replace the existing loop with one that consults the stashed caps:
+
+```python
+        # Step 4: Dense gene expression
+        # Each gene expressed as: Facts (KV pairs) + Source + Raw content
+        # Dense format minimizes prose for small model extraction.
+        spliced_map = {}
+        answer_slate_lines = []  # MoE answer slate — flat KV pairs
+        foveated_caps = getattr(self, "_last_foveated_caps", None)
+        foveated_base = self.config.budget.foveated_base_chars
+        for idx, g in enumerate(candidates):
+            src = g.source_id or ""
+            short = ""
+            if src and not src.startswith("_"):
+                parts = src.replace("\\", "/").split("/")
+                try:
+                    j = parts.index("Projects")
+                    short = "/".join(parts[j + 1:])
+                except ValueError:
+                    short = "/".join(parts[-3:]) if len(parts) > 3 else src
+            kv_attrs = ""
+            if g.key_values:
+                kv_pairs = " ".join(g.key_values[:5])
+                kv_attrs = f' facts="{kv_pairs}"'
+                for kv in g.key_values[:5]:
+                    answer_slate_lines.append(kv)
+            src_attr = f' src="{short}"' if short else ""
+            # Foveated path overrides the uniform 1000-char target with a
+            # rank-proportional cap per gene. When foveated_caps is None
+            # (default / non-BROAD / disabled), preserve current behavior.
+            if foveated_caps is not None:
+                target = max(1, int(foveated_caps[idx] * foveated_base))
+            else:
+                target = 1000
+            content = compress_text(
+                g.content,
+                target_chars=target,
+                content_type=g.promoter.domains,
+            )
+            spliced_map[g.gene_id] = f"<GENE{src_attr}{kv_attrs}>\n{content}\n</GENE>"
+```
+
+> **Implementer note:** The only behavior change when `foveated_caps is None` is replacing the implicit `for g in candidates:` with `for idx, g in enumerate(candidates):`. The hardcoded `target_chars=1000` becomes the explicit `target = 1000` else-branch. No change to the `<GENE>` rendering, KV attrs, or `spliced_map` shape.
+
+- [ ] **Step 5: Pass `respect_caller_order` to `_assemble`**
+
+Around line 974, change the `_assemble` call to forward the foveated flag:
+
+```python
+        window = self._assemble(
+            query, candidates, spliced_map, relation_graph,
+            query_signals=(domains, entities),
+            answer_slate=answer_slate_lines if use_slate else None,
+            session_id=session_id,
+            ignore_delivered=ignore_delivered,
+            decoder_prompt_override=effective_decoder_prompt,
+            respect_caller_order=getattr(self, "_last_foveated_active", False),
+        )
+```
+
+- [ ] **Step 6: Stash telemetry metadata when foveated fired**
+
+After the existing `window.metadata["budget_tokens_est"] = budget_tokens_est` line (around line 986), add:
+
+```python
+            if getattr(self, "_last_foveated_active", False):
+                # Spec §8: per-call provenance for post-hoc α-curve attribution.
+                # Absent when foveated_enabled=false or tier != broad.
+                window.metadata["foveated_caps"] = self._last_foveated_caps
+                window.metadata["foveated_alpha"] = self.config.budget.foveated_alpha
+```
+
+- [ ] **Step 7: Run tests — expect PASS**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py -v`
+
+Expected: all foveated tests PASS (helper unit tests from Task 2, ordering test from Task 3, tier-gating + reverse-rank end-to-end from Task 4).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add helix_context/context_manager.py tests/test_foveated_splice.py
+git commit -m "feat(context): wire foveated-splice into BROAD tier
+
+After BROAD tier resolves, compute power-law per-gene compression caps,
+reverse (candidates, caps) together, and stash on the manager. Step 4's
+compress_text() consumes the stashed cap when present (else falls back
+to the uniform 1000-char target). _assemble receives respect_caller_order
+so reverse-rank placement reaches the prompt. Telemetry stashes
+metadata['foveated_caps'] + ['foveated_alpha'] for post-hoc attribution.
+
+Spec: docs/specs/2026-05-03-foveated-splice-design.md §4-8
+Plan: docs/plans/2026-05-05-foveated-splice.md Task 4
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Regression sweep
+
+**Files:** none modified — this is a verification task.
+
+- [ ] **Step 1: Run the foveated test file**
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py -v`
+
+Expected: 8+ tests pass, exactly the spec §10 cases plus helper unit tests + the `_assemble` ordering tests.
+
+- [ ] **Step 2: Run the surrounding suites flagged by the spec**
+
+Run: `py -3 -m pytest tests/test_abstain_tier.py tests/test_pipeline.py tests/test_context_manager_classifier.py tests/test_config.py -q`
+
+Expected: all green. ABSTAIN tier and classifier integration unaffected because `foveated_enabled = False` is the default.
+
+- [ ] **Step 3: Run the full project suite as a final sanity check**
+
+Run: `py -3 -m pytest -q`
+
+Expected: no new failures vs the pre-foveated master baseline. (Some pre-existing test files may already be skipped/marked — accept whatever was green on master.)
+
+- [ ] **Step 4: Smoke-test foveated_enabled at runtime**
+
+```bash
+HELIX_CONFIG=/tmp/helix_foveated_smoke.toml py -3 -c "
+from helix_context.config import HelixConfig
+cfg = HelixConfig()
+cfg.budget.foveated_enabled = True
+cfg.budget.foveated_alpha = 1.0
+print('foveated config OK:', cfg.budget.foveated_enabled, cfg.budget.foveated_alpha)
+"
+```
+
+Expected: prints `foveated config OK: True 1.0`. (No real query — that's the bench's job; this just confirms the config wires through.)
+
+- [ ] **Step 5: Commit (if any test fixture cleanup landed)**
+
+If the regression sweep surfaced any fixture or test cleanups, commit them now with a message like `chore(tests): foveated regression cleanup`. Otherwise skip.
+
+---
+
+## Task 6: Bench-prep + PR scaffolding
+
+**Files:**
+- Create (or update): `overnight_logs/.gitkeep` if it doesn't exist (most overnight logs are gitignored — see spec §9.4 `git add -f` instruction).
+- Add a PR-body template at `docs/plans/2026-05-05-foveated-splice.md` bottom? **No — the PR body is composed at PR-creation time, not in the plan.** This task is just a checklist for the human reviewer.
+
+- [ ] **Step 1: Verify `overnight_logs/` is in `.gitignore`**
+
+Run: `grep -n "overnight_logs" .gitignore`
+
+Expected: matches a line. The spec instructs phase reports to be committed with `git add -f` because the directory is gitignored.
+
+- [ ] **Step 2: Confirm Phase 0 baseline exists**
+
+The spec §9.1 references `overnight_logs/diamond_2026-05-03_report.md` as the post-ABSTAIN baseline. Verify it's accessible from the bench machine — if not, surface to the human before attempting Phase 1.
+
+- [ ] **Step 3: Stop here — bench is out of plan scope**
+
+The bench plan (spec §9) is a 4-cell, ~20-28h overnight effort run on a bench machine with the appropriate fixtures. It is NOT executed as part of this implementation plan. This plan ships:
+
+- Code: `foveated_enabled = false` default, no behavior change in production
+- Tests: 8+ passing tests
+- Telemetry: `foveated_caps` / `foveated_alpha` keys stashed when active
+
+Phase 1 + 2 + the on-by-default flip are gated on §9.4 pass criteria and happen in a follow-up commit, NOT this plan.
+
+---
+
+## Out of Scope (Deferred — see spec §11)
+
+- **Lagrangian-optimal log-utility schedule** — v2 if power-law underperforms.
+- **Score-driven (vs rank-driven) schedule** — v2 if rank fails on flat-score corpora.
+- **Foveated extending to TIGHT/FOCUSED** — v3 once BROAD validates.
+- **Sandwich placement** — v3, orthogonal.
+- **BROAD budget tighten** — separate spec.
+- **`HELIX_FOVEATED_DISABLE` env override** — added when foveated flips on by default.
+
+---
+
+## Risk Register Cross-Check (spec §12)
+
+| Spec risk | Plan mitigation |
+| --- | --- |
+| Wrong attribution if interventions bundled | Phase 1 (placement isolation at α=1) is bench-driven, NOT in this plan. This plan ships both code paths but `foveated_enabled = false` so production sees neither until bench picks the winner. |
+| α=1 is wrong default | Default is harmonic-ish per spec; bench Phase 2 sweeps and ships winner. |
+| Reverse-rank breaks classifier integration | Task 5 Step 2 runs `tests/test_context_manager_classifier.py` as a regression gate. |
+| Per-gene byte-cap mid-token truncation | Task 4 uses real `compress_text()` (not a mock) so any truncation pathology surfaces in Test 8 (helper unit test) and the end-to-end tests. |
+| 15-25% missed-paper risk | Out of scope for the plan; the spec §13 prior-art section is the artifact for the eventual paper draft. |
+| Bench cells take longer than expected | Out of scope for the plan — Task 6 explicitly punts bench to a follow-up commit. |
+| Foveated flips on by default before validation | Default is `false`; flip requires a separate config commit gated on §9.4 pass criteria. |

--- a/docs/specs/2026-05-03-foveated-splice-design.md
+++ b/docs/specs/2026-05-03-foveated-splice-design.md
@@ -1,0 +1,457 @@
+# Foveated-Splice — Rank-Scaled Compression Schedule for BROAD Tier — Design Spec
+
+**Date:** 2026-05-03
+**Status:** Approved for implementation planning (pending bench validation)
+**Scope:** `helix_context/context_manager.py` (BROAD branch only), `helix_context/config.py`,
+`helix.toml`, new `tests/test_foveated_splice.py`. **Depends on the ABSTAIN tier
+(2026-05-02 spec) being merged first** — foveated-splice only modifies the BROAD
+tier behavior; ABSTAIN owns the lower-bound cliff.
+
+## 1. Motivation
+
+The 2026-05-02 ABSTAIN tier closes the latency regression on `fic=False` (retrieval-
+missed) queries by skipping injection entirely. It does **not** address the residual
+ceiling on `fic=True` accuracy: when retrieval succeeds, helix today ships up to 12
+candidate genes at uniform compression fidelity into the small e4b model's system
+prompt. Two known small-model effects mean uniform-fidelity injection
+under-utilizes the retrieval signal:
+
+1. **Effective attention bandwidth.** gemma4:e4b on 12K tokens of mixed-relevance
+   content spreads attention thin across all genes regardless of their score —
+   the top-1 gene gets the same per-token attention budget as rank-12.
+2. **Lost in the middle** (Liu et al. 2023). Small models attend disproportionately
+   to the start and end of context. Helix's current rank-order injection (top-1
+   first) buries the most-relevant content far from the user query, where attention
+   weight is lowest.
+
+This spec adds **foveated-splice**: rank-scaled per-gene compression for the BROAD
+tier paired with reverse-rank placement. Top-1 gets full content nearest the query;
+lower-ranked genes get progressively compressed and pushed away from the cursor.
+The retrieval signal is preserved with higher fidelity where the model can use it,
+and noise is shed where the model would spread attention thin anyway.
+
+The framing analogy: foveated rendering in real-time graphics allocates GPU
+budget to the foveal cone of the eye and lets resolution decay outward.
+Foveated-splice does the same for the LLM's "attention pointer" (the user query):
+top-rank content stays high-fidelity near the cursor; rank decays both in
+compression and in position toward the periphery of the system prompt.
+
+## 2. Non-Goals
+
+- **No change to ABSTAIN, FOCUSED, or TIGHT tiers.** Foveated-splice only modifies
+  the BROAD branch of the budget-tier block in `_build_context_internal`. ABSTAIN
+  owns the lower-bound cliff; TIGHT/FOCUSED stay on uniform compression because
+  they retrieve fewer genes and the rank gradient is less informative there.
+  Extending foveated to TIGHT/FOCUSED is a deferred v3 item (§11).
+- **No change to total token budget for BROAD.** Today's BROAD ships ~12K tokens.
+  Foveated-splice redistributes those bytes by rank but holds total constant.
+  BROAD budget tighten (12K → 6-8K) is a separate spec that can compose with
+  foveated after both validate independently.
+- **No change to retrieval scoring or candidate selection.** The set of 12
+  candidates and their scores come out of `_express` + `_apply_candidate_refiners`
+  unchanged. Foveated only affects how those 12 are compressed and placed.
+- **No new compression backend.** Per-gene byte caps feed into the existing
+  splice infrastructure via `max_item_chars` — no new ribosome interface, no
+  LLMLingua wrapper, no headroom changes.
+- **No on-by-default ship.** Unlike ABSTAIN (which shipped on as a fix),
+  foveated-splice ships off-by-default for a measurement period (§6.3).
+- **No bundled-attribution claim.** Schedule shape and placement are benched
+  independently in Phase 1 of the bench plan (§9). Shipping both without
+  isolation would conflate the well-known position-bias effect with the novel
+  schedule-shape contribution and weaken the publication framing.
+
+## 3. Trigger / Scope
+
+Foveated-splice activates when:
+
+1. `foveated_enabled` is true (config flag, default false; see §6)
+2. The dynamic-budget tier resolves to `"broad"` (the existing post-refinement
+   path at `context_manager.py` budget-tier block, which fires when the query
+   is not weak-enough for ABSTAIN AND not strong-enough for TIGHT/FOCUSED)
+
+Inside the BROAD branch, foveated replaces today's uniform per-gene
+`max_item_chars` with a rank-scaled vector and reverses the assembly order.
+All other branches (ABSTAIN, FOCUSED, TIGHT, the empty-candidates short-circuit)
+are unaffected.
+
+## 4. Maths — Schedule Shape
+
+### 4.1 Power-law per-gene compression ratio
+
+For BROAD with N candidates ranked by score `s_1 ≥ s_2 ≥ ... ≥ s_N`:
+
+```
+c_i = max(c_min, c_max · i^(-α))    for i ∈ [1, N]
+```
+
+Where:
+- `i` is the gene's rank (1 = top, N = bottom of BROAD set)
+- `α` (default `1.0`) is the power-law exponent, the only tunable knob
+- `c_max` (default `1.0`) is the rank-1 ceiling — full content
+- `c_min` (default `0.15`) is the rank-N floor — heavily compressed
+
+Each gene's effective byte cap = `c_i · _DEFAULT_MAX_ITEM_CHARS`, passed to
+`_build_item(...)` which already accepts a `max_item_chars` parameter.
+
+### 4.2 Schedule shape comparison
+
+Behavior at `α ∈ {0.5, 1.0, 2.0}` for N = 12:
+
+| rank | α=0.5 | α=1.0 | α=2.0 |
+| --- | --- | --- | --- |
+|  1 | 1.00 | 1.00 | 1.00 |
+|  2 | 0.71 | 0.50 | 0.25 |
+|  3 | 0.58 | 0.33 | 0.15 |
+|  6 | 0.41 | 0.17 | 0.15 |
+| 12 | 0.29 | 0.15 | 0.15 |
+
+`α=0.5` is gentle decay; `α=2.0` collapses to floor by rank 3-4 and is
+effectively a "top-3 dominate" schedule. `α=1.0` (harmonic-ish) is the
+balanced default.
+
+### 4.3 Why power-law
+
+Three families were considered:
+
+- **Linear-in-rank** — single tunable [c_min, c_max], no curve choice. Too
+  rigid: doesn't capture aggressive top-1-bias scenarios.
+- **Power-law** (chosen) — single knob `α`, captures linear-ish (small α),
+  harmonic (α=1), aggressive falloff (α=2). Easiest implementation that
+  spans the relevant design space.
+- **Lagrangian-optimal log-utility** — derived from `maximize Σ s_i · log(1+c_i)`
+  subject to `Σ c_i · |g_i| ≤ B`. Theoretically grounded but requires per-call
+  λ-binary-search and assumes log-utility as the relevance model. Deferred
+  to v2 if power-law underperforms (§11).
+
+### 4.4 Why this is novel
+
+Per the 2026-05-03 arXiv verification (medium-high confidence, ~15-25% missed-
+paper risk):
+
+- **AdaComp** (arXiv:2409.01579) does per-query top-k selection — global cutoff,
+  not per-doc continuous fidelity rate.
+- **EXIT** (arXiv:2412.12559) does sentence-level binary keep/drop within docs —
+  binary, not continuous compression rate.
+- **PyramidKV / PyramidInfer** (2024) has the math (non-uniform budget along an
+  axis with information-theoretic justification) but applies it to layer depth,
+  not retrieval rank.
+- **LongLLMLingua** (arXiv:2310.06839) does per-doc allocation but heuristic, not
+  a derived schedule, and at token-drop granularity rather than continuous
+  fidelity.
+- **Ms-PoE** (NeurIPS 2024) addresses position bias but doesn't compress.
+
+The exact fusion (rank-axis × continuous-fidelity × derived-optimal schedule)
+remains unclaimed. The novelty is the schedule shape and its derivation, not
+"rank-aware RAG" broadly. The placement intervention is acknowledged prior art
+(Liu 2023, Ms-PoE 2024) and benched separately to keep attribution clean.
+
+The work also engages with **Spectrum Projection Score** (arXiv:2508.05909),
+which argues the *selection metric* matters more than the *rate*. Foveated-
+splice implicitly assumes the retrieval score is well-calibrated; helix's
+KV-harvest 2026-04-12 calibration of `FOCUSED_SCORE_FLOOR = 2.5` and the
+shadow-pool / 15%-of-top score-gate floor satisfy that assumption.
+
+## 5. Placement — Reverse Rank Order
+
+For BROAD only, reverse the assembly order so the top-ranked gene lands
+**immediately before the user query** rather than at the start of the system
+prompt. This exploits the lost-in-the-middle effect (Liu 2023): small models
+attend most to tokens nearest the cursor.
+
+```
+[system prompt]
+  decoder_prompt
+  ----
+  gene 12 (heavily compressed, c_12 ≈ 0.15)
+  gene 6  (moderate, c_6 ≈ 0.17)
+  gene 3  (lighter, c_3 ≈ 0.33)
+  gene 1  (full content, c_1 = 1.00)
+  ----
+[user]
+  <query>
+```
+
+TIGHT and FOCUSED keep their current rank-order placement; only BROAD reverses.
+Implementation: a single `list.reverse()` call at the assembly boundary,
+guarded by the `foveated_enabled` flag.
+
+**Attribution boundary.** Schedule shape (§4) and placement (§5) are
+**conceptually independent** interventions. Schedule is the novel contribution;
+placement is well-known prior art. Phase 1 of the bench plan (§9) isolates
+placement so the headline paper claim — "the schedule shape contributes X
+beyond well-known position-bias effects" — is defensible.
+
+## 6. Config Surface
+
+### 6.1 helix.toml
+
+```toml
+[budget]
+# ... existing keys ...
+
+# Foveated-splice (BROAD tier only). When true, the BROAD branch of the
+# dynamic-budget tier replaces uniform per-gene compression with a rank-scaled
+# power-law schedule and reverses the assembly order so the top-ranked gene
+# lands immediately before the user query (lost-in-the-middle exploit). Off
+# by default for the measurement period — flip to true after the α-sweep
+# bench (spec §9) identifies a winner. See docs/specs/2026-05-03-foveated-
+# splice-design.md.
+foveated_enabled = false
+
+# Power-law exponent for the per-gene compression schedule:
+#   c_i = max(c_min, c_max · i^(-α))
+# α=0.5 = gentle decay; α=1.0 (default) = harmonic-ish; α=2.0 = aggressive
+# top-bias. Bench sweeps {0.5, 1.0, 2.0} during Phase 2 validation; ship the
+# winner as the new default.
+foveated_alpha = 1.0
+
+# Rank-N (bottom of BROAD set) minimum compression ratio. Each gene's byte
+# cap = max(foveated_c_min, foveated_alpha-driven c_i) × _DEFAULT_MAX_ITEM_CHARS.
+foveated_c_min = 0.15
+```
+
+### 6.2 BudgetConfig
+
+`helix_context/config.py`:
+
+```python
+@dataclass
+class BudgetConfig:
+    # ... existing fields ...
+    abstain_enabled: bool = True
+    foveated_enabled: bool = False        # NEW
+    foveated_alpha: float = 1.0           # NEW
+    foveated_c_min: float = 0.15          # NEW
+```
+
+Loader in `load_config` reads each new key with the standard
+`b.get("foveated_*", cfg.budget.foveated_*)` pattern.
+
+### 6.3 Rollout posture
+
+Off by default for the measurement period. Different from ABSTAIN's on-by-default
+ship — ABSTAIN was a fix for a known regression with calibrated thresholds;
+foveated-splice has a 3-cell α-sweep ahead of it and ships into a less-instrumented
+part of the pipeline. Flipping to on requires bench evidence (§9 pass criteria).
+
+No env override (`HELIX_FOVEATED_DISABLE` is overkill for an off-by-default
+feature). When/if foveated flips on by default in a future release, an env
+override can be added then with the same `_env_truthy` helper ABSTAIN uses.
+
+## 7. Integration Point
+
+The change lives entirely inside the BROAD branch of the budget-tier block in
+`HelixContextManager.build_context` (the section currently around
+`context_manager.py:817-840`, the post-FOCUSED `# else: broad` fallthrough).
+
+```python
+# Existing: BROAD is the default fallthrough — no per-gene compression today.
+# else: broad — keep current up-to-max_genes set
+#   (weak absolute scores or weak ratio → widen the net)
+
+# NEW: foveated-splice (BROAD only)
+foveated_enabled = (
+    self.config.budget.foveated_enabled
+    and not _env_truthy("HELIX_FOVEATED_DISABLE")  # consistency with ABSTAIN
+)
+if budget_tier == "broad" and foveated_enabled and len(candidates) > 1:
+    α = self.config.budget.foveated_alpha
+    c_min = self.config.budget.foveated_c_min
+    c_max = 1.0
+    foveated_caps = [
+        max(c_min, c_max * (i ** -α))
+        for i in range(1, len(candidates) + 1)
+    ]
+    # Reverse for placement: top-rank lands nearest user query
+    candidates = list(reversed(candidates))
+    foveated_caps = list(reversed(foveated_caps))
+    # foveated_caps[i] now corresponds to candidates[i] in their new order
+    # Stash for the assembly path to consume via _build_item(max_item_chars=...)
+    self._last_foveated_caps = foveated_caps
+else:
+    self._last_foveated_caps = None
+```
+
+The assembly path (`_build_item`-style construction during expression) reads
+`self._last_foveated_caps[i] · _DEFAULT_MAX_ITEM_CHARS` per gene when the
+attribute is non-None. When None, today's uniform behavior is preserved.
+
+**Why pre-splice byte-cap, not splice_aggressiveness vector.** The
+`splice_aggressiveness` knob is a scalar shared across the codons / splice /
+ribosome layers. Plumbing it as a per-gene array touches multiple modules.
+Per-gene `max_item_chars` is already a parameter on `_build_item` (used by
+the `/context` packet path with `_RAW_MAX_ITEM_CHARS`), so this is a single-
+module change with a clean existing seam.
+
+## 8. Telemetry
+
+Per-call metadata addition on the BROAD path when foveated fires:
+
+```python
+metadata["foveated_caps"] = foveated_caps   # list[float], len == len(candidates)
+metadata["foveated_alpha"] = α
+```
+
+This lets us measure post-hoc whether a particular `α` value's curve shape
+correlates with accuracy/latency on real production queries — without needing
+to re-run the bench. No new metric counter; BROAD trip-rate is already on
+`budget_tier_counter`.
+
+When `foveated_enabled = false`, `metadata["foveated_caps"]` is absent.
+Dashboards can detect the rollout state via metric presence/absence.
+
+## 9. Bench Plan — Phased Attribution
+
+### 9.1 Phase 0: Establish post-ABSTAIN baseline
+
+Already running 2026-05-02 → 2026-05-03 overnight. All foveated bench cells
+compare against this baseline, NOT against the pre-ABSTAIN 2026-05-01 run.
+
+Output: `overnight_logs/diamond_2026-05-03_report.md`. Headline number to beat:
+the post-ABSTAIN p95 on `fic=True` and `fic=False` subsets respectively.
+
+### 9.2 Phase 1: Placement isolation
+
+Two cells, ~10-14h overnight:
+
+```
+cell A:  forward-rank + α=1.0    (schedule alone, no placement flip)
+cell B:  reverse-rank + α=1.0    (schedule + placement)
+```
+
+**Decide:** which placement wins on `fic=True` accuracy at α=1. Hold winner
+for Phase 2.
+
+**Pass criterion to advance:** the winning placement matches or exceeds the
+Phase 0 baseline on `fic=True` accuracy. If both regress accuracy, the schedule
+shape itself is broken at α=1 — pause before Phase 2 and revisit the design.
+
+### 9.3 Phase 2: α-sweep on placement winner
+
+Two cells, ~10-14h overnight:
+
+```
+cell C:  winner-placement + α=0.5
+cell D:  winner-placement + α=2.0
+(cell B from Phase 1 is the α=1.0 mid-point)
+```
+
+**Decide:** α winner. Ship that triple `(placement, α, c_min=0.15)` as
+`foveated_alpha` default with `foveated_enabled = true`.
+
+### 9.4 Pass criteria to merge / flip on by default
+
+For the winning configuration on `fic=True` queries (where retrieval succeeded
+— foveated's target population):
+
+- Latency: p95 drops by ≥ 5s OR accuracy lifts by ≥ 2pp
+- `fic=False` subset: no regression on latency or accuracy (foveated doesn't
+  fire there — ABSTAIN owns it — but worth verifying as a sanity check)
+
+Commit each phase's report to `overnight_logs/diamond_foveated_<DATE>_phaseN_report.md`
+with `git add -f` (overnight_logs/ is gitignored). Cross-link from the
+implementing PR's body.
+
+### 9.5 Total cost
+
+4 bench cells × ~5-7h each = ~20-28h. Two overnight cycles.
+
+## 10. Tests
+
+New file `tests/test_foveated_splice.py` covering eight cases. Test fixtures
+mirror the `tests/test_abstain_tier.py` pattern (in-memory genome, mock
+backend, controllable scores via `_stub_express`).
+
+| # | Case | foveated_enabled | tier expected | Pinned behavior |
+| --- | --- | --- | --- | --- |
+| 1 | Disabled, BROAD | False | broad | `metadata["foveated_caps"]` absent; uniform compression preserved |
+| 2 | Enabled, BROAD | True | broad | `metadata["foveated_caps"]` present, len = len(candidates), values match power-law formula |
+| 3 | Enabled, TIGHT | True | tight | `metadata["foveated_caps"]` absent (foveated only fires on BROAD) |
+| 4 | Enabled, FOCUSED | True | focused | `metadata["foveated_caps"]` absent |
+| 5 | Enabled, ABSTAIN | True | abstain | `metadata["foveated_caps"]` absent (gate fires before BROAD branch) |
+| 6 | α formula | True | broad | for N=12, α=1: caps[0] == 1.0, caps[5] == 0.5, caps[11] == max(0.15, 1/12) |
+| 7 | Reverse-rank order | True | broad | the gene with the highest score is the LAST in the assembled candidates list |
+| 8 | c_min floor | True | broad | for α=2 and N=12, caps[5..11] all == c_min (0.15) |
+
+Run: `py -3 -m pytest tests/test_foveated_splice.py -v` — expected 8 passes.
+Plus regression check: `py -3 -m pytest tests/test_abstain_tier.py
+tests/test_pipeline.py tests/test_context_manager_classifier.py
+tests/test_config.py -q` — all pass (no regression in ABSTAIN or surrounding
+suites).
+
+## 11. Out of Scope (Deferred)
+
+- **Lagrangian-optimal log-utility schedule.** v2 if power-law underperforms
+  on the bench, OR for the publication path where a derived schedule is a
+  stronger contribution than a parametric one.
+- **Score-driven (vs rank-driven) schedule.** v2 if rank-based shows a
+  "score gradient sensitivity" failure mode (e.g., flat-score corpus where
+  rank doesn't carry information).
+- **Foveated extending to TIGHT/FOCUSED.** v3 once BROAD-only validates.
+  TIGHT has 3 candidates and FOCUSED has 6 — the rank gradient is less
+  informative, so the win is smaller and the bench cost-per-cell is higher.
+- **Sandwich placement** (top-1 at start AND end, primacy + recency). v3
+  orthogonal to schedule; would need its own attribution work.
+- **BROAD budget tighten** (12K → 6-8K). Separate spec; can compose with
+  foveated after both validate independently. The 2026-05-02 ABSTAIN-tier
+  spec §11 already lists this as a deferred follow-up.
+- **HELIX_FOVEATED_DISABLE env override.** Skipped while foveated is
+  off-by-default. Add when foveated flips on by default in a future release.
+
+## 12. Risk Register
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Wrong attribution if interventions bundled (schedule + placement shipped together without isolation) | High | Phase 1 of bench (§9.2) isolates placement at α=1; schedule sweep happens in Phase 2 on the placement winner. Cost: 1 extra bench cell, ~5-7h. |
+| α=1 is wrong default — needs per-corpus tuning | Medium | Phase 2 sweeps {0.5, 1.0, 2.0} pre-merge; ship winner as default; off-by-default until winner identified. |
+| Reverse-rank placement breaks classifier integration | Medium | Phase 1 cells A/B include classifier-tagged queries; bench reports stratified by classifier class. |
+| Per-gene byte-cap interacts badly with splice's content-summary boundary (e.g., truncation mid-sentence for c_min=0.15 genes) | Medium | Test fixture uses real splice path, not mock. Test 8 verifies the c_min floor is respected. If 0.15 truncates mid-token meaningfully, raise c_min to 0.20 in Phase 2 sweep. |
+| 15-25% missed-paper risk from arXiv check | Low-Medium | Spec frames novelty as "schedule shape + derivation"; placement is acknowledged prior art (Liu 2023, Ms-PoE 2024). AdaComp and EXIT cited as closest competitors with explicit differentiation. |
+| Bench cells take longer than expected | Low | Each cell ~5-7h. Total ~20-28h split across 2 overnights. If 3rd overnight needed, slip release by 1 day. |
+| Foveated flips on by default before validation | Low | `foveated_enabled = false` default; PR body's pre-merge checklist requires §9.4 pass criteria as a checkbox. |
+
+## 13. Spec Positioning vs Prior Work
+
+For the implementing PR's body and the eventual paper draft:
+
+- **AdaComp** ([arXiv:2409.01579](https://arxiv.org/abs/2409.01579)) — closest
+  competitor on retrieval-quality-aware compression. Differs: per-query global
+  top-k cutoff, not per-doc continuous fidelity rate.
+- **EXIT** ([arXiv:2412.12559](https://arxiv.org/abs/2412.12559)) — closest
+  competitor on context-aware extractive compression. Differs: per-sentence
+  binary keep/drop, not continuous compression rate per doc.
+- **LongLLMLingua** ([arXiv:2310.06839](https://arxiv.org/abs/2310.06839)) —
+  per-doc heuristic compression with question-conditioned importance score.
+  Cite as prior art for the relevance-scoring infrastructure we're wrapping.
+- **PyramidKV / PyramidInfer** (2024) — non-uniform KV budget across layers.
+  Cite as prior art for the math (cross-axis transplant: layer-depth →
+  retrieval-rank). The geometric/linear decay framing is theirs; we apply it
+  to a different axis.
+- **Ms-PoE** (NeurIPS 2024) — position-bias mitigation. Cite as prior art for
+  the placement-order rationale.
+- **Spectrum Projection Score** ([arXiv:2508.05909](https://arxiv.org/abs/2508.05909))
+  — argues selection metric matters more than rate. Engage with one sentence:
+  foveated-splice's value depends on a calibrated relevance score, which
+  helix's prior work (FOCUSED_SCORE_FLOOR calibration on KV-harvest 2026-04-12)
+  has established.
+
+## 14. Reframing for Substack Paper Series
+
+The 2026-05-02 Substack #2 ("The Same Move at Every Layer") committed publicly to
+a head-to-head benchmark fight as the next post, gated on three §7 blockers
+(BM25 vs helix_rag, PKI tier broken, helix_only 4555-char ceiling). ABSTAIN
+addressed the BM25 reframe (helix needed a confidence gate, not speed).
+Foveated-splice addresses a different §7 blocker indirectly: the helix_only
+4555-char assembly ceiling is partially a uniform-compression artifact —
+ranking 12 genes equally at the same compression rate hits a global token
+ceiling earlier than rank-scaled compression would.
+
+Foveated-splice is paper-shape work in its own right. Two viable paths:
+
+1. **Foveated as paper #3** (its own post) — if Phase 1+2 benches show clean
+   schedule-shape attribution, the rank-axis × continuous-fidelity × power-law
+   contribution is publication-grade with the citations above.
+2. **Foveated as the §7 unblocker** — the head-to-head paper writes itself if
+   foveated closes the helix_only ceiling AND the BM25 gap simultaneously.
+
+Decision deferred until bench results are in.

--- a/docs/specs/2026-05-03-foveated-splice-design.md
+++ b/docs/specs/2026-05-03-foveated-splice-design.md
@@ -249,11 +249,10 @@ The change lives entirely inside the BROAD branch of the budget-tier block in
 # else: broad — keep current up-to-max_genes set
 #   (weak absolute scores or weak ratio → widen the net)
 
-# NEW: foveated-splice (BROAD only)
-foveated_enabled = (
-    self.config.budget.foveated_enabled
-    and not _env_truthy("HELIX_FOVEATED_DISABLE")  # consistency with ABSTAIN
-)
+# NEW: foveated-splice (BROAD only). No env override in v1 — see §6.3.
+# When foveated flips on by default in a future release, add
+# HELIX_FOVEATED_DISABLE via the existing _env_truthy helper at that point.
+foveated_enabled = self.config.budget.foveated_enabled
 if budget_tier == "broad" and foveated_enabled and len(candidates) > 1:
     α = self.config.budget.foveated_alpha
     c_min = self.config.budget.foveated_c_min
@@ -369,7 +368,7 @@ backend, controllable scores via `_stub_express`).
 | 3 | Enabled, TIGHT | True | tight | `metadata["foveated_caps"]` absent (foveated only fires on BROAD) |
 | 4 | Enabled, FOCUSED | True | focused | `metadata["foveated_caps"]` absent |
 | 5 | Enabled, ABSTAIN | True | abstain | `metadata["foveated_caps"]` absent (gate fires before BROAD branch) |
-| 6 | α formula | True | broad | for N=12, α=1: caps[0] == 1.0, caps[5] == 0.5, caps[11] == max(0.15, 1/12) |
+| 6 | α formula | True | broad | for N=12, α=1: caps[0] == 1.0, caps[1] == 0.5, caps[5] ≈ 1/6, caps[11] == max(0.15, 1/12) (= 0.15 since 1/12 < c_min) |
 | 7 | Reverse-rank order | True | broad | the gene with the highest score is the LAST in the assembled candidates list |
 | 8 | c_min floor | True | broad | for α=2 and N=12, caps[5..11] all == c_min (0.15) |
 

--- a/helix.toml
+++ b/helix.toml
@@ -82,6 +82,26 @@ session_delivery_enabled = true
 # behavior (BROAD takes the negative space). HELIX_ABSTAIN_DISABLE=1 env
 # var forces off without redeploy. See docs/specs/2026-05-02-abstain-tier-design.md.
 abstain_enabled = true
+# Foveated-splice (BROAD tier only). When True, the BROAD branch of the
+# dynamic-budget tier replaces uniform per-gene compression with a rank-
+# scaled power-law schedule and reverses the assembly order so the top-
+# ranked gene lands immediately before the user query. Off by default for
+# the measurement period — see docs/specs/2026-05-03-foveated-splice-
+# design.md §6.3.
+foveated_enabled = false
+
+# Power-law exponent: c_i = max(c_min, c_max · i^(-α)). α=0.5 = gentle
+# decay, α=1.0 (default) = harmonic-ish, α=2.0 = aggressive top-bias.
+# Bench Phase 2 sweeps {0.5, 1.0, 2.0}; ship the winner.
+foveated_alpha = 1.0
+
+# Rank-N (bottom of BROAD) compression floor. Each gene's effective char
+# cap = max(foveated_c_min · base, c_i · base) where c_i = c_max · i^(-α).
+foveated_c_min = 0.15
+
+# Per-gene char-budget multiplier. target_chars per gene = int(c_i · base).
+# Default 1000 matches current uniform Step 4 behavior at c_i = 1.0.
+foveated_base_chars = 1000
 
 [session]
 # CWoLa session / party fallback. Prior to 2026-04-13 the /context endpoint

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -133,6 +133,23 @@ class BudgetConfig:
     # ship — flip to true in helix.toml to A/B. See session_delivery.py.
     session_delivery_enabled: bool = False
     abstain_enabled: bool = True       # NEW — see docs/specs/2026-05-02-abstain-tier-design.md
+    # Foveated-splice (BROAD tier only). Off by default for the measurement
+    # period — see docs/specs/2026-05-03-foveated-splice-design.md §6.3 and
+    # docs/plans/2026-05-05-foveated-splice.md. Flip to True only after the
+    # phased α-sweep bench (§9) identifies a winning configuration.
+    foveated_enabled: bool = False
+    # Power-law exponent for c_i = max(c_min, c_max · i^(-α)). α=0.5 = gentle
+    # decay, α=1.0 = harmonic-ish, α=2.0 = aggressive top-bias.
+    foveated_alpha: float = 1.0
+    # Rank-N floor compression ratio. Pinned at 0.15 by spec §4.1.
+    foveated_c_min: float = 0.15
+    # Per-gene char-budget multiplier. Each gene's target_chars =
+    # int(c_i · foveated_base_chars). Default 1000 matches the current
+    # uniform behavior at c_i = 1.0. The Step 4 compression loop in
+    # context_manager.py uses 1000 today; keeping this configurable lets
+    # bench cells (and a future on-by-default ship) tune the top-1 ceiling
+    # without touching code.
+    foveated_base_chars: int = 1000
 
 
 @dataclass
@@ -414,6 +431,10 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             legibility_enabled=bool(b.get("legibility_enabled", cfg.budget.legibility_enabled)),
             session_delivery_enabled=bool(b.get("session_delivery_enabled", cfg.budget.session_delivery_enabled)),
             abstain_enabled=bool(b.get("abstain_enabled", cfg.budget.abstain_enabled)),
+            foveated_enabled=bool(b.get("foveated_enabled", cfg.budget.foveated_enabled)),
+            foveated_alpha=float(b.get("foveated_alpha", cfg.budget.foveated_alpha)),
+            foveated_c_min=float(b.get("foveated_c_min", cfg.budget.foveated_c_min)),
+            foveated_base_chars=int(b.get("foveated_base_chars", cfg.budget.foveated_base_chars)),
         )
 
     # Genome

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -667,6 +667,15 @@ class HelixContextManager:
         """
         self._maybe_compact()
 
+        # Per-call locals for foveated-splice state (spec §4-5). Local —
+        # not instance state — so concurrent build_context calls cannot
+        # race on writes/reads, and a prior call's state cannot leak in
+        # if the dynamic-budget block is skipped this call (e.g. small
+        # candidate set or all-zero scores). Same threading pattern as
+        # decoder_prompt_override at line ~1949. See code review I1/I2.
+        foveated_caps: Optional[List[float]] = None
+        foveated_active: bool = False
+
         # Step 0a: Upstream query classifier / injection router.
         # Always runs (cheap, no I/O) — even when decoder_override is set,
         # so the audit trail records what the classifier *would* have picked.
@@ -864,35 +873,6 @@ class HelixContextManager:
                 # else: broad — keep current up-to-max_genes set
                 #   (weak absolute scores or weak ratio → widen the net)
 
-                # Foveated-splice (spec §4-5): for BROAD only, replace uniform
-                # per-gene compression with a rank-scaled power-law schedule
-                # AND reverse the assembly order so top-rank lands nearest
-                # the user query (lost-in-the-middle exploit). Off by default;
-                # see docs/specs/2026-05-03-foveated-splice-design.md §6.3.
-                # No env override in v1 — when foveated flips on by default
-                # later, add HELIX_FOVEATED_DISABLE via _env_truthy at that
-                # point (spec §6.3).
-                foveated_active = (
-                    budget_tier == "broad"
-                    and self.config.budget.foveated_enabled
-                    and len(candidates) > 1
-                )
-                if foveated_active:
-                    caps = _compute_foveated_caps(
-                        n=len(candidates),
-                        alpha=self.config.budget.foveated_alpha,
-                        c_min=self.config.budget.foveated_c_min,
-                        c_max=1.0,
-                    )
-                    # Reverse together so caps[i] still pairs with candidates[i]
-                    candidates = list(reversed(candidates))
-                    caps = list(reversed(caps))
-                    self._last_foveated_caps = caps
-                    self._last_foveated_active = True
-                else:
-                    self._last_foveated_caps = None
-                    self._last_foveated_active = False
-
                 # Stash shadow pool for Lagrange check (#3)
                 self._last_shadow_pool = shadow_pool
                 self._last_shadow_scores = {
@@ -974,6 +954,37 @@ class HelixContextManager:
             )
             candidates = candidates[: classifier_result.assembly_max_genes_cap]
 
+        # Foveated-splice (spec §4-5): for BROAD only, replace uniform per-gene
+        # compression with a rank-scaled power-law schedule AND reverse the
+        # assembly order so top-rank lands nearest the user query (lost-in-the-
+        # middle exploit). Off by default; see docs/specs/2026-05-03-foveated-
+        # splice-design.md §6.3.
+        #
+        # Placed AFTER the classifier cap so reversal operates on the final
+        # post-cap candidate list (otherwise classifier truncation would
+        # silently drop the top-rank gene under reverse-rank — see code
+        # review C1).
+        #
+        # Uses local variables (not self._last_*) so concurrent build_context
+        # calls don't race and stale state from a prior call can't leak into
+        # the current one (see code review I1/I2; same pattern as
+        # decoder_prompt_override threading).
+        if (
+            budget_tier == "broad"
+            and self.config.budget.foveated_enabled
+            and len(candidates) > 1
+        ):
+            caps = _compute_foveated_caps(
+                n=len(candidates),
+                alpha=self.config.budget.foveated_alpha,
+                c_min=self.config.budget.foveated_c_min,
+                c_max=1.0,
+            )
+            # Reverse together so caps[i] still pairs with candidates[i].
+            candidates = list(reversed(candidates))
+            foveated_caps = list(reversed(caps))
+            foveated_active = True
+
         # Step 3.5: NLI classification (optional, DeBERTa backend only)
         relation_graph = {}
         if hasattr(self.ribosome, 'classify_relations'):
@@ -987,7 +998,7 @@ class HelixContextManager:
         # Dense format minimizes prose for small model extraction.
         spliced_map = {}
         answer_slate_lines = []  # MoE answer slate — flat KV pairs
-        foveated_caps = getattr(self, "_last_foveated_caps", None)
+        # foveated_caps / foveated_active are call-local; see top of build_context.
         foveated_base = self.config.budget.foveated_base_chars
         for idx, g in enumerate(candidates):
             src = g.source_id or ""
@@ -1038,18 +1049,29 @@ class HelixContextManager:
             session_id=session_id,
             ignore_delivered=ignore_delivered,
             decoder_prompt_override=effective_decoder_prompt,
-            respect_caller_order=getattr(self, "_last_foveated_active", False),
+            respect_caller_order=foveated_active,
         )
 
         # Annotate window with dynamic budget tier (for telemetry/benchmarks)
         if window.metadata is not None:
             window.metadata["budget_tier"] = budget_tier
             window.metadata["budget_tokens_est"] = budget_tokens_est
-            if getattr(self, "_last_foveated_active", False):
+            if foveated_active and foveated_caps is not None:
                 # Spec §8: per-call provenance for post-hoc α-curve attribution.
                 # Absent when foveated_enabled=false or tier != broad.
-                window.metadata["foveated_caps"] = self._last_foveated_caps
+                window.metadata["foveated_caps"] = foveated_caps
                 window.metadata["foveated_alpha"] = self.config.budget.foveated_alpha
+                # Scalar reductions for Prometheus translation paths that
+                # flatten only scalar attributes (the list above can be
+                # silently dropped). See code review I3. Under reverse-rank
+                # ordering caps[-1] is the c_max applied to the TOP-rank
+                # gene (closest to the user query) and caps[0] is the
+                # c_min applied to the BOTTOM-rank gene — the names
+                # `_top` / `_min` reflect the rank semantic, not the
+                # list-index semantic.
+                window.metadata["foveated_cap_top"] = foveated_caps[-1]
+                window.metadata["foveated_cap_min"] = foveated_caps[0]
+                window.metadata["foveated_cap_n"] = len(foveated_caps)
 
         # Classifier observability payload (spec section 5.2).
         if classifier_result is not None and window.metadata is not None:

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -1955,9 +1955,29 @@ class HelixContextManager:
         budget = self.config.budget.ribosome_tokens + self.config.budget.expression_tokens
 
         if est_tokens > budget and len(parts) > 1:
-            # Drop from the end (lowest-ranked after re-rank)
+            # Default path: parts[-1] is the LOWEST-rank gene (sorted_genes was
+            # ordered score-DESC or by sequence_index), so popping from the
+            # back drops the least-important entry first.
+            #
+            # Foveated reverse-rank path (respect_caller_order=True, spec §5):
+            # the caller emits BROAD candidates in REVERSE-rank order so the
+            # top-rank gene lands LAST in the prompt (closest to user query
+            # under decoder-only attention). Under that ordering parts[-1] is
+            # the TOP-rank gene — popping from the back here would silently
+            # drop the most important gene first, the exact opposite of what
+            # the spec wants. Pop from the FRONT instead to drop the
+            # bottom-rank gene and preserve the placement invariant.
+            #
+            # sorted_genes is kept aligned with parts so the post-trim
+            # delivered_ids / expressed_gene_ids slices stay correct under
+            # both directions.
             while est_tokens > budget and len(parts) > 1:
-                parts.pop()
+                if respect_caller_order:
+                    parts.pop(0)
+                    sorted_genes.pop(0)
+                else:
+                    parts.pop()
+                    sorted_genes.pop()
                 expressed = "\n---\n".join(parts)
                 expressed_wrapped = f"<expressed_context>\n{expressed}\n</expressed_context>"
                 est_tokens = estimate_tokens(decoder_prompt) + estimate_tokens(expressed_wrapped)

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -167,6 +167,27 @@ def _env_truthy(name: str) -> bool:
     return v.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _compute_foveated_caps(
+    n: int,
+    alpha: float,
+    c_min: float,
+    c_max: float = 1.0,
+) -> list[float]:
+    """Power-law per-gene compression caps for foveated-splice.
+
+    c_i = max(c_min, c_max · i^(-α))    for i ∈ [1, N]
+
+    Returns a list of N floats in forward-rank order (caps[0] = rank-1 cap,
+    caps[N-1] = rank-N cap). Caller reverses to pair with reverse-rank
+    candidate placement.
+
+    Spec: docs/specs/2026-05-03-foveated-splice-design.md §4.1
+    """
+    if n <= 0:
+        return []
+    return [max(c_min, c_max * ((i + 1) ** -alpha)) for i in range(n)]
+
+
 class HelixContextManager:
     """
     Main orchestrator. Sits between the client and the upstream LLM.

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -864,6 +864,35 @@ class HelixContextManager:
                 # else: broad — keep current up-to-max_genes set
                 #   (weak absolute scores or weak ratio → widen the net)
 
+                # Foveated-splice (spec §4-5): for BROAD only, replace uniform
+                # per-gene compression with a rank-scaled power-law schedule
+                # AND reverse the assembly order so top-rank lands nearest
+                # the user query (lost-in-the-middle exploit). Off by default;
+                # see docs/specs/2026-05-03-foveated-splice-design.md §6.3.
+                # No env override in v1 — when foveated flips on by default
+                # later, add HELIX_FOVEATED_DISABLE via _env_truthy at that
+                # point (spec §6.3).
+                foveated_active = (
+                    budget_tier == "broad"
+                    and self.config.budget.foveated_enabled
+                    and len(candidates) > 1
+                )
+                if foveated_active:
+                    caps = _compute_foveated_caps(
+                        n=len(candidates),
+                        alpha=self.config.budget.foveated_alpha,
+                        c_min=self.config.budget.foveated_c_min,
+                        c_max=1.0,
+                    )
+                    # Reverse together so caps[i] still pairs with candidates[i]
+                    candidates = list(reversed(candidates))
+                    caps = list(reversed(caps))
+                    self._last_foveated_caps = caps
+                    self._last_foveated_active = True
+                else:
+                    self._last_foveated_caps = None
+                    self._last_foveated_active = False
+
                 # Stash shadow pool for Lagrange check (#3)
                 self._last_shadow_pool = shadow_pool
                 self._last_shadow_scores = {
@@ -958,14 +987,16 @@ class HelixContextManager:
         # Dense format minimizes prose for small model extraction.
         spliced_map = {}
         answer_slate_lines = []  # MoE answer slate — flat KV pairs
-        for g in candidates:
+        foveated_caps = getattr(self, "_last_foveated_caps", None)
+        foveated_base = self.config.budget.foveated_base_chars
+        for idx, g in enumerate(candidates):
             src = g.source_id or ""
             short = ""
             if src and not src.startswith("_"):
                 parts = src.replace("\\", "/").split("/")
                 try:
-                    idx = parts.index("Projects")
-                    short = "/".join(parts[idx + 1:])
+                    j = parts.index("Projects")
+                    short = "/".join(parts[j + 1:])
                 except ValueError:
                     short = "/".join(parts[-3:]) if len(parts) > 3 else src
             # Dense XML gene format — structured for small model extraction
@@ -983,9 +1014,17 @@ class HelixContextManager:
             # diff→DiffCompressor, else→Kompress (ModernBERT).
             # CodeCompressor disabled (40% invalid syntax — see 2f518dc).
             # Falls back to content[:1000].strip() when headroom is unavailable.
+            #
+            # Foveated path overrides the uniform 1000-char target with a
+            # rank-proportional cap per gene. When foveated_caps is None
+            # (default / non-BROAD / disabled), preserve current behavior.
+            if foveated_caps is not None:
+                target = max(1, int(foveated_caps[idx] * foveated_base))
+            else:
+                target = 1000
             content = compress_text(
                 g.content,
-                target_chars=1000,
+                target_chars=target,
                 content_type=g.promoter.domains,
             )
             spliced_map[g.gene_id] = f"<GENE{src_attr}{kv_attrs}>\n{content}\n</GENE>"
@@ -999,12 +1038,18 @@ class HelixContextManager:
             session_id=session_id,
             ignore_delivered=ignore_delivered,
             decoder_prompt_override=effective_decoder_prompt,
+            respect_caller_order=getattr(self, "_last_foveated_active", False),
         )
 
         # Annotate window with dynamic budget tier (for telemetry/benchmarks)
         if window.metadata is not None:
             window.metadata["budget_tier"] = budget_tier
             window.metadata["budget_tokens_est"] = budget_tokens_est
+            if getattr(self, "_last_foveated_active", False):
+                # Spec §8: per-call provenance for post-hoc α-curve attribution.
+                # Absent when foveated_enabled=false or tier != broad.
+                window.metadata["foveated_caps"] = self._last_foveated_caps
+                window.metadata["foveated_alpha"] = self.config.budget.foveated_alpha
 
         # Classifier observability payload (spec section 5.2).
         if classifier_result is not None and window.metadata is not None:

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -1743,6 +1743,7 @@ class HelixContextManager:
         session_id: Optional[str] = None,
         ignore_delivered: bool = False,
         decoder_prompt_override: Optional[str] = None,
+        respect_caller_order: bool = False,
     ) -> ContextWindow:
         """
         Sort spliced parts, join with dividers, wrap in expressed_context tags.
@@ -1759,7 +1760,13 @@ class HelixContextManager:
         elision. ignore_delivered=True bypasses the check (still logs).
         """
         use_slate = answer_slate is not None
-        if use_slate:
+        if respect_caller_order:
+            # Foveated-splice path (spec §5): the caller has already arranged
+            # candidates in the desired emission order (e.g., reverse-rank
+            # for BROAD). Skip the re-sort so reverse-rank actually reaches
+            # the prompt instead of being clobbered back to score-DESC.
+            sorted_genes = list(candidates)
+        elif use_slate:
             # MoE/small-model: relevance-first ordering — best gene at position 0
             # so it's within every sliding-window attention layer
             scores = self.genome.last_query_scores or {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,3 +116,40 @@ def test_no_device_config_defaults_to_auto(tmp_path):
     cfg = load_config(str(p))
     assert cfg.hardware.device == "auto"
     assert cfg.hardware.batch_sizes == {}
+
+
+def test_budget_foveated_defaults_off_with_alpha_one():
+    """Regression: foveated ships off-by-default with alpha=1.0, c_min=0.15.
+
+    The 2026-05-03 foveated-splice spec (docs/specs/2026-05-03-foveated-
+    splice-design.md §6.3) ships off-by-default for a measurement period.
+    A bench α-sweep is required before flipping on. Bumping any default
+    here without bench evidence would silently change BROAD-tier
+    compression on every install.
+    """
+    from helix_context.config import HelixConfig
+    cfg = HelixConfig()
+    assert cfg.budget.foveated_enabled is False
+    assert cfg.budget.foveated_alpha == 1.0
+    assert cfg.budget.foveated_c_min == 0.15
+    assert cfg.budget.foveated_base_chars == 1000
+
+
+def test_budget_foveated_toml_override(tmp_path):
+    """Regression: helix.toml [budget] foveated_* keys are honored."""
+    import tomli_w
+    from helix_context.config import load_config
+    p = tmp_path / "helix.toml"
+    p.write_bytes(tomli_w.dumps({
+        "budget": {
+            "foveated_enabled": True,
+            "foveated_alpha": 2.0,
+            "foveated_c_min": 0.20,
+            "foveated_base_chars": 1500,
+        }
+    }).encode())
+    cfg = load_config(str(p))
+    assert cfg.budget.foveated_enabled is True
+    assert cfg.budget.foveated_alpha == 2.0
+    assert cfg.budget.foveated_c_min == 0.20
+    assert cfg.budget.foveated_base_chars == 1500

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,17 +137,12 @@ def test_budget_foveated_defaults_off_with_alpha_one():
 
 def test_budget_foveated_toml_override(tmp_path):
     """Regression: helix.toml [budget] foveated_* keys are honored."""
-    import tomli_w
     from helix_context.config import load_config
     p = tmp_path / "helix.toml"
-    p.write_bytes(tomli_w.dumps({
-        "budget": {
-            "foveated_enabled": True,
-            "foveated_alpha": 2.0,
-            "foveated_c_min": 0.20,
-            "foveated_base_chars": 1500,
-        }
-    }).encode())
+    p.write_text(
+        "[budget]\nfoveated_enabled = true\nfoveated_alpha = 2.0\nfoveated_c_min = 0.20\nfoveated_base_chars = 1500\n",
+        encoding="utf-8",
+    )
     cfg = load_config(str(p))
     assert cfg.budget.foveated_enabled is True
     assert cfg.budget.foveated_alpha == 2.0

--- a/tests/test_foveated_splice.py
+++ b/tests/test_foveated_splice.py
@@ -330,11 +330,61 @@ class TestFoveatedReverseRankEndToEnd:
         m.config.budget.foveated_enabled = True
         window = m.build_context("a query that lands in BROAD")
         # The fixture seeds gene_0..gene_11 with descending scores. With
-        # foveated on, gene_0 (highest score) should be reversed to LAST.
-        idx_top = window.expressed_context.find("gene_0")
+        # foveated on, gene_00 (highest score) should be reversed to LAST.
+        # Search by full gene_id (gene_00, gene_11) — the bare prefix
+        # "gene_0" would also match gene_01..gene_09 and find the wrong
+        # position under reverse-rank ordering.
+        idx_top = window.expressed_context.find("gene_00")
         idx_bottom = window.expressed_context.find("gene_11")
         assert idx_top != -1 and idx_bottom != -1
         assert idx_top > idx_bottom, (
             "Reverse-rank failed: top-score gene should appear AFTER "
             "bottom-rank gene in the assembled window."
+        )
+
+
+class TestFoveatedBudgetTrim:
+    """Budget-overflow trim must drop the BOTTOM-rank gene under reverse-rank,
+    not the top-rank gene (spec §5 placement invariant).
+
+    Latent under default config (default budget never overflows for 12 short
+    genes), but a footgun the moment foveated_base_chars is bumped at bench
+    time: parts[-1] under reverse-rank IS the top-rank gene, so a naive
+    parts.pop() at the trim site would silently drop the most important
+    gene first — the exact opposite of what foveated wants.
+
+    Fix shape: when respect_caller_order=True, _assemble pops from the FRONT
+    of parts (and sorted_genes in lockstep) instead of the back.
+    """
+
+    def test_top_rank_survives_budget_trim_under_reverse_rank(
+        self, helix_manager_broad_with_twelve_genes,
+    ):
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = True
+        # Force the budget-overflow trim to fire by shrinking the budget
+        # below what 12 genes can fit. With 12 genes and reverse-rank
+        # assembly, even short test content + the legibility headers
+        # comfortably overflows a ~30-token budget.
+        m.config.budget.expression_tokens = 20
+        m.config.budget.ribosome_tokens = 10
+
+        window = m.build_context("a query that lands in BROAD")
+
+        # Sanity: the trim actually fired (we should have fewer than 12
+        # genes in the final window).
+        assert window.metadata.get("budget_tier") == "broad"
+        assert window.metadata.get("genes_expressed", 12) < 12, (
+            "Test setup did not force a budget-overflow trim — bump the "
+            "budget down further or seed longer content."
+        )
+
+        # The actual invariant: the TOP-rank gene (gene_00, highest score)
+        # MUST still be in the assembled context after the trim. Under
+        # reverse-rank ordering parts[-1] is gene_00, so popping from the
+        # back (the pre-fix behavior) would have dropped it first.
+        assert "gene_00" in window.expressed_context, (
+            "Foveated budget-trim dropped the top-rank gene. Under "
+            "reverse-rank ordering parts[-1] is the TOP-rank gene; the "
+            "trim must pop from the FRONT (lowest rank) instead."
         )

--- a/tests/test_foveated_splice.py
+++ b/tests/test_foveated_splice.py
@@ -8,6 +8,65 @@ import pytest
 from helix_context.context_manager import _compute_foveated_caps
 
 
+@pytest.fixture
+def helix_manager_with_three_genes(tmp_path):
+    """Minimal HelixContextManager with three genes of distinct scores.
+
+    Avoids the tests.test_pipeline import (broken at collection time
+    due to module-level helix_context.server.create_app() failure).
+    Constructs the manager directly with model='mock' (no real backend
+    load) and an in-memory genome, then seeds last_query_scores so the
+    slate-path sort has something to sort by.
+    """
+    from helix_context.config import (
+        BudgetConfig,
+        ClassifierConfig,
+        GenomeConfig,
+        HelixConfig,
+        RibosomeConfig,
+    )
+    from helix_context.context_manager import HelixContextManager
+    from helix_context.schemas import Gene, PromoterTags
+
+    cfg = HelixConfig(
+        ribosome=RibosomeConfig(model="mock", timeout=5),
+        budget=BudgetConfig(max_genes_per_turn=12),
+        genome=GenomeConfig(path=":memory:", cold_start_threshold=5),
+        classifier=ClassifierConfig(enabled=False),
+    )
+    mgr = HelixContextManager(cfg)
+    g_low = Gene(
+        gene_id="g_low",
+        content="low content",
+        complement="low",
+        codons=["c"],
+        promoter=PromoterTags(sequence_index=0),
+    )
+    g_mid = Gene(
+        gene_id="g_mid",
+        content="mid content",
+        complement="mid",
+        codons=["c"],
+        promoter=PromoterTags(sequence_index=1),
+    )
+    g_high = Gene(
+        gene_id="g_high",
+        content="high content",
+        complement="high",
+        codons=["c"],
+        promoter=PromoterTags(sequence_index=2),
+    )
+    # Seed scores so the default slate-path sort has something to sort by.
+    # This is what _assemble reads at line ~1745 via self.genome.last_query_scores.
+    mgr.genome.last_query_scores = {
+        "g_low": 1.0,
+        "g_mid": 5.0,
+        "g_high": 9.0,
+    }
+    yield mgr, g_low, g_mid, g_high
+    mgr.close()
+
+
 class TestComputeFoveatedCaps:
     """Pure-function tests for the schedule-shape helper (spec §4.1)."""
 
@@ -50,3 +109,46 @@ class TestComputeFoveatedCaps:
     def test_n_zero_returns_empty(self):
         """Edge case: empty input → empty output, never raises."""
         assert _compute_foveated_caps(n=0, alpha=1.0, c_min=0.15) == []
+
+
+class TestAssembleRespectsCallerOrder:
+    """When respect_caller_order=True, _assemble preserves the candidates list
+    order verbatim — no score-desc or sequence-index re-sort. This is what
+    makes reverse-rank placement actually reach the prompt (spec §5)."""
+
+    def test_assemble_default_resorts_by_score_for_slate(self, helix_manager_with_three_genes):
+        """Sanity: default (use_slate=True) re-sorts by score DESC."""
+        m, g_low, g_mid, g_high = helix_manager_with_three_genes
+        # Pass in low→high; default behavior should re-emit high→low
+        window = m._assemble(
+            query="q",
+            candidates=[g_low, g_mid, g_high],
+            spliced_map={
+                g_low.gene_id: "<G>L</G>",
+                g_mid.gene_id: "<G>M</G>",
+                g_high.gene_id: "<G>H</G>",
+            },
+            relation_graph={},
+            answer_slate=["k=v"],  # forces use_slate=True
+        )
+        # Top-score gene (g_high) should appear first in the rendered text.
+        assert window.expressed_context.find("H") < window.expressed_context.find("L")
+
+    def test_assemble_respects_caller_order_when_flagged(self, helix_manager_with_three_genes):
+        """With respect_caller_order=True, the input order is preserved."""
+        m, g_low, g_mid, g_high = helix_manager_with_three_genes
+        # Pass in reverse-rank order (low→high → bottom-rank first, top-rank last)
+        window = m._assemble(
+            query="q",
+            candidates=[g_low, g_mid, g_high],
+            spliced_map={
+                g_low.gene_id: "<G>L</G>",
+                g_mid.gene_id: "<G>M</G>",
+                g_high.gene_id: "<G>H</G>",
+            },
+            relation_graph={},
+            answer_slate=["k=v"],
+            respect_caller_order=True,
+        )
+        # L came first in input → stays first in text. H last in input → last.
+        assert window.expressed_context.find("L") < window.expressed_context.find("M") < window.expressed_context.find("H")

--- a/tests/test_foveated_splice.py
+++ b/tests/test_foveated_splice.py
@@ -388,3 +388,119 @@ class TestFoveatedBudgetTrim:
             "reverse-rank ordering parts[-1] is the TOP-rank gene; the "
             "trim must pop from the FRONT (lowest rank) instead."
         )
+
+
+def _make_manager_with_n_genes_classifier_enabled(n, scores_fn):
+    """Same shape as _make_manager_with_n_genes, but with the classifier
+    ENABLED so a wh-style factual query routes through assembly_max_genes_cap=5.
+
+    Used by TestFoveatedClassifierInteraction to exercise the C1 invariant
+    (foveated must run AFTER classifier cap, not before).
+    """
+    from helix_context.config import (
+        BudgetConfig, ClassifierConfig, GenomeConfig, HelixConfig,
+        RibosomeConfig,
+    )
+    from helix_context.context_manager import HelixContextManager
+    from tests.conftest import make_gene
+
+    cfg = HelixConfig(
+        ribosome=RibosomeConfig(model="mock", timeout=5),
+        budget=BudgetConfig(max_genes_per_turn=n + 2, abstain_enabled=True),
+        genome=GenomeConfig(path=":memory:", cold_start_threshold=5),
+        classifier=ClassifierConfig(enabled=True),
+    )
+    mgr = HelixContextManager(cfg)
+    candidates = [
+        make_gene(f"gene_{i} content", gene_id=f"gene_{i:02d}")
+        for i in range(n)
+    ]
+    scores = {candidates[i].gene_id: scores_fn(i) for i in range(n)}
+    _stub_express(mgr, candidates=candidates, scores=scores)
+    return mgr
+
+
+class TestFoveatedClassifierInteraction:
+    """Regression tests for the foveated x classifier-cap interaction (C1).
+
+    Foveated reversal must operate on the FINAL post-cap candidate list. If
+    foveated runs BEFORE classifier cap, then candidates[:cap] keeps the
+    LOWEST-ranked genes (top-rank was reversed to candidates[-1] and gets
+    dropped). Plus foveated_caps would be misaligned with the truncated list.
+    """
+
+    def test_foveated_top_rank_survives_classifier_cap(self):
+        """Regression: foveated must run AFTER classifier cap, not before.
+
+        Setup: 12 BROAD genes with descending scores + a wh-style factual
+        query ("what is the helix port") that the classifier routes to
+        assembly_max_genes_cap=5. Foveated enabled.
+
+        Assertions:
+          - foveated_caps exists and len == 5 (post-cap), NOT 12 (pre-cap).
+          - foveated_cap_top == 1.0 (c_max applied to surviving top-rank).
+          - "gene_00" (top-rank) appears in expressed_context (survived cap).
+          - "gene_11" (bottom-rank) does NOT appear (capped out).
+        """
+        # 12 genes, scores 3.0, 2.9, ..., 1.9 → BROAD tier
+        # (top=3.0 < TIGHT_SCORE_FLOOR=5.0, ratio≈1.22 < 1.8 → BROAD).
+        mgr = _make_manager_with_n_genes_classifier_enabled(
+            12,
+            lambda i: 3.0 - i * 0.1,
+        )
+        try:
+            mgr.config.budget.foveated_enabled = True
+            # "what is X" is a wh-word + <15 words → cls=factual → cap=5.
+            window = mgr.build_context("what is the helix retrieval port")
+
+            # Sanity: BROAD tier resolved (foveated only fires on BROAD).
+            assert window.metadata.get("budget_tier") == "broad"
+
+            caps = window.metadata.get("foveated_caps")
+            assert caps is not None, (
+                "foveated_caps absent — foveated did not fire. Either the "
+                "classifier didn't route to factual or BROAD didn't resolve."
+            )
+            # C1 invariant: caps length matches post-cap candidate count.
+            # If foveated ran BEFORE the cap, caps would have length 12.
+            assert len(caps) == 5, (
+                f"foveated_caps length={len(caps)}; expected 5 (post-cap). "
+                "If this is 12, foveated ran BEFORE classifier cap (C1)."
+            )
+
+            # Scalar reductions (I3) — caps[-1] is c_max for top-rank gene.
+            assert window.metadata.get("foveated_cap_top") == 1.0
+            assert window.metadata.get("foveated_cap_n") == 5
+            assert window.metadata.get("foveated_cap_min") == caps[0]
+
+            # The actual top-rank gene must survive. Under the BUGGY pre-cap
+            # ordering: foveated reversed first → candidates[:5] kept genes
+            # 11..7 (worst 5), and gene_00 (best) was dropped.
+            assert "gene_00" in window.expressed_context, (
+                "Top-rank gene was dropped by classifier cap because "
+                "foveated reversed candidates BEFORE the cap (C1 bug)."
+            )
+            # And the bottom-rank gene must be capped out.
+            assert "gene_11" not in window.expressed_context, (
+                "Bottom-rank gene survived — classifier cap did not fire."
+            )
+        finally:
+            mgr.close()
+
+    def test_foveated_scalar_reductions_present_when_active(
+        self, helix_manager_broad_with_twelve_genes,
+    ):
+        """I3: when foveated fires, the scalar reductions are stashed
+        alongside the list. Confirms keys exist on the no-classifier path
+        (the fixture has classifier disabled) so non-classifier callers
+        also benefit from the scalar reductions for Prom translation."""
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in BROAD")
+        assert window.metadata.get("budget_tier") == "broad"
+        assert "foveated_cap_top" in window.metadata
+        assert "foveated_cap_min" in window.metadata
+        assert "foveated_cap_n" in window.metadata
+        # Reverse-rank: caps[-1] (top-rank) == 1.0 (c_max).
+        assert window.metadata["foveated_cap_top"] == 1.0
+        assert window.metadata["foveated_cap_n"] == 12

--- a/tests/test_foveated_splice.py
+++ b/tests/test_foveated_splice.py
@@ -1,0 +1,52 @@
+"""Tests for foveated-splice — rank-scaled BROAD compression schedule.
+
+Spec: docs/specs/2026-05-03-foveated-splice-design.md
+Plan: docs/plans/2026-05-05-foveated-splice.md
+"""
+import pytest
+
+from helix_context.context_manager import _compute_foveated_caps
+
+
+class TestComputeFoveatedCaps:
+    """Pure-function tests for the schedule-shape helper (spec §4.1)."""
+
+    def test_alpha_one_n_twelve_matches_spec_table(self):
+        """Spec §10 Test 6: caps[0]=1.0, caps[1]=0.5, caps[5]≈1/6, caps[11]=c_min."""
+        caps = _compute_foveated_caps(n=12, alpha=1.0, c_min=0.15, c_max=1.0)
+        assert len(caps) == 12
+        assert caps[0] == 1.0
+        assert caps[1] == 0.5
+        assert caps[5] == pytest.approx(1 / 6, abs=1e-9)
+        # rank-12 → 1/12 ≈ 0.083 < c_min=0.15, so floor wins
+        assert caps[11] == 0.15
+
+    def test_alpha_two_collapses_to_floor_by_rank_three(self):
+        """Spec §10 Test 8: α=2 floors caps[5..11] at c_min."""
+        caps = _compute_foveated_caps(n=12, alpha=2.0, c_min=0.15, c_max=1.0)
+        # 1/3^2 = 0.111 < 0.15 → already floored at rank 3
+        for i in range(2, 12):
+            assert caps[i] == 0.15, f"caps[{i}]={caps[i]} expected 0.15"
+
+    def test_alpha_half_gentle_decay(self):
+        """Spec §4.2 table: α=0.5 caps[1] ≈ 0.71."""
+        caps = _compute_foveated_caps(n=12, alpha=0.5, c_min=0.15, c_max=1.0)
+        assert caps[0] == 1.0
+        assert caps[1] == pytest.approx(1 / (2 ** 0.5), abs=1e-9)  # ≈ 0.7071
+        assert caps[2] == pytest.approx(1 / (3 ** 0.5), abs=1e-9)  # ≈ 0.5774
+
+    def test_c_min_floor_is_inclusive_lower_bound(self):
+        """A custom c_min raises the floor for low-rank genes."""
+        caps = _compute_foveated_caps(n=12, alpha=1.0, c_min=0.30, c_max=1.0)
+        assert caps[0] == 1.0
+        # rank-4 → 0.25 < c_min=0.30, floors at 0.30
+        for i in range(3, 12):
+            assert caps[i] == 0.30
+
+    def test_n_one_returns_single_c_max(self):
+        """Edge case: a single-candidate BROAD set returns [c_max]."""
+        assert _compute_foveated_caps(n=1, alpha=1.0, c_min=0.15) == [1.0]
+
+    def test_n_zero_returns_empty(self):
+        """Edge case: empty input → empty output, never raises."""
+        assert _compute_foveated_caps(n=0, alpha=1.0, c_min=0.15) == []

--- a/tests/test_foveated_splice.py
+++ b/tests/test_foveated_splice.py
@@ -152,3 +152,189 @@ class TestAssembleRespectsCallerOrder:
         )
         # L came first in input → stays first in text. H last in input → last.
         assert window.expressed_context.find("L") < window.expressed_context.find("M") < window.expressed_context.find("H")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers for tier-gating + reverse-rank end-to-end tests.
+#
+# We replicate _stub_express inline (rather than importing from
+# tests.test_abstain_tier) because that module transitively imports
+# tests.test_pipeline, which fails at collection time due to a
+# module-level helix_context.server.create_app() call without a real
+# genome DB. Inline replication keeps this file collectable in
+# isolation. See plan §"Step 1: Write the failing tests" notes.
+# ---------------------------------------------------------------------------
+
+
+def _stub_express(manager, *, candidates, scores):
+    """Replicated from tests/test_abstain_tier.py:87 to avoid the broken
+    test_pipeline import path. Bypasses real retrieval so tier-resolution
+    tests can pin top_score/ratio precisely."""
+    def fake_express(domains, entities, max_genes, **_kwargs):
+        manager.genome.last_query_scores = dict(scores)
+        return list(candidates)
+    manager._express = fake_express
+
+    def fake_refiners(query, candidates, max_genes, **_kwargs):
+        return list(candidates), {}
+    manager._apply_candidate_refiners = fake_refiners
+
+
+def _make_manager_with_n_genes(n, scores_fn):
+    """Build a HelixContextManager and stub _express to return n genes
+    with scores supplied by scores_fn(i) for i in [0, n).
+
+    scores_fn maps position to score. Caller picks scores to land the
+    tier resolution at the desired bucket.
+    """
+    from helix_context.config import (
+        BudgetConfig, ClassifierConfig, GenomeConfig, HelixConfig,
+        RibosomeConfig,
+    )
+    from helix_context.context_manager import HelixContextManager
+    from tests.conftest import make_gene
+
+    cfg = HelixConfig(
+        ribosome=RibosomeConfig(model="mock", timeout=5),
+        budget=BudgetConfig(max_genes_per_turn=n + 2, abstain_enabled=True),
+        genome=GenomeConfig(path=":memory:", cold_start_threshold=5),
+        classifier=ClassifierConfig(enabled=False),
+    )
+    mgr = HelixContextManager(cfg)
+    candidates = [
+        make_gene(f"gene_{i} content", gene_id=f"gene_{i:02d}")
+        for i in range(n)
+    ]
+    scores = {candidates[i].gene_id: scores_fn(i) for i in range(n)}
+    _stub_express(mgr, candidates=candidates, scores=scores)
+    return mgr
+
+
+@pytest.fixture
+def helix_manager_broad_with_twelve_genes():
+    """12 genes whose scores land the dynamic budget in BROAD.
+
+    Scores: 3.0, 2.9, 2.8, ..., 1.9 → top=3.0 (>=2.5 escapes ABSTAIN,
+    <5.0 fails TIGHT). mean ≈ 2.45, ratio ≈ 1.22 (<1.8 fails FOCUSED) → BROAD.
+    """
+    mgr = _make_manager_with_n_genes(
+        12,
+        lambda i: 3.0 - i * 0.1,
+    )
+    yield mgr
+    mgr.close()
+
+
+@pytest.fixture
+def helix_manager_tight():
+    """4 genes — top dominates so the dynamic budget tiers as TIGHT.
+
+    top=20.0, others=0.1 → mean≈5.075, ratio≈3.94. PASSES TIGHT
+    (ratio>=3.0, top>=5.0, len>=3). The score-floor gates 3 of the 4
+    out (floor = 20*0.15 = 3.0), but len(gated)<3 so candidates stays
+    at 4, then TIGHT trims to candidates[:3].
+    """
+    mgr = _make_manager_with_n_genes(
+        4,
+        lambda i: 20.0 if i == 0 else 0.1,
+    )
+    yield mgr
+    mgr.close()
+
+
+@pytest.fixture
+def helix_manager_focused():
+    """6 genes that pass FOCUSED but fail TIGHT.
+
+    top=4.5, others=2.0 → mean=2.42, ratio≈1.86. PASSES FOCUSED
+    (ratio>=1.8, top>=2.5, len>=6). Fails TIGHT (top<5.0 and ratio<3.0).
+    Score floor = 4.5*0.15 = 0.675 → all 6 survive.
+    """
+    mgr = _make_manager_with_n_genes(
+        6,
+        lambda i: 4.5 if i == 0 else 2.0,
+    )
+    yield mgr
+    mgr.close()
+
+
+@pytest.fixture
+def helix_manager_abstain():
+    """8 genes whose scores trigger ABSTAIN: top<2.5 AND ratio<1.8.
+
+    top=1.5, others=1.2 → mean≈1.24, ratio≈1.21. ABSTAIN gate fires
+    before BROAD/TIGHT/FOCUSED resolution.
+    """
+    mgr = _make_manager_with_n_genes(
+        8,
+        lambda i: 1.5 if i == 0 else 1.2,
+    )
+    yield mgr
+    mgr.close()
+
+
+class TestFoveatedTierGating:
+    """Foveated only fires on BROAD (spec §3, §10 Tests 1-5)."""
+
+    def test_disabled_broad_no_metadata(self, helix_manager_broad_with_twelve_genes):
+        """Test 1: foveated_enabled=False on BROAD → no metadata key, uniform compression."""
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = False
+        window = m.build_context("a query that lands in BROAD")
+        assert window.metadata.get("budget_tier") == "broad"
+        assert "foveated_caps" not in window.metadata
+
+    def test_enabled_broad_metadata_present(self, helix_manager_broad_with_twelve_genes):
+        """Test 2: foveated_enabled=True on BROAD → metadata['foveated_caps'] is a list, len = N."""
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in BROAD")
+        assert window.metadata.get("budget_tier") == "broad"
+        caps = window.metadata.get("foveated_caps")
+        assert isinstance(caps, list)
+        assert len(caps) == 12
+        assert window.metadata.get("foveated_alpha") == 1.0
+
+    def test_enabled_tight_no_metadata(self, helix_manager_tight):
+        """Test 3: foveated_enabled=True but tier=tight → no metadata key."""
+        m = helix_manager_tight
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in TIGHT")
+        assert window.metadata.get("budget_tier") == "tight"
+        assert "foveated_caps" not in window.metadata
+
+    def test_enabled_focused_no_metadata(self, helix_manager_focused):
+        """Test 4: foveated_enabled=True but tier=focused → no metadata key."""
+        m = helix_manager_focused
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in FOCUSED")
+        assert window.metadata.get("budget_tier") == "focused"
+        assert "foveated_caps" not in window.metadata
+
+    def test_enabled_abstain_no_metadata(self, helix_manager_abstain):
+        """Test 5: foveated_enabled=True but ABSTAIN gate fired first → no metadata key."""
+        m = helix_manager_abstain
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a weak query that triggers ABSTAIN")
+        assert window.metadata.get("budget_tier") == "abstain"
+        assert "foveated_caps" not in window.metadata
+
+
+class TestFoveatedReverseRankEndToEnd:
+    """Top-rank gene lands LAST in the assembled prompt (spec §10 Test 7)."""
+
+    def test_top_rank_gene_appears_last_in_window_text(
+        self, helix_manager_broad_with_twelve_genes,
+    ):
+        m = helix_manager_broad_with_twelve_genes
+        m.config.budget.foveated_enabled = True
+        window = m.build_context("a query that lands in BROAD")
+        # The fixture seeds gene_0..gene_11 with descending scores. With
+        # foveated on, gene_0 (highest score) should be reversed to LAST.
+        idx_top = window.expressed_context.find("gene_0")
+        idx_bottom = window.expressed_context.find("gene_11")
+        assert idx_top != -1 and idx_bottom != -1
+        assert idx_top > idx_bottom, (
+            "Reverse-rank failed: top-score gene should appear AFTER "
+            "bottom-rank gene in the assembled window."
+        )


### PR DESCRIPTION
## Summary

Implements [docs/specs/2026-05-03-foveated-splice-design.md](docs/specs/2026-05-03-foveated-splice-design.md) — rank-scaled per-gene compression + reverse-rank placement for the BROAD tier of `build_context`. Off by default (`foveated_enabled = false`); flip on requires bench evidence per spec §9.4.

- **Schedule:** `c_i = max(c_min, c_max · i^(-α))` with α=1.0 default. Each gene's `target_chars = int(c_i · foveated_base_chars)`.
- **Placement:** under foveated, top-rank gene lands LAST in the prompt (closest to user query, lost-in-the-middle exploit).
- **Default-off invariant:** verified byte-identical to pre-branch master when `foveated_enabled=false`.

## What's in the diff

| Layer | Change |
|---|---|
| Config | 4 new `BudgetConfig` fields (`foveated_enabled`, `foveated_alpha`, `foveated_c_min`, `foveated_base_chars`) + `helix.toml [budget]` keys + loader |
| Helper | Pure `_compute_foveated_caps(n, alpha, c_min, c_max)` |
| `_assemble` | New `respect_caller_order: bool = False` parameter; when True, skips score-DESC and sequence-index re-sorts so reverse-rank reaches the prompt |
| `build_context` | Foveated block runs AFTER classifier cap (so classifier truncation can't drop the top-rank gene); locals threaded through Step 4 + `_assemble` (no instance state, concurrency-safe) |
| Budget-trim | `_assemble`'s overflow trim now pops from the front under reverse-rank so top-rank survives |
| Telemetry | `metadata["foveated_caps"]` (full list for log-scrape) + `foveated_alpha`, `foveated_cap_top`, `foveated_cap_min`, `foveated_cap_n` (scalars for dashboards) |

## Note on spec/code seam

Spec §7 originally named `_build_item(max_item_chars=...)` as the integration seam, but on master that function lives only in `context_packet.py` (the `/context` packet endpoint) and is not reachable from `build_context`. The actual seam is `compress_text(target_chars=...)` at `context_manager.py:965`. The plan codifies this; spec §7 still has the original phrasing — worth a follow-up patch.

## Test Plan

- [x] `py -3 -m pytest tests/test_foveated_splice.py -v` — 17/17 (15 spec §10 + helper unit tests + budget-trim invariant + classifier-cap regression)
- [x] `py -3 -m pytest tests/test_config.py -v` — 10/10
- [x] Targeted regression: `py -3 -m pytest tests/test_legibility.py tests/test_session_delivery.py tests/test_abstain_tier.py tests/test_context_manager_classifier.py -q` — 91/91 (covers `_assemble`, budget-trim, BROAD/TIGHT/FOCUSED tier resolution, classifier path)
- [x] Full suite: 1532/1540 (8 failures all in unrelated subsystems — `test_ray_trace`, `test_registry::HITLEvents`, `test_server::ProxyEndpoint`, `test_integration` — confirmed pre-existing)
- [x] Smoke: `py -3 -c "from helix_context.config import HelixConfig; cfg = HelixConfig(); ..."` confirms config knob works at runtime
- [ ] **Pre-flip-on bench gate (spec §9.4):** p95 drops by ≥ 5s OR accuracy lifts by ≥ 2pp on `fic=True` with no regression on `fic=False`. Phase 1 (placement isolation, α=1.0 forward vs reverse) and Phase 2 (α-sweep on placement winner) per spec §9.

## Rollout

- Lands with `foveated_enabled = false` — zero behavior change in production.
- Bench Phase 1+2 (4 cells × ~5-7h, ~2 overnights) determines `(placement, α)` winner.
- Default flip happens in a follow-up commit gated on §9.4 pass criteria — NOT this PR.

## Review history

Each task was reviewed in two stages (spec compliance + code quality) by `superpowers:code-reviewer`. The whole-implementation final review caught one Critical (classifier-cap interaction) and two Important (stale instance state + concurrency race) issues which the final commit (`439187d`) fixes via parameter-threading and block reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)