### PR TITLE
helix_announce: env-var IDE detect + agent self-report + tooltip

### DIFF
--- a/docs/architecture/SESSION_REGISTRY.md
+++ b/docs/architecture/SESSION_REGISTRY.md
@@ -157,6 +157,13 @@ MCP host identity first-class in the registry:
 
 - `agent_kind`    — vendor family ("claude-code", "codex", "gemini") — added 2026-05-05
 - `mcp_host`      — host capability tag ("antigravity", "vscode", "cursor") — added 2026-05-05
+- `ide_detected`       — adapter env-var fingerprint at register time
+                         ("vscode", "cursor", or NULL on no_match) — added 2026-05-06
+- `ide_detection_via`  — how IDE was determined ("env:VSCODE_PID",
+                         "explicit:HELIX_MCP_HOST", "agent_override",
+                         "no_match") — added 2026-05-06
+- `model_id`           — agent self-reported via helix_announce
+                         (free-form, NULL until announced) — added 2026-05-06
 
 Both are nullable. Pre-2026-05-05 rows read as `NULL`. These fields are sourced from the
 `HELIX_AGENT_KIND` and `HELIX_MCP_HOST` environment variables respectively and persist on
@@ -249,6 +256,9 @@ Request body:
 | `metadata` | object | no | Arbitrary JSON for future extension. |
 | `agent_kind` | string | no | Vendor family — `"claude-code"`, `"codex"`, `"gemini"`. Sourced from `HELIX_AGENT_KIND`. Added 2026-05-05. |
 | `mcp_host` | string | no | Host capability tag — `"antigravity"`, `"vscode"`, `"cursor"`. Sourced from `HELIX_MCP_HOST`. The literal `"unknown"` is normalized to NULL at the wire. Added 2026-05-05. |
+| `ide_detected` | string | no | Adapter env-var fingerprint result. Sourced from `helix_context.launcher.ide_fingerprint.detect_ide()`. Added 2026-05-06. |
+| `ide_detection_via` | string | no | The evidence behind `ide_detected`. Added 2026-05-06. |
+| `model_id` | string | no | Optional at register time — typically supplied later via the announce endpoint. Added 2026-05-06. |
 
 Response:
 
@@ -292,6 +302,32 @@ Response:
 If the participant was previously `stale` or `gone`, the heartbeat resurrects
 it and returns `status: "active"`. If the `participant_id` is unknown, returns
 `404` and the client should re-register.
+
+<a id="announce-endpoint"></a>
+### POST /sessions/{participant_id}/announce  *(added 2026-05-06)*
+
+Agent self-report endpoint. Called once per session by the agent via
+the `helix_announce` MCP tool, after the MCP adapter has registered
+the participant.
+
+```bash
+curl -X POST http://127.0.0.1:11437/sessions/<participant_id>/announce \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_id": "claude-opus-4-7",
+    "ide_override": "cursor"
+  }'
+```
+
+Request body:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `model_id` | string | yes | Free-form model identifier. No allowlist validation. |
+| `ide_override` | string | no | Replaces `ide_detected` and forces `ide_detection_via='agent_override'`. |
+
+Silent no-op on unknown `participant_id` (returns 200) — matches
+heartbeat semantics. Multiple calls are idempotent (last-write-wins).
 
 ### `GET /sessions`
 

--- a/docs/clients/claude-code.md
+++ b/docs/clients/claude-code.md
@@ -92,6 +92,22 @@ only smuggled in via `capabilities`). The dashboard's Agents and
 Identities panels render a "Claude Code + VS Code" pretty-label
 chip when both are present.
 
+As of 2026-05-06, the MCP adapter additionally **auto-detects** the
+host IDE from intentional env vars (`VSCODE_PID`, `CURSOR_TRACE_ID`)
+and the agent **self-reports** its model via the new `helix_announce`
+MCP tool. Together they populate three new columns on the
+`participants` row — `ide_detected`, `ide_detection_via`, `model_id`
+— and the dashboard renders the full identity in a tooltip on the
+agent host chip. See
+[`SESSION_REGISTRY.md`](../architecture/SESSION_REGISTRY.md#announce-endpoint)
+for the API and [`skills/helix/SKILL.md`](../../skills/helix/SKILL.md#workflow)
+for the agent contract.
+
+The legacy `HELIX_MCP_HOST` env var is now optional — the adapter
+will detect the IDE without it. Set it only when you want to override
+the auto-detection (e.g., running Claude Code from a non-VS-Code
+terminal but want the chip to say `"vscode"` anyway).
+
 ## Request lifecycle
 
 **On MCP subprocess start** — `mcp_server.py:_register_with_registry()`:

--- a/docs/superpowers/plans/2026-05-06-helix-announce-self-report.md
+++ b/docs/superpowers/plans/2026-05-06-helix-announce-self-report.md
@@ -561,7 +561,14 @@ Add a new method `update_announcement` (placement near `heartbeat()` — they're
         self.genome.conn.commit()
 ```
 
-`COALESCE(?, model_id)` lets the announce call set OR clear OR no-op on `model_id` cleanly: passing `None` keeps the existing value (no-op), passing a string overwrites. (If you actively want to NULL out model_id, that's a separate concern not in this spec.)
+**About the `COALESCE(?, model_id)` pattern (read this carefully):**
+
+- When the bound parameter is `None` (Python passes `None` for an unset kwarg), `COALESCE` returns the column's existing value — the UPDATE is a **no-op for that field**.
+- When the bound parameter is a real string (e.g. `"claude-opus-4-7"`), `COALESCE` returns the string — the column is **overwritten**.
+
+This lets one method handle both "agent set the model" and "agent only sent ide_override, leave model alone". If you actively want to clear `model_id` back to NULL, you'd need a separate code path; this spec doesn't require that.
+
+The `ide_override` branch does NOT use COALESCE because when `ide_override` is set, we want to unconditionally overwrite both `ide_detected` and `ide_detection_via` (the via must become `'agent_override'` exactly).
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -824,7 +831,7 @@ def test_announce_method_without_ide_override(monkeypatch, bridge_with_capture):
     assert "ide_override" not in body  # not included when None
 ```
 
-If `bridge_with_capture` doesn't already exist as a fixture in this file, build one that captures the http_post payload. The existing PR-#26 test for `register_participant_sends_vendor_host` likely uses a similar pattern — copy it.
+If `bridge_with_capture` doesn't already exist as a fixture in this file, build one that captures the http_post payload. The existing PR-#26 test for `register_participant_sends_vendor_host` uses an inline `httpx.post` patch with a `captured` dict — copy that pattern into a fixture and yield `(bridge, captured)`. Do NOT mutate any existing fixture; the existing PR #26 tests should keep working unchanged. If you find yourself touching an existing fixture, stop and add a new one instead.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -970,7 +977,17 @@ def test_helix_announce_tool_calls_bridge_announce(monkeypatch, mock_bridge):
     assert call["ide_override"] is None
 ```
 
-The `mock_bridge` fixture from PR #26 needs to grow an `announce_calls` list. Update the fixture:
+The `mock_bridge` fixture from PR #26 needs to grow an `announce_calls` list AND a stub `announce()` method. **The reset block at the end of the fixture must reset BOTH lists** so cross-test pollution doesn't sneak in (a missing reset would let one test's announce call leak into another's assertions).
+
+After updating, run the existing PR #26 MCP tests (`test_register_with_registry_sends_env_vendor_host`, `test_register_with_registry_omits_unset_env`) explicitly to confirm the fixture mutation didn't break them:
+
+```bash
+python -m pytest tests/test_mcp_server.py -v
+```
+
+Expected: existing tests + 3 new pass; zero regressions.
+
+Updated fixture:
 
 ```python
 @pytest.fixture
@@ -1372,6 +1389,21 @@ def _build_tooltip(participant: Dict[str, Any]) -> Dict[str, str]:
     The ide_detection_via line tells the operator how (or whether) the
     IDE value was obtained: "env:VSCODE_PID", "agent_override",
     "no_match", "explicit:HELIX_MCP_HOST".
+
+    ide_label fallback chain (in order):
+      1. ide_detected — populated by this change's adapter detect at
+         register time, or by an agent's ide_override via helix_announce.
+         Authoritative when present.
+      2. mcp_host — PR #26's column. Sessions registered after PR #26 but
+         before this change will have ide_detected=NULL but mcp_host set
+         from HELIX_MCP_HOST env. Fall back so those sessions' chips
+         still render correctly until they re-register.
+      3. "Not detected" — explicit placeholder when neither column
+         carries a value, so the tooltip surfaces the gap rather than
+         hiding the row.
+
+    There is no equivalent fallback chain for model_id (the column is
+    new in this change; there is no prior column to fall back to).
     """
     return {
         "model_label": model_pretty(participant.get("model_id")) or "Not announced",
@@ -1417,13 +1449,29 @@ CSS-only `:hover` reveal. No JS.
 - Modify: `helix_context/launcher/templates/components/participants_panel.html`
 - Modify: `helix_context/launcher/static/launcher.css`
 
-- [ ] **Step 1: Read the existing chip block in agents_panel.html**
+- [ ] **Step 1: Locate every chip block to wrap**
 
-Read `helix_context/launcher/templates/components/agents_panel.html` to find the existing `chip--agent-host` block from PR #26 (around line 49). The new tooltip wraps this chip so the existing `:hover` target stays the chip itself.
+The `chip--agent-host` chip from PR #26 appears in **three places** inside `agents_panel.html` — one per sub-view (active, all, historical disconnected). Find them all before editing:
 
-- [ ] **Step 2: Modify agents_panel.html**
+```bash
+grep -n "chip--agent-host" helix_context/launcher/templates/components/agents_panel.html
+```
 
-Replace each occurrence of the `chip--agent-host` chip block (there are three — active, all, historical) with a wrapped version. Pattern for the active sub-view:
+Expected output: 3 matches. The plan's wrapping change must apply to all three; missing one leaves an inconsistent dashboard.
+
+In each match, the surrounding loop variable is `agent` (the iteration var of the outer `{% for agent in state.all_agents.entries %}`). Confirm by reading 5 lines of context above each match.
+
+The participants panel has the same chip in **one place** (added in PR #26 Task 9):
+
+```bash
+grep -n "chip--agent-host" helix_context/launcher/templates/components/participants_panel.html
+```
+
+Expected: 1 match. The loop variable there is `p`, not `agent`.
+
+- [ ] **Step 2: Modify agents_panel.html — wrap all three occurrences**
+
+For each of the three matches found in Step 1, replace the chip block with a wrapped version. Pattern (loop variable is `agent`):
 
 ```jinja
 {% if agent.host_label or agent.tooltip %}

--- a/docs/superpowers/plans/2026-05-06-helix-announce-self-report.md
+++ b/docs/superpowers/plans/2026-05-06-helix-announce-self-report.md
@@ -1,0 +1,1850 @@
+# Helix Announce: Self-Report + IDE Auto-Detect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the launcher dashboard display IDE/CLI + agent model robustly across vendors via env-var fingerprinting (adapter side) and a `helix_announce` MCP tool (agent side), with progressive disclosure on a tooltip and explicit "not announced/detected/set" placeholders for missing data.
+
+**Architecture:** Three new nullable columns on `participants` (`ide_detected`, `ide_detection_via`, `model_id`) supplement the `agent_kind` / `mcp_host` from PR #26. A small pure-function `ide_fingerprint.py` module runs at MCP startup. A new MCP tool `helix_announce` lets the agent self-report model + override IDE. A new endpoint `POST /sessions/{participant_id}/announce` PATCHes those fields on the participant row. Templates render a CSS-only `:hover` tooltip on the existing chip with explicit placeholders for missing fields.
+
+**Tech Stack:** Python 3.11+, SQLite (via `genome.conn`), Pydantic v2, FastAPI, Jinja2, pytest. Pure CSS for tooltip (no JS).
+
+**Spec:** [docs/superpowers/specs/2026-05-06-helix-announce-self-report-design.md](../specs/2026-05-06-helix-announce-self-report-design.md)
+
+**Prerequisite:** PR #26 (`feat/vendor-host-badges` — `agent_kind`/`mcp_host` columns + chip plumbing) must be merged into master first, OR this branch must branch off `feat/vendor-host-badges`. The implementation assumes PR #26's schema + collector + template wiring is in place.
+
+---
+
+## Scope check
+
+Single subsystem (the participant registry's identity fields + dashboard rendering). Does NOT need decomposition.
+
+## File structure
+
+**Create:**
+- `helix_context/launcher/ide_fingerprint.py` — env-var fingerprint chain, ~50 lines
+- `helix_context/launcher/model_labels.py` — pretty-map for known `model_id` strings, ~40 lines
+- `tests/test_ide_fingerprint.py`
+- `tests/test_model_labels.py`
+- `tests/test_helix_announce_plumbing.py` — E2E
+
+**Modify:**
+- `helix_context/genome.py` — 3 idempotent ALTER TABLE statements
+- `helix_context/schemas.py` — add 3 fields to `Participant` + `ParticipantInfo`
+- `helix_context/registry.py` — accept/persist/project new fields in register; new `update_announcement()` method
+- `helix_context/server.py` — `/sessions/register` accepts new fields (optional); new `POST /sessions/{participant_id}/announce` endpoint
+- `helix_context/bridge.py` — `register_participant` forwards new fields; new `announce()` method
+- `helix_context/mcp_server.py` — `_register_with_registry` calls `detect_ide()`; expose new `helix_announce` MCP tool
+- `helix_context/launcher/collector.py` — populate tooltip fields on entries
+- `helix_context/launcher/templates/components/agents_panel.html` — add tooltip block
+- `helix_context/launcher/templates/components/participants_panel.html` — add tooltip block
+- `helix_context/launcher/static/launcher.css` — `:hover` tooltip styling
+- `skills/helix/SKILL.md` — add one sentence in Workflow section about `helix_announce`
+- `docs/clients/claude-code.md` — document the new tool + auto-detect; deprecate `HELIX_MCP_HOST` guidance
+- `docs/architecture/SESSION_REGISTRY.md` — document new columns + `/announce` endpoint
+
+**Delete:** None — purely additive.
+
+---
+
+## Task 1: IDE fingerprint module + unit tests (no dependencies)
+
+Pure-function module first. Easiest to TDD; everything else depends on its output shape.
+
+**Files:**
+- Create: `helix_context/launcher/ide_fingerprint.py`
+- Test: `tests/test_ide_fingerprint.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_ide_fingerprint.py
+"""Env-var fingerprint chain for detecting which IDE/CLI spawned the
+MCP adapter.
+
+Exercises:
+- HELIX_MCP_HOST explicit override (highest priority, "explicit:..." via)
+- VSCODE_PID present → ("vscode", "env:VSCODE_PID")
+- CURSOR_TRACE_ID present → ("cursor", "env:CURSOR_TRACE_ID")
+- nothing matches → (None, "no_match")
+- "unknown" sentinel for HELIX_MCP_HOST falls through, doesn't trigger explicit branch
+"""
+import pytest
+
+from helix_context.launcher.ide_fingerprint import detect_ide
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip every env var the chain might read so each test is isolated."""
+    for key in (
+        "HELIX_MCP_HOST",
+        "VSCODE_PID",
+        "VSCODE_IPC_HOOK",
+        "CURSOR_TRACE_ID",
+        "TERM_PROGRAM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_explicit_helix_mcp_host_wins(monkeypatch):
+    monkeypatch.setenv("HELIX_MCP_HOST", "claude-code")
+    monkeypatch.setenv("VSCODE_PID", "1234")  # would otherwise win
+    assert detect_ide() == ("claude-code", "explicit:HELIX_MCP_HOST")
+
+
+def test_helix_mcp_host_unknown_sentinel_falls_through(monkeypatch):
+    """HELIX_MCP_HOST=unknown is the legacy default — treat as unset."""
+    monkeypatch.setenv("HELIX_MCP_HOST", "unknown")
+    monkeypatch.setenv("VSCODE_PID", "1234")
+    assert detect_ide() == ("vscode", "env:VSCODE_PID")
+
+
+def test_vscode_pid_detects_vscode(monkeypatch):
+    monkeypatch.setenv("VSCODE_PID", "1234")
+    assert detect_ide() == ("vscode", "env:VSCODE_PID")
+
+
+def test_cursor_trace_id_detects_cursor(monkeypatch):
+    monkeypatch.setenv("CURSOR_TRACE_ID", "abc-123")
+    assert detect_ide() == ("cursor", "env:CURSOR_TRACE_ID")
+
+
+def test_vscode_priority_over_cursor(monkeypatch):
+    """If both env vars are set (shouldn't happen in practice but make the
+    behavior deterministic), VSCODE_PID wins because it's earlier in the chain."""
+    monkeypatch.setenv("VSCODE_PID", "1234")
+    monkeypatch.setenv("CURSOR_TRACE_ID", "abc-123")
+    assert detect_ide() == ("vscode", "env:VSCODE_PID")
+
+
+def test_no_match_returns_none(monkeypatch):
+    """All env vars stripped — no signal."""
+    assert detect_ide() == (None, "no_match")
+
+
+def test_empty_string_env_treated_as_unset(monkeypatch):
+    """An empty VSCODE_PID is not a real signal."""
+    monkeypatch.setenv("VSCODE_PID", "")
+    assert detect_ide() == (None, "no_match")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_ide_fingerprint.py -v`
+Expected: ImportError or ModuleNotFoundError on `helix_context.launcher.ide_fingerprint`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# helix_context/launcher/ide_fingerprint.py
+"""Env-var fingerprint chain for IDE/CLI detection at MCP-adapter startup.
+
+Used by ``mcp_server._register_with_registry`` to populate the
+``ide_detected`` and ``ide_detection_via`` columns on the participants
+row without depending on each MCP host vendor to set ``HELIX_MCP_HOST``
+correctly.
+
+Only env vars set intentionally by the host process are trusted as
+signals. No PPID walking, no terminal-program guessing, no inference.
+When no signal matches we return ``(None, "no_match")`` and let the
+agent self-report later via ``helix_announce``.
+
+Priority chain (first match wins):
+    1. HELIX_MCP_HOST explicit (and not the legacy "unknown" sentinel)
+    2. VSCODE_PID
+    3. CURSOR_TRACE_ID
+    4. fallback → (None, "no_match")
+
+Extending: add a new branch ABOVE the fallback. New branch must (a) read
+a single, intentional env var that the host actually sets, and (b) return
+the canonical short host id paired with ``"env:<VAR_NAME>"`` as the via.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+
+def detect_ide() -> Tuple[Optional[str], str]:
+    """Return ``(ide_value, detection_via)``.
+
+    ``ide_value`` is a canonical short id (e.g. ``"vscode"``, ``"cursor"``)
+    or ``None`` when no signal matched. ``detection_via`` always contains
+    a string documenting how the result was reached, suitable for the
+    tooltip's diagnostic line.
+    """
+    explicit = os.environ.get("HELIX_MCP_HOST", "").strip()
+    if explicit and explicit != "unknown":
+        return explicit, "explicit:HELIX_MCP_HOST"
+
+    if os.environ.get("VSCODE_PID", "").strip():
+        return "vscode", "env:VSCODE_PID"
+
+    if os.environ.get("CURSOR_TRACE_ID", "").strip():
+        return "cursor", "env:CURSOR_TRACE_ID"
+
+    return None, "no_match"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_ide_fingerprint.py -v`
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/launcher/ide_fingerprint.py tests/test_ide_fingerprint.py
+git commit -m "feat(launcher): add ide_fingerprint module
+
+Env-var fingerprint chain for detecting which IDE/CLI spawned the
+MCP adapter. Pure-function detect_ide() returns (ide_value, via).
+Branches: explicit HELIX_MCP_HOST > VSCODE_PID > CURSOR_TRACE_ID >
+no_match. No inference, no PPID walking — only intentional env vars
+the host process sets."
+```
+
+---
+
+## Task 2: Schema migration
+
+Add 3 columns to `participants` (idempotent ALTER TABLE).
+
+**Files:**
+- Modify: `helix_context/genome.py` — `_ensure_registry_schema` method
+- Test: `tests/test_registry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_registry.py`:
+
+```python
+def test_participants_table_has_announce_columns(genome):
+    """Schema migration adds ide_detected, ide_detection_via, model_id columns."""
+    cur = genome.conn.cursor()
+    cols = {r[1] for r in cur.execute("PRAGMA table_info(participants)").fetchall()}
+    assert "ide_detected" in cols, f"ide_detected missing; got {cols}"
+    assert "ide_detection_via" in cols, f"ide_detection_via missing; got {cols}"
+    assert "model_id" in cols, f"model_id missing; got {cols}"
+```
+
+The existing `test_schema_migration_is_idempotent` from PR #26 already covers re-run safety; no new idempotency test needed.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_registry.py::test_participants_table_has_announce_columns -v`
+Expected: FAIL — at least one column missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/genome.py::_ensure_registry_schema`, locate the existing PR-#26 ALTER TABLE block for `agent_kind`/`mcp_host` (added 2026-05-05). Add a sibling block immediately after it:
+
+```python
+        # Announce columns (added 2026-05-06; design spec
+        # docs/superpowers/specs/2026-05-06-helix-announce-self-report-design.md).
+        # `ide_detected`:      adapter-side env-var fingerprint at register time
+        #                      ("vscode", "cursor", "claude-code", or NULL on no_match).
+        # `ide_detection_via`: how we figured it out — "env:VSCODE_PID",
+        #                      "explicit:HELIX_MCP_HOST", "agent_override", "no_match".
+        # `model_id`:          agent self-reported via helix_announce; NULL until announced.
+        for col in ("ide_detected", "ide_detection_via", "model_id"):
+            try:
+                cur.execute(f"ALTER TABLE participants ADD COLUMN {col} TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already exists — idempotent
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_registry.py -k "announce_columns or schema_migration_is_idempotent" -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/genome.py tests/test_registry.py
+git commit -m "feat(genome): add ide_detected+ide_detection_via+model_id columns
+
+Idempotent ALTER TABLE in _ensure_registry_schema. Pre-2026-05-06 rows
+read NULL on all three. Plumbing for the helix_announce self-report
+feature."
+```
+
+---
+
+## Task 3: Pydantic models
+
+Add 3 optional fields to `Participant` and `ParticipantInfo`.
+
+**Files:**
+- Modify: `helix_context/schemas.py` — `Participant` and `ParticipantInfo` classes
+- Test: `tests/test_registry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_registry.py`:
+
+```python
+def test_participant_model_accepts_announce_fields():
+    from helix_context.schemas import Participant
+    p = Participant(
+        participant_id="abc",
+        party_id="party",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="claude-opus-4-7",
+    )
+    assert p.ide_detected == "vscode"
+    assert p.ide_detection_via == "env:VSCODE_PID"
+    assert p.model_id == "claude-opus-4-7"
+
+
+def test_participant_info_accepts_announce_fields():
+    from helix_context.schemas import ParticipantInfo
+    p = ParticipantInfo(
+        participant_id="abc",
+        party_id="party",
+        handle="laude",
+        status="active",
+        last_seen_s_ago=0.0,
+        started_at=0.0,
+        ide_detected="cursor",
+        ide_detection_via="env:CURSOR_TRACE_ID",
+        model_id="gpt-5",
+    )
+    assert p.ide_detected == "cursor"
+    assert p.ide_detection_via == "env:CURSOR_TRACE_ID"
+    assert p.model_id == "gpt-5"
+
+
+def test_participant_info_defaults_announce_fields_to_none():
+    from helix_context.schemas import ParticipantInfo
+    p = ParticipantInfo(
+        participant_id="abc",
+        party_id="party",
+        handle="laude",
+        status="active",
+        last_seen_s_ago=0.0,
+        started_at=0.0,
+    )
+    assert p.ide_detected is None
+    assert p.ide_detection_via is None
+    assert p.model_id is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_registry.py -k "participant_model_accepts_announce or participant_info_accepts_announce" -v`
+Expected: FAIL — extra_forbidden or attribute missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/schemas.py`, append three fields to the END of `Participant` (preserving all existing fields including the `agent_kind`/`mcp_host` from PR #26):
+
+```python
+    ide_detected: Optional[str] = None        # adapter detect at register time
+    ide_detection_via: Optional[str] = None   # "env:VSCODE_PID", "agent_override", etc.
+    model_id: Optional[str] = None            # agent self-reported via helix_announce
+```
+
+Same three fields appended to the END of `ParticipantInfo`:
+
+```python
+    ide_detected: Optional[str] = None
+    ide_detection_via: Optional[str] = None
+    model_id: Optional[str] = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_registry.py -k "announce" -v`
+Expected: passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/schemas.py tests/test_registry.py
+git commit -m "feat(schemas): add ide_detected+ide_detection_via+model_id
+
+Optional fields, default None on both Participant and ParticipantInfo.
+Round-trip vehicle for the new participants columns."
+```
+
+---
+
+## Task 4: Registry — accept, persist, project, update
+
+Two related changes: `register_participant` accepts the three new fields and writes them; new `update_announcement()` method PATCHes them on an existing row.
+
+**Files:**
+- Modify: `helix_context/registry.py` — `register_participant` signature/INSERT/return, `list_participants` SELECT/projection, `get_participant` SELECT/return, NEW `update_announcement()` method
+- Test: `tests/test_registry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_registry.py`:
+
+```python
+def test_register_participant_persists_announce_fields(registry, genome):
+    p = registry.register_participant(
+        party_id="party_a",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    assert p.ide_detected == "vscode"
+    assert p.ide_detection_via == "env:VSCODE_PID"
+    assert p.model_id is None  # not yet announced
+
+    cur = genome.conn.cursor()
+    row = cur.execute(
+        "SELECT ide_detected, ide_detection_via, model_id "
+        "FROM participants WHERE participant_id = ?",
+        (p.participant_id,),
+    ).fetchone()
+    assert row[0] == "vscode"
+    assert row[1] == "env:VSCODE_PID"
+    assert row[2] is None
+
+
+def test_register_participant_omitting_announce_fields_stores_null(registry):
+    p = registry.register_participant(party_id="party_b", handle="taude")
+    assert p.ide_detected is None
+    assert p.ide_detection_via is None
+    assert p.model_id is None
+
+
+def test_list_participants_projects_announce_fields(registry):
+    registry.register_participant(
+        party_id="party_c",
+        handle="laude",
+        ide_detected="cursor",
+        ide_detection_via="env:CURSOR_TRACE_ID",
+    )
+    rows = registry.list_participants(party_id="party_c", status_filter="all")
+    assert len(rows) == 1
+    assert rows[0].ide_detected == "cursor"
+    assert rows[0].ide_detection_via == "env:CURSOR_TRACE_ID"
+    assert rows[0].model_id is None
+
+
+def test_get_participant_projects_announce_fields(registry):
+    p = registry.register_participant(
+        party_id="party_d",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched is not None
+    assert fetched.ide_detected == "vscode"
+    assert fetched.model_id is None
+
+
+def test_update_announcement_sets_model_id(registry):
+    p = registry.register_participant(
+        party_id="party_e",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    registry.update_announcement(
+        participant_id=p.participant_id,
+        model_id="claude-opus-4-7",
+    )
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched.model_id == "claude-opus-4-7"
+    # IDE should be unchanged when no override is supplied
+    assert fetched.ide_detected == "vscode"
+    assert fetched.ide_detection_via == "env:VSCODE_PID"
+
+
+def test_update_announcement_with_ide_override_sets_via_to_agent_override(registry):
+    p = registry.register_participant(
+        party_id="party_f",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    registry.update_announcement(
+        participant_id=p.participant_id,
+        model_id="gpt-5",
+        ide_override="cursor",
+    )
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched.ide_detected == "cursor"
+    assert fetched.ide_detection_via == "agent_override"
+    assert fetched.model_id == "gpt-5"
+
+
+def test_update_announcement_is_idempotent(registry):
+    """Multiple calls overwrite — last write wins."""
+    p = registry.register_participant(party_id="party_g", handle="laude")
+    registry.update_announcement(participant_id=p.participant_id, model_id="claude-opus-4-7")
+    registry.update_announcement(participant_id=p.participant_id, model_id="claude-sonnet-4-6")
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched.model_id == "claude-sonnet-4-6"
+
+
+def test_update_announcement_unknown_participant_id_raises_or_noops(registry):
+    """Calling update_announcement on an unknown id should be safe."""
+    # Pick the contract: either raise KeyError or no-op silently.
+    # Recommended: silent no-op + log.warning, mirroring the registry's
+    # other update methods (heartbeat etc).
+    registry.update_announcement(
+        participant_id="does-not-exist",
+        model_id="claude-opus-4-7",
+    )
+    # No assertion on raise; if implementation chooses to raise, change
+    # this test to expect the exception type. But the registry's existing
+    # heartbeat() updates silently no-op on unknown ids, so this should match.
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_registry.py -k "announce_fields or update_announcement" -v`
+Expected: FAIL — `register_participant() got an unexpected keyword argument 'ide_detected'` or `Registry has no attribute 'update_announcement'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/registry.py`, modify `register_participant`. Add three new kwargs at the END of the signature (preserving all existing kwargs from PR #26):
+
+```python
+        ide_detected: Optional[str] = None,
+        ide_detection_via: Optional[str] = None,
+        model_id: Optional[str] = None,
+```
+
+Update the INSERT to include 3 new columns and 3 new placeholders + 3 new tuple entries at the END of the VALUES tuple. Update the returned `Participant(...)` constructor with `ide_detected=...`, `ide_detection_via=...`, `model_id=...`.
+
+Update `list_participants` and `get_participant` similarly: add the 3 columns to SELECT, add the 3 keyword args to `ParticipantInfo(...)` / `Participant(...)`.
+
+Add a new method `update_announcement` (placement near `heartbeat()` — they're both PATCH-style updates):
+
+```python
+    def update_announcement(
+        self,
+        participant_id: str,
+        model_id: Optional[str] = None,
+        ide_override: Optional[str] = None,
+    ) -> None:
+        """PATCH model_id and (optionally) ide_detected on a participant row.
+
+        Called by the announce endpoint when an agent self-reports its
+        identity. ``ide_override`` replaces ``ide_detected`` and forces
+        ``ide_detection_via='agent_override'`` so the tooltip can surface
+        that the IDE came from the agent rather than env detection.
+
+        Idempotent: multiple calls overwrite (last write wins). Silently
+        no-ops on unknown ``participant_id`` to match the heartbeat path
+        — the agent has no useful action to take if the participant has
+        already TTL'd out.
+        """
+        cur = self.genome.conn.cursor()
+        if ide_override is not None:
+            cur.execute(
+                "UPDATE participants "
+                "SET model_id = COALESCE(?, model_id), "
+                "    ide_detected = ?, "
+                "    ide_detection_via = 'agent_override' "
+                "WHERE participant_id = ?",
+                (model_id, ide_override, participant_id),
+            )
+        else:
+            cur.execute(
+                "UPDATE participants "
+                "SET model_id = COALESCE(?, model_id) "
+                "WHERE participant_id = ?",
+                (model_id, participant_id),
+            )
+        self.genome.conn.commit()
+```
+
+`COALESCE(?, model_id)` lets the announce call set OR clear OR no-op on `model_id` cleanly: passing `None` keeps the existing value (no-op), passing a string overwrites. (If you actively want to NULL out model_id, that's a separate concern not in this spec.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_registry.py -k "announce_fields or update_announcement" -v`
+Expected: 8 passed.
+
+Run full file: `python -m pytest tests/test_registry.py -v`
+Expected: no NEW failures (pre-existing 3 from PR #26 era still expected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/registry.py tests/test_registry.py
+git commit -m "feat(registry): persist+project announce fields; add update_announcement
+
+register_participant accepts ide_detected/ide_detection_via/model_id
+optional kwargs and writes them. list_participants and get_participant
+project them through. New update_announcement() method PATCHes model_id
+and (optionally) ide_detected; ide_override forces detection_via to
+'agent_override' for tooltip diagnostic. Silent no-op on unknown
+participant_id, matching heartbeat() semantics."
+```
+
+---
+
+## Task 5: Server endpoints
+
+Two changes: `/sessions/register` accepts the three new fields in the body; new `POST /sessions/{participant_id}/announce` endpoint.
+
+**Files:**
+- Modify: `helix_context/server.py` — `/sessions/register` endpoint, NEW announce endpoint
+- Test: `tests/test_server.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_server.py`:
+
+```python
+def test_sessions_register_accepts_announce_fields(client):
+    resp = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "party_register_announce",
+            "handle": "laude",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["participant_id"]
+
+    listing = client.get("/sessions", params={"party_id": "party_register_announce"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert len(matching) == 1
+    assert matching[0]["ide_detected"] == "vscode"
+    assert matching[0]["ide_detection_via"] == "env:VSCODE_PID"
+    assert matching[0].get("model_id") is None
+
+
+def test_announce_endpoint_sets_model_id(client):
+    """POST /sessions/{participant_id}/announce updates model_id."""
+    reg = client.post(
+        "/sessions/register",
+        json={"party_id": "party_announce", "handle": "laude"},
+    )
+    pid = reg.json()["participant_id"]
+
+    resp = client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "claude-opus-4-7"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    listing = client.get("/sessions", params={"party_id": "party_announce"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert matching[0]["model_id"] == "claude-opus-4-7"
+
+
+def test_announce_endpoint_with_ide_override_sets_agent_override_via(client):
+    reg = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "party_override",
+            "handle": "laude",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+        },
+    )
+    pid = reg.json()["participant_id"]
+
+    resp = client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "gpt-5", "ide_override": "cursor"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    listing = client.get("/sessions", params={"party_id": "party_override"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert matching[0]["ide_detected"] == "cursor"
+    assert matching[0]["ide_detection_via"] == "agent_override"
+    assert matching[0]["model_id"] == "gpt-5"
+
+
+def test_announce_endpoint_unknown_participant_returns_200(client):
+    """Silent no-op on unknown participant_id matches registry semantics
+    and avoids leaking participant existence via 404 vs 200 distinction."""
+    resp = client.post(
+        "/sessions/does-not-exist/announce",
+        json={"model_id": "claude-opus-4-7"},
+    )
+    assert resp.status_code == 200, resp.text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_server.py -k "announce" -v`
+Expected: FAIL — fields not surfacing or 404 from unknown route.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/server.py`, modify the `/sessions/register` endpoint. Locate the call to `registry.register_participant(...)` and append three more kwargs (preserving the agent_kind/mcp_host from PR #26):
+
+```python
+                ide_detected=data.get("ide_detected"),
+                ide_detection_via=data.get("ide_detection_via"),
+                model_id=data.get("model_id"),
+```
+
+Add a new endpoint immediately AFTER the `/sessions/register` endpoint:
+
+```python
+@app.post("/sessions/{participant_id}/announce")
+async def session_announce_endpoint(participant_id: str, request: Request):
+    """Update model_id and (optionally) ide_detected on a participant.
+
+    Called by the agent via the helix_announce MCP tool after the MCP
+    adapter has registered the session. Body fields:
+
+    - model_id: required string. Free-form, no validation.
+    - ide_override: optional string. Replaces ide_detected and sets
+      ide_detection_via='agent_override'.
+
+    Silent no-op on unknown participant_id (matches heartbeat semantics
+    and registry update_announcement contract).
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    model_id = data.get("model_id")
+    ide_override = data.get("ide_override")
+    if model_id is not None and not isinstance(model_id, str):
+        raise HTTPException(status_code=400, detail="model_id must be a string")
+    if ide_override is not None and not isinstance(ide_override, str):
+        raise HTTPException(status_code=400, detail="ide_override must be a string")
+
+    try:
+        registry.update_announcement(
+            participant_id=participant_id,
+            model_id=model_id,
+            ide_override=ide_override,
+        )
+    except Exception as exc:
+        log.warning("Announce failed: %s", exc, exc_info=True)
+        return JSONResponse(
+            {"error": f"Announce failed: {exc}"},
+            status_code=500,
+        )
+
+    return JSONResponse({"ok": True})
+```
+
+`registry` is the existing module-level registry singleton — re-use the same accessor pattern as the existing `/sessions/register` endpoint.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_server.py -k "announce" -v`
+Expected: 4 passed.
+
+Run: `python -m pytest tests/test_server.py -v`
+Expected: no NEW failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/server.py tests/test_server.py
+git commit -m "feat(server): /sessions/register passes through announce fields; new /announce endpoint
+
+POST /sessions/register now forwards optional ide_detected/
+ide_detection_via/model_id to registry.register_participant. New
+POST /sessions/{participant_id}/announce endpoint maps to the
+registry's update_announcement() PATCH for agent self-report. Silent
+no-op on unknown participant_id matches heartbeat semantics."
+```
+
+---
+
+## Task 6: AgentBridge — pass-through and announce
+
+The HTTP-client wrapper used by `_register_with_registry` and (new) by the `helix_announce` MCP tool.
+
+**Files:**
+- Modify: `helix_context/bridge.py` — `register_participant` accepts new fields; new `announce()` method
+- Test: `tests/test_bridge_registry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_bridge_registry.py`:
+
+```python
+def test_register_participant_sends_announce_fields(monkeypatch, bridge_with_capture):
+    """AgentBridge.register_participant forwards ide_detected/via and model_id."""
+    bridge, captured = bridge_with_capture
+    bridge.register_participant(
+        party_id="party_z",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    body = captured["body"]
+    assert body["ide_detected"] == "vscode"
+    assert body["ide_detection_via"] == "env:VSCODE_PID"
+    # model_id NOT included when not passed (don't send NULL kwargs)
+    assert "model_id" not in body
+
+
+def test_register_participant_omits_unset_announce_fields(monkeypatch, bridge_with_capture):
+    """When kwargs are None, the body omits them entirely."""
+    bridge, captured = bridge_with_capture
+    bridge.register_participant(party_id="party_y", handle="taude")
+    body = captured["body"]
+    assert "ide_detected" not in body
+    assert "ide_detection_via" not in body
+    assert "model_id" not in body
+
+
+def test_announce_method_posts_to_announce_endpoint(monkeypatch, bridge_with_capture):
+    """AgentBridge.announce(participant_id, model_id, ide_override) hits
+    POST /sessions/{participant_id}/announce."""
+    bridge, captured = bridge_with_capture
+    # Pre-set the bridge's known participant_id so announce() can target it
+    bridge._participant_id = "test-pid-123"
+    bridge.announce(model_id="claude-opus-4-7", ide_override="cursor")
+    assert captured["url"].endswith("/sessions/test-pid-123/announce")
+    body = captured["body"]
+    assert body["model_id"] == "claude-opus-4-7"
+    assert body["ide_override"] == "cursor"
+
+
+def test_announce_method_without_ide_override(monkeypatch, bridge_with_capture):
+    bridge, captured = bridge_with_capture
+    bridge._participant_id = "test-pid-456"
+    bridge.announce(model_id="gpt-5")
+    body = captured["body"]
+    assert body["model_id"] == "gpt-5"
+    assert "ide_override" not in body  # not included when None
+```
+
+If `bridge_with_capture` doesn't already exist as a fixture in this file, build one that captures the http_post payload. The existing PR-#26 test for `register_participant_sends_vendor_host` likely uses a similar pattern — copy it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_bridge_registry.py -k "announce_fields or announce_method" -v`
+Expected: FAIL — keyword args not accepted; AttributeError on `bridge.announce`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/bridge.py`, modify `AgentBridge.register_participant`. Add three new optional kwargs at the END of the signature:
+
+```python
+        ide_detected: Optional[str] = None,
+        ide_detection_via: Optional[str] = None,
+        model_id: Optional[str] = None,
+```
+
+Add three conditional body-building lines following the existing pattern (`if X is not None: body["X"] = X`):
+
+```python
+        if ide_detected is not None:
+            body["ide_detected"] = ide_detected
+        if ide_detection_via is not None:
+            body["ide_detection_via"] = ide_detection_via
+        if model_id is not None:
+            body["model_id"] = model_id
+```
+
+Add a new method `announce` (place near `register_participant`):
+
+```python
+    def announce(
+        self,
+        model_id: str,
+        ide_override: Optional[str] = None,
+    ) -> bool:
+        """POST to /sessions/{participant_id}/announce for self-report.
+
+        Requires that ``register_participant`` has already been called
+        successfully (sets ``self._participant_id``). If not yet
+        registered, this is a no-op returning False — the agent shouldn't
+        call announce before the adapter has registered.
+
+        Returns True on HTTP 200, False otherwise. Failures are logged
+        but non-fatal — model_id is best-effort.
+        """
+        if not getattr(self, "_participant_id", None):
+            log.warning("announce() called before register_participant; skipping")
+            return False
+
+        body: Dict[str, Any] = {"model_id": model_id}
+        if ide_override is not None:
+            body["ide_override"] = ide_override
+
+        try:
+            self._http_post(
+                f"/sessions/{self._participant_id}/announce",
+                json_body=body,
+            )
+            return True
+        except Exception as exc:
+            log.warning("announce() failed: %s", exc)
+            return False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_bridge_registry.py -v`
+Expected: existing tests + 4 new pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/bridge.py tests/test_bridge_registry.py
+git commit -m "feat(bridge): forward announce fields; add announce() method
+
+AgentBridge.register_participant accepts optional ide_detected/
+ide_detection_via/model_id kwargs that are conditionally included
+in the POST body. New announce() method POSTs to /sessions/
+{participant_id}/announce for agent self-report; no-op if not yet
+registered. Failures non-fatal — model_id is best-effort."
+```
+
+---
+
+## Task 7: MCP integration — startup detect + helix_announce tool
+
+The trigger surface — wires the adapter to call `detect_ide()` at startup, and exposes `helix_announce` as a new MCP tool the agent can call.
+
+**Files:**
+- Modify: `helix_context/mcp_server.py` — `_register_with_registry` calls `detect_ide()`; new `@mcp.tool() helix_announce(...)`
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mcp_server.py`:
+
+```python
+def test_register_with_registry_calls_detect_ide(monkeypatch, mock_bridge):
+    """_register_with_registry calls detect_ide() and forwards both fields."""
+    monkeypatch.setenv("HELIX_MCP_HANDLE", "laude")
+    monkeypatch.setenv("HELIX_PARTY_ID", "swift_wing21")
+    monkeypatch.delenv("HELIX_MCP_HOST", raising=False)
+    monkeypatch.setenv("VSCODE_PID", "9999")
+
+    from helix_context import mcp_server
+    mcp_server._register_with_registry()
+
+    call = mock_bridge.register_participant_calls[-1]
+    assert call["ide_detected"] == "vscode"
+    assert call["ide_detection_via"] == "env:VSCODE_PID"
+
+
+def test_register_with_registry_no_match_sends_none(monkeypatch, mock_bridge):
+    """When fingerprint chain has no signal, ide_detected is None and via is no_match."""
+    monkeypatch.setenv("HELIX_MCP_HANDLE", "laude")
+    monkeypatch.setenv("HELIX_PARTY_ID", "swift_wing21")
+    monkeypatch.delenv("HELIX_MCP_HOST", raising=False)
+    monkeypatch.delenv("VSCODE_PID", raising=False)
+    monkeypatch.delenv("CURSOR_TRACE_ID", raising=False)
+
+    from helix_context import mcp_server
+    mcp_server._register_with_registry()
+
+    call = mock_bridge.register_participant_calls[-1]
+    assert call["ide_detected"] is None
+    assert call["ide_detection_via"] == "no_match"
+
+
+def test_helix_announce_tool_calls_bridge_announce(monkeypatch, mock_bridge):
+    """The helix_announce MCP tool delegates to AgentBridge.announce()."""
+    from helix_context import mcp_server
+    # Need to invoke the tool function. Tools are registered via @mcp.tool();
+    # the test should access the underlying function. Use the same pattern
+    # the file uses for testing other tools (often _ToolName or direct
+    # function attribute on the module).
+    result = mcp_server.helix_announce(
+        model_id="claude-opus-4-7",
+        ide_override=None,
+    )
+    # Confirm bridge.announce was called with the right args
+    call = mock_bridge.announce_calls[-1]
+    assert call["model_id"] == "claude-opus-4-7"
+    assert call["ide_override"] is None
+```
+
+The `mock_bridge` fixture from PR #26 needs to grow an `announce_calls` list. Update the fixture:
+
+```python
+@pytest.fixture
+def mock_bridge(monkeypatch):
+    class _MockBridge:
+        register_participant_calls = []
+        announce_calls = []
+        _participant_id = "mock-participant-id"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def register_participant(self, **kwargs):
+            type(self).register_participant_calls.append(kwargs)
+            return "mock-participant-id"
+
+        def announce(self, model_id, ide_override=None):
+            type(self).announce_calls.append({
+                "model_id": model_id,
+                "ide_override": ide_override,
+            })
+            return True
+
+    monkeypatch.setattr("helix_context.bridge.AgentBridge", _MockBridge)
+    _MockBridge.register_participant_calls = []
+    _MockBridge.announce_calls = []
+    yield _MockBridge
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py -k "detect_ide or no_match or helix_announce" -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/mcp_server.py`, modify `_register_with_registry` to call `detect_ide()` and forward results. Place the `from helix_context.launcher.ide_fingerprint import detect_ide` import inside the function (matches the existing late-binding pattern for `AgentBridge`):
+
+```python
+def _register_with_registry() -> None:
+    """... (existing docstring; extend to mention IDE auto-detect)"""
+    try:
+        from helix_context.bridge import AgentBridge
+        from helix_context.launcher.ide_fingerprint import detect_ide
+    except Exception as exc:
+        log.warning("Registry bridge import failed, skipping registration: %s", exc)
+        return
+
+    handle = os.environ.get("HELIX_MCP_HANDLE", f"mcp-{os.getpid()}")
+    party_id = _default_party_id()
+    mcp_host_env = os.environ.get("HELIX_MCP_HOST", "unknown")
+    agent_kind_env = os.environ.get("HELIX_AGENT_KIND")
+    workspace: Optional[str]
+    try:
+        workspace = os.getcwd()
+    except Exception:
+        workspace = None
+
+    capabilities = ["mcp_tools", f"host:{mcp_host_env}"]
+    mcp_host = None if mcp_host_env == "unknown" else mcp_host_env
+
+    # IDE auto-detect via env-var fingerprint chain. Falls back to
+    # (None, "no_match") when no signal — agent can later override via
+    # helix_announce(ide_override=...).
+    ide_detected, ide_detection_via = detect_ide()
+
+    bridge = AgentBridge(helix_base_url=HELIX_URL)
+    participant_id = bridge.register_participant(
+        party_id=party_id,
+        handle=handle,
+        workspace=workspace,
+        capabilities=capabilities,
+        agent_kind=agent_kind_env,
+        mcp_host=mcp_host,
+        ide_detected=ide_detected,
+        ide_detection_via=ide_detection_via,
+        start_auto_heartbeat=True,
+    )
+    # Stash the bridge for the helix_announce tool to use later.
+    if participant_id:
+        global _registered_bridge
+        _registered_bridge = bridge
+        log.info(
+            "Registered as %s (party=%s, kind=%s, host=%s, ide=%s/%s, pid=%d)",
+            handle, party_id, agent_kind_env, mcp_host,
+            ide_detected, ide_detection_via, os.getpid(),
+        )
+    else:
+        log.warning(
+            "Session registration failed (is helix running at %s?) "
+            "— tool calls will still work",
+            HELIX_URL,
+        )
+```
+
+Add module-level state:
+
+```python
+# Set by _register_with_registry on success; consumed by the
+# helix_announce MCP tool to PATCH the same participant row.
+_registered_bridge: Optional[Any] = None
+```
+
+Add the new MCP tool. Place near other `@mcp.tool()`-decorated functions:
+
+```python
+@mcp.tool()
+def helix_announce(
+    model_id: str,
+    ide_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Self-report the agent's model identity and (optionally) override
+    the auto-detected IDE.
+
+    Call this once per session, after your first ``helix_health`` call,
+    so the dashboard can display your model in the agent badge tooltip.
+
+    Args:
+        model_id: Free-form model identifier. Examples:
+            "claude-opus-4-7", "claude-sonnet-4-6", "gpt-5",
+            "gemini-2-5-pro". The dashboard pretty-maps known IDs to
+            display names; unknown IDs render verbatim.
+        ide_override: Optional. Replaces the adapter's auto-detected
+            IDE. Use only when env-var detection got it wrong.
+
+    Returns:
+        {"ok": True} on success, {"ok": False, "error": "..."} on
+        failure. Failures are non-fatal — the rest of the session
+        continues to work.
+    """
+    if _registered_bridge is None:
+        return {
+            "ok": False,
+            "error": "Not yet registered with helix; announce skipped.",
+        }
+    success = _registered_bridge.announce(
+        model_id=model_id,
+        ide_override=ide_override,
+    )
+    return {"ok": success}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py -v`
+Expected: existing tests + 3 new pass; no NEW regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(mcp): _register_with_registry calls detect_ide; new helix_announce tool
+
+MCP adapter now fingerprints the host IDE at register time via
+ide_fingerprint.detect_ide() and forwards (ide_detected,
+ide_detection_via) through AgentBridge.
+
+New helix_announce MCP tool delegates to AgentBridge.announce() so
+the agent can self-report its model_id and (optionally) override the
+auto-detected IDE. The skill instructs the agent to call this once
+per session after the first helix_health."
+```
+
+---
+
+## Task 8: model_labels module + tests
+
+Pretty-mapping for known `model_id` strings. Same pattern as `host_labels.py`.
+
+**Files:**
+- Create: `helix_context/launcher/model_labels.py`
+- Test: `tests/test_model_labels.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_model_labels.py
+"""Pretty-label module for model_id strings.
+
+Same pattern as host_labels: known IDs map to canonical display form,
+unknown IDs echo verbatim, None/empty returns None.
+"""
+from helix_context.launcher.model_labels import model_pretty
+
+
+def test_known_anthropic_models():
+    assert model_pretty("claude-opus-4-7") == "Claude Opus 4.7"
+    assert model_pretty("claude-sonnet-4-6") == "Claude Sonnet 4.6"
+    assert model_pretty("claude-haiku-4-5") == "Claude Haiku 4.5"
+
+
+def test_known_anthropic_with_context_qualifier():
+    assert model_pretty("claude-opus-4-7-1m") == "Claude Opus 4.7 (1M context)"
+
+
+def test_known_openai_models():
+    assert model_pretty("gpt-5") == "GPT-5"
+
+
+def test_known_google_models():
+    assert model_pretty("gemini-2-5-pro") == "Gemini 2.5 Pro"
+
+
+def test_unknown_model_id_echoes_verbatim():
+    """Don't fabricate a pretty form — echo what the agent reported."""
+    assert model_pretty("acme-experimental-7b") == "acme-experimental-7b"
+
+
+def test_none_returns_none():
+    assert model_pretty(None) is None
+    assert model_pretty("") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_model_labels.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# helix_context/launcher/model_labels.py
+"""Pretty-label module for model_id strings reported via helix_announce.
+
+Maps known model identifiers to canonical display form for the dashboard
+tooltip. Unknown IDs echo verbatim — no fabrication. The map grows as
+agents announce new IDs. There is no allowlist gate on what an agent
+can report; the registry stores whatever the agent says, and this
+module is a display-only convenience.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+_MODEL_MAP = {
+    # Anthropic
+    "claude-opus-4-7": "Claude Opus 4.7",
+    "claude-opus-4-7-1m": "Claude Opus 4.7 (1M context)",
+    "claude-sonnet-4-6": "Claude Sonnet 4.6",
+    "claude-haiku-4-5": "Claude Haiku 4.5",
+    # OpenAI
+    "gpt-5": "GPT-5",
+    # Google
+    "gemini-2-5-pro": "Gemini 2.5 Pro",
+}
+
+
+def model_pretty(value: Optional[str]) -> Optional[str]:
+    """Map a known model_id to its display form, or echo verbatim if
+    unknown. None / empty input returns None."""
+    if not value:
+        return None
+    return _MODEL_MAP.get(value, value)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_model_labels.py -v`
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/launcher/model_labels.py tests/test_model_labels.py
+git commit -m "feat(launcher): add model_labels pretty-map
+
+Maps known model_id strings (claude-opus-4-7, gpt-5, gemini-2-5-pro,
+etc.) to display form. Unknown IDs echo verbatim — no fabrication.
+Same pattern as host_labels.py."
+```
+
+---
+
+## Task 9: Collector — populate tooltip fields
+
+Each panel entry now carries a tooltip-ready field bundle so the templates can render the progressive-disclosure tooltip.
+
+**Files:**
+- Modify: `helix_context/launcher/collector.py` — `_all_agents_panel`, `_disconnected_agents_panel`, `_participants_panel`
+- Test: `tests/test_collector_host_label.py` (extend existing PR #26 tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_collector_host_label.py`:
+
+```python
+def test_all_agents_panel_emits_tooltip_fields_when_announced():
+    """Entry has model_pretty/ide_pretty/agent_kind_pretty/ide_detection_via."""
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(
+        agent_kind="claude-code",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="claude-opus-4-7",
+    )
+    panel = collector._all_agents_panel([p])
+    entry = panel["entries"][0]
+    tooltip = entry["tooltip"]
+    assert tooltip["model_label"] == "Claude Opus 4.7"
+    assert tooltip["ide_label"] == "VS Code"
+    assert tooltip["agent_kind_label"] == "Claude Code"
+    assert tooltip["ide_detection_via"] == "env:VSCODE_PID"
+
+
+def test_all_agents_panel_emits_placeholders_when_missing():
+    """Missing fields render as 'Not announced' / 'Not detected' / 'Not set'."""
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant()  # all announce fields None; agent_kind also None
+    panel = collector._all_agents_panel([p])
+    entry = panel["entries"][0]
+    tooltip = entry["tooltip"]
+    assert tooltip["model_label"] == "Not announced"
+    assert tooltip["ide_label"] == "Not detected"
+    assert tooltip["agent_kind_label"] == "Not set"
+
+
+def test_all_agents_panel_emits_unknown_model_id_verbatim():
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(model_id="acme-experimental-7b")
+    panel = collector._all_agents_panel([p])
+    assert panel["entries"][0]["tooltip"]["model_label"] == "acme-experimental-7b"
+
+
+def test_disconnected_agents_panel_also_emits_tooltip():
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(
+        status="stale",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="claude-opus-4-7",
+    )
+    panel = collector._disconnected_agents_panel([p])
+    assert panel is not None
+    tooltip = panel["entries"][0]["tooltip"]
+    assert tooltip["model_label"] == "Claude Opus 4.7"
+    assert tooltip["ide_label"] == "VS Code"
+
+
+def test_participants_panel_also_emits_tooltip():
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="gpt-5",
+    )
+    panel = collector._participants_panel([p])
+    tooltip = panel["entries"][0]["tooltip"]
+    assert tooltip["model_label"] == "GPT-5"
+    assert tooltip["ide_label"] == "VS Code"
+```
+
+Update the `_make_participant` helper in this file to include the three new fields with `None` defaults (so existing PR-#26 tests still work):
+
+```python
+def _make_participant(**overrides):
+    base = {
+        "participant_id": "abc12345",
+        "handle": "laude",
+        "party_id": "party_x",
+        "workspace": "F:\\Projects",
+        "status": "active",
+        "last_seen_s_ago": 1.0,
+        "agent_kind": None,
+        "mcp_host": None,
+        "ide_detected": None,
+        "ide_detection_via": None,
+        "model_id": None,
+    }
+    base.update(overrides)
+    return base
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_collector_host_label.py -v`
+Expected: FAIL — `tooltip` key missing on entries.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `helix_context/launcher/collector.py`, at the top of the file add an import (alongside the existing `host_labels` import from PR #26):
+
+```python
+from helix_context.launcher.host_labels import compose_label, host_pretty, vendor_pretty
+from helix_context.launcher.model_labels import model_pretty
+```
+
+Add a small private helper at module level (before `class StateCollector`) — keeps the three panel methods DRY:
+
+```python
+def _build_tooltip(participant: Dict[str, Any]) -> Dict[str, str]:
+    """Compose the tooltip field bundle from a participant dict.
+
+    Each label is either a pretty-mapped value or an explicit placeholder
+    that hints at the cause:
+      - model_label: "Not announced" when model_id is NULL
+      - ide_label:   "Not detected" when ide_detected is NULL
+      - agent_kind_label: "Not set"  when agent_kind is NULL
+    The ide_detection_via line tells the operator how (or whether) the
+    IDE value was obtained: "env:VSCODE_PID", "agent_override",
+    "no_match", "explicit:HELIX_MCP_HOST".
+    """
+    return {
+        "model_label": model_pretty(participant.get("model_id")) or "Not announced",
+        "ide_label": (
+            host_pretty(participant.get("ide_detected"))
+            or host_pretty(participant.get("mcp_host"))   # PR #26 backward-compat fallback
+            or "Not detected"
+        ),
+        "agent_kind_label": vendor_pretty(participant.get("agent_kind")) or "Not set",
+        "ide_detection_via": participant.get("ide_detection_via") or "no_match",
+    }
+```
+
+In each of `_all_agents_panel`, `_disconnected_agents_panel`, `_participants_panel`, add `"tooltip": _build_tooltip(participant)` to the entry dict (alongside the existing `host_label` from PR #26).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_collector_host_label.py -v`
+Expected: all (PR-#26 + 5 new) pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helix_context/launcher/collector.py tests/test_collector_host_label.py
+git commit -m "feat(collector): emit tooltip field bundle on agent panel entries
+
+Each entry now carries tooltip = {model_label, ide_label,
+agent_kind_label, ide_detection_via}. Pretty-mapped via host_labels
+and model_labels; missing fields render as 'Not announced/detected/
+set' explicit placeholders. ide_label falls back to PR #26 mcp_host
+when ide_detected is NULL (backward-compat for sessions registered
+before this change)."
+```
+
+---
+
+## Task 10: Templates + CSS — render the tooltip
+
+CSS-only `:hover` reveal. No JS.
+
+**Files:**
+- Modify: `helix_context/launcher/templates/components/agents_panel.html`
+- Modify: `helix_context/launcher/templates/components/participants_panel.html`
+- Modify: `helix_context/launcher/static/launcher.css`
+
+- [ ] **Step 1: Read the existing chip block in agents_panel.html**
+
+Read `helix_context/launcher/templates/components/agents_panel.html` to find the existing `chip--agent-host` block from PR #26 (around line 49). The new tooltip wraps this chip so the existing `:hover` target stays the chip itself.
+
+- [ ] **Step 2: Modify agents_panel.html**
+
+Replace each occurrence of the `chip--agent-host` chip block (there are three — active, all, historical) with a wrapped version. Pattern for the active sub-view:
+
+```jinja
+{% if agent.host_label or agent.tooltip %}
+<span class="chip-with-tooltip">
+  {% if agent.host_label %}
+    <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+  {% endif %}
+  {% if agent.tooltip %}
+    <div class="tooltip-content">
+      <div class="tooltip-row"><span class="tooltip-key">Model:</span> {{ agent.tooltip.model_label }}</div>
+      <div class="tooltip-row"><span class="tooltip-key">Wrapper:</span> {{ agent.tooltip.agent_kind_label }}</div>
+      <div class="tooltip-row"><span class="tooltip-key">IDE:</span> {{ agent.tooltip.ide_label }}
+        <span class="tooltip-via">({{ agent.tooltip.ide_detection_via }})</span>
+      </div>
+    </div>
+  {% endif %}
+</span>
+{% endif %}
+```
+
+Apply the same wrapping in the **all** sub-view and the **historical disconnected** sub-view of the same template.
+
+- [ ] **Step 3: Modify participants_panel.html**
+
+Same wrapping treatment for the chip block added in PR #26 Task 9. Use `p.host_label` and `p.tooltip` since the loop variable is `p`.
+
+- [ ] **Step 4: Add CSS**
+
+Append to `helix_context/launcher/static/launcher.css`:
+
+```css
+/* Tooltip — CSS-only :hover reveal on the agent host chip. */
+.chip-with-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.chip-with-tooltip .tooltip-content {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 6px;
+  padding: 8px 12px;
+  background: rgba(20, 20, 24, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease, visibility 0s linear 120ms;
+  z-index: 10;
+  font-size: 12px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.chip-with-tooltip:hover .tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.chip-with-tooltip .tooltip-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chip-with-tooltip .tooltip-key {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.6);
+  min-width: 64px;
+}
+
+.chip-with-tooltip .tooltip-via {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+```
+
+Match the existing CSS file's style (look at how chips already in the file are styled — colors, transitions, etc.). Adjust hex/rgba values if the file's palette differs from the values above.
+
+- [ ] **Step 5: Smoke test the templates**
+
+Same approach as PR #26 Task 9 smoke test: render the templates with synthetic state and grep for the tooltip text.
+
+```bash
+cd f:/Projects/helix-context && python -c "
+from jinja2 import Environment, FileSystemLoader, select_autoescape, ChainableUndefined
+env = Environment(
+    loader=FileSystemLoader('helix_context/launcher/templates'),
+    autoescape=select_autoescape(['html', 'xml']),
+    undefined=ChainableUndefined,
+)
+state = {
+    'all_agents': {
+        'count': 1, 'active_count': 1,
+        'entries': [{
+            'handle': 'laude', 'party_id': 'swift_wing21',
+            'workspace': 'F:\\\\Projects', 'status': 'active',
+            'last_seen_s_ago': 1.2, 'participant_id': 'abc12345-deadbeef',
+            'participant_id_short': 'abc12345', 'identifier': 'swift_wing21',
+            'host_label': 'Claude Code + VS Code',
+            'tooltip': {
+                'model_label': 'Claude Opus 4.7',
+                'ide_label': 'VS Code',
+                'agent_kind_label': 'Claude Code',
+                'ide_detection_via': 'env:VSCODE_PID',
+            },
+        }],
+    },
+    'participants': {'count': 0, 'identity_total_count': 0, 'total_count': 0, 'entries': []},
+}
+html = env.get_template('components/agents_panel.html').render(state=state)
+assert 'tooltip-content' in html, 'tooltip wrapper missing'
+assert 'Claude Opus 4.7' in html, 'model label missing'
+assert 'env:VSCODE_PID' in html, 'detection via missing'
+print('PASS')
+"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helix_context/launcher/templates/components/agents_panel.html \
+        helix_context/launcher/templates/components/participants_panel.html \
+        helix_context/launcher/static/launcher.css
+git commit -m "feat(launcher): add :hover tooltip to agent host chip
+
+CSS-only reveal — no JS. Tooltip shows Model / Wrapper / IDE rows
+plus the ide_detection_via diagnostic. Wrapping applied in
+agents_panel (active/all/disconnected sub-views) and
+participants_panel for parity."
+```
+
+---
+
+## Task 11: Skill update
+
+One sentence in the Workflow section.
+
+**Files:**
+- Modify: `skills/helix/SKILL.md`
+
+- [ ] **Step 1: Add the workflow item**
+
+In `skills/helix/SKILL.md`, locate the `## Workflow` section (currently has 6 numbered items). Append item 7:
+
+```markdown
+7. After your first `helix_health` call in a session, also call
+   `helix_announce(model_id=...)` once with your model identifier
+   (e.g., `"claude-opus-4-7"`, `"gpt-5"`, `"gemini-2-5-pro"`) so the
+   dashboard can display your model in the agent badge tooltip. If
+   the IDE auto-detection got it wrong, pass `ide_override=...` to
+   correct it.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/helix/SKILL.md
+git commit -m "docs(skill): instruct agents to call helix_announce
+
+One-line workflow addition: after first helix_health, agents call
+helix_announce(model_id=...) so the dashboard tooltip can display
+the model. Optional ide_override when env detect was wrong."
+```
+
+---
+
+## Task 12: End-to-end plumbing test
+
+Verifies the whole chain: env → adapter detect → register → announce → list → collector entry.
+
+**Files:**
+- Create: `tests/test_helix_announce_plumbing.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""End-to-end plumbing for helix_announce + IDE auto-detect.
+
+Exercises: VSCODE_PID env → adapter detect_ide → POST /sessions/register
+→ POST /sessions/{participant_id}/announce → GET /sessions →
+collector entry has all the right fields. Catches regressions where
+any layer in the chain drops something.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app_with_clean_genome(tmp_path, monkeypatch):
+    monkeypatch.setenv("HELIX_GENOME_PATH", str(tmp_path / "genome.db"))
+    from helix_context.server import build_app  # or whatever the file's app factory is
+    app = build_app()
+    return app
+
+
+def test_register_then_announce_round_trips_through_get_sessions(app_with_clean_genome):
+    """Full plumbing: simulated MCP startup populates ide_detected via the
+    body fields the adapter would have sent; agent then announces model_id;
+    GET /sessions reflects both."""
+    client = TestClient(app_with_clean_genome)
+
+    # Stage 1 — adapter posts the detected IDE at register time
+    reg_resp = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "swift_wing21",
+            "handle": "laude",
+            "workspace": "F:\\Projects",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+            "agent_kind": "claude-code",  # backward-compat from PR #26
+        },
+    )
+    assert reg_resp.status_code == 200, reg_resp.text
+    pid = reg_resp.json()["participant_id"]
+
+    # Stage 2 — agent announces its model
+    ann_resp = client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "claude-opus-4-7"},
+    )
+    assert ann_resp.status_code == 200, ann_resp.text
+
+    # Stage 3 — GET projection reflects both
+    listing = client.get("/sessions", params={"party_id": "swift_wing21"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert len(matching) == 1, f"expected one matching row, got: {rows}"
+    row = matching[0]
+    assert row["ide_detected"] == "vscode"
+    assert row["ide_detection_via"] == "env:VSCODE_PID"
+    assert row["model_id"] == "claude-opus-4-7"
+    assert row["agent_kind"] == "claude-code"
+
+
+def test_announce_with_ide_override_changes_via_to_agent_override(app_with_clean_genome):
+    """Agent override path: register with one IDE, announce with override,
+    confirm ide_detection_via flips to agent_override."""
+    client = TestClient(app_with_clean_genome)
+    reg = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "party_override",
+            "handle": "laude",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+        },
+    )
+    pid = reg.json()["participant_id"]
+
+    client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "gpt-5", "ide_override": "cursor"},
+    )
+
+    listing = client.get("/sessions", params={"party_id": "party_override"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    row = rows[0] if rows else {}
+    assert row["ide_detected"] == "cursor"
+    assert row["ide_detection_via"] == "agent_override"
+    assert row["model_id"] == "gpt-5"
+```
+
+The fixture body shape (`build_app` vs module-level `app`) follows whatever the existing PR #26 plumbing test (`tests/test_vendor_host_plumbing.py`) used — adapt to match.
+
+- [ ] **Step 2: Run the test**
+
+Run: `python -m pytest tests/test_helix_announce_plumbing.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_helix_announce_plumbing.py
+git commit -m "test: end-to-end plumbing for helix_announce + IDE auto-detect
+
+Verifies env-detected IDE survives /sessions/register → list, plus
+the announce endpoint round-trips model_id and the ide_override
+flow flips ide_detection_via to 'agent_override'. Single integration
+test guards against future drops in any layer."
+```
+
+---
+
+## Task 13: Documentation update
+
+Reflect the new fields and endpoint in the routing guide and SESSION_REGISTRY spec.
+
+**Files:**
+- Modify: `docs/clients/claude-code.md`
+- Modify: `docs/architecture/SESSION_REGISTRY.md`
+
+- [ ] **Step 1: Update docs/clients/claude-code.md**
+
+Find the existing 2026-05-05 paragraph from PR #26 Task 11 (the one starting "As of 2026-05-05, `HELIX_AGENT_KIND` and `HELIX_MCP_HOST` are persisted as first-class columns..."). Add a new paragraph immediately after it:
+
+```markdown
+As of 2026-05-06, the MCP adapter additionally **auto-detects** the
+host IDE from intentional env vars (`VSCODE_PID`, `CURSOR_TRACE_ID`)
+and the agent **self-reports** its model via the new `helix_announce`
+MCP tool. Together they populate three new columns on the
+`participants` row — `ide_detected`, `ide_detection_via`, `model_id`
+— and the dashboard renders the full identity in a tooltip on the
+agent host chip. See
+[`SESSION_REGISTRY.md`](../architecture/SESSION_REGISTRY.md#announce-endpoint)
+for the API and [`skills/helix/SKILL.md`](../../skills/helix/SKILL.md#workflow)
+for the agent contract.
+
+The legacy `HELIX_MCP_HOST` env var is now optional — the adapter
+will detect the IDE without it. Set it only when you want to override
+the auto-detection (e.g., running Claude Code from a non-VS-Code
+terminal but want the chip to say `"vscode"` anyway).
+```
+
+- [ ] **Step 2: Update docs/architecture/SESSION_REGISTRY.md**
+
+Locate the participants table schema (the existing one updated in PR #26 Task 11). Add three more bullets to the column list:
+
+```markdown
+- `ide_detected`       — adapter env-var fingerprint at register time
+                         ("vscode", "cursor", or NULL on no_match) — added 2026-05-06
+- `ide_detection_via`  — how IDE was determined ("env:VSCODE_PID",
+                         "explicit:HELIX_MCP_HOST", "agent_override",
+                         "no_match") — added 2026-05-06
+- `model_id`           — agent self-reported via helix_announce
+                         (free-form, NULL until announced) — added 2026-05-06
+```
+
+Add a new endpoint subsection (where other endpoints are documented):
+
+```markdown
+### POST /sessions/{participant_id}/announce  *(added 2026-05-06)*
+
+Agent self-report endpoint. Called once per session by the agent via
+the `helix_announce` MCP tool, after the MCP adapter has registered
+the participant.
+
+```bash
+curl -X POST http://127.0.0.1:11437/sessions/<participant_id>/announce \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_id": "claude-opus-4-7",
+    "ide_override": "cursor"
+  }'
+```
+
+Request body:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `model_id` | string | yes | Free-form model identifier. No allowlist validation. |
+| `ide_override` | string | no | Replaces `ide_detected` and forces `ide_detection_via='agent_override'`. |
+
+Silent no-op on unknown `participant_id` (returns 200) — matches
+heartbeat semantics. Multiple calls are idempotent (last-write-wins).
+```
+
+- [ ] **Step 3: Update the existing /sessions/register reference table**
+
+Find the `POST /sessions/register` section in `SESSION_REGISTRY.md` (PR #26 Task 11 fix already added `agent_kind` and `mcp_host` rows). Add three more rows to the same body field table:
+
+```markdown
+| `ide_detected` | string | no | Adapter env-var fingerprint result. Sourced from `helix_context.launcher.ide_fingerprint.detect_ide()`. Added 2026-05-06. |
+| `ide_detection_via` | string | no | The evidence behind `ide_detected`. Added 2026-05-06. |
+| `model_id` | string | no | Optional at register time — typically supplied later via the announce endpoint. Added 2026-05-06. |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/clients/claude-code.md docs/architecture/SESSION_REGISTRY.md
+git commit -m "docs: document helix_announce + IDE auto-detect
+
+claude-code.md: explain how auto-detect + self-report combine to
+populate the new ide_detected/ide_detection_via/model_id columns;
+note that HELIX_MCP_HOST is now optional override.
+
+SESSION_REGISTRY.md: add the three new column descriptions, the
+POST /sessions/{participant_id}/announce endpoint section, and the
+new optional fields on the existing /sessions/register reference."
+```
+
+---
+
+## Manual verification (post-merge)
+
+Not a TDD step — a human-in-the-loop check that the dashboard actually shows what we want.
+
+- [ ] Restart the helix server with this branch.
+- [ ] Restart Claude Code with the .mcp.json from `docs/clients/claude-code.md` (env block from PR #26 still works; `HELIX_MCP_HOST` is now optional).
+- [ ] Open the launcher dashboard.
+- [ ] Confirm: Agents panel shows the chip from PR #26.
+- [ ] Hover the chip → tooltip appears with Model / Wrapper / IDE rows.
+- [ ] If you've added the workflow line to your skill / asked Claude in-session, verify Model row shows the model you announced (e.g., "Claude Opus 4.7"). Otherwise it should show "Not announced".
+- [ ] IDE row should show the detected IDE + the via diagnostic — for VS Code: "VS Code (env:VSCODE_PID)".
+- [ ] Repeat with a Codex session (no client config change). Tooltip's IDE row should now show "VS Code (env:VSCODE_PID)" instead of "Codex" — the auto-detect worked.
+
+---
+
+## Out of scope (deferred follow-ups)
+
+- Per-vendor `.mcp.json` template installer (so users don't have to
+  hand-curate the env block — touch the launcher's installer).
+- Backfill of pre-existing participant rows from `mcp_host` →
+  `ide_detected`. Write-only mitigation; new sessions auto-populate.
+- Removal of the now-redundant `mcp_host` column. Wait for an
+  adoption period; do as a separate cleanup plan.
+- Allowlist validation on `model_id` (would force us to chase every
+  new model release).
+- Real-time model-version updates if the agent switches mid-session
+  (rare; current design is "last-write-wins" so a second
+  `helix_announce` call already handles it).
+- Federation: synchronizing `ide_detected` / `model_id` across remote
+  parties.
+- Antigravity / Claude Desktop fingerprint branches in
+  `ide_fingerprint.py` (add as we collect telltale env vars per host).

--- a/docs/superpowers/specs/2026-05-06-helix-announce-self-report-design.md
+++ b/docs/superpowers/specs/2026-05-06-helix-announce-self-report-design.md
@@ -1,0 +1,302 @@
+# Helix Announce: Self-Report + Auto-Detect for Agent Identity
+
+**Date:** 2026-05-06
+**Status:** Design — pending implementation plan
+**Predecessor:** [PR #26 — Vendor+host badges](https://github.com/SwiftWing21/helix-context/pull/26) ([plan](../plans/2026-05-05-vendor-host-badges.md))
+
+## Goal
+
+Surface **IDE/CLI + agent model** in the launcher dashboard for any
+client, without depending on each vendor's MCP wrapper to set the
+correct env vars in `.mcp.json`. Display only what we actually know —
+no inferred values, explicit placeholders for what's missing.
+
+## Why
+
+PR #26 made `agent_kind` / `mcp_host` first-class columns on the
+`participants` table, plumbed end-to-end from `HELIX_AGENT_KIND` /
+`HELIX_MCP_HOST` env vars to the dashboard chip. **It works when the
+client wraps correctly** — Claude Code's `.mcp.json` sets the env, the
+chip renders "Claude Code + VS Code", everyone's happy.
+
+It breaks when a vendor mis-configures its wrapper. Codex's MCP
+adapter sends `mcp_host=codex` (the vendor's own name) instead of
+`vscode` (the IDE Codex actually runs inside). Result: the chip
+displays "Codex + Codex" — technically correct from the env, but not
+informative.
+
+Three brittleness points:
+1. Per-vendor `.mcp.json` correctness — every new vendor is another
+   place to depend on someone else getting it right.
+2. No way to know the **model** (Opus 4.7 vs Sonnet 4.6 vs GPT-5 vs
+   Gemini 2.5 Pro) — env vars don't carry it; only the agent knows.
+3. No mechanism for the agent to self-correct when env is wrong.
+
+## Goals (testable)
+
+1. **Codex sessions, no client config change**, render with the correct
+   IDE — adapter detects VS Code from `VSCODE_PID` env. Chip becomes
+   "VS Code + Codex" instead of "Codex + Codex".
+2. **Claude Code sessions** render the model on hover when the agent
+   self-reports — tooltip shows "Model: Claude Opus 4.7 (1M context)".
+3. **No fabricated data.** When the model isn't known, tooltip shows
+   "Not announced", not a guess inferred from `agent_kind`.
+4. **Backward-compatible.** Sessions registered via PR #26's path
+   continue to render as before. New columns are nullable; their
+   absence falls back to PR #26 behavior.
+
+## Non-goals
+
+- Validating that the agent is honest about its model — trust-on-first-use,
+  same as the rest of the registry.
+- Real-time model switching mid-session.
+- Backfill of pre-existing participants from `agent_kind`/`mcp_host`.
+- Heuristic detection beyond known env-var fingerprints (no PPID
+  walking, no terminal-program guessing).
+
+## Architecture
+
+Two complementary mechanisms on the same write surface (the
+`participants` row):
+
+```
+                                                 ┌─────────────────────────────┐
+                                                 │  participants table         │
+┌────────────────────────────────────┐           │                             │
+│ Adapter at MCP startup             │  PATCH    │  ide_detected      TEXT     │
+│ (_register_with_registry +         │ ────────► │  ide_detection_via TEXT     │
+│  ide_fingerprint.detect())         │           │  model_id          TEXT     │
+└────────────────────────────────────┘           │  (agent_kind, mcp_host      │
+                                                 │   from PR #26 still here)   │
+┌────────────────────────────────────┐           │                             │
+│ Agent at session start             │  PATCH    │                             │
+│ (helix_announce MCP tool, called   │ ────────► │                             │
+│  per skill instruction)            │           │                             │
+└────────────────────────────────────┘           └─────────────────────────────┘
+```
+
+### Adapter side: env-var fingerprint chain
+
+A new module `helix_context/launcher/ide_fingerprint.py` exposes one
+function:
+
+```python
+def detect_ide() -> tuple[str | None, str]:
+    """Return (ide_value, detection_via).
+
+    ide_value is one of: "vscode", "cursor", "claude-desktop", or None.
+    detection_via documents the evidence: "env:VSCODE_PID",
+    "env:CURSOR_TRACE_ID", "explicit:HELIX_MCP_HOST", or "no_match".
+    """
+```
+
+Fingerprint chain (first match wins):
+
+| Priority | Signal | Result |
+|---|---|---|
+| 1 | `HELIX_MCP_HOST` set and not `"unknown"` | trust the operator; via=`"explicit:HELIX_MCP_HOST"` |
+| 2 | `VSCODE_PID` set | `"vscode"`; via=`"env:VSCODE_PID"` |
+| 3 | `CURSOR_TRACE_ID` set | `"cursor"`; via=`"env:CURSOR_TRACE_ID"` |
+| 4 | (placeholders for Antigravity, Claude Desktop as we collect their telltale env vars) | tracked in follow-ups |
+| 99 | no signal matched | `(None, "no_match")` |
+
+**No PPID walking.** No terminal-program guessing. Only env vars set
+intentionally by the host process. The fingerprint module is small
+(~50 lines), pure-function, easy to unit-test and easy to extend per
+vendor as we learn what they set.
+
+`_register_with_registry` calls `detect_ide()` at startup and passes
+both fields through `AgentBridge.register_participant` →
+`/sessions/register` → `registry.register_participant`. New nullable
+columns; old code paths unaffected.
+
+### Agent side: `helix_announce` MCP tool
+
+New tool exposed by the MCP adapter (`helix_context/mcp_server.py`):
+
+```python
+@mcp.tool()
+def helix_announce(
+    model_id: str,
+    ide_override: str | None = None,
+) -> dict:
+    """Announce agent identity to the registry.
+
+    Updates this MCP session's participant row:
+    - model_id: agent's self-reported model identifier (free-form;
+      examples: "claude-opus-4-7", "gpt-5", "gemini-2-5-pro").
+      No allowlist validation. No vendor inference.
+    - ide_override: when set, replaces the adapter's auto-detected
+      ide_detected and sets ide_detection_via="agent_override".
+
+    Idempotent: multiple calls overwrite (last write wins). Designed to
+    be called once per session; subsequent calls let the agent correct
+    itself.
+    """
+```
+
+Server-side: a new endpoint `PATCH /sessions/{participant_id}/announce`
+(or extend `POST /sessions/register` — TBD in implementation plan).
+Maps to `registry.update_announcement(participant_id, model_id,
+ide_override)`.
+
+### Skill update
+
+`skills/helix/SKILL.md` adds one sentence in the **Workflow** section:
+
+> 7. After your first `helix_health` call in a session, also call
+>    `helix_announce(model_id=...)` once with your model identifier
+>    so the dashboard can display it on hover.
+
+The agent is the only authority for model. If they skip the skill,
+`model_id` stays NULL and the tooltip says "Model: Not announced" —
+diagnostic, not broken.
+
+### Display
+
+**Surface chip** — same `chip--agent-host` class as PR #26, but
+sources data from the new fields with graceful single-chip degradation:
+
+| `ide_detected` | `agent_kind` | Surface chip |
+|---|---|---|
+| `"vscode"` | `"claude-code"` | `VS Code + Claude Code` |
+| `"vscode"` | NULL | `VS Code` *(single chip)* |
+| NULL | `"claude-code"` | `Claude Code` *(single chip)* |
+| NULL | NULL | *(no chip)* |
+
+When both `ide_detected` and `agent_kind` are NULL, the `{% if %}` skips
+rendering — same fall-through as today.
+
+**Tooltip** — CSS-only `:hover` reveal on the same chip. Always-visible
+fields, explicit placeholders for what's missing:
+
+```
+swift_wing21 / F:\Projects
+laude  ·  active 26.7s ago
+─────────────────────────────────
+Model:    Claude Opus 4.7 (1M context)
+Wrapper:  Claude Code
+IDE:      VS Code  (detected via env:VSCODE_PID)
+```
+
+When a field is missing:
+
+| Field | Source | Placeholder when missing | Hint |
+|---|---|---|---|
+| Model | `model_id` | "Not announced" | agent hasn't called `helix_announce` |
+| Wrapper | `agent_kind` | "Not set" | `HELIX_AGENT_KIND` env not configured |
+| IDE | `ide_detected` | "Not detected" | adapter heuristics didn't fire |
+
+`ide_detection_via` always renders next to the IDE value (or as a
+diagnostic when "Not detected"). This makes the gap visible to anyone
+reading the tooltip and gives them a clear path to fix it.
+
+**Pretty-mapping for `model_id`** — extend `host_labels.py` (or a new
+sibling `model_labels.py`) with a small lookup map:
+
+```python
+_MODEL_MAP = {
+    "claude-opus-4-7": "Claude Opus 4.7",
+    "claude-opus-4-7-1m": "Claude Opus 4.7 (1M context)",
+    "claude-sonnet-4-6": "Claude Sonnet 4.6",
+    "claude-haiku-4-5": "Claude Haiku 4.5",
+    "gpt-5": "GPT-5",
+    "gemini-2-5-pro": "Gemini 2.5 Pro",
+    # ... grows as agents announce new IDs
+}
+```
+
+**Unknown `model_id` echoes verbatim** — same pattern as `host_labels`.
+A new model that's not in the map renders as whatever string the agent
+sent. No fabrication; no silent drop.
+
+## Data model — schema changes
+
+Add three columns to `participants` (idempotent `ALTER TABLE`, same
+pattern as PR #26):
+
+```sql
+ALTER TABLE participants ADD COLUMN ide_detected TEXT;        -- "vscode", "cursor", "claude-desktop", NULL
+ALTER TABLE participants ADD COLUMN ide_detection_via TEXT;   -- "env:VSCODE_PID", "explicit:HELIX_MCP_HOST", "agent_override", "no_match"
+ALTER TABLE participants ADD COLUMN model_id TEXT;            -- agent self-reported, NULL until announced
+```
+
+Existing columns kept:
+- `agent_kind` — wrapper vendor, still sourced from `HELIX_AGENT_KIND`
+- `mcp_host` — kept for backward-compat reads only; new writes go to
+  `ide_detected`. Migration path noted below.
+
+## Migration / backward-compat
+
+- Sessions registered before this change: NULL on all three new
+  columns. Display falls back to PR #26's `agent_kind` + `mcp_host`
+  rendering. No regression.
+- Sessions registered after this change with old client configs: the
+  fingerprint chain populates `ide_detected` from `VSCODE_PID` etc.
+  Chip renders correctly without the client changing anything.
+- `mcp_host` is read-only deprecated. New code paths read
+  `ide_detected` first, fall back to `mcp_host` if NULL. After a
+  reasonable adoption period, `mcp_host` can be removed (separate plan).
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| `VSCODE_PID` set but Code crashed before MCP started | adapter still records `ide_detected="vscode"` — fine; reflects what we know at register time |
+| Agent skips `helix_announce` | `model_id` stays NULL; tooltip shows "Model: Not announced"; everything else works |
+| Agent calls `helix_announce(model_id="bogus-name-xyz")` | stored as-is; pretty-map echoes verbatim; tooltip shows "Model: bogus-name-xyz" — honest about what was reported |
+| Agent calls `helix_announce(ide_override="cursor")` from a VSCode session | `ide_detected` becomes "cursor", `ide_detection_via="agent_override"`; tooltip shows "IDE: Cursor (agent_override)" — gives the operator a way to debug if this is wrong |
+| Two MCP sessions on same `HELIX_MCP_HANDLE` race on announce | last write wins (idempotent PATCH); not a real concern in practice |
+
+## File-level breakdown (for the implementation plan to follow)
+
+| File | Action | Responsibility |
+|---|---|---|
+| `helix_context/launcher/ide_fingerprint.py` | **create** | env-var fingerprint chain, `detect_ide() -> (str\|None, str)` |
+| `helix_context/genome.py` | modify | add 3 idempotent ALTER TABLE statements |
+| `helix_context/schemas.py` | modify | add 3 fields to `Participant` and `ParticipantInfo` |
+| `helix_context/registry.py` | modify | persist + project new fields; add `update_announcement()` method |
+| `helix_context/server.py` | modify | new endpoint for the announce PATCH; thread fields through `/sessions/register` |
+| `helix_context/bridge.py` | modify | `AgentBridge.announce()` HTTP wrapper |
+| `helix_context/mcp_server.py` | modify | call `detect_ide()` at startup; expose `helix_announce` tool |
+| `helix_context/launcher/host_labels.py` | modify (or split) | add `model_pretty()` and `compose_tooltip()` |
+| `helix_context/launcher/collector.py` | modify | populate tooltip fields on entries |
+| `helix_context/launcher/templates/components/agents_panel.html` | modify | add `data-tooltip` attribute or `<div class="tooltip">` block |
+| `helix_context/launcher/templates/components/participants_panel.html` | modify | same tooltip pattern |
+| `helix_context/launcher/static/launcher.css` | modify | `:hover` tooltip styling (no JS) |
+| `skills/helix/SKILL.md` | modify | add the workflow sentence about `helix_announce` |
+| `docs/clients/claude-code.md` | modify | document the new tool + auto-detect; deprecate `HELIX_MCP_HOST` guidance |
+| `docs/architecture/SESSION_REGISTRY.md` | modify | document new columns + the PATCH endpoint |
+
+## Testing strategy
+
+Each module gets unit tests for its own concern:
+
+- `ide_fingerprint`: each branch of the chain — env var present
+  triggers correct return; no env vars triggers `(None, "no_match")`;
+  `HELIX_MCP_HOST` explicit overrides everything.
+- Schema migration: same pattern as PR #26 — column existence + idempotency.
+- Pydantic models: round-trip with new fields.
+- Registry: persist + project + `update_announcement` (overwrite, idempotent).
+- Endpoint: PATCH accepts payload; rejects invalid participant_id.
+- Bridge: `AgentBridge.announce()` sends correct body.
+- MCP tool: `helix_announce` invokes bridge with right args.
+- Collector: tooltip fields populate; missing fields render as "Not …".
+- Pretty-map: known IDs map; unknown echo; "unknown" sentinel returns None.
+- E2E plumbing test: env → adapter detect → register → announce → list →
+  collector entry has all three new fields.
+- Template smoke: render with synthetic data, grep for tooltip text +
+  surface chip text.
+
+## Out of scope (deferred)
+
+- Per-vendor `.mcp.json` template installer (so users don't hand-curate
+  env blocks)
+- Backfill of pre-existing participants from `agent_kind`/`mcp_host` →
+  `ide_detected`
+- `mcp_host` column removal (separate cleanup plan after adoption)
+- Validating `model_id` against an allowlist
+- Real-time model switching telemetry
+- Tracking vendor explicitly (no `model_vendor` column — agents report
+  IDs, no inference; future agents can carry vendor in `model_id`
+  itself)

--- a/helix_context/bridge.py
+++ b/helix_context/bridge.py
@@ -381,6 +381,9 @@ class AgentBridge:
         start_auto_heartbeat: bool = False,
         agent_kind: Optional[str] = None,
         mcp_host: Optional[str] = None,
+        ide_detected: Optional[str] = None,
+        ide_detection_via: Optional[str] = None,
+        model_id: Optional[str] = None,
     ) -> Optional[str]:
         """Register a participant with the helix session registry.
 
@@ -408,6 +411,12 @@ class AgentBridge:
             body["agent_kind"] = agent_kind
         if mcp_host is not None:
             body["mcp_host"] = mcp_host
+        if ide_detected is not None:
+            body["ide_detected"] = ide_detected
+        if ide_detection_via is not None:
+            body["ide_detection_via"] = ide_detection_via
+        if model_id is not None:
+            body["model_id"] = model_id
         try:
             body["pid"] = os.getpid()
         except Exception:
@@ -429,6 +438,39 @@ class AgentBridge:
         if start_auto_heartbeat:
             self.start_auto_heartbeat()
         return self._participant_id
+
+    def announce(
+        self,
+        model_id: str,
+        ide_override: Optional[str] = None,
+    ) -> bool:
+        """POST to /sessions/{participant_id}/announce for self-report.
+
+        Requires that ``register_participant`` has already been called
+        successfully (sets ``self._participant_id``). If not yet
+        registered, this is a no-op returning False — the agent shouldn't
+        call announce before the adapter has registered.
+
+        Returns True on HTTP 200, False otherwise. Failures are logged
+        but non-fatal — model_id is best-effort.
+        """
+        if not getattr(self, "_participant_id", None):
+            log.warning("announce() called before register_participant; skipping")
+            return False
+
+        body: Dict[str, Any] = {"model_id": model_id}
+        if ide_override is not None:
+            body["ide_override"] = ide_override
+
+        try:
+            self._http_post(
+                f"/sessions/{self._participant_id}/announce",
+                json_body=body,
+            )
+            return True
+        except Exception as exc:
+            log.warning("announce() failed: %s", exc)
+            return False
 
     @property
     def participant_id(self) -> Optional[str]:

--- a/helix_context/bridge.py
+++ b/helix_context/bridge.py
@@ -463,11 +463,11 @@ class AgentBridge:
             body["ide_override"] = ide_override
 
         try:
-            self._http_post(
+            result = self._http_post(
                 f"/sessions/{self._participant_id}/announce",
                 json_body=body,
             )
-            return True
+            return result is not None
         except Exception as exc:
             log.warning("announce() failed: %s", exc)
             return False

--- a/helix_context/genome.py
+++ b/helix_context/genome.py
@@ -787,6 +787,19 @@ class Genome:
             except sqlite3.OperationalError:
                 pass  # column already exists — idempotent
 
+        # Announce columns (added 2026-05-06; design spec
+        # docs/superpowers/specs/2026-05-06-helix-announce-self-report-design.md).
+        # `ide_detected`:      adapter-side env-var fingerprint at register time
+        #                      ("vscode", "cursor", "claude-code", or NULL on no_match).
+        # `ide_detection_via`: how we figured it out — "env:VSCODE_PID",
+        #                      "explicit:HELIX_MCP_HOST", "agent_override", "no_match".
+        # `model_id`:          agent self-reported via helix_announce; NULL until announced.
+        for col in ("ide_detected", "ide_detection_via", "model_id"):
+            try:
+                cur.execute(f"ALTER TABLE participants ADD COLUMN {col} TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already exists — idempotent
+
         # ── Layer 4: agents (AI personas under a participant) ───────
         # An agent is the AI persona doing the work on behalf of a human
         # participant: "laude", "taude", "raude", "claude-code", "gemini",

--- a/helix_context/launcher/collector.py
+++ b/helix_context/launcher/collector.py
@@ -19,9 +19,48 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .supervisor import HelixSupervisor
-from .host_labels import compose_label
+from .host_labels import compose_label, host_pretty, vendor_pretty
+from .model_labels import model_pretty
 
 log = logging.getLogger("helix.launcher.collector")
+
+
+def _build_tooltip(participant: Dict[str, Any]) -> Dict[str, str]:
+    """Compose the tooltip field bundle from a participant dict.
+
+    Each label is either a pretty-mapped value or an explicit placeholder
+    that hints at the cause:
+      - model_label: "Not announced" when model_id is NULL
+      - ide_label:   "Not detected" when ide_detected is NULL
+      - agent_kind_label: "Not set"  when agent_kind is NULL
+    The ide_detection_via line tells the operator how (or whether) the
+    IDE value was obtained: "env:VSCODE_PID", "agent_override",
+    "no_match", "explicit:HELIX_MCP_HOST".
+
+    ide_label fallback chain (in order):
+      1. ide_detected — populated by the adapter at register time, or by
+         an agent's ide_override via helix_announce. Authoritative when present.
+      2. mcp_host — PR #26's column. Sessions registered after PR #26 but
+         before this change will have ide_detected=NULL but mcp_host set
+         from HELIX_MCP_HOST env. Fall back so those sessions' chips
+         still render correctly until they re-register.
+      3. "Not detected" — explicit placeholder when neither column
+         carries a value, so the tooltip surfaces the gap rather than
+         hiding the row.
+
+    There is no equivalent fallback chain for model_id (the column is
+    new in this change; there is no prior column to fall back to).
+    """
+    return {
+        "model_label": model_pretty(participant.get("model_id")) or "Not announced",
+        "ide_label": (
+            host_pretty(participant.get("ide_detected"))
+            or host_pretty(participant.get("mcp_host"))   # PR #26 backward-compat fallback
+            or "Not detected"
+        ),
+        "agent_kind_label": vendor_pretty(participant.get("agent_kind")) or "Not set",
+        "ide_detection_via": participant.get("ide_detection_via") or "no_match",
+    }
 
 
 class StateCollector:
@@ -223,6 +262,7 @@ class StateCollector:
                         participant.get("agent_kind"),
                         participant.get("mcp_host"),
                     ),
+                    "tooltip": _build_tooltip(participant),
                 }
                 grouped[key] = group
 
@@ -270,6 +310,7 @@ class StateCollector:
                         participant.get("agent_kind"),
                         participant.get("mcp_host"),
                     ),
+                    "tooltip": _build_tooltip(participant),
                 }
             )
         return {
@@ -305,6 +346,7 @@ class StateCollector:
                         participant.get("agent_kind"),
                         participant.get("mcp_host"),
                     ),
+                    "tooltip": _build_tooltip(participant),
                 }
             )
         if not entries:

--- a/helix_context/launcher/ide_fingerprint.py
+++ b/helix_context/launcher/ide_fingerprint.py
@@ -1,0 +1,47 @@
+"""Env-var fingerprint chain for IDE/CLI detection at MCP-adapter startup.
+
+Used by ``mcp_server._register_with_registry`` to populate the
+``ide_detected`` and ``ide_detection_via`` columns on the participants
+row without depending on each MCP host vendor to set ``HELIX_MCP_HOST``
+correctly.
+
+Only env vars set intentionally by the host process are trusted as
+signals. No PPID walking, no terminal-program guessing, no inference.
+When no signal matches we return ``(None, "no_match")`` and let the
+agent self-report later via ``helix_announce``.
+
+Priority chain (first match wins):
+    1. HELIX_MCP_HOST explicit (and not the legacy "unknown" sentinel)
+    2. VSCODE_PID
+    3. CURSOR_TRACE_ID
+    4. fallback → (None, "no_match")
+
+Extending: add a new branch ABOVE the fallback. New branch must (a) read
+a single, intentional env var that the host actually sets, and (b) return
+the canonical short host id paired with ``"env:<VAR_NAME>"`` as the via.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+
+def detect_ide() -> Tuple[Optional[str], str]:
+    """Return ``(ide_value, detection_via)``.
+
+    ``ide_value`` is a canonical short id (e.g. ``"vscode"``, ``"cursor"``)
+    or ``None`` when no signal matched. ``detection_via`` always contains
+    a string documenting how the result was reached, suitable for the
+    tooltip's diagnostic line.
+    """
+    explicit = os.environ.get("HELIX_MCP_HOST", "").strip()
+    if explicit and explicit != "unknown":
+        return explicit, "explicit:HELIX_MCP_HOST"
+
+    if os.environ.get("VSCODE_PID", "").strip():
+        return "vscode", "env:VSCODE_PID"
+
+    if os.environ.get("CURSOR_TRACE_ID", "").strip():
+        return "cursor", "env:CURSOR_TRACE_ID"
+
+    return None, "no_match"

--- a/helix_context/launcher/model_labels.py
+++ b/helix_context/launcher/model_labels.py
@@ -1,0 +1,32 @@
+"""Pretty-label module for model_id strings reported via helix_announce.
+
+Maps known model identifiers to canonical display form for the dashboard
+tooltip. Unknown IDs echo verbatim — no fabrication. The map grows as
+agents announce new IDs. There is no allowlist gate on what an agent
+can report; the registry stores whatever the agent says, and this
+module is a display-only convenience.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+_MODEL_MAP = {
+    # Anthropic
+    "claude-opus-4-7": "Claude Opus 4.7",
+    "claude-opus-4-7-1m": "Claude Opus 4.7 (1M context)",
+    "claude-sonnet-4-6": "Claude Sonnet 4.6",
+    "claude-haiku-4-5": "Claude Haiku 4.5",
+    # OpenAI
+    "gpt-5": "GPT-5",
+    # Google
+    "gemini-2-5-pro": "Gemini 2.5 Pro",
+}
+
+
+def model_pretty(value: Optional[str]) -> Optional[str]:
+    """Map a known model_id to its display form, or echo verbatim if
+    unknown. None / empty input returns None."""
+    if not value:
+        return None
+    return _MODEL_MAP.get(value, value)

--- a/helix_context/launcher/static/launcher.css
+++ b/helix_context/launcher/static/launcher.css
@@ -816,7 +816,7 @@ p {
   margin-bottom: 6px;
   padding: 8px 12px;
   background: rgba(20, 20, 24, 0.96);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   white-space: nowrap;
   pointer-events: none;

--- a/helix_context/launcher/static/launcher.css
+++ b/helix_context/launcher/static/launcher.css
@@ -802,3 +802,53 @@ p {
     grid-template-columns: 1fr;
   }
 }
+
+/* Tooltip — CSS-only :hover reveal on the agent host chip. */
+.chip-with-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.chip-with-tooltip .tooltip-content {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 6px;
+  padding: 8px 12px;
+  background: rgba(20, 20, 24, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease, visibility 0s linear 120ms;
+  z-index: 10;
+  font-size: 12px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.chip-with-tooltip:hover .tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.chip-with-tooltip .tooltip-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chip-with-tooltip .tooltip-key {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.6);
+  min-width: 64px;
+}
+
+.chip-with-tooltip .tooltip-via {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}

--- a/helix_context/launcher/templates/components/agents_panel.html
+++ b/helix_context/launcher/templates/components/agents_panel.html
@@ -46,8 +46,21 @@
                 <div class="panel-list__row">
                   <span class="chip chip--participant">{{ agent.handle }}</span>
                   <span class="chip chip--agent-id">{{ agent.participant_id_short }}</span>
-                  {% if agent.host_label %}
-                    <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+                  {% if agent.host_label or agent.tooltip %}
+                  <span class="chip-with-tooltip">
+                    {% if agent.host_label %}
+                      <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+                    {% endif %}
+                    {% if agent.tooltip %}
+                      <div class="tooltip-content">
+                        <div class="tooltip-row"><span class="tooltip-key">Model:</span> {{ agent.tooltip.model_label }}</div>
+                        <div class="tooltip-row"><span class="tooltip-key">Wrapper:</span> {{ agent.tooltip.agent_kind_label }}</div>
+                        <div class="tooltip-row"><span class="tooltip-key">IDE:</span> {{ agent.tooltip.ide_label }}
+                          <span class="tooltip-via">({{ agent.tooltip.ide_detection_via }})</span>
+                        </div>
+                      </div>
+                    {% endif %}
+                  </span>
                   {% endif %}
                   <span class="muted">/ {{ agent.status }} / {{ agent.last_seen_s_ago }}s ago</span>
                 </div>
@@ -75,8 +88,21 @@
               <div class="panel-list__row">
                 <span class="chip chip--participant">{{ agent.handle }}</span>
                 <span class="chip chip--agent-id">{{ agent.participant_id_short }}</span>
-                {% if agent.host_label %}
-                  <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+                {% if agent.host_label or agent.tooltip %}
+                <span class="chip-with-tooltip">
+                  {% if agent.host_label %}
+                    <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+                  {% endif %}
+                  {% if agent.tooltip %}
+                    <div class="tooltip-content">
+                      <div class="tooltip-row"><span class="tooltip-key">Model:</span> {{ agent.tooltip.model_label }}</div>
+                      <div class="tooltip-row"><span class="tooltip-key">Wrapper:</span> {{ agent.tooltip.agent_kind_label }}</div>
+                      <div class="tooltip-row"><span class="tooltip-key">IDE:</span> {{ agent.tooltip.ide_label }}
+                        <span class="tooltip-via">({{ agent.tooltip.ide_detection_via }})</span>
+                      </div>
+                    </div>
+                  {% endif %}
+                </span>
                 {% endif %}
                 <span class="muted">/ {{ agent.status }} / {{ agent.last_seen_s_ago }}s ago</span>
               </div>
@@ -103,8 +129,21 @@
               <div class="panel-list__row">
                 <span class="chip chip--participant">{{ agent.handle }}</span>
                 <span class="chip chip--agent-id">{{ agent.participant_id_short }}</span>
-                {% if agent.host_label %}
-                  <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+                {% if agent.host_label or agent.tooltip %}
+                <span class="chip-with-tooltip">
+                  {% if agent.host_label %}
+                    <span class="chip chip--agent-host">{{ agent.host_label }}</span>
+                  {% endif %}
+                  {% if agent.tooltip %}
+                    <div class="tooltip-content">
+                      <div class="tooltip-row"><span class="tooltip-key">Model:</span> {{ agent.tooltip.model_label }}</div>
+                      <div class="tooltip-row"><span class="tooltip-key">Wrapper:</span> {{ agent.tooltip.agent_kind_label }}</div>
+                      <div class="tooltip-row"><span class="tooltip-key">IDE:</span> {{ agent.tooltip.ide_label }}
+                        <span class="tooltip-via">({{ agent.tooltip.ide_detection_via }})</span>
+                      </div>
+                    </div>
+                  {% endif %}
+                </span>
                 {% endif %}
                 <span class="chip chip--agent-status chip--agent-status-{{ agent.status }}">{{ agent.status }}</span>
                 <span class="muted">{{ agent.last_seen_s_ago }}s ago</span>

--- a/helix_context/launcher/templates/components/participants_panel.html
+++ b/helix_context/launcher/templates/components/participants_panel.html
@@ -12,8 +12,21 @@
     {% for p in state.participants.entries %}
       <li class="panel-list__item">
         <span class="chip chip--participant">{{ p.handle }}</span>
-        {% if p.host_label %}
-          <span class="chip chip--agent-host">{{ p.host_label }}</span>
+        {% if p.host_label or p.tooltip %}
+        <span class="chip-with-tooltip">
+          {% if p.host_label %}
+            <span class="chip chip--agent-host">{{ p.host_label }}</span>
+          {% endif %}
+          {% if p.tooltip %}
+            <div class="tooltip-content">
+              <div class="tooltip-row"><span class="tooltip-key">Model:</span> {{ p.tooltip.model_label }}</div>
+              <div class="tooltip-row"><span class="tooltip-key">Wrapper:</span> {{ p.tooltip.agent_kind_label }}</div>
+              <div class="tooltip-row"><span class="tooltip-key">IDE:</span> {{ p.tooltip.ide_label }}
+                <span class="tooltip-via">({{ p.tooltip.ide_detection_via }})</span>
+              </div>
+            </div>
+          {% endif %}
+        </span>
         {% endif %}
         <span class="muted">· {{ p.identifier }}</span>
         <span class="muted">· {{ p.status }} · {{ p.last_seen_s_ago }}s ago</span>

--- a/helix_context/mcp_server.py
+++ b/helix_context/mcp_server.py
@@ -118,6 +118,10 @@ TIMEOUT_S = float(os.environ.get("HELIX_MCP_TIMEOUT", "30"))
 # scheme, so the session_id here aligns with the registry participant.
 MCP_SESSION_ID = os.environ.get("HELIX_MCP_HANDLE", f"mcp-{os.getpid()}")
 
+# Set by _register_with_registry on success; consumed by the
+# helix_announce MCP tool to PATCH the same participant row.
+_registered_bridge: Optional[Any] = None
+
 
 def _default_party_id() -> str:
     """Resolve a party_id without hardcoded project defaults.
@@ -663,6 +667,47 @@ def helix_health() -> Dict[str, Any]:
     return _normalize_health_payload(_http("GET", "/health"))
 
 
+# ── Tool: helix_announce ─────────────────────────────────────────────
+# Self-report model identity + optional IDE override. Call once per
+# session after helix_health so the dashboard can display the model
+# in the agent badge tooltip.
+
+@mcp.tool()
+def helix_announce(
+    model_id: str,
+    ide_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Self-report the agent's model identity and (optionally) override
+    the auto-detected IDE.
+
+    Call this once per session, after your first ``helix_health`` call,
+    so the dashboard can display your model in the agent badge tooltip.
+
+    Args:
+        model_id: Free-form model identifier. Examples:
+            "claude-opus-4-7", "claude-sonnet-4-6", "gpt-5",
+            "gemini-2-5-pro". The dashboard pretty-maps known IDs to
+            display names; unknown IDs render verbatim.
+        ide_override: Optional. Replaces the adapter's auto-detected
+            IDE. Use only when env-var detection got it wrong.
+
+    Returns:
+        {"ok": True} on success, {"ok": False, "error": "..."} on
+        failure. Failures are non-fatal — the rest of the session
+        continues to work.
+    """
+    if _registered_bridge is None:
+        return {
+            "ok": False,
+            "error": "Not yet registered with helix; announce skipped.",
+        }
+    success = _registered_bridge.announce(
+        model_id=model_id,
+        ide_override=ide_override,
+    )
+    return {"ok": success}
+
+
 # ── Tool: helix_metrics_tokens ───────────────────────────────────────
 # Session + lifetime token counters, exact-from-upstream when possible,
 # char-estimate fallback. Surfaces helix's cost/savings story.
@@ -913,6 +958,7 @@ def _register_with_registry() -> None:
     """
     try:
         from helix_context.bridge import AgentBridge
+        from helix_context.launcher.ide_fingerprint import detect_ide
     except Exception as exc:
         log.warning("Registry bridge import failed, skipping registration: %s", exc)
         return
@@ -935,6 +981,11 @@ def _register_with_registry() -> None:
     # older dashboard parsers that expect the "host:<x>" capability tag.
     capabilities = ["mcp_tools", f"host:{mcp_host_env}"]
 
+    # IDE auto-detect via env-var fingerprint chain. Falls back to
+    # (None, "no_match") when no signal — agent can later override via
+    # helix_announce(ide_override=...).
+    ide_detected, ide_detection_via = detect_ide()
+
     bridge = AgentBridge(helix_base_url=HELIX_URL)
     participant_id = bridge.register_participant(
         party_id=party_id,
@@ -943,12 +994,18 @@ def _register_with_registry() -> None:
         capabilities=capabilities,
         agent_kind=agent_kind_env,
         mcp_host=mcp_host,
+        ide_detected=ide_detected,
+        ide_detection_via=ide_detection_via,
         start_auto_heartbeat=True,
     )
+    # Stash the bridge for the helix_announce tool to use later.
     if participant_id:
+        global _registered_bridge
+        _registered_bridge = bridge
         log.info(
-            "Registered as %s (party=%s, kind=%s, host=%s, pid=%d)",
-            handle, party_id, agent_kind_env, mcp_host, os.getpid(),
+            "Registered as %s (party=%s, kind=%s, host=%s, ide=%s/%s, pid=%d)",
+            handle, party_id, agent_kind_env, mcp_host,
+            ide_detected, ide_detection_via, os.getpid(),
         )
     else:
         log.warning(

--- a/helix_context/registry.py
+++ b/helix_context/registry.py
@@ -104,6 +104,9 @@ class Registry:
         display_name: Optional[str] = None,
         agent_kind: Optional[str] = None,
         mcp_host: Optional[str] = None,
+        ide_detected: Optional[str] = None,
+        ide_detection_via: Optional[str] = None,
+        model_id: Optional[str] = None,
     ) -> Participant:
         """Register a new participant. Creates the party row on first use (trust-on-first-use).
 
@@ -124,8 +127,9 @@ class Registry:
         cur.execute(
             "INSERT INTO participants "
             "(participant_id, party_id, handle, workspace, pid, started_at, "
-            " last_heartbeat, status, capabilities, metadata, agent_kind, mcp_host) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?)",
+            " last_heartbeat, status, capabilities, metadata, agent_kind, mcp_host, "
+            " ide_detected, ide_detection_via, model_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?)",
             (
                 participant_id,
                 party_id,
@@ -138,6 +142,9 @@ class Registry:
                 json_dumps(metadata) if metadata else None,
                 agent_kind,
                 mcp_host,
+                ide_detected,
+                ide_detection_via,
+                model_id,
             ),
         )
         self.genome.conn.commit()
@@ -159,6 +166,9 @@ class Registry:
             metadata=metadata,
             agent_kind=agent_kind,
             mcp_host=mcp_host,
+            ide_detected=ide_detected,
+            ide_detection_via=ide_detection_via,
+            model_id=model_id,
         )
 
     def local_org(
@@ -353,6 +363,50 @@ class Registry:
         self.genome.conn.commit()
         return (DEFAULT_TTL_S, "active")
 
+    def update_announcement(
+        self,
+        participant_id: str,
+        model_id: Optional[str] = None,
+        ide_override: Optional[str] = None,
+    ) -> None:
+        """PATCH model_id and (optionally) ide_detected on a participant row.
+
+        Called by the announce endpoint when an agent self-reports its
+        identity. ``ide_override`` replaces ``ide_detected`` and forces
+        ``ide_detection_via='agent_override'`` so the tooltip can surface
+        that the IDE came from the agent rather than env detection.
+
+        ``COALESCE(?, model_id)`` lets a None Python value (unset kwarg)
+        leave the existing column value intact, while a real string
+        overwrites it. This handles "agent sent only ide_override, leave
+        model alone" without a separate code path. To clear model_id back
+        to NULL a distinct code path would be needed; this spec does not
+        require it.
+
+        Idempotent: multiple calls overwrite (last write wins). Silently
+        no-ops on unknown ``participant_id`` to match the heartbeat path
+        — the agent has no useful action to take if the participant has
+        already TTL'd out.
+        """
+        cur = self.genome.conn.cursor()
+        if ide_override is not None:
+            cur.execute(
+                "UPDATE participants "
+                "SET model_id = COALESCE(?, model_id), "
+                "    ide_detected = ?, "
+                "    ide_detection_via = 'agent_override' "
+                "WHERE participant_id = ?",
+                (model_id, ide_override, participant_id),
+            )
+        else:
+            cur.execute(
+                "UPDATE participants "
+                "SET model_id = COALESCE(?, model_id) "
+                "WHERE participant_id = ?",
+                (model_id, participant_id),
+            )
+        self.genome.conn.commit()
+
     def upsert_presence_gene(
         self,
         participant_id: str,
@@ -483,7 +537,8 @@ class Registry:
         cur = self.genome.conn.cursor()
         sql = (
             "SELECT participant_id, party_id, handle, workspace, "
-            "       started_at, last_heartbeat, agent_kind, mcp_host "
+            "       started_at, last_heartbeat, agent_kind, mcp_host, "
+            "       ide_detected, ide_detection_via, model_id "
             "FROM participants"
         )
         params: list = []
@@ -515,6 +570,9 @@ class Registry:
                 started_at=r["started_at"],
                 agent_kind=r["agent_kind"],
                 mcp_host=r["mcp_host"],
+                ide_detected=r["ide_detected"],
+                ide_detection_via=r["ide_detection_via"],
+                model_id=r["model_id"],
             ))
         return out
 
@@ -524,7 +582,8 @@ class Registry:
         r = cur.execute(
             "SELECT participant_id, party_id, handle, workspace, pid, "
             "       started_at, last_heartbeat, status, capabilities, metadata, "
-            "       agent_kind, mcp_host "
+            "       agent_kind, mcp_host, "
+            "       ide_detected, ide_detection_via, model_id "
             "FROM participants WHERE participant_id = ?",
             (participant_id,),
         ).fetchone()
@@ -553,6 +612,9 @@ class Registry:
             metadata=meta,
             agent_kind=r["agent_kind"],
             mcp_host=r["mcp_host"],
+            ide_detected=r["ide_detected"],
+            ide_detection_via=r["ide_detection_via"],
+            model_id=r["model_id"],
         )
 
     def get_recent_by_handle(

--- a/helix_context/schemas.py
+++ b/helix_context/schemas.py
@@ -311,6 +311,9 @@ class Participant(BaseModel):
     metadata: Optional[dict] = None
     agent_kind: Optional[str] = None    # vendor family — "claude-code", "codex"
     mcp_host: Optional[str] = None      # host tag — "vscode", "cursor"
+    ide_detected: Optional[str] = None        # adapter detect at register time
+    ide_detection_via: Optional[str] = None   # "env:VSCODE_PID", "agent_override", etc.
+    model_id: Optional[str] = None            # agent self-reported via helix_announce
 
 
 class ParticipantInfo(BaseModel):
@@ -324,6 +327,9 @@ class ParticipantInfo(BaseModel):
     started_at: float
     agent_kind: Optional[str] = None
     mcp_host: Optional[str] = None
+    ide_detected: Optional[str] = None
+    ide_detection_via: Optional[str] = None
+    model_id: Optional[str] = None
 
 
 class GeneAttribution(BaseModel):

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -1881,6 +1881,9 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
                 display_name=data.get("display_name"),
                 agent_kind=data.get("agent_kind"),
                 mcp_host=data.get("mcp_host"),
+                ide_detected=data.get("ide_detected"),
+                ide_detection_via=data.get("ide_detection_via"),
+                model_id=data.get("model_id"),
             )
         except Exception as exc:
             log.warning("Session register failed: %s", exc, exc_info=True)
@@ -1896,6 +1899,47 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
             "heartbeat_interval_s": DEFAULT_HEARTBEAT_INTERVAL_S,
             "ttl_s": DEFAULT_TTL_S,
         }
+
+    @app.post("/sessions/{participant_id}/announce")
+    async def session_announce_endpoint(participant_id: str, request: Request):
+        """Update model_id and (optionally) ide_detected on a participant.
+
+        Called by the agent via the helix_announce MCP tool after the MCP
+        adapter has registered the session. Body fields:
+
+        - model_id: required string. Free-form, no validation.
+        - ide_override: optional string. Replaces ide_detected and sets
+          ide_detection_via='agent_override'.
+
+        Silent no-op on unknown participant_id (matches heartbeat semantics
+        and registry update_announcement contract).
+        """
+        try:
+            data = await request.json()
+        except Exception:
+            return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+        model_id = data.get("model_id")
+        ide_override = data.get("ide_override")
+        if model_id is not None and not isinstance(model_id, str):
+            raise HTTPException(status_code=400, detail="model_id must be a string")
+        if ide_override is not None and not isinstance(ide_override, str):
+            raise HTTPException(status_code=400, detail="ide_override must be a string")
+
+        try:
+            registry.update_announcement(
+                participant_id=participant_id,
+                model_id=model_id,
+                ide_override=ide_override,
+            )
+        except Exception as exc:
+            log.warning("Announce failed: %s", exc, exc_info=True)
+            return JSONResponse(
+                {"error": f"Announce failed: {exc}"},
+                status_code=500,
+            )
+
+        return JSONResponse({"ok": True})
 
     @app.post("/sessions/{participant_id}/heartbeat")
     async def session_heartbeat_endpoint(

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -1907,7 +1907,9 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
         Called by the agent via the helix_announce MCP tool after the MCP
         adapter has registered the session. Body fields:
 
-        - model_id: required string. Free-form, no validation.
+        - model_id: optional string. Free-form, no validation. When omitted,
+          model_id is preserved (no-op for that field; useful when the agent
+          is only setting ide_override).
         - ide_override: optional string. Replaces ide_detected and sets
           ide_detection_via='agent_override'.
 

--- a/overnight_diamond.sh
+++ b/overnight_diamond.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Full GPQA Diamond overnight — kicked off 2026-05-01.
+# Runs n=198 (full diamond) off + on with bumped timeouts on both
+# layers (httpx client 180s, helix upstream 240s in helix.toml).
+# Auto-reverts helix.toml at end.
+
+set -u
+
+cd "$(dirname "$0")"
+mkdir -p overnight_logs benchmarks/results
+
+LOG=overnight_logs/diamond_2026-05-01.log
+STATUS=overnight_logs/diamond_2026-05-01.status
+REPORT=overnight_logs/diamond_2026-05-01_report.md
+HELIX_TOML=helix.toml
+HELIX_TOML_BACKUP=helix.toml.bench-backup
+
+MODEL=gemma4:e4b
+CLIENT_TIMEOUT=180
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG"; }
+write_status() { echo "$1" > "$STATUS"; }
+
+# Save current helix.toml so we can restore it at end (the upstream_timeout=240
+# bump is for this run only — not committed).
+cp -p "$HELIX_TOML" "$HELIX_TOML_BACKUP"
+
+revert_config() {
+  if [ -f "$HELIX_TOML_BACKUP" ]; then
+    log "Reverting $HELIX_TOML to pre-run state"
+    cp -p "$HELIX_TOML_BACKUP" "$HELIX_TOML"
+    rm "$HELIX_TOML_BACKUP"
+  fi
+}
+# Ensure config is reverted even on Ctrl-C / kill.
+trap 'revert_config; write_status "INTERRUPTED at $(ts)"' INT TERM
+
+run_step() {
+  local name="$1"; shift
+  log "=== START: $name ==="
+  write_status "RUNNING: $name (started $(ts))"
+  local t0=$(date +%s)
+  "$@" >>"$LOG" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local dur=$((t1 - t0))
+  if [ $rc -eq 0 ]; then
+    log "=== DONE:  $name  (rc=$rc, ${dur}s = $((dur/60))min) ==="
+  else
+    log "=== FAIL:  $name  (rc=$rc, ${dur}s) — continuing ==="
+  fi
+  return $rc
+}
+
+run_bench() {
+  local mode="$1"
+  local out="$2"
+  run_step "gpqa $mode (full diamond)" \
+    py -3 -u benchmarks/bench_aa_suite.py \
+      --benchmark gpqa \
+      --mode "$mode" \
+      --model "$MODEL" \
+      --timeout "$CLIENT_TIMEOUT" \
+      --output "$out"
+}
+
+# -- Begin run -------------------------------------------------------
+
+log "Diamond overnight run starting"
+log "Model: $MODEL    Client timeout: ${CLIENT_TIMEOUT}s    Helix upstream_timeout: 240s (helix.toml)"
+log "Helix server health:"
+curl -s -m 5 http://127.0.0.1:11437/health >> "$LOG" 2>&1 || true
+echo "" >> "$LOG"
+log "WIP in working tree: gemini's accel.py expand_query_terms + lexical_rescue + chunk_fetch + relevance_window"
+log "Branch: $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)"
+
+# -- Full Diamond off / on -------------------------------------------
+
+run_bench off benchmarks/results/gpqa_off_diamond_2026-05-01.json
+run_bench on  benchmarks/results/gpqa_on_diamond_2026-05-01.json
+
+# -- Aggregate report ------------------------------------------------
+
+write_status "RUNNING: report generation"
+log "=== Generating aggregated report ==="
+
+OFF=benchmarks/results/gpqa_off_diamond_2026-05-01.json
+ON=benchmarks/results/gpqa_on_diamond_2026-05-01.json
+
+cat > "$REPORT" <<EOF
+# GPQA Diamond Overnight Report — 2026-05-01
+
+**Started:** $(head -1 "$LOG" | sed 's/^\[\(.*\)\].*/\1/')
+**Completed:** $(ts)
+**Model:** $MODEL
+**Helix server:** http://127.0.0.1:11437
+**Branch:** $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)
+**Timeouts:** httpx client = ${CLIENT_TIMEOUT}s, helix upstream = 240s
+**WIP:** gemini's accel.py expand_query_terms + lexical_rescue + chunk_fetch + relevance_window
+
+## Headline numbers
+
+EOF
+
+py -3 <<'PYEOF' >> "$REPORT" 2>&1
+import json, sys
+off = json.load(open("benchmarks/results/gpqa_off_diamond_2026-05-01.json"))
+on  = json.load(open("benchmarks/results/gpqa_on_diamond_2026-05-01.json"))
+
+def stats(d, label):
+    res = d['results']
+    n = len(res)
+    succ = [r for r in res if not r.get('error')]
+    fail = [r for r in res if r.get('error')]
+    correct = sum(1 for r in succ if r.get('answer_correct'))
+    proxy_succ = sorted(r['proxy_latency_s'] for r in succ if r['proxy_latency_s'] > 0)
+    err_kinds = {}
+    for r in fail:
+        e = r.get('error') or ''
+        kind = 'timeout' if 'timed out' in e else ('proxy_500' if '500' in e else 'other')
+        err_kinds[kind] = err_kinds.get(kind, 0) + 1
+    def pct(L, p):
+        if not L: return 0
+        return L[max(0, min(len(L)-1, int(len(L)*p)))]
+    return {
+        'n': n, 'succ': len(succ), 'fail': len(fail),
+        'correct': correct,
+        'p50': pct(proxy_succ, 0.5),
+        'p90': pct(proxy_succ, 0.9),
+        'p95': pct(proxy_succ, 0.95),
+        'mx':  max(proxy_succ) if proxy_succ else 0,
+        'err_kinds': err_kinds,
+    }
+
+so = stats(off, 'OFF'); sn = stats(on, 'ON')
+
+print(f"| | n | completed | correct | accuracy (of completed) | errors | error breakdown |")
+print(f"|---|---|---|---|---|---|---|")
+for label, s in [('OFF', so), ('ON', sn)]:
+    acc = (s['correct']/s['succ']*100) if s['succ'] else 0
+    eb = ', '.join(f'{k}={v}' for k,v in s['err_kinds'].items()) or '—'
+    print(f"| {label} | {s['n']} | {s['succ']} | {s['correct']} | {acc:.1f}% | {s['fail']} | {eb} |")
+
+# Apples-to-apples on the intersection
+on_by_id  = {r['id']: r for r in on['results']}
+off_by_id = {r['id']: r for r in off['results']}
+both_ok = [pid for pid in on_by_id
+           if not on_by_id[pid].get('error') and not off_by_id.get(pid, {}).get('error')]
+oc = sum(1 for pid in both_ok if off_by_id[pid].get('answer_correct'))
+nc = sum(1 for pid in both_ok if on_by_id[pid].get('answer_correct'))
+print()
+print("## Apples-to-apples (only problems where BOTH modes completed)")
+print()
+print(f"- n_both_completed = **{len(both_ok)}**")
+print(f"- OFF correct: {oc}/{len(both_ok)} = {100*oc/max(len(both_ok),1):.1f}%")
+print(f"- ON  correct: {nc}/{len(both_ok)} = {100*nc/max(len(both_ok),1):.1f}%")
+delta_pp = 100*nc/max(len(both_ok),1) - 100*oc/max(len(both_ok),1)
+print(f"- **Delta: {delta_pp:+.1f}pp**")
+
+# Latency story
+print()
+print("## Latency on successes")
+print()
+print(f"| | p50 | p90 | p95 | max |")
+print(f"|---|---|---|---|---|")
+for label, s in [('OFF', so), ('ON', sn)]:
+    print(f"| {label} | {s['p50']:.1f}s | {s['p90']:.1f}s | {s['p95']:.1f}s | {s['mx']:.1f}s |")
+PYEOF
+
+echo "" >> "$REPORT"
+echo "## Raw compare_ab" >> "$REPORT"
+echo "" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+py -3 benchmarks/compare_ab.py "$OFF" "$ON" >> "$REPORT" 2>&1 || echo "(compare_ab.py failed)" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+
+# Restore helix.toml
+revert_config
+
+write_status "DONE at $(ts)"
+log "Diamond overnight run COMPLETE — report at $REPORT"
+log "helix.toml has been reverted to pre-run state. Server still has 240s upstream_timeout in memory; restart helix to pick up the reverted config."

--- a/overnight_diamond_abstain_2026-05-03.sh
+++ b/overnight_diamond_abstain_2026-05-03.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Full GPQA Diamond overnight — ABSTAIN tier bench gate (spec §9).
+# Date: 2026-05-03. Branch: feat/abstain-tier.
+# Runs n=198 (full diamond) off + on with bumped timeouts on both
+# layers (httpx client 180s, helix upstream 240s in helix.toml).
+# helix.toml is auto-reverted at end (the upstream_timeout=240 line is
+# applied for this run only — the committed default stays 180).
+#
+# Spec: docs/specs/2026-05-02-abstain-tier-design.md
+# Pre-flight (already done by operator): helix server PID 95240 was
+# stale (started 2026-05-01, before abstain code landed) — killed and
+# restarted; smoke test confirmed budget_tier=abstain on a noise query.
+
+set -u
+
+cd "$(dirname "$0")"
+mkdir -p overnight_logs benchmarks/results
+
+LOG=overnight_logs/diamond_2026-05-03.log
+STATUS=overnight_logs/diamond_2026-05-03.status
+REPORT=overnight_logs/diamond_2026-05-03_report.md
+HELIX_TOML=helix.toml
+HELIX_TOML_BACKUP=helix.toml.bench-backup
+
+MODEL=gemma4:e4b
+CLIENT_TIMEOUT=180
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG"; }
+write_status() { echo "$1" > "$STATUS"; }
+
+# Save current helix.toml so we can restore it at end (the upstream_timeout=240
+# bump is for this run only — not committed).
+cp -p "$HELIX_TOML" "$HELIX_TOML_BACKUP"
+
+revert_config() {
+  if [ -f "$HELIX_TOML_BACKUP" ]; then
+    log "Reverting $HELIX_TOML to pre-run state"
+    cp -p "$HELIX_TOML_BACKUP" "$HELIX_TOML"
+    rm "$HELIX_TOML_BACKUP"
+  fi
+}
+# Ensure config is reverted even on Ctrl-C / kill.
+trap 'revert_config; write_status "INTERRUPTED at $(ts)"' INT TERM
+
+run_step() {
+  local name="$1"; shift
+  log "=== START: $name ==="
+  write_status "RUNNING: $name (started $(ts))"
+  local t0=$(date +%s)
+  "$@" >>"$LOG" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local dur=$((t1 - t0))
+  if [ $rc -eq 0 ]; then
+    log "=== DONE:  $name  (rc=$rc, ${dur}s = $((dur/60))min) ==="
+  else
+    log "=== FAIL:  $name  (rc=$rc, ${dur}s) — continuing ==="
+  fi
+  return $rc
+}
+
+run_bench() {
+  local mode="$1"
+  local out="$2"
+  run_step "gpqa $mode (full diamond)" \
+    py -3 -u benchmarks/bench_aa_suite.py \
+      --benchmark gpqa \
+      --mode "$mode" \
+      --model "$MODEL" \
+      --timeout "$CLIENT_TIMEOUT" \
+      --output "$out"
+}
+
+# -- Begin run -------------------------------------------------------
+
+log "Diamond overnight run starting — ABSTAIN tier ON (helix.toml default)"
+log "Spec: docs/specs/2026-05-02-abstain-tier-design.md"
+log "Model: $MODEL    Client timeout: ${CLIENT_TIMEOUT}s    Helix upstream_timeout: 240s (helix.toml)"
+log "Helix server health:"
+curl -s -m 5 http://127.0.0.1:11437/health >> "$LOG" 2>&1 || true
+echo "" >> "$LOG"
+log "Branch: $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)"
+
+# -- Full Diamond off / on -------------------------------------------
+
+run_bench off benchmarks/results/gpqa_off_diamond_2026-05-03.json
+run_bench on  benchmarks/results/gpqa_on_diamond_2026-05-03.json
+
+# -- Aggregate report ------------------------------------------------
+
+write_status "RUNNING: report generation"
+log "=== Generating aggregated report ==="
+
+OFF=benchmarks/results/gpqa_off_diamond_2026-05-03.json
+ON=benchmarks/results/gpqa_on_diamond_2026-05-03.json
+
+cat > "$REPORT" <<EOF
+# GPQA Diamond Overnight Report — 2026-05-03 (ABSTAIN tier ON)
+
+**Started:** $(head -1 "$LOG" | sed 's/^\[\(.*\)\].*/\1/')
+**Completed:** $(ts)
+**Model:** $MODEL
+**Helix server:** http://127.0.0.1:11437
+**Branch:** $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)
+**Timeouts:** httpx client = ${CLIENT_TIMEOUT}s, helix upstream = 240s
+**Mode:** ABSTAIN tier ON (helix.toml default; abstain_enabled = true)
+**Spec:** [2026-05-02-abstain-tier-design.md](../docs/specs/2026-05-02-abstain-tier-design.md)
+
+## Headline numbers
+
+EOF
+
+py -3 <<'PYEOF' >> "$REPORT" 2>&1
+import json, sys
+off = json.load(open("benchmarks/results/gpqa_off_diamond_2026-05-03.json"))
+on  = json.load(open("benchmarks/results/gpqa_on_diamond_2026-05-03.json"))
+
+def stats(d, label):
+    res = d['results']
+    n = len(res)
+    succ = [r for r in res if not r.get('error')]
+    fail = [r for r in res if r.get('error')]
+    correct = sum(1 for r in succ if r.get('answer_correct'))
+    proxy_succ = sorted(r['proxy_latency_s'] for r in succ if r['proxy_latency_s'] > 0)
+    err_kinds = {}
+    for r in fail:
+        e = r.get('error') or ''
+        kind = 'timeout' if 'timed out' in e else ('proxy_500' if '500' in e else 'other')
+        err_kinds[kind] = err_kinds.get(kind, 0) + 1
+    def pct(L, p):
+        if not L: return 0
+        return L[max(0, min(len(L)-1, int(len(L)*p)))]
+    return {
+        'n': n, 'succ': len(succ), 'fail': len(fail),
+        'correct': correct,
+        'p50': pct(proxy_succ, 0.5),
+        'p90': pct(proxy_succ, 0.9),
+        'p95': pct(proxy_succ, 0.95),
+        'mx':  max(proxy_succ) if proxy_succ else 0,
+        'err_kinds': err_kinds,
+    }
+
+so = stats(off, 'OFF'); sn = stats(on, 'ON')
+
+print(f"| | n | completed | correct | accuracy (of completed) | errors | error breakdown |")
+print(f"|---|---|---|---|---|---|---|")
+for label, s in [('OFF', so), ('ON', sn)]:
+    acc = (s['correct']/s['succ']*100) if s['succ'] else 0
+    eb = ', '.join(f'{k}={v}' for k,v in s['err_kinds'].items()) or '—'
+    print(f"| {label} | {s['n']} | {s['succ']} | {s['correct']} | {acc:.1f}% | {s['fail']} | {eb} |")
+
+# Apples-to-apples on the intersection
+on_by_id  = {r['id']: r for r in on['results']}
+off_by_id = {r['id']: r for r in off['results']}
+both_ok = [pid for pid in on_by_id
+           if not on_by_id[pid].get('error') and not off_by_id.get(pid, {}).get('error')]
+oc = sum(1 for pid in both_ok if off_by_id[pid].get('answer_correct'))
+nc = sum(1 for pid in both_ok if on_by_id[pid].get('answer_correct'))
+print()
+print("## Apples-to-apples (only problems where BOTH modes completed)")
+print()
+print(f"- n_both_completed = **{len(both_ok)}**")
+print(f"- OFF correct: {oc}/{len(both_ok)} = {100*oc/max(len(both_ok),1):.1f}%")
+print(f"- ON  correct: {nc}/{len(both_ok)} = {100*nc/max(len(both_ok),1):.1f}%")
+delta_pp = 100*nc/max(len(both_ok),1) - 100*oc/max(len(both_ok),1)
+print(f"- **Delta: {delta_pp:+.1f}pp**")
+
+# Latency story
+print()
+print("## Latency on successes (all completed)")
+print()
+print(f"| | p50 | p90 | p95 | max |")
+print(f"|---|---|---|---|---|")
+for label, s in [('OFF', so), ('ON', sn)]:
+    print(f"| {label} | {s['p50']:.1f}s | {s['p90']:.1f}s | {s['p95']:.1f}s | {s['mx']:.1f}s |")
+
+# -----------------------------------------------------------------
+# Spec §9 stratified-by-fic gate analysis (ABSTAIN bench gate).
+# Pass criteria:
+#   - p95 latency on n=147 fic=False subset drops by >= 15s (ON vs OFF)
+#   - fic=True accuracy is unchanged (no abstain false-positives on hits)
+# -----------------------------------------------------------------
+print()
+print("## Spec §9 — Stratified by `found_in_context`")
+print()
+
+def stratified(results_list, fic_value):
+    succ = [r for r in results_list
+            if not r.get('error')
+            and r.get('found_in_context') is fic_value
+            and r.get('proxy_latency_s', 0) > 0]
+    lat = sorted(r['proxy_latency_s'] for r in succ)
+    correct = sum(1 for r in succ if r.get('answer_correct'))
+    def pct(L, p):
+        if not L: return 0
+        return L[max(0, min(len(L)-1, int(len(L)*p)))]
+    return {
+        'n': len(succ),
+        'correct': correct,
+        'acc': (100*correct/len(succ)) if succ else 0.0,
+        'p50': pct(lat, 0.5),
+        'p90': pct(lat, 0.9),
+        'p95': pct(lat, 0.95),
+        'mx': max(lat) if lat else 0,
+    }
+
+# Use ON's fic for stratification — fic is computed per-(query, mode) but
+# the cleanest gate is "queries the genome had no useful context for,
+# during the ON run". Cross-reference with both for sanity.
+for fic_val, label in [(False, 'fic=False (genome miss — ABSTAIN target)'),
+                       (True,  'fic=True  (genome hit — must stay accurate)')]:
+    soff = stratified(off['results'], fic_val)
+    son  = stratified(on['results'],  fic_val)
+    print()
+    print(f"### {label}")
+    print()
+    print(f"| | n | correct | accuracy | p50 | p90 | p95 | max |")
+    print(f"|---|---|---|---|---|---|---|---|")
+    print(f"| OFF | {soff['n']} | {soff['correct']} | {soff['acc']:.1f}% | {soff['p50']:.1f}s | {soff['p90']:.1f}s | {soff['p95']:.1f}s | {soff['mx']:.1f}s |")
+    print(f"| ON  | {son['n']}  | {son['correct']}  | {son['acc']:.1f}%  | {son['p50']:.1f}s  | {son['p90']:.1f}s  | {son['p95']:.1f}s  | {son['mx']:.1f}s |")
+    p95_delta = son['p95'] - soff['p95']
+    acc_delta = son['acc'] - soff['acc']
+    print(f"- p95 delta (ON − OFF): **{p95_delta:+.1f}s**")
+    print(f"- accuracy delta (ON − OFF): **{acc_delta:+.1f}pp**")
+
+# Apples-to-apples within fic=False using ON's fic flag (consistent stratification).
+print()
+print("### Spec §9 gate verdict")
+print()
+on_fic_false_ids = {r['id'] for r in on['results']
+                    if r.get('found_in_context') is False and not r.get('error')}
+on_fic_true_ids  = {r['id'] for r in on['results']
+                    if r.get('found_in_context') is True and not r.get('error')}
+
+def aa_strat(ids):
+    pairs = []
+    for pid in ids:
+        oo = off_by_id.get(pid); nn = on_by_id.get(pid)
+        if not oo or not nn: continue
+        if oo.get('error') or nn.get('error'): continue
+        pairs.append((oo, nn))
+    return pairs
+
+def aa_metrics(pairs, side):
+    lat = sorted(r[side]['proxy_latency_s'] for r in [{'OFF':p[0],'ON':p[1]} for p in pairs] if r[side]['proxy_latency_s']>0)
+    correct = sum(1 for p in pairs if p[0 if side=='OFF' else 1].get('answer_correct'))
+    def pct(L,p):
+        if not L: return 0
+        return L[max(0, min(len(L)-1, int(len(L)*p)))]
+    return {'n': len(pairs), 'correct': correct,
+            'acc': (100*correct/len(pairs)) if pairs else 0.0,
+            'p95': pct(lat, 0.95)}
+
+ff = aa_strat(on_fic_false_ids)
+ft = aa_strat(on_fic_true_ids)
+ff_off = aa_metrics(ff, 'OFF'); ff_on = aa_metrics(ff, 'ON')
+ft_off = aa_metrics(ft, 'OFF'); ft_on = aa_metrics(ft, 'ON')
+
+p95_drop_false = ff_off['p95'] - ff_on['p95']
+acc_change_true = ft_on['acc'] - ft_off['acc']
+
+print(f"- **fic=False (n_aa={ff_on['n']}):** OFF p95={ff_off['p95']:.1f}s, ON p95={ff_on['p95']:.1f}s, **drop={p95_drop_false:+.1f}s**  (target: >= +15s drop)")
+print(f"- **fic=True  (n_aa={ft_on['n']}):** OFF acc={ft_off['acc']:.1f}%, ON acc={ft_on['acc']:.1f}%, **delta={acc_change_true:+.1f}pp**  (target: unchanged ±0pp)")
+print()
+gate_p95 = "PASS" if p95_drop_false >= 15.0 else "FAIL"
+gate_acc = "PASS" if abs(acc_change_true) < 0.5 else ("WARN" if abs(acc_change_true) < 2.0 else "FAIL")
+print(f"- p95 gate: **{gate_p95}**")
+print(f"- accuracy gate: **{gate_acc}**")
+verdict = "PASS" if (gate_p95=="PASS" and gate_acc!="FAIL") else "FAIL"
+print(f"- **OVERALL: {verdict}**")
+PYEOF
+
+echo "" >> "$REPORT"
+echo "## Raw compare_ab" >> "$REPORT"
+echo "" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+py -3 benchmarks/compare_ab.py "$OFF" "$ON" >> "$REPORT" 2>&1 || echo "(compare_ab.py failed)" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+
+# Restore helix.toml
+revert_config
+
+write_status "DONE at $(ts)"
+log "Diamond overnight run COMPLETE — report at $REPORT"
+log "helix.toml has been reverted to pre-run state. Server still has 240s upstream_timeout in memory; restart helix to pick up the reverted config."

--- a/overnight_diamond_abstain_control_2026-05-03b.sh
+++ b/overnight_diamond_abstain_control_2026-05-03b.sh
@@ -1,0 +1,535 @@
+#!/usr/bin/env bash
+# Full GPQA Diamond overnight — ABSTAIN tier in-run control bench (spec §9, take 2).
+# Date: 2026-05-03b. Branch: feat/abstain-tier. HEAD: 24dd0cf.
+#
+# Today's morning OFF/ON bench showed +14.7pp accuracy with abstain ON, but the
+# OFF run was a "no helix" baseline, not an abstain-disabled control on the same
+# gene state. This script produces the missing control by running TWO ON cells
+# back-to-back on the same gene state:
+#   Cell 1: ON with abstain DISABLED (helix.toml abstain_enabled = false)
+#   Cell 2: ON with abstain ENABLED  (helix.toml abstain_enabled = true)
+# Then a head-to-head report compares them.
+#
+# Today's no-helix OFF baseline is benchmarks/results/gpqa_off_diamond_2026-05-03.json
+# (available for reference, not the comparison axis here).
+#
+# Spec: docs/specs/2026-05-02-abstain-tier-design.md
+
+set -u
+
+cd "$(dirname "$0")"
+mkdir -p overnight_logs benchmarks/results
+
+LOG=overnight_logs/diamond_2026-05-03b.log
+STATUS=overnight_logs/diamond_2026-05-03b.status
+REPORT=overnight_logs/diamond_2026-05-03b_report.md
+HELIX_TOML=helix.toml
+HELIX_TOML_BACKUP=helix.toml.bench-backup
+
+MODEL=gemma4:e4b
+CLIENT_TIMEOUT=180
+HELIX_PORT=11437
+HEALTH_URL="http://127.0.0.1:${HELIX_PORT}/health"
+CONTEXT_URL="http://127.0.0.1:${HELIX_PORT}/context"
+
+CELL_A_OUT=benchmarks/results/gpqa_on_disabled_2026-05-03b.json
+CELL_B_OUT=benchmarks/results/gpqa_on_enabled_2026-05-03b.json
+
+CELL_A_LOG=overnight_logs/helix_server_2026-05-03b_disabled.log
+CELL_A_ERR=overnight_logs/helix_server_2026-05-03b_disabled.err
+CELL_A_PID=overnight_logs/helix_server_2026-05-03b_disabled.pid
+CELL_A_SMOKE=overnight_logs/abstain_smoke_2026-05-03b_disabled.json
+
+CELL_B_LOG=overnight_logs/helix_server_2026-05-03b_enabled.log
+CELL_B_ERR=overnight_logs/helix_server_2026-05-03b_enabled.err
+CELL_B_PID=overnight_logs/helix_server_2026-05-03b_enabled.pid
+CELL_B_SMOKE=overnight_logs/abstain_smoke_2026-05-03b_enabled.json
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG"; }
+write_status() { echo "$1" > "$STATUS"; }
+
+# Save current helix.toml so we can restore it at end.
+cp -p "$HELIX_TOML" "$HELIX_TOML_BACKUP"
+
+# Track the currently-spawned bench server PID so we can clean it up on exit.
+CURRENT_SERVER_PID=""
+
+stop_server() {
+  local pid="$1"
+  local label="$2"
+  if [ -z "$pid" ]; then return 0; fi
+  if kill -0 "$pid" 2>/dev/null; then
+    log "Stopping $label server PID=$pid"
+    taskkill //PID "$pid" //F >>"$LOG" 2>&1 || true
+    # Give Windows a moment to release the port.
+    local i=0
+    while kill -0 "$pid" 2>/dev/null && [ $i -lt 10 ]; do
+      sleep 1
+      i=$((i+1))
+    done
+  else
+    log "$label server PID=$pid already gone"
+  fi
+}
+
+revert_config() {
+  if [ -f "$HELIX_TOML_BACKUP" ]; then
+    log "Reverting $HELIX_TOML to pre-run state"
+    cp -p "$HELIX_TOML_BACKUP" "$HELIX_TOML"
+    rm "$HELIX_TOML_BACKUP"
+  fi
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "$CURRENT_SERVER_PID" ]; then
+    stop_server "$CURRENT_SERVER_PID" "(cleanup)"
+    CURRENT_SERVER_PID=""
+  fi
+  revert_config
+  if [ "$rc" -ne 0 ]; then
+    write_status "EXITED rc=$rc at $(ts)"
+  fi
+}
+# Cleanup on any exit, including success — revert + kill any spawned server.
+trap 'cleanup' EXIT
+trap 'log "Caught signal; cleaning up"; write_status "INTERRUPTED at $(ts)"; exit 130' INT TERM
+
+# Set abstain_enabled to a given value (true|false) inside the [budget] block.
+# Uses sed to rewrite the abstain_enabled = ... line directly. The current
+# helix.toml has exactly one such line, on line 68; we match by key name to
+# stay robust to small line shifts.
+set_abstain() {
+  local val="$1"
+  if ! grep -q '^abstain_enabled' "$HELIX_TOML"; then
+    log "ERROR: no 'abstain_enabled' line in $HELIX_TOML — bailing"
+    return 1
+  fi
+  # Use a temp file so sed -i works portably on Windows.
+  sed -E "s/^(abstain_enabled[[:space:]]*=[[:space:]]*)(true|false)/\1${val}/" \
+    "$HELIX_TOML" > "${HELIX_TOML}.tmp" && mv "${HELIX_TOML}.tmp" "$HELIX_TOML"
+  local now
+  now=$(grep '^abstain_enabled' "$HELIX_TOML" | head -1)
+  log "helix.toml now: $now"
+  if ! echo "$now" | grep -q "= ${val}"; then
+    log "ERROR: failed to set abstain_enabled=${val} (got: $now)"
+    return 1
+  fi
+}
+
+# Spawn a fresh helix server in the background. Args: log err pid_file
+start_server() {
+  local out_log="$1" out_err="$2" pid_file="$3"
+  log "Starting fresh helix server: log=$out_log err=$out_err pid=$pid_file"
+  # Subshell + & detaches from this script so it survives until we kill it.
+  (
+    py -3 -u -m uvicorn helix_context.server:app \
+      --host 127.0.0.1 --port "$HELIX_PORT" \
+      >"$out_log" 2>"$out_err" &
+    echo $! > "$pid_file"
+  )
+  # Re-read the pid the subshell wrote.
+  local pid
+  pid=$(cat "$pid_file" 2>/dev/null || echo "")
+  if [ -z "$pid" ]; then
+    log "ERROR: failed to capture spawned PID"
+    return 1
+  fi
+  log "Spawned helix server PID=$pid"
+  CURRENT_SERVER_PID="$pid"
+  return 0
+}
+
+# Wait for /health 200 + the "Application startup complete." + "Uvicorn running"
+# marker in the err log. Up to 90s. Returns 0 on ready.
+wait_for_ready() {
+  local err_log="$1"
+  local pid="$2"
+  local deadline=$(( $(date +%s) + 90 ))
+  log "Waiting up to 90s for /health 200 + Uvicorn ready markers..."
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      log "ERROR: helix server PID=$pid died during warmup; tail of err:"
+      tail -40 "$err_log" >>"$LOG" 2>&1 || true
+      return 1
+    fi
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "$HEALTH_URL" 2>/dev/null || echo "000")
+    if [ "$code" = "200" ] \
+       && grep -q "Application startup complete" "$err_log" 2>/dev/null \
+       && grep -q "Uvicorn running on http://127.0.0.1:${HELIX_PORT}" "$err_log" 2>/dev/null; then
+      log "Helix server ready (health=200, uvicorn marker seen)"
+      return 0
+    fi
+    sleep 2
+  done
+  log "ERROR: helix server did not become ready within 90s"
+  log "Tail of err log:"
+  tail -60 "$err_log" >>"$LOG" 2>&1 || true
+  return 1
+}
+
+# POST a noise query; expect a particular budget_tier ("abstain" or "broad").
+# Args: out_file expected_tier
+smoke_test() {
+  local out_file="$1" expected="$2"
+  local body='{"query": "qzqx9k7m banana fluxcapacitor", "include_cold": false}'
+  log "Smoke test: POST $CONTEXT_URL expecting budget_tier=$expected"
+  curl -s -m 30 -H 'Content-Type: application/json' -d "$body" "$CONTEXT_URL" > "$out_file" 2>>"$LOG"
+  if [ ! -s "$out_file" ]; then
+    log "ERROR: smoke response empty (saved to $out_file)"
+    return 1
+  fi
+  log "Smoke response saved to $out_file"
+  # Extract budget_tier without depending on jq.
+  local tier
+  tier=$(py -3 -c "import json,sys
+d=json.load(open(sys.argv[1]))
+# Response is a list of one Pydantic record per spec.
+if isinstance(d, list) and d:
+    d = d[0]
+print(d.get('agent', {}).get('budget_tier', 'MISSING'))
+" "$out_file" 2>>"$LOG" || echo "PARSE_ERR")
+  log "Smoke budget_tier=$tier (expected=$expected)"
+  if [ "$tier" != "$expected" ]; then
+    log "ERROR: smoke mismatch — expected $expected got $tier"
+    return 1
+  fi
+  return 0
+}
+
+run_step() {
+  local name="$1"; shift
+  log "=== START: $name ==="
+  write_status "RUNNING: $name (started $(ts))"
+  local t0=$(date +%s)
+  "$@" >>"$LOG" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local dur=$((t1 - t0))
+  if [ $rc -eq 0 ]; then
+    log "=== DONE:  $name  (rc=$rc, ${dur}s = $((dur/60))min) ==="
+  else
+    log "=== FAIL:  $name  (rc=$rc, ${dur}s) — continuing ==="
+  fi
+  return $rc
+}
+
+run_bench() {
+  local mode="$1" out="$2" tag="$3"
+  run_step "gpqa $mode (full diamond, $tag)" \
+    py -3 -u benchmarks/bench_aa_suite.py \
+      --benchmark gpqa \
+      --mode "$mode" \
+      --model "$MODEL" \
+      --timeout "$CLIENT_TIMEOUT" \
+      --output "$out"
+}
+
+# -- Begin run -------------------------------------------------------
+
+log "============================================================"
+log "Diamond ABSTAIN in-run control bench starting"
+log "Branch: $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)"
+log "Model: $MODEL    Client timeout: ${CLIENT_TIMEOUT}s"
+log "Cell A: ON, abstain DISABLED -> $CELL_A_OUT"
+log "Cell B: ON, abstain ENABLED  -> $CELL_B_OUT"
+log "============================================================"
+
+# -- Stop the currently running helix server (PID from this morning's run).
+if [ -f overnight_logs/helix_server_2026-05-03.pid ]; then
+  EXISTING_PID=$(cat overnight_logs/helix_server_2026-05-03.pid 2>/dev/null || true)
+  if [ -n "$EXISTING_PID" ]; then
+    log "Existing helix PID from morning run: $EXISTING_PID"
+    if kill -0 "$EXISTING_PID" 2>/dev/null; then
+      log "Killing existing helix server PID=$EXISTING_PID"
+      taskkill //PID "$EXISTING_PID" //F >>"$LOG" 2>&1 || true
+      sleep 3
+    else
+      log "PID $EXISTING_PID already gone"
+    fi
+  fi
+fi
+
+# Belt-and-braces: anything still bound to 11437?
+PORT_OWNER=$(netstat -ano 2>/dev/null | grep "127.0.0.1:${HELIX_PORT} " | grep LISTENING | awk '{print $5}' | head -1 || true)
+if [ -n "$PORT_OWNER" ]; then
+  log "Port ${HELIX_PORT} still owned by PID=$PORT_OWNER; force-killing"
+  taskkill //PID "$PORT_OWNER" //F >>"$LOG" 2>&1 || true
+  sleep 3
+fi
+
+# =========================================================================
+# Cell A: ON, abstain DISABLED
+# =========================================================================
+log ""
+log ">>>>>>>>>>>> Cell A: ON, abstain DISABLED <<<<<<<<<<<<"
+write_status "RUNNING: cell A (ON, abstain disabled) at $(ts)"
+
+set_abstain "false" || { log "ABORT: could not set abstain_enabled=false"; write_status "ABORT cell A toml at $(ts)"; exit 1; }
+
+start_server "$CELL_A_LOG" "$CELL_A_ERR" "$CELL_A_PID" \
+  || { log "ABORT: failed to start Cell A server"; write_status "ABORT cell A start at $(ts)"; exit 1; }
+
+CELL_A_PID_VAL=$(cat "$CELL_A_PID")
+
+wait_for_ready "$CELL_A_ERR" "$CELL_A_PID_VAL" \
+  || { log "ABORT: Cell A server not ready"; write_status "ABORT cell A ready at $(ts)"; exit 1; }
+
+# Smoke: with abstain disabled, the noise query must NOT abstain — should fall
+# through to broad (legacy behavior).
+if ! smoke_test "$CELL_A_SMOKE" "broad"; then
+  log "ABORT: Cell A smoke failed — abstain should be OFF but tier mismatch"
+  write_status "ABORT cell A smoke at $(ts)"
+  exit 1
+fi
+
+run_bench on "$CELL_A_OUT" "abstain-disabled"
+CELL_A_RC=$?
+log "Cell A bench rc=$CELL_A_RC"
+
+stop_server "$CELL_A_PID_VAL" "Cell A"
+CURRENT_SERVER_PID=""
+
+# =========================================================================
+# Cell B: ON, abstain ENABLED
+# =========================================================================
+log ""
+log ">>>>>>>>>>>> Cell B: ON, abstain ENABLED <<<<<<<<<<<<"
+write_status "RUNNING: cell B (ON, abstain enabled) at $(ts)"
+
+set_abstain "true" || { log "ABORT: could not set abstain_enabled=true"; write_status "ABORT cell B toml at $(ts)"; exit 1; }
+
+start_server "$CELL_B_LOG" "$CELL_B_ERR" "$CELL_B_PID" \
+  || { log "ABORT: failed to start Cell B server"; write_status "ABORT cell B start at $(ts)"; exit 1; }
+
+CELL_B_PID_VAL=$(cat "$CELL_B_PID")
+
+wait_for_ready "$CELL_B_ERR" "$CELL_B_PID_VAL" \
+  || { log "ABORT: Cell B server not ready"; write_status "ABORT cell B ready at $(ts)"; exit 1; }
+
+# Smoke: with abstain enabled, the noise query SHOULD abstain.
+if ! smoke_test "$CELL_B_SMOKE" "abstain"; then
+  log "WARN: Cell B smoke did not return abstain — proceeding but flagging"
+  # Don't abort: this might be a regression worth measuring, log will surface it.
+fi
+
+run_bench on "$CELL_B_OUT" "abstain-enabled"
+CELL_B_RC=$?
+log "Cell B bench rc=$CELL_B_RC"
+
+stop_server "$CELL_B_PID_VAL" "Cell B"
+CURRENT_SERVER_PID=""
+
+# =========================================================================
+# Report
+# =========================================================================
+log ""
+log "=== Generating head-to-head report ==="
+write_status "RUNNING: report generation at $(ts)"
+
+cat > "$REPORT" <<EOF
+# GPQA Diamond ABSTAIN in-run control — 2026-05-03b
+
+**Started:** $(head -1 "$LOG" | sed 's/^\[\(.*\)\].*/\1/')
+**Completed:** $(ts)
+**Model:** $MODEL
+**Helix server:** http://127.0.0.1:${HELIX_PORT}
+**Branch:** $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)
+**Timeouts:** httpx client = ${CLIENT_TIMEOUT}s
+**Spec:** [2026-05-02-abstain-tier-design.md](../docs/specs/2026-05-02-abstain-tier-design.md)
+
+This run produces the in-run abstain-disabled control that the morning OFF/ON
+bench could not provide. Both cells use ON-mode helix retrieval on the same
+gene state; the only difference is the \`abstain_enabled\` toggle in
+\`[budget]\`. Cell A = abstain DISABLED. Cell B = abstain ENABLED.
+
+- Cell A bench rc: ${CELL_A_RC}
+- Cell B bench rc: ${CELL_B_RC}
+
+## Headline numbers
+
+EOF
+
+py -3 - "$CELL_A_OUT" "$CELL_B_OUT" >> "$REPORT" 2>&1 <<'PYEOF'
+import sys, json
+
+# Force ASCII-safe stdout — last night's heredoc crashed on a Unicode minus.
+try:
+    sys.stdout.reconfigure(encoding='utf-8')
+except Exception:
+    pass
+
+a_path, b_path = sys.argv[1], sys.argv[2]
+a = json.load(open(a_path, encoding='utf-8'))
+b = json.load(open(b_path, encoding='utf-8'))
+
+def stats(d):
+    res = d.get('results', [])
+    n = len(res)
+    succ = [r for r in res if not r.get('error')]
+    fail = [r for r in res if r.get('error')]
+    correct = sum(1 for r in succ if r.get('answer_correct'))
+    proxy_succ = sorted(r.get('proxy_latency_s', 0) for r in succ if r.get('proxy_latency_s', 0) > 0)
+    err_kinds = {}
+    for r in fail:
+        e = r.get('error') or ''
+        kind = 'timeout' if 'timed out' in e else ('proxy_500' if '500' in e else 'other')
+        err_kinds[kind] = err_kinds.get(kind, 0) + 1
+    def pct(L, p):
+        if not L:
+            return 0
+        return L[max(0, min(len(L) - 1, int(len(L) * p)))]
+    return {
+        'n': n, 'succ': len(succ), 'fail': len(fail),
+        'correct': correct,
+        'p50': pct(proxy_succ, 0.5),
+        'p90': pct(proxy_succ, 0.9),
+        'p95': pct(proxy_succ, 0.95),
+        'mx':  max(proxy_succ) if proxy_succ else 0,
+        'err_kinds': err_kinds,
+    }
+
+sa = stats(a)
+sb = stats(b)
+
+print("| cell | n | completed | correct | accuracy (of completed) | errors | error breakdown |")
+print("|---|---|---|---|---|---|---|")
+for label, s in [('A: ON abstain-disabled', sa), ('B: ON abstain-enabled', sb)]:
+    acc = (s['correct'] / s['succ'] * 100) if s['succ'] else 0
+    eb = ', '.join(f"{k}={v}" for k, v in s['err_kinds'].items()) or '-'
+    print(f"| {label} | {s['n']} | {s['succ']} | {s['correct']} | {acc:.1f}% | {s['fail']} | {eb} |")
+
+# Apples-to-apples on the intersection (only problems where BOTH cells completed).
+a_by_id = {r['id']: r for r in a.get('results', [])}
+b_by_id = {r['id']: r for r in b.get('results', [])}
+both_ok = [pid for pid in a_by_id
+           if not a_by_id[pid].get('error') and not b_by_id.get(pid, {}).get('error')]
+ac = sum(1 for pid in both_ok if a_by_id[pid].get('answer_correct'))
+bc = sum(1 for pid in both_ok if b_by_id[pid].get('answer_correct'))
+print()
+print("## Apples-to-apples (only problems where BOTH cells completed)")
+print()
+print(f"- n_both_completed = **{len(both_ok)}**")
+print(f"- Cell A (abstain-disabled) correct: {ac}/{len(both_ok)} = {100*ac/max(len(both_ok),1):.1f}%")
+print(f"- Cell B (abstain-enabled)  correct: {bc}/{len(both_ok)} = {100*bc/max(len(both_ok),1):.1f}%")
+delta_pp = 100 * bc / max(len(both_ok), 1) - 100 * ac / max(len(both_ok), 1)
+print(f"- **Accuracy delta (B - A): {delta_pp:+.1f}pp**")
+
+# ----- Latency tables (full, fic=False, fic=True) ----------------------------
+def lat_table_for(filter_fn, title):
+    print()
+    print(f"## Latency on successes ({title})")
+    print()
+    a_lat = sorted(r.get('proxy_latency_s', 0) for r in a.get('results', [])
+                   if not r.get('error') and filter_fn(r) and r.get('proxy_latency_s', 0) > 0)
+    b_lat = sorted(r.get('proxy_latency_s', 0) for r in b.get('results', [])
+                   if not r.get('error') and filter_fn(r) and r.get('proxy_latency_s', 0) > 0)
+    def pct(L, p):
+        if not L:
+            return 0
+        return L[max(0, min(len(L) - 1, int(len(L) * p)))]
+    def row(label, L):
+        return (label, len(L),
+                pct(L, 0.5), pct(L, 0.9), pct(L, 0.95),
+                max(L) if L else 0)
+    print("| cell | n | p50 | p90 | p95 | max |")
+    print("|---|---|---|---|---|---|")
+    for label, lat in [('A: ON abstain-disabled', a_lat), ('B: ON abstain-enabled', b_lat)]:
+        _, n, p50, p90, p95, mx = row(label, lat)
+        print(f"| {label} | {n} | {p50:.1f}s | {p90:.1f}s | {p95:.1f}s | {mx:.1f}s |")
+
+lat_table_for(lambda r: True, "all completed")
+lat_table_for(lambda r: r.get('found_in_context') is False, "fic=False (genome miss)")
+lat_table_for(lambda r: r.get('found_in_context') is True,  "fic=True  (genome hit)")
+
+# ----- Stratified by found_in_context ---------------------------------------
+def stratified(results_list, fic_value):
+    succ = [r for r in results_list
+            if not r.get('error')
+            and r.get('found_in_context') is fic_value
+            and r.get('proxy_latency_s', 0) > 0]
+    lat = sorted(r.get('proxy_latency_s', 0) for r in succ)
+    correct = sum(1 for r in succ if r.get('answer_correct'))
+    def pct(L, p):
+        if not L:
+            return 0
+        return L[max(0, min(len(L) - 1, int(len(L) * p)))]
+    timeouts = sum(1 for r in results_list
+                   if (r.get('error') or '').find('timed out') >= 0
+                   and r.get('found_in_context') is fic_value)
+    return {
+        'n': len(succ),
+        'correct': correct,
+        'acc': (100 * correct / len(succ)) if succ else 0.0,
+        'p50': pct(lat, 0.5),
+        'p90': pct(lat, 0.9),
+        'p95': pct(lat, 0.95),
+        'mx': max(lat) if lat else 0,
+        'timeouts': timeouts,
+    }
+
+print()
+print("## Stratified by `found_in_context`")
+print()
+strat_pairs = []
+for fic_val, label in [(False, 'fic=False (genome miss - ABSTAIN target)'),
+                       (True,  'fic=True  (genome hit  - must stay accurate)')]:
+    sa_strat = stratified(a.get('results', []), fic_val)
+    sb_strat = stratified(b.get('results', []), fic_val)
+    strat_pairs.append((label, fic_val, sa_strat, sb_strat))
+    print()
+    print(f"### {label}")
+    print()
+    print("| cell | n | correct | accuracy | p50 | p90 | p95 | max | timeouts |")
+    print("|---|---|---|---|---|---|---|---|---|")
+    print(f"| A: abstain-disabled | {sa_strat['n']} | {sa_strat['correct']} | {sa_strat['acc']:.1f}% | {sa_strat['p50']:.1f}s | {sa_strat['p90']:.1f}s | {sa_strat['p95']:.1f}s | {sa_strat['mx']:.1f}s | {sa_strat['timeouts']} |")
+    print(f"| B: abstain-enabled  | {sb_strat['n']} | {sb_strat['correct']} | {sb_strat['acc']:.1f}% | {sb_strat['p50']:.1f}s | {sb_strat['p90']:.1f}s | {sb_strat['p95']:.1f}s | {sb_strat['mx']:.1f}s | {sb_strat['timeouts']} |")
+    p95_delta = sb_strat['p95'] - sa_strat['p95']
+    acc_delta = sb_strat['acc'] - sa_strat['acc']
+    to_delta = sb_strat['timeouts'] - sa_strat['timeouts']
+    print(f"- p95 delta (B - A): **{p95_delta:+.1f}s**")
+    print(f"- accuracy delta (B - A): **{acc_delta:+.1f}pp**")
+    print(f"- timeout delta (B - A): **{to_delta:+d}**")
+
+# ----- Headline: Does the abstain gate help? --------------------------------
+print()
+print("## Headline: Does the abstain gate help?")
+print()
+
+# Overall deltas (apples-to-apples, lat over A intersection-completed).
+overall_acc_delta = 100 * bc / max(len(both_ok), 1) - 100 * ac / max(len(both_ok), 1)
+overall_p95_delta = sb['p95'] - sa['p95']
+overall_to_delta = sb['fail'] - sa['fail']
+
+print(f"- **Accuracy delta (B - A, apples-to-apples):** {overall_acc_delta:+.1f}pp")
+print(f"- **p95 latency delta (B - A, all successes):** {overall_p95_delta:+.1f}s")
+print(f"- **Total errors delta (B - A):** {overall_to_delta:+d}")
+print()
+print("### Per stratum")
+print()
+print("| stratum | accuracy delta (B-A) | p95 delta (B-A) | timeout delta (B-A) |")
+print("|---|---|---|---|")
+for label, fic_val, sa_strat, sb_strat in strat_pairs:
+    print(f"| {label} | {sb_strat['acc'] - sa_strat['acc']:+.1f}pp | {sb_strat['p95'] - sa_strat['p95']:+.1f}s | {sb_strat['timeouts'] - sa_strat['timeouts']:+d} |")
+print()
+print("Interpretation guide:")
+print("- The abstain gate is a **win** if fic=False shows lower p95 / fewer timeouts at unchanged accuracy.")
+print("- A regression on fic=True accuracy means the gate is firing on hits (false-positive abstains).")
+print("- Net accuracy can go up if abstain prevents the small model from being misled by junk context on misses.")
+PYEOF
+
+echo "" >> "$REPORT"
+echo "## Raw compare_ab" >> "$REPORT"
+echo "" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+py -3 benchmarks/compare_ab.py "$CELL_A_OUT" "$CELL_B_OUT" >> "$REPORT" 2>&1 || echo "(compare_ab.py failed)" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+
+# Restore helix.toml (also handled by EXIT trap, but explicit here for clarity).
+revert_config
+
+write_status "DONE at $(ts)"
+log "Diamond ABSTAIN control bench COMPLETE — report at $REPORT"
+log "helix.toml has been reverted to pre-run state."

--- a/overnight_diamond_e4b_qwen3_2026-05-05.sh
+++ b/overnight_diamond_e4b_qwen3_2026-05-05.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Fresh GPQA Diamond pass — 2026-05-05.
+# e4b (off + on) -> qwen3:8b (off + on), full n=198 each.
+# Last full e4b run was 2026-05-03; this is a re-baseline before the
+# qwen3:8b head-to-head.
+#
+# Runtime expectation: ~8-10 hours total based on the 2026-05-01 e4b
+# numbers (off=129min). qwen3:8b is roughly comparable.
+#
+# helix.toml is NOT modified; default upstream_timeout used.
+# Helix server expected to already be running on :11437.
+
+set -u
+
+cd "$(dirname "$0")"
+mkdir -p overnight_logs benchmarks/results
+
+DATE=2026-05-05
+LOG=overnight_logs/diamond_${DATE}_e4b_qwen3.log
+STATUS=overnight_logs/diamond_${DATE}_e4b_qwen3.status
+REPORT=overnight_logs/diamond_${DATE}_e4b_qwen3_report.md
+
+CLIENT_TIMEOUT=180
+HELIX_URL=http://127.0.0.1:11437
+
+E4B_MODEL=gemma4:e4b
+QWEN_MODEL=qwen3:8b
+
+E4B_OFF=benchmarks/results/gpqa_off_diamond_${DATE}_e4b.json
+E4B_ON=benchmarks/results/gpqa_on_diamond_${DATE}_e4b.json
+QWEN_OFF=benchmarks/results/gpqa_off_diamond_${DATE}_qwen3-8b.json
+QWEN_ON=benchmarks/results/gpqa_on_diamond_${DATE}_qwen3-8b.json
+
+# Prior e4b baseline (2026-05-03) for delta comparison.
+E4B_OFF_PRIOR=benchmarks/results/gpqa_off_diamond_2026-05-03.json
+E4B_ON_PRIOR=benchmarks/results/gpqa_on_diamond_2026-05-03.json
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG"; }
+write_status() { echo "$1" > "$STATUS"; }
+
+trap 'log "Caught signal; bailing"; write_status "INTERRUPTED at $(ts)"; exit 130' INT TERM
+
+run_step() {
+  local name="$1"; shift
+  log "=== START: $name ==="
+  write_status "RUNNING: $name (started $(ts))"
+  local t0=$(date +%s)
+  "$@" >>"$LOG" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local dur=$((t1 - t0))
+  if [ $rc -eq 0 ]; then
+    log "=== DONE:  $name  (rc=$rc, ${dur}s = $((dur/60))min) ==="
+  else
+    log "=== FAIL:  $name  (rc=$rc, ${dur}s) — continuing ==="
+  fi
+  return $rc
+}
+
+run_bench() {
+  local model="$1"; local mode="$2"; local out="$3"
+  run_step "gpqa $mode model=$model (full diamond)" \
+    py -3 -u benchmarks/bench_aa_suite.py \
+      --benchmark gpqa \
+      --mode "$mode" \
+      --model "$model" \
+      --timeout "$CLIENT_TIMEOUT" \
+      --output "$out"
+}
+
+# -- Begin run -------------------------------------------------------
+
+log "============================================================"
+log "Fresh diamond pass starting (e4b -> qwen3:8b, n=198 each)"
+log "Branch: $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)"
+log "Models: $E4B_MODEL then $QWEN_MODEL"
+log "Client timeout: ${CLIENT_TIMEOUT}s"
+log "Outputs:"
+log "  $E4B_OFF"
+log "  $E4B_ON"
+log "  $QWEN_OFF"
+log "  $QWEN_ON"
+log "============================================================"
+
+log "Helix server health:"
+curl -s -m 5 "$HELIX_URL/health" >> "$LOG" 2>&1 || true
+echo "" >> "$LOG"
+
+# Phase 1: e4b
+run_bench "$E4B_MODEL" off "$E4B_OFF"
+run_bench "$E4B_MODEL" on  "$E4B_ON"
+
+# Phase 2: qwen3:8b (only after e4b finishes)
+run_bench "$QWEN_MODEL" off "$QWEN_OFF"
+run_bench "$QWEN_MODEL" on  "$QWEN_ON"
+
+# -- Aggregate report -----------------------------------------------
+
+log ""
+log "=== Generating 4-way report ==="
+write_status "RUNNING: report at $(ts)"
+
+cat > "$REPORT" <<EOF
+# GPQA Diamond fresh pass — ${DATE}
+
+**Started:** $(head -1 "$LOG" | sed 's/^\[\(.*\)\].*/\1/')
+**Completed:** $(ts)
+**Models:** \`$E4B_MODEL\` then \`$QWEN_MODEL\`
+**Helix server:** $HELIX_URL
+**Branch:** $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)
+**Client timeout:** ${CLIENT_TIMEOUT}s
+**Mode definitions:**
+- \`off\`: background injected directly into prompt (no helix retrieval).
+- \`on\`: helix \`/context\` queried first; LLM then answers from question alone.
+
+EOF
+
+py -3 - "$E4B_OFF" "$E4B_ON" "$QWEN_OFF" "$QWEN_ON" "$E4B_OFF_PRIOR" "$E4B_ON_PRIOR" >> "$REPORT" 2>&1 <<'PYEOF'
+import json, sys, os
+
+def load(p):
+    if not os.path.exists(p):
+        return None
+    with open(p, encoding="utf-8") as f:
+        return json.load(f)
+
+def pct(L, p):
+    if not L:
+        return 0.0
+    return L[max(0, min(len(L) - 1, int(len(L) * p)))]
+
+def stats(d, label):
+    if d is None:
+        return {"label": label, "missing": True}
+    res = d.get("results", [])
+    succ = [r for r in res if not r.get("error")]
+    fail = [r for r in res if r.get("error")]
+    correct = sum(1 for r in succ if r.get("answer_correct"))
+    found = sum(1 for r in succ if r.get("found_in_context"))
+    lats = sorted(r.get("proxy_latency_s", 0) for r in succ if r.get("proxy_latency_s", 0) > 0)
+    err_kinds = {}
+    for r in fail:
+        e = r.get("error") or ""
+        kind = "timeout" if "timed out" in e else ("proxy_500" if "500" in e else "other")
+        err_kinds[kind] = err_kinds.get(kind, 0) + 1
+    return {
+        "label": label,
+        "missing": False,
+        "n": len(res),
+        "succ": len(succ),
+        "fail": len(fail),
+        "correct": correct,
+        "found": found,
+        "p50": pct(lats, 0.5),
+        "p90": pct(lats, 0.9),
+        "p95": pct(lats, 0.95),
+        "mx": max(lats) if lats else 0.0,
+        "err_kinds": err_kinds,
+    }
+
+paths = sys.argv[1:7]
+labels = ["e4b OFF (fresh)", "e4b ON (fresh)", "qwen3:8b OFF", "qwen3:8b ON",
+          "e4b OFF (2026-05-03)", "e4b ON (2026-05-03)"]
+runs = [stats(load(p), lab) for p, lab in zip(paths, labels)]
+
+print("## Headline numbers")
+print()
+print("| run | n | completed | correct | accuracy (of completed) | found_in_ctx | errors |")
+print("|---|---|---|---|---|---|---|")
+for s in runs:
+    if s.get("missing"):
+        print(f"| {s['label']} | — | — | — | MISSING | — | — |")
+        continue
+    acc = (s["correct"] / s["succ"] * 100) if s["succ"] else 0
+    eb = ", ".join(f"{k}={v}" for k, v in s["err_kinds"].items()) or "—"
+    print(f"| {s['label']} | {s['n']} | {s['succ']} | {s['correct']} | {acc:.1f}% | {s['found']} | {eb} |")
+
+print()
+print("## Latency on successes")
+print()
+print("| run | p50 | p90 | p95 | max |")
+print("|---|---|---|---|---|")
+for s in runs:
+    if s.get("missing"):
+        continue
+    print(f"| {s['label']} | {s['p50']:.1f}s | {s['p90']:.1f}s | {s['p95']:.1f}s | {s['mx']:.1f}s |")
+
+# Apples-to-apples deltas where both runs of a pair completed.
+def pair_delta(off, on, label):
+    if off is None or on is None:
+        return
+    on_by_id = {r["id"]: r for r in on.get("results", [])}
+    off_by_id = {r["id"]: r for r in off.get("results", [])}
+    both_ok = [pid for pid in on_by_id
+               if not on_by_id[pid].get("error") and not off_by_id.get(pid, {}).get("error")]
+    if not both_ok:
+        return
+    oc = sum(1 for pid in both_ok if off_by_id[pid].get("answer_correct"))
+    nc = sum(1 for pid in both_ok if on_by_id[pid].get("answer_correct"))
+    print(f"### {label}")
+    print()
+    print(f"- n_both_completed = **{len(both_ok)}**")
+    print(f"- OFF correct: {oc}/{len(both_ok)} = {100*oc/len(both_ok):.1f}%")
+    print(f"- ON  correct: {nc}/{len(both_ok)} = {100*nc/len(both_ok):.1f}%")
+    print(f"- **Delta: {100*nc/len(both_ok) - 100*oc/len(both_ok):+.1f}pp**")
+    print()
+
+print()
+print("## Apples-to-apples (only problems where BOTH off+on modes completed)")
+print()
+e4b_off, e4b_on, qwen_off, qwen_on, e4b_off_prior, e4b_on_prior = [load(p) for p in paths]
+pair_delta(e4b_off, e4b_on, "e4b (fresh)")
+pair_delta(qwen_off, qwen_on, "qwen3:8b")
+pair_delta(e4b_off_prior, e4b_on_prior, "e4b (2026-05-03 reference)")
+PYEOF
+
+write_status "DONE at $(ts)"
+log "Diamond fresh pass COMPLETE — report at $REPORT"

--- a/overnight_diamond_native_n20_2026-05-04.sh
+++ b/overnight_diamond_native_n20_2026-05-04.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Native-stack regression bench (n=20) for the native-observability-sidecar PR.
+# Date: 2026-05-04. Branch: feat/native-observability-sidecar. HEAD: e57f567.
+#
+# Spec gate (docs/specs/2026-05-04-native-observability-sidecar-design.md):
+#   p95(native) - p95(docker baseline, same problem IDs) <= 5s
+#
+# Docker baseline: benchmarks/results/gpqa_on_diamond_2026-05-03.json
+# Native output:   benchmarks/results/gpqa_native_n20_2026-05-04.json
+#
+# This is a SINGLE-cell ON-mode run. No abstain toggle (helix.toml stays at
+# its current state), no helix.toml mutation. Native observability stack
+# (otelcol/prom/tempo/loki/grafana) must already be running -- the user
+# launches it via the helix tray. Helix server on :11437 will be stopped
+# (taskkill) and respawned by this script for clean lifecycle.
+
+set -u
+
+cd "$(dirname "$0")"
+mkdir -p overnight_logs benchmarks/results
+
+LOG=overnight_logs/diamond_native_n20_2026-05-04.log
+STATUS=overnight_logs/diamond_native_n20_2026-05-04.status
+REPORT=overnight_logs/diamond_native_n20_2026-05-04_report.md
+
+MODEL=gemma4:e4b
+CLIENT_TIMEOUT=180
+N_LIMIT=20
+HELIX_PORT=11437
+HEALTH_URL="http://127.0.0.1:${HELIX_PORT}/health"
+
+CELL_OUT=benchmarks/results/gpqa_native_n20_2026-05-04.json
+CELL_LOG=overnight_logs/helix_server_native_n20_2026-05-04.log
+CELL_ERR=overnight_logs/helix_server_native_n20_2026-05-04.err
+CELL_PID=overnight_logs/helix_server_native_n20_2026-05-04.pid
+
+DOCKER_BASELINE=benchmarks/results/gpqa_on_diamond_2026-05-03.json
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG"; }
+write_status() { echo "$1" > "$STATUS"; }
+
+CURRENT_SERVER_PID=""
+
+stop_server() {
+  local pid="$1"
+  local label="$2"
+  if [ -z "$pid" ]; then return 0; fi
+  if kill -0 "$pid" 2>/dev/null; then
+    log "Stopping $label PID=$pid"
+    taskkill //PID "$pid" //F >>"$LOG" 2>&1 || true
+    local i=0
+    while kill -0 "$pid" 2>/dev/null && [ $i -lt 10 ]; do
+      sleep 1
+      i=$((i+1))
+    done
+  else
+    log "$label PID=$pid already gone"
+  fi
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "$CURRENT_SERVER_PID" ]; then
+    stop_server "$CURRENT_SERVER_PID" "(cleanup)"
+    CURRENT_SERVER_PID=""
+  fi
+  if [ "$rc" -ne 0 ]; then
+    write_status "EXITED rc=$rc at $(ts)"
+  fi
+}
+trap 'cleanup' EXIT
+trap 'log "Caught signal; cleaning up"; write_status "INTERRUPTED at $(ts)"; exit 130' INT TERM
+
+start_server() {
+  local out_log="$1" out_err="$2" pid_file="$3"
+  log "Starting fresh helix server: log=$out_log err=$out_err pid=$pid_file"
+  (
+    py -3 -u -m uvicorn helix_context.server:app \
+      --host 127.0.0.1 --port "$HELIX_PORT" \
+      >"$out_log" 2>"$out_err" &
+    echo $! > "$pid_file"
+  )
+  local pid
+  pid=$(cat "$pid_file" 2>/dev/null || echo "")
+  if [ -z "$pid" ]; then
+    log "ERROR: failed to capture spawned PID"
+    return 1
+  fi
+  log "Spawned helix server PID=$pid"
+  CURRENT_SERVER_PID="$pid"
+  return 0
+}
+
+wait_for_ready() {
+  local err_log="$1"
+  local pid="$2"
+  local deadline=$(( $(date +%s) + 90 ))
+  log "Waiting up to 90s for /health 200 + Uvicorn ready markers..."
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      log "ERROR: helix server PID=$pid died during warmup; tail of err:"
+      tail -40 "$err_log" >>"$LOG" 2>&1 || true
+      return 1
+    fi
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "$HEALTH_URL" 2>/dev/null || echo "000")
+    if [ "$code" = "200" ] \
+       && grep -q "Application startup complete" "$err_log" 2>/dev/null \
+       && grep -q "Uvicorn running on http://127.0.0.1:${HELIX_PORT}" "$err_log" 2>/dev/null; then
+      log "Helix server ready (health=200, uvicorn marker seen)"
+      return 0
+    fi
+    sleep 2
+  done
+  log "ERROR: helix server did not become ready within 90s"
+  log "Tail of err log:"
+  tail -60 "$err_log" >>"$LOG" 2>&1 || true
+  return 1
+}
+
+run_step() {
+  local name="$1"; shift
+  log "=== START: $name ==="
+  write_status "RUNNING: $name (started $(ts))"
+  local t0=$(date +%s)
+  "$@" >>"$LOG" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local dur=$((t1 - t0))
+  if [ $rc -eq 0 ]; then
+    log "=== DONE:  $name  (rc=$rc, ${dur}s = $((dur/60))min) ==="
+  else
+    log "=== FAIL:  $name  (rc=$rc, ${dur}s) ==="
+  fi
+  return $rc
+}
+
+run_bench() {
+  run_step "gpqa on (native, limit=${N_LIMIT})" \
+    py -3 -u benchmarks/bench_aa_suite.py \
+      --benchmark gpqa \
+      --mode on \
+      --model "$MODEL" \
+      --limit "$N_LIMIT" \
+      --timeout "$CLIENT_TIMEOUT" \
+      --output "$CELL_OUT"
+}
+
+# -- Begin run -------------------------------------------------------
+
+log "============================================================"
+log "Native sidecar regression bench (n=${N_LIMIT}) starting"
+log "Branch: $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)"
+log "Model: $MODEL    Client timeout: ${CLIENT_TIMEOUT}s    Limit: ${N_LIMIT}"
+log "Native output:   $CELL_OUT"
+log "Docker baseline: $DOCKER_BASELINE"
+log "============================================================"
+
+# Verify native observability stack is up.
+log "Checking native observability sidecar ports..."
+MISSING=""
+for port in 4317 9090 3200 3100 3000; do
+  owner=$(netstat -ano 2>/dev/null | grep -E "[: ]${port} " | grep LISTENING | head -1 | awk '{print $5}' || true)
+  if [ -z "$owner" ]; then
+    MISSING="$MISSING $port"
+  else
+    log "  port $port: PID=$owner"
+  fi
+done
+if [ -n "$MISSING" ]; then
+  log "ABORT: native observability ports not bound:$MISSING"
+  write_status "ABORT native_stack at $(ts)"
+  exit 1
+fi
+log "Native observability stack OK."
+
+# Stop any existing helix server on :11437 (likely the tray-launched one).
+PORT_OWNER=$(netstat -ano 2>/dev/null | grep "127.0.0.1:${HELIX_PORT} " | grep LISTENING | awk '{print $5}' | head -1 || true)
+if [ -n "$PORT_OWNER" ]; then
+  log "Port ${HELIX_PORT} held by PID=$PORT_OWNER; stopping"
+  taskkill //PID "$PORT_OWNER" //F >>"$LOG" 2>&1 || true
+  sleep 3
+fi
+
+# Start fresh helix server.
+start_server "$CELL_LOG" "$CELL_ERR" "$CELL_PID" \
+  || { log "ABORT: failed to start helix"; write_status "ABORT start at $(ts)"; exit 1; }
+
+CELL_PID_VAL=$(cat "$CELL_PID")
+
+wait_for_ready "$CELL_ERR" "$CELL_PID_VAL" \
+  || { log "ABORT: helix not ready"; write_status "ABORT ready at $(ts)"; exit 1; }
+
+# Run the bench.
+run_bench
+BENCH_RC=$?
+log "Bench rc=$BENCH_RC"
+
+stop_server "$CELL_PID_VAL" "bench helix"
+CURRENT_SERVER_PID=""
+
+# Build the report.
+log ""
+log "=== Generating native-vs-docker report ==="
+write_status "RUNNING: report at $(ts)"
+
+cat > "$REPORT" <<EOF
+# GPQA Diamond native-stack regression (n=${N_LIMIT}) -- 2026-05-04
+
+**Started:** $(head -1 "$LOG" | sed 's/^\[\(.*\)\].*/\1/')
+**Completed:** $(ts)
+**Model:** $MODEL
+**Helix server:** http://127.0.0.1:${HELIX_PORT}
+**Branch:** $(git rev-parse --abbrev-ref HEAD)  HEAD: $(git rev-parse --short HEAD)
+**Spec:** [2026-05-04-native-observability-sidecar-design.md](../docs/specs/2026-05-04-native-observability-sidecar-design.md)
+**Spec gate:** p95(native) - p95(docker, same IDs) <= 5s
+
+- Native bench rc: ${BENCH_RC}
+
+EOF
+
+py -3 - "$CELL_OUT" "$DOCKER_BASELINE" >> "$REPORT" 2>&1 <<'PYEOF'
+import sys, json
+
+try:
+    sys.stdout.reconfigure(encoding='utf-8')
+except Exception:
+    pass
+
+native_path, docker_path = sys.argv[1], sys.argv[2]
+nat = json.load(open(native_path, encoding='utf-8'))
+doc = json.load(open(docker_path, encoding='utf-8'))
+
+def pct(L, p):
+    if not L:
+        return 0.0
+    return L[max(0, min(len(L) - 1, int(len(L) * p)))]
+
+def summarize(d, label):
+    res = d.get('results', [])
+    succ = [r for r in res if not r.get('error')]
+    correct = sum(1 for r in succ if r.get('answer_correct'))
+    lats = sorted(r.get('proxy_latency_s', 0) for r in succ if r.get('proxy_latency_s', 0) > 0)
+    return {
+        'label': label,
+        'n_total': len(res),
+        'n_succ': len(succ),
+        'n_fail': len(res) - len(succ),
+        'correct': correct,
+        'p50': pct(lats, 0.5),
+        'p90': pct(lats, 0.9),
+        'p95': pct(lats, 0.95),
+        'mx': max(lats) if lats else 0.0,
+    }
+
+s_nat = summarize(nat, 'native (n=20)')
+s_doc_full = summarize(doc, 'docker (full n=198)')
+
+# Apples-to-apples: filter docker baseline to the same problem IDs the native run hit.
+nat_ids = {r['id'] for r in nat.get('results', [])}
+doc_subset = {'results': [r for r in doc.get('results', []) if r['id'] in nat_ids]}
+s_doc_subset = summarize(doc_subset, f'docker (same {len(nat_ids)} IDs)')
+
+print("## Headline numbers")
+print()
+print("| run | n | completed | correct | p50 | p90 | p95 | max |")
+print("|---|---|---|---|---|---|---|---|")
+for s in (s_nat, s_doc_subset, s_doc_full):
+    print(f"| {s['label']} | {s['n_total']} | {s['n_succ']} | {s['correct']} | {s['p50']:.1f}s | {s['p90']:.1f}s | {s['p95']:.1f}s | {s['mx']:.1f}s |")
+
+print()
+print("## Spec gate verdict")
+print()
+delta_p95 = s_nat['p95'] - s_doc_subset['p95']
+print(f"- p95(native, n=20)              = **{s_nat['p95']:.2f}s**")
+print(f"- p95(docker, same {len(nat_ids)} IDs) = **{s_doc_subset['p95']:.2f}s**")
+print(f"- p95 delta (native - docker, same IDs) = **{delta_p95:+.2f}s**")
+print()
+print(f"- p95(docker, full n=198 baseline) = {s_doc_full['p95']:.2f}s (reference only)")
+print()
+gate_pass = delta_p95 <= 5.0
+print(f"- **Spec gate (delta <= 5s): {'PASS' if gate_pass else 'FAIL'}**")
+
+# Errors / timeouts breakdown
+print()
+print("## Error breakdown")
+print()
+def err_kinds(d):
+    kinds = {}
+    for r in d.get('results', []):
+        e = r.get('error')
+        if not e:
+            continue
+        if 'timed out' in e:
+            kinds['timeout'] = kinds.get('timeout', 0) + 1
+        elif '500' in e:
+            kinds['proxy_500'] = kinds.get('proxy_500', 0) + 1
+        else:
+            kinds['other'] = kinds.get('other', 0) + 1
+    return kinds
+
+print(f"- native:                     {err_kinds(nat) or '-'}")
+print(f"- docker (same {len(nat_ids)} IDs):  {err_kinds(doc_subset) or '-'}")
+PYEOF
+
+write_status "DONE at $(ts)"
+log "Native regression bench COMPLETE -- report at $REPORT"

--- a/overnight_run.sh
+++ b/overnight_run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Overnight benchmark orchestrator — kicked off 2026-04-29 evening.
+# Captures real-dataset GPQA + SciCode (off vs on) plus the existing
+# mock A/B suite (IFBench, AA-Omniscience, CritPt). Logs everything
+# with timestamps to overnight_logs/overnight_2026-04-29.log.
+
+set -u  # treat unset vars as errors; intentionally NOT -e so a single
+        # benchmark failure does not nuke the whole run.
+
+cd "$(dirname "$0")"
+mkdir -p overnight_logs benchmarks/results
+
+LOG=overnight_logs/overnight_2026-04-29.log
+STATUS=overnight_logs/overnight_2026-04-29.status
+REPORT=overnight_logs/overnight_2026-04-29_report.md
+
+PYBIN=py
+PYARGS="-3"
+MODEL=gemma4:e4b
+GPQA_LIMIT=100
+SCICODE_LIMIT=100   # SciCode dataset has fewer; this is an upper bound.
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG"; }
+
+write_status() {
+  echo "$1" > "$STATUS"
+}
+
+run_step() {
+  local name="$1"; shift
+  log "=== START: $name ==="
+  write_status "RUNNING: $name (started $(ts))"
+  local t0=$(date +%s)
+  "$@" >>"$LOG" 2>&1
+  local rc=$?
+  local t1=$(date +%s)
+  local dur=$((t1 - t0))
+  if [ $rc -eq 0 ]; then
+    log "=== DONE:  $name  (rc=$rc, ${dur}s) ==="
+  else
+    log "=== FAIL:  $name  (rc=$rc, ${dur}s) — continuing ==="
+  fi
+  return $rc
+}
+
+run_bench() {
+  local benchmark="$1"
+  local mode="$2"
+  local out="$3"
+  local extra=("${@:4}")
+  run_step "${benchmark} ${mode}" \
+    $PYBIN $PYARGS benchmarks/bench_aa_suite.py \
+      --benchmark "$benchmark" \
+      --mode "$mode" \
+      --model "$MODEL" \
+      --output "$out" \
+      "${extra[@]}"
+}
+
+compare() {
+  local off="$1"
+  local on="$2"
+  local label="$3"
+  echo "" >> "$REPORT"
+  echo "## $label" >> "$REPORT"
+  echo "" >> "$REPORT"
+  echo "\`\`\`" >> "$REPORT"
+  $PYBIN $PYARGS benchmarks/compare_ab.py "$off" "$on" >> "$REPORT" 2>&1 \
+    || echo "compare_ab.py failed" >> "$REPORT"
+  echo "\`\`\`" >> "$REPORT"
+}
+
+# -- Begin run -------------------------------------------------------
+
+log "Overnight benchmark run starting"
+log "Model: $MODEL    GPQA limit: $GPQA_LIMIT    SciCode limit: $SCICODE_LIMIT"
+log "Helix server health:"
+curl -s -m 5 http://127.0.0.1:11437/health >> "$LOG" 2>&1 || true
+echo "" >> "$LOG"
+
+write_status "RUNNING: setup"
+
+# -- Real-dataset benchmarks -----------------------------------------
+
+# GPQA off / on (HuggingFace dataset; real)
+run_bench gpqa off    benchmarks/results/gpqa_off_2026-04-29.json    --limit "$GPQA_LIMIT"
+run_bench gpqa on     benchmarks/results/gpqa_on_2026-04-29.json     --limit "$GPQA_LIMIT"
+
+# SciCode off / on (HuggingFace dataset; real)
+run_bench scicode off benchmarks/results/scicode_off_2026-04-29.json --limit "$SCICODE_LIMIT"
+run_bench scicode on  benchmarks/results/scicode_on_2026-04-29.json  --limit "$SCICODE_LIMIT"
+
+# -- Mock-dataset A/B suite (small, but completes the picture) -------
+
+run_bench ifbench         off benchmarks/results/ifbench_off_2026-04-29.json
+run_bench ifbench         on  benchmarks/results/ifbench_on_2026-04-29.json
+run_bench aa-omniscience  off benchmarks/results/omn_off_2026-04-29.json
+run_bench aa-omniscience  on  benchmarks/results/omn_on_2026-04-29.json
+run_bench critpt          off benchmarks/results/critpt_off_2026-04-29.json
+run_bench critpt          on  benchmarks/results/critpt_on_2026-04-29.json
+
+# -- Aggregate report -------------------------------------------------
+
+write_status "RUNNING: report generation"
+log "=== Generating aggregated report ==="
+
+cat > "$REPORT" <<EOF
+# Overnight Benchmark Report — 2026-04-29
+
+**Started:** $(head -1 "$LOG" | sed 's/^\[\(.*\)\].*/\1/')
+**Completed:** $(ts)
+**Model:** $MODEL
+**Helix server:** http://127.0.0.1:11437 (17,090 genes at start)
+**Branch:** master ($(git rev-parse --short HEAD))
+**WIP in working tree:** accel.py expand_query_terms + lexical_rescue + chunk_fetch + relevance_window (gemini's uncommitted work)
+EOF
+
+compare benchmarks/results/gpqa_off_2026-04-29.json    benchmarks/results/gpqa_on_2026-04-29.json    "GPQA Diamond (real, n≤$GPQA_LIMIT)"
+compare benchmarks/results/scicode_off_2026-04-29.json benchmarks/results/scicode_on_2026-04-29.json "SciCode (real, n≤$SCICODE_LIMIT)"
+compare benchmarks/results/ifbench_off_2026-04-29.json benchmarks/results/ifbench_on_2026-04-29.json "IFBench (mock, smoke)"
+compare benchmarks/results/omn_off_2026-04-29.json     benchmarks/results/omn_on_2026-04-29.json     "AA-Omniscience (mock, smoke)"
+compare benchmarks/results/critpt_off_2026-04-29.json  benchmarks/results/critpt_on_2026-04-29.json  "CritPt (mock, smoke)"
+
+echo "" >> "$REPORT"
+echo "## Per-benchmark error counts" >> "$REPORT"
+echo "" >> "$REPORT"
+echo "\`\`\`" >> "$REPORT"
+for f in benchmarks/results/*_2026-04-29.json; do
+  $PYBIN $PYARGS -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    res = d.get('results', [])
+    n = len(res)
+    correct = sum(1 for r in res if r.get('answer_correct'))
+    errs = sum(1 for r in res if r.get('error'))
+    print(f'{sys.argv[1]:60s} n={n:4d} correct={correct:4d} errors={errs:4d}')
+except Exception as e:
+    print(f'{sys.argv[1]}: PARSE ERROR {e}')
+" "$f" >> "$REPORT" 2>&1
+done
+echo "\`\`\`" >> "$REPORT"
+
+write_status "DONE at $(ts)"
+log "Overnight benchmark run COMPLETE — report at $REPORT"

--- a/run_full_suite.ps1
+++ b/run_full_suite.ps1
@@ -1,0 +1,21 @@
+$env:PYTHONUNBUFFERED="1"
+
+Write-Host "Running IFBench..."
+python benchmarks/bench_aa_suite.py --benchmark ifbench --mode off --model gemma4:e4b --output benchmarks/ifbench_off.json
+python benchmarks/bench_aa_suite.py --benchmark ifbench --mode on --model gemma4:e4b --output benchmarks/ifbench_on.json
+Write-Host "--- IFBench Results ---" > benchmarks/full_suite_report.txt
+python benchmarks/compare_ab.py benchmarks/ifbench_off.json benchmarks/ifbench_on.json >> benchmarks/full_suite_report.txt
+
+Write-Host "Running AA-Omniscience..."
+python benchmarks/bench_aa_suite.py --benchmark aa-omniscience --mode off --model gemma4:e4b --output benchmarks/omn_off.json
+python benchmarks/bench_aa_suite.py --benchmark aa-omniscience --mode on --model gemma4:e4b --output benchmarks/omn_on.json
+Write-Host "`n--- AA-Omniscience Results ---" >> benchmarks/full_suite_report.txt
+python benchmarks/compare_ab.py benchmarks/omn_off.json benchmarks/omn_on.json >> benchmarks/full_suite_report.txt
+
+Write-Host "Running CritPt..."
+python benchmarks/bench_aa_suite.py --benchmark critpt --mode off --model gemma4:e4b --output benchmarks/critpt_off.json
+python benchmarks/bench_aa_suite.py --benchmark critpt --mode on --model gemma4:e4b --output benchmarks/critpt_on.json
+Write-Host "`n--- CritPt Results ---" >> benchmarks/full_suite_report.txt
+python benchmarks/compare_ab.py benchmarks/critpt_off.json benchmarks/critpt_on.json >> benchmarks/full_suite_report.txt
+
+Write-Host "Full suite complete! Report saved to benchmarks/full_suite_report.txt"

--- a/run_overnight_bench.ps1
+++ b/run_overnight_bench.ps1
@@ -1,0 +1,15 @@
+$env:PYTHONUNBUFFERED="1"
+
+Write-Host "Starting Overnight Benchmark Suite with gemma4:e4b"
+Write-Host "=================================================="
+
+Write-Host "1. Running Baseline (Off Mode)..."
+python benchmarks/bench_aa_suite.py --benchmark scicode --mode off --model gemma4:e4b --output benchmarks/scicode_overnight_off.json
+
+Write-Host "2. Running Treatment (On Mode)..."
+python benchmarks/bench_aa_suite.py --benchmark scicode --mode on --model gemma4:e4b --output benchmarks/scicode_overnight_on.json
+
+Write-Host "3. Generating Comparison Report..."
+python benchmarks/compare_ab.py benchmarks/scicode_overnight_off.json benchmarks/scicode_overnight_on.json > benchmarks/scicode_overnight_report.txt
+
+Write-Host "Overnight benchmark complete! Report saved to benchmarks/scicode_overnight_report.txt"

--- a/run_pr9_sweep.ps1
+++ b/run_pr9_sweep.ps1
@@ -1,0 +1,24 @@
+$env:PYTHONUNBUFFERED="1"
+
+Write-Host "Running PR #9 Benchmark Sweep with Query Classifier..."
+Write-Host "======================================================"
+
+Write-Host "`nRunning AA-LCR (Multi-Hop Test)..."
+python benchmarks/bench_aa_suite.py --benchmark aa-lcr --mode off --model gemma4:e4b --output benchmarks/pr9_aalcr_off.json
+python benchmarks/bench_aa_suite.py --benchmark aa-lcr --mode on --model gemma4:e4b --output benchmarks/pr9_aalcr_on.json
+Write-Host "--- AA-LCR Results ---" > benchmarks/pr9_sweep_report.txt
+python benchmarks/compare_ab.py benchmarks/pr9_aalcr_off.json benchmarks/pr9_aalcr_on.json >> benchmarks/pr9_sweep_report.txt
+
+Write-Host "`nRunning Terminal-Bench (Log Parsing Test)..."
+python benchmarks/bench_aa_suite.py --benchmark terminal-bench --mode off --model gemma4:e4b --output benchmarks/pr9_term_off.json
+python benchmarks/bench_aa_suite.py --benchmark terminal-bench --mode on --model gemma4:e4b --output benchmarks/pr9_term_on.json
+Write-Host "`n--- Terminal-Bench Results ---" >> benchmarks/pr9_sweep_report.txt
+python benchmarks/compare_ab.py benchmarks/pr9_term_off.json benchmarks/pr9_term_on.json >> benchmarks/pr9_sweep_report.txt
+
+Write-Host "`nRunning CritPt (Planning Test)..."
+python benchmarks/bench_aa_suite.py --benchmark critpt --mode off --model gemma4:e4b --output benchmarks/pr9_crit_off.json
+python benchmarks/bench_aa_suite.py --benchmark critpt --mode on --model gemma4:e4b --output benchmarks/pr9_crit_on.json
+Write-Host "`n--- CritPt Results ---" >> benchmarks/pr9_sweep_report.txt
+python benchmarks/compare_ab.py benchmarks/pr9_crit_off.json benchmarks/pr9_crit_on.json >> benchmarks/pr9_sweep_report.txt
+
+Write-Host "`nSweep complete! Report saved to benchmarks/pr9_sweep_report.txt"

--- a/skills/helix/SKILL.md
+++ b/skills/helix/SKILL.md
@@ -66,6 +66,12 @@ Start with `helix_context`.
 5. When coordinating with sibling agents, use `helix_sessions_list` and `helix_session_recent` instead of guessing from logs or git state.
 6. Treat session presence and authored ingests as complementary:
    `helix_sessions_list` tells you who is alive now; ingest attribution tells you who authored a stored gene.
+7. After your first `helix_health` call in a session, also call
+   `helix_announce(model_id=...)` once with your model identifier
+   (e.g., `"claude-opus-4-7"`, `"gpt-5"`, `"gemini-2-5-pro"`) so the
+   dashboard can display your model in the agent badge tooltip. If
+   the IDE auto-detection got it wrong, pass `ide_override=...` to
+   correct it.
 
 ## Attribution Expectations
 

--- a/tests/test_bridge_registry.py
+++ b/tests/test_bridge_registry.py
@@ -37,6 +37,31 @@ def bridge(tmp_path):
     return AgentBridge(shared_dir=str(tmp_path / "shared"))
 
 
+@pytest.fixture
+def bridge_with_capture(tmp_path):
+    """Fixture that provides a bridge + a dict to capture httpx.post requests.
+
+    Used by tests that need to verify request body contents.
+    Returns (bridge, captured_dict) where captured_dict has 'url', 'body', etc.
+    """
+    bridge = AgentBridge(shared_dir=str(tmp_path / "shared"))
+    captured = {}
+
+    def capture_post(url, json=None, **kwargs):
+        captured["url"] = url
+        captured["body"] = json
+        return _ok_response({
+            "participant_id": "test-participant-123",
+            "party_id": "test-party",
+            "registered_at": time.time(),
+            "heartbeat_interval_s": 30.0,
+            "ttl_s": 120.0,
+        })
+
+    with patch("httpx.post", side_effect=capture_post):
+        yield bridge, captured
+
+
 def _ok_response(json_body):
     resp = MagicMock()
     resp.status_code = 200
@@ -123,6 +148,49 @@ class TestRegisterParticipant:
             bridge.register_participant(party_id="max@local", handle="taude")
         assert "pid" in captured["body"]
         assert isinstance(captured["body"]["pid"], int)
+
+    def test_register_participant_sends_announce_fields(self, bridge_with_capture):
+        """AgentBridge.register_participant forwards ide_detected/via and model_id."""
+        bridge, captured = bridge_with_capture
+        bridge.register_participant(
+            party_id="party_z",
+            handle="laude",
+            ide_detected="vscode",
+            ide_detection_via="env:VSCODE_PID",
+        )
+        body = captured["body"]
+        assert body["ide_detected"] == "vscode"
+        assert body["ide_detection_via"] == "env:VSCODE_PID"
+        # model_id NOT included when not passed (don't send NULL kwargs)
+        assert "model_id" not in body
+
+    def test_register_participant_omits_unset_announce_fields(self, bridge_with_capture):
+        """When kwargs are None, the body omits them entirely."""
+        bridge, captured = bridge_with_capture
+        bridge.register_participant(party_id="party_y", handle="taude")
+        body = captured["body"]
+        assert "ide_detected" not in body
+        assert "ide_detection_via" not in body
+        assert "model_id" not in body
+
+    def test_announce_method_posts_to_announce_endpoint(self, bridge_with_capture):
+        """AgentBridge.announce(participant_id, model_id, ide_override) hits
+        POST /sessions/{participant_id}/announce."""
+        bridge, captured = bridge_with_capture
+        bridge._participant_id = "test-pid-123"
+        bridge.announce(model_id="claude-opus-4-7", ide_override="cursor")
+        assert captured["url"].endswith("/sessions/test-pid-123/announce")
+        body = captured["body"]
+        assert body["model_id"] == "claude-opus-4-7"
+        assert body["ide_override"] == "cursor"
+
+    def test_announce_method_without_ide_override(self, bridge_with_capture):
+        bridge, captured = bridge_with_capture
+        bridge._participant_id = "test-pid-456"
+        bridge.announce(model_id="gpt-5")
+        body = captured["body"]
+        assert body["model_id"] == "gpt-5"
+        assert "ide_override" not in body  # not included when None
 
 
 class TestHeartbeat:

--- a/tests/test_collector_host_label.py
+++ b/tests/test_collector_host_label.py
@@ -26,6 +26,9 @@ def _make_participant(**overrides):
         "last_seen_s_ago": 1.0,
         "agent_kind": None,
         "mcp_host": None,
+        "ide_detected": None,
+        "ide_detection_via": None,
+        "model_id": None,
     }
     base.update(overrides)
     return base
@@ -63,3 +66,68 @@ def test_disconnected_agents_panel_emits_host_label():
     panel = collector._disconnected_agents_panel([p])
     assert panel is not None
     assert panel["entries"][0]["host_label"] == "Claude Code + Antigravity"
+
+
+def test_all_agents_panel_emits_tooltip_fields_when_announced():
+    """Entry has model_pretty/ide_pretty/agent_kind_pretty/ide_detection_via."""
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(
+        agent_kind="claude-code",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="claude-opus-4-7",
+    )
+    panel = collector._all_agents_panel([p])
+    entry = panel["entries"][0]
+    tooltip = entry["tooltip"]
+    assert tooltip["model_label"] == "Claude Opus 4.7"
+    assert tooltip["ide_label"] == "VS Code"
+    assert tooltip["agent_kind_label"] == "Claude Code"
+    assert tooltip["ide_detection_via"] == "env:VSCODE_PID"
+
+
+def test_all_agents_panel_emits_placeholders_when_missing():
+    """Missing fields render as 'Not announced' / 'Not detected' / 'Not set'."""
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant()  # all announce fields None; agent_kind also None
+    panel = collector._all_agents_panel([p])
+    entry = panel["entries"][0]
+    tooltip = entry["tooltip"]
+    assert tooltip["model_label"] == "Not announced"
+    assert tooltip["ide_label"] == "Not detected"
+    assert tooltip["agent_kind_label"] == "Not set"
+
+
+def test_all_agents_panel_emits_unknown_model_id_verbatim():
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(model_id="acme-experimental-7b")
+    panel = collector._all_agents_panel([p])
+    assert panel["entries"][0]["tooltip"]["model_label"] == "acme-experimental-7b"
+
+
+def test_disconnected_agents_panel_also_emits_tooltip():
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(
+        status="stale",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="claude-opus-4-7",
+    )
+    panel = collector._disconnected_agents_panel([p])
+    assert panel is not None
+    tooltip = panel["entries"][0]["tooltip"]
+    assert tooltip["model_label"] == "Claude Opus 4.7"
+    assert tooltip["ide_label"] == "VS Code"
+
+
+def test_participants_panel_also_emits_tooltip():
+    collector = StateCollector(supervisor=_make_supervisor())
+    p = _make_participant(
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="gpt-5",
+    )
+    panel = collector._participants_panel([p])
+    tooltip = panel["entries"][0]["tooltip"]
+    assert tooltip["model_label"] == "GPT-5"
+    assert tooltip["ide_label"] == "VS Code"

--- a/tests/test_helix_announce_plumbing.py
+++ b/tests/test_helix_announce_plumbing.py
@@ -1,0 +1,119 @@
+"""End-to-end plumbing for helix_announce + IDE auto-detect.
+
+Exercises: VSCODE_PID env → adapter detect_ide → POST /sessions/register
+→ POST /sessions/{participant_id}/announce → GET /sessions →
+collector entry has all the right fields. Catches regressions where
+any layer in the chain drops something.
+"""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from helix_context.config import (
+    BudgetConfig,
+    GenomeConfig,
+    HelixConfig,
+    RibosomeConfig,
+    ServerConfig,
+)
+from helix_context.server import create_app
+
+
+class _MinimalMockBackend:
+    """Minimal ribosome mock — only needs to not crash for registry tests."""
+
+    def complete(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+        if "compression engine" in system:
+            return json.dumps({
+                "codons": [{"meaning": "test_codon", "weight": 0.8, "is_exon": True}],
+                "complement": "Compressed test content.",
+                "promoter": {
+                    "domains": ["test"],
+                    "entities": ["TestEntity"],
+                    "intent": "test",
+                    "summary": "Test content for plumbing tests",
+                },
+            })
+        return "{}"
+
+
+@pytest.fixture
+def client():
+    """TestClient backed by a fresh in-memory genome for full isolation."""
+    config = HelixConfig(
+        ribosome=RibosomeConfig(model="mock", timeout=5),
+        budget=BudgetConfig(max_genes_per_turn=4),
+        genome=GenomeConfig(path=":memory:", cold_start_threshold=5),
+        server=ServerConfig(upstream="http://localhost:11434"),
+    )
+    app = create_app(config)
+    app.state.helix.ribosome.backend = _MinimalMockBackend()
+    with TestClient(app) as c:
+        yield c
+
+
+def test_register_then_announce_round_trips_through_get_sessions(client):
+    """Full plumbing: simulated MCP startup populates ide_detected via the
+    body fields the adapter would have sent; agent then announces model_id;
+    GET /sessions reflects both."""
+
+    # Stage 1 — adapter posts the detected IDE at register time
+    reg_resp = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "swift_wing21",
+            "handle": "laude",
+            "workspace": "F:\\Projects",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+            "agent_kind": "claude-code",  # backward-compat from PR #26
+        },
+    )
+    assert reg_resp.status_code == 200, reg_resp.text
+    pid = reg_resp.json()["participant_id"]
+
+    # Stage 2 — agent announces its model
+    ann_resp = client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "claude-opus-4-7"},
+    )
+    assert ann_resp.status_code == 200, ann_resp.text
+
+    # Stage 3 — GET projection reflects both
+    listing = client.get("/sessions", params={"party_id": "swift_wing21", "status": "all"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert len(matching) == 1, f"expected one matching row, got: {rows}"
+    row = matching[0]
+    assert row["ide_detected"] == "vscode"
+    assert row["ide_detection_via"] == "env:VSCODE_PID"
+    assert row["model_id"] == "claude-opus-4-7"
+    assert row["agent_kind"] == "claude-code"
+
+
+def test_announce_with_ide_override_changes_via_to_agent_override(client):
+    """Agent override path: register with one IDE, announce with override,
+    confirm ide_detection_via flips to agent_override."""
+    reg = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "party_override",
+            "handle": "laude",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+        },
+    )
+    pid = reg.json()["participant_id"]
+
+    client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "gpt-5", "ide_override": "cursor"},
+    )
+
+    listing = client.get("/sessions", params={"party_id": "party_override", "status": "all"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    row = rows[0] if rows else {}
+    assert row["ide_detected"] == "cursor"
+    assert row["ide_detection_via"] == "agent_override"
+    assert row["model_id"] == "gpt-5"

--- a/tests/test_ide_fingerprint.py
+++ b/tests/test_ide_fingerprint.py
@@ -1,0 +1,68 @@
+"""Env-var fingerprint chain for detecting which IDE/CLI spawned the
+MCP adapter.
+
+Exercises:
+- HELIX_MCP_HOST explicit override (highest priority, "explicit:..." via)
+- VSCODE_PID present → ("vscode", "env:VSCODE_PID")
+- CURSOR_TRACE_ID present → ("cursor", "env:CURSOR_TRACE_ID")
+- nothing matches → (None, "no_match")
+- "unknown" sentinel for HELIX_MCP_HOST falls through, doesn't trigger explicit branch
+"""
+import pytest
+
+from helix_context.launcher.ide_fingerprint import detect_ide
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip every env var the chain might read so each test is isolated."""
+    for key in (
+        "HELIX_MCP_HOST",
+        "VSCODE_PID",
+        "VSCODE_IPC_HOOK",
+        "CURSOR_TRACE_ID",
+        "TERM_PROGRAM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_explicit_helix_mcp_host_wins(monkeypatch):
+    monkeypatch.setenv("HELIX_MCP_HOST", "claude-code")
+    monkeypatch.setenv("VSCODE_PID", "1234")  # would otherwise win
+    assert detect_ide() == ("claude-code", "explicit:HELIX_MCP_HOST")
+
+
+def test_helix_mcp_host_unknown_sentinel_falls_through(monkeypatch):
+    """HELIX_MCP_HOST=unknown is the legacy default — treat as unset."""
+    monkeypatch.setenv("HELIX_MCP_HOST", "unknown")
+    monkeypatch.setenv("VSCODE_PID", "1234")
+    assert detect_ide() == ("vscode", "env:VSCODE_PID")
+
+
+def test_vscode_pid_detects_vscode(monkeypatch):
+    monkeypatch.setenv("VSCODE_PID", "1234")
+    assert detect_ide() == ("vscode", "env:VSCODE_PID")
+
+
+def test_cursor_trace_id_detects_cursor(monkeypatch):
+    monkeypatch.setenv("CURSOR_TRACE_ID", "abc-123")
+    assert detect_ide() == ("cursor", "env:CURSOR_TRACE_ID")
+
+
+def test_vscode_priority_over_cursor(monkeypatch):
+    """If both env vars are set (shouldn't happen in practice but make the
+    behavior deterministic), VSCODE_PID wins because it's earlier in the chain."""
+    monkeypatch.setenv("VSCODE_PID", "1234")
+    monkeypatch.setenv("CURSOR_TRACE_ID", "abc-123")
+    assert detect_ide() == ("vscode", "env:VSCODE_PID")
+
+
+def test_no_match_returns_none(monkeypatch):
+    """All env vars stripped — no signal."""
+    assert detect_ide() == (None, "no_match")
+
+
+def test_empty_string_env_treated_as_unset(monkeypatch):
+    """An empty VSCODE_PID is not a real signal."""
+    monkeypatch.setenv("VSCODE_PID", "")
+    assert detect_ide() == (None, "no_match")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,8 @@ from helix_context.mcp_server import _default_ingest_identity, _normalize_health
 def mock_bridge(monkeypatch):
     class _MockBridge:
         register_participant_calls = []
+        announce_calls = []
+        _participant_id = "mock-participant-id"
 
         def __init__(self, *args, **kwargs):
             pass
@@ -17,8 +19,17 @@ def mock_bridge(monkeypatch):
             type(self).register_participant_calls.append(kwargs)
             return "mock-participant-id"
 
+        @classmethod
+        def announce(cls, model_id, ide_override=None):
+            cls.announce_calls.append({
+                "model_id": model_id,
+                "ide_override": ide_override,
+            })
+            return True
+
     monkeypatch.setattr("helix_context.bridge.AgentBridge", _MockBridge)
     _MockBridge.register_participant_calls = []  # reset between tests
+    _MockBridge.announce_calls = []
     yield _MockBridge
 
 
@@ -142,3 +153,48 @@ class TestRegisterWithRegistry:
         call = mock_bridge.register_participant_calls[-1]
         assert call["agent_kind"] is None
         assert call["mcp_host"] == "antigravity"
+
+
+def test_register_with_registry_calls_detect_ide(monkeypatch, mock_bridge):
+    """_register_with_registry calls detect_ide() and forwards both fields."""
+    monkeypatch.setenv("HELIX_MCP_HANDLE", "laude")
+    monkeypatch.setenv("HELIX_PARTY_ID", "swift_wing21")
+    monkeypatch.delenv("HELIX_MCP_HOST", raising=False)
+    monkeypatch.setenv("VSCODE_PID", "9999")
+
+    from helix_context import mcp_server
+    mcp_server._register_with_registry()
+
+    call = mock_bridge.register_participant_calls[-1]
+    assert call["ide_detected"] == "vscode"
+    assert call["ide_detection_via"] == "env:VSCODE_PID"
+
+
+def test_register_with_registry_no_match_sends_none(monkeypatch, mock_bridge):
+    """When fingerprint chain has no signal, ide_detected is None and via is no_match."""
+    monkeypatch.setenv("HELIX_MCP_HANDLE", "laude")
+    monkeypatch.setenv("HELIX_PARTY_ID", "swift_wing21")
+    monkeypatch.delenv("HELIX_MCP_HOST", raising=False)
+    monkeypatch.delenv("VSCODE_PID", raising=False)
+    monkeypatch.delenv("CURSOR_TRACE_ID", raising=False)
+
+    from helix_context import mcp_server
+    mcp_server._register_with_registry()
+
+    call = mock_bridge.register_participant_calls[-1]
+    assert call["ide_detected"] is None
+    assert call["ide_detection_via"] == "no_match"
+
+
+def test_helix_announce_tool_calls_bridge_announce(monkeypatch, mock_bridge):
+    """The helix_announce MCP tool delegates to AgentBridge.announce()."""
+    from helix_context import mcp_server
+    # Force the module to think it's registered so helix_announce proceeds
+    mcp_server._registered_bridge = mock_bridge
+    result = mcp_server.helix_announce(
+        model_id="claude-opus-4-7",
+        ide_override=None,
+    )
+    call = mock_bridge.announce_calls[-1]
+    assert call["model_id"] == "claude-opus-4-7"
+    assert call["ide_override"] is None

--- a/tests/test_model_labels.py
+++ b/tests/test_model_labels.py
@@ -1,0 +1,34 @@
+"""Pretty-label module for model_id strings.
+
+Same pattern as host_labels: known IDs map to canonical display form,
+unknown IDs echo verbatim, None/empty returns None.
+"""
+from helix_context.launcher.model_labels import model_pretty
+
+
+def test_known_anthropic_models():
+    assert model_pretty("claude-opus-4-7") == "Claude Opus 4.7"
+    assert model_pretty("claude-sonnet-4-6") == "Claude Sonnet 4.6"
+    assert model_pretty("claude-haiku-4-5") == "Claude Haiku 4.5"
+
+
+def test_known_anthropic_with_context_qualifier():
+    assert model_pretty("claude-opus-4-7-1m") == "Claude Opus 4.7 (1M context)"
+
+
+def test_known_openai_models():
+    assert model_pretty("gpt-5") == "GPT-5"
+
+
+def test_known_google_models():
+    assert model_pretty("gemini-2-5-pro") == "Gemini 2.5 Pro"
+
+
+def test_unknown_model_id_echoes_verbatim():
+    """Don't fabricate a pretty form — echo what the agent reported."""
+    assert model_pretty("acme-experimental-7b") == "acme-experimental-7b"
+
+
+def test_none_returns_none():
+    assert model_pretty(None) is None
+    assert model_pretty("") is None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1258,3 +1258,115 @@ def test_participant_info_defaults_announce_fields_to_none():
     assert p.ide_detected is None
     assert p.ide_detection_via is None
     assert p.model_id is None
+
+
+def test_register_participant_persists_announce_fields(registry, genome):
+    p = registry.register_participant(
+        party_id="party_a",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    assert p.ide_detected == "vscode"
+    assert p.ide_detection_via == "env:VSCODE_PID"
+    assert p.model_id is None  # not yet announced
+
+    cur = genome.conn.cursor()
+    row = cur.execute(
+        "SELECT ide_detected, ide_detection_via, model_id "
+        "FROM participants WHERE participant_id = ?",
+        (p.participant_id,),
+    ).fetchone()
+    assert row[0] == "vscode"
+    assert row[1] == "env:VSCODE_PID"
+    assert row[2] is None
+
+
+def test_register_participant_omitting_announce_fields_stores_null(registry):
+    p = registry.register_participant(party_id="party_b", handle="taude")
+    assert p.ide_detected is None
+    assert p.ide_detection_via is None
+    assert p.model_id is None
+
+
+def test_list_participants_projects_announce_fields(registry):
+    registry.register_participant(
+        party_id="party_c",
+        handle="laude",
+        ide_detected="cursor",
+        ide_detection_via="env:CURSOR_TRACE_ID",
+    )
+    rows = registry.list_participants(party_id="party_c", status_filter="all")
+    assert len(rows) == 1
+    assert rows[0].ide_detected == "cursor"
+    assert rows[0].ide_detection_via == "env:CURSOR_TRACE_ID"
+    assert rows[0].model_id is None
+
+
+def test_get_participant_projects_announce_fields(registry):
+    p = registry.register_participant(
+        party_id="party_d",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched is not None
+    assert fetched.ide_detected == "vscode"
+    assert fetched.model_id is None
+
+
+def test_update_announcement_sets_model_id(registry):
+    p = registry.register_participant(
+        party_id="party_e",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    registry.update_announcement(
+        participant_id=p.participant_id,
+        model_id="claude-opus-4-7",
+    )
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched.model_id == "claude-opus-4-7"
+    # IDE should be unchanged when no override is supplied
+    assert fetched.ide_detected == "vscode"
+    assert fetched.ide_detection_via == "env:VSCODE_PID"
+
+
+def test_update_announcement_with_ide_override_sets_via_to_agent_override(registry):
+    p = registry.register_participant(
+        party_id="party_f",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+    )
+    registry.update_announcement(
+        participant_id=p.participant_id,
+        model_id="gpt-5",
+        ide_override="cursor",
+    )
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched.ide_detected == "cursor"
+    assert fetched.ide_detection_via == "agent_override"
+    assert fetched.model_id == "gpt-5"
+
+
+def test_update_announcement_is_idempotent(registry):
+    """Multiple calls overwrite — last write wins."""
+    p = registry.register_participant(party_id="party_g", handle="laude")
+    registry.update_announcement(participant_id=p.participant_id, model_id="claude-opus-4-7")
+    registry.update_announcement(participant_id=p.participant_id, model_id="claude-sonnet-4-6")
+    fetched = registry.get_participant(p.participant_id)
+    assert fetched.model_id == "claude-sonnet-4-6"
+
+
+def test_update_announcement_unknown_participant_id_silent_no_op(registry):
+    """Calling update_announcement on an unknown id should not raise.
+    The registry's existing heartbeat() updates silently no-op on unknown
+    ids, and update_announcement should match that contract."""
+    registry.update_announcement(
+        participant_id="does-not-exist",
+        model_id="claude-opus-4-7",
+    )
+    # Should not raise. No further assertion needed.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -137,6 +137,14 @@ class TestSchemaMigration:
         genome._ensure_registry_schema(cur)
         genome.conn.commit()
 
+    def test_participants_table_has_announce_columns(self, genome):
+        """Schema migration adds ide_detected, ide_detection_via, model_id columns."""
+        cur = genome.conn.cursor()
+        cols = {r[1] for r in cur.execute("PRAGMA table_info(participants)").fetchall()}
+        assert "ide_detected" in cols, f"ide_detected missing; got {cols}"
+        assert "ide_detection_via" in cols, f"ide_detection_via missing; got {cols}"
+        assert "model_id" in cols, f"model_id missing; got {cols}"
+
 
 class TestRegisterParticipant:
     def test_register_creates_party_on_first_use(self, registry, genome):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1210,3 +1210,51 @@ def test_get_participant_projects_vendor_host(registry):
     assert fetched is not None
     assert fetched.agent_kind == "gemini"
     assert fetched.mcp_host == "antigravity"
+
+
+def test_participant_model_accepts_announce_fields():
+    from helix_context.schemas import Participant
+    p = Participant(
+        participant_id="abc",
+        party_id="party",
+        handle="laude",
+        ide_detected="vscode",
+        ide_detection_via="env:VSCODE_PID",
+        model_id="claude-opus-4-7",
+    )
+    assert p.ide_detected == "vscode"
+    assert p.ide_detection_via == "env:VSCODE_PID"
+    assert p.model_id == "claude-opus-4-7"
+
+
+def test_participant_info_accepts_announce_fields():
+    from helix_context.schemas import ParticipantInfo
+    p = ParticipantInfo(
+        participant_id="abc",
+        party_id="party",
+        handle="laude",
+        status="active",
+        last_seen_s_ago=0.0,
+        started_at=0.0,
+        ide_detected="cursor",
+        ide_detection_via="env:CURSOR_TRACE_ID",
+        model_id="gpt-5",
+    )
+    assert p.ide_detected == "cursor"
+    assert p.ide_detection_via == "env:CURSOR_TRACE_ID"
+    assert p.model_id == "gpt-5"
+
+
+def test_participant_info_defaults_announce_fields_to_none():
+    from helix_context.schemas import ParticipantInfo
+    p = ParticipantInfo(
+        participant_id="abc",
+        party_id="party",
+        handle="laude",
+        status="active",
+        last_seen_s_ago=0.0,
+        started_at=0.0,
+    )
+    assert p.ide_detected is None
+    assert p.ide_detection_via is None
+    assert p.model_id is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1168,3 +1168,84 @@ class TestSessionsRegister:
         assert len(matching) == 1
         assert matching[0].get("agent_kind") is None
         assert matching[0].get("mcp_host") is None
+
+
+# -- Announce endpoint tests -------------------------------------------
+
+
+def test_sessions_register_accepts_announce_fields(client):
+    resp = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "party_register_announce",
+            "handle": "laude",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["participant_id"]
+
+    listing = client.get("/sessions", params={"party_id": "party_register_announce"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert len(matching) == 1
+    assert matching[0]["ide_detected"] == "vscode"
+    assert matching[0]["ide_detection_via"] == "env:VSCODE_PID"
+    assert matching[0].get("model_id") is None
+
+
+def test_announce_endpoint_sets_model_id(client):
+    """POST /sessions/{participant_id}/announce updates model_id."""
+    reg = client.post(
+        "/sessions/register",
+        json={"party_id": "party_announce", "handle": "laude"},
+    )
+    pid = reg.json()["participant_id"]
+
+    resp = client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "claude-opus-4-7"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    listing = client.get("/sessions", params={"party_id": "party_announce"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert matching[0]["model_id"] == "claude-opus-4-7"
+
+
+def test_announce_endpoint_with_ide_override_sets_agent_override_via(client):
+    reg = client.post(
+        "/sessions/register",
+        json={
+            "party_id": "party_override",
+            "handle": "laude",
+            "ide_detected": "vscode",
+            "ide_detection_via": "env:VSCODE_PID",
+        },
+    )
+    pid = reg.json()["participant_id"]
+
+    resp = client.post(
+        f"/sessions/{pid}/announce",
+        json={"model_id": "gpt-5", "ide_override": "cursor"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    listing = client.get("/sessions", params={"party_id": "party_override"}).json()
+    rows = listing if isinstance(listing, list) else listing.get("participants", [])
+    matching = [r for r in rows if r.get("participant_id") == pid]
+    assert matching[0]["ide_detected"] == "cursor"
+    assert matching[0]["ide_detection_via"] == "agent_override"
+    assert matching[0]["model_id"] == "gpt-5"
+
+
+def test_announce_endpoint_unknown_participant_returns_200(client):
+    """Silent no-op on unknown participant_id matches registry semantics
+    and avoids leaking participant existence via 404 vs 200 distinction."""
+    resp = client.post(
+        "/sessions/does-not-exist/announce",
+        json={"model_id": "claude-opus-4-7"},
+    )
+    assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Stacked on #26. Replaces the brittle vendor-name → host inference with two layers of authoritative data plus an on-hover tooltip:

- **IDE auto-detect** — adapter-side env-var fingerprint at register time (`VSCODE_PID` → vscode, `CURSOR_TRACE_ID` → cursor, falls back to explicit `HELIX_MCP_HOST` override). No client config required for VS Code / Cursor.
- **Agent self-report** — new `helix_announce(model_id, ide_override?)` MCP tool. Agent calls it once after first `helix_health` to declare its model. Optional `ide_override` flips `ide_detection_via='agent_override'`.
- **Dashboard tooltip** — CSS-only `:hover` reveal on the agent-host chip from #26. Surface chip stays compact; tooltip shows Model / Wrapper / IDE rows + the `ide_detection_via` diagnostic. Explicit "Not announced/detected/set" placeholders — no hardcoded inference.

Three new participants columns: `ide_detected`, `ide_detection_via`, `model_id`. Idempotent ALTER TABLE; backward-compat fallback to #26's `mcp_host` for sessions registered before this change.

## Why

The "Codex + codex" rendering on the dashboard exposed that PR #26 had no way to distinguish CLI vendor from host IDE without each MCP client sending the right env block. This PR removes that requirement: VS Code/Cursor are detected automatically, and the agent fills in the model itself.

## What changed

- **New module** `helix_context/launcher/ide_fingerprint.py` — pure-function `detect_ide()`
- **New module** `helix_context/launcher/model_labels.py` — pretty-map for known model IDs (Claude 4.x, GPT-5, Gemini 2.5 Pro); unknown IDs echo verbatim
- **New endpoint** `POST /sessions/{participant_id}/announce` (returns 200 silently on unknown id, last-write-wins)
- **New MCP tool** `helix_announce`
- **Schema/registry/bridge** plumbing for the 3 new fields
- **Templates + CSS** wrap chip in `.chip-with-tooltip` (3 occurrences in agents_panel + 1 in participants_panel); CSS uses `var(--color-border)` for theme consistency
- **SKILL.md** workflow item 7 instructs agents to call `helix_announce`
- **Docs** updated in `docs/clients/claude-code.md` and `docs/architecture/SESSION_REGISTRY.md`
- **End-to-end plumbing test** `tests/test_helix_announce_plumbing.py` covers the full chain

## Test plan

- [ ] Restart Helix + relaunch the launcher dashboard
- [ ] Open Helix from VS Code Claude Code session — chip shows "Claude Code + VS Code"
- [ ] Hover the chip — tooltip appears with Model / Wrapper / IDE rows
- [ ] Model row shows the announced model (e.g., "Claude Opus 4.7 (1M context)") if agent has called `helix_announce`; otherwise "Not announced"
- [ ] IDE row shows "VS Code (env:VSCODE_PID)"
- [ ] Repeat from a Codex session — IDE row should show "VS Code (env:VSCODE_PID)" via auto-detect, not "Codex"
- [ ] Old participants without the new columns still render (mcp_host fallback path)

## Follow-ups (non-blocking)

- Empty-string `model_id` flows through `COALESCE` and overwrites prior value with `""`. Cosmetically harmless (renders "Not announced" via `model_pretty`) but a `model_id != ""` guard in `update_announcement` would tighten it. Confidence below threshold for blocking.
- `bottom: 100%` tooltip positioning may clip when chip is at top of viewport. Out of CSS-only scope.
- Antigravity / Claude Desktop env-var branches in `ide_fingerprint.py` (no documented sentinel env vars per host yet).

## Reviews

All 13 tasks passed two-stage review (spec compliance + code quality) per the subagent-driven-development workflow. Final whole-branch review verdict: READY_TO_MERGE — field-name consistency verified across all 9 layers; idempotent migration; backward-compat preserved.

Test count: 1341 passed (+2 from this branch's plumbing tests), 26 pre-existing failures unrelated to this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)