### PR TITLE
chore(tests): graceful skip for missing optional deps (closes #28)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ scorerift = ["scorerift"]
 # CPU-resident semantic compression for gene content. Headroom by Tejas Chopra
 # (https://github.com/chopratejas/headroom, Apache-2.0). See NOTICE.
 codec = ["headroom-ai[proxy,code]>=0.5.21"]
-dev = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "numpy", "spacy>=3.7"]
 # `all` covers the full feature surface minus contributor-only extras
 # (dev) and the LGPL launcher-tray variant. Dep bulk dominated by
 # sentence-transformers + torch + spacy + tree-sitter + headroom-ai.

--- a/tests/test_fusion_plr.py
+++ b/tests/test_fusion_plr.py
@@ -9,10 +9,15 @@ import hashlib
 import json
 from pathlib import Path
 
-import joblib
-import numpy as np
 import pytest
-from sklearn.ensemble import GradientBoostingClassifier
+
+pytest.importorskip("numpy", reason="fusion_plr stacked head needs numpy")
+pytest.importorskip("sklearn", reason="fusion_plr stacked head needs scikit-learn")
+pytest.importorskip("joblib", reason="fusion_plr stacked head needs joblib")
+
+import joblib  # noqa: E402
+import numpy as np  # noqa: E402
+from sklearn.ensemble import GradientBoostingClassifier  # noqa: E402
 
 from helix_context import fusion_plr
 from helix_context.fusion_plr import (

--- a/tests/test_ray_trace_theta.py
+++ b/tests/test_ray_trace_theta.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 
 import math
 
-import numpy as np
 import pytest
 
-from helix_context.ray_trace import (
+pytest.importorskip("numpy", reason="theta-bias tests use numpy for vector math")
+
+import numpy as np  # noqa: E402
+
+from helix_context.ray_trace import (  # noqa: E402
     _theta_choice,
     cast_evidence_rays,
 )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -20,6 +20,12 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
+try:
+    import pytest_asyncio  # noqa: F401
+    _PYTEST_ASYNCIO_AVAILABLE = True
+except ImportError:
+    _PYTEST_ASYNCIO_AVAILABLE = False
+
 
 async def await_until(condition, timeout: float = 2.0, interval: float = 0.02) -> bool:
     """Await ``condition()`` returning truthy, polling every ``interval``
@@ -489,6 +495,10 @@ class TestSweep:
         assert row["status"] == "stale"
 
 
+@pytest.mark.skipif(
+    not _PYTEST_ASYNCIO_AVAILABLE,
+    reason="async tests require pytest-asyncio (install via pip install -e .[dev])",
+)
 class TestBackgroundSweepTask:
     """Item 7 — _background_registry_sweep async helper.
 

--- a/tests/test_tagger_filename_domains.py
+++ b/tests/test_tagger_filename_domains.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("spacy", reason="CpuTagger imports spacy at runtime via _get_nlp()")
+
 from helix_context.tagger import CpuTagger
 
 _TAGGER = None


### PR DESCRIPTION
Closes #28.

## Summary

Test suite previously reported **26 failures + 2 collection errors** on a minimal install — most caused by optional dependencies that crashed at import or marker registration instead of skipping cleanly. This PR makes the suite well-behaved on partial installs and provides a one-shot install path for full coverage.

## Changes

- **`pyproject.toml`** — `[dev]` extra now pulls `numpy` + `spacy>=3.7` alongside the existing `pytest` + `pytest-asyncio`. A single `pip install -e ".[dev]"` now runs the full mock suite.
- **`tests/test_tagger_filename_domains.py`** — `pytest.importorskip("spacy")` at module top (the tagger does runtime `import spacy` inside `_get_nlp()`).
- **`tests/test_fusion_plr.py`** — `pytest.importorskip` for numpy, sklearn, and joblib.
- **`tests/test_ray_trace_theta.py`** — `pytest.importorskip("numpy")`.
- **`tests/test_registry.py`** — `TestBackgroundSweepTask` now skips at class level when `pytest-asyncio` is missing (try/except import + `pytest.mark.skipif`), with a hint to `pip install -e .[dev]`.

## Test impact (without installing deps)

| | Before | After |
|---|---|---|
| Failed | 26 | 16 |
| Passed | 1339 | 1267 |
| Skipped | 50 | 60 |
| Collection errors | 2 | 0 |

10 noisy failures + 2 errors are now graceful skips. The remaining 16 failures are all test/implementation drift — tracked separately in #29.

## After this merges

Contributors should run `pip install -e ".[dev]"` to get the full test suite running locally. CI configs that target `[dev]` will automatically pick up numpy/spacy on the next run.

## Test plan

- [ ] `pip install -e ".[dev]"` then `pytest tests/ -m "not live"` — should run all the now-guarded tests instead of skipping them
- [ ] `pip install -e .` (no extras) then same command — should report 16 failed (drift from #29) + ~60 skipped, no collection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)