### PR TITLE
fix(genome): release reader WAL snapshot + cap journal_size_limit

### DIFF
--- a/helix_context/genome.py
+++ b/helix_context/genome.py
@@ -372,6 +372,9 @@ class Genome:
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute("PRAGMA busy_timeout=30000")  # 30s retry on lock
+        # Cap WAL file size — without this, SQLite resets (zero-fills) the
+        # WAL on truncate but keeps the high-water-mark size on disk.
+        self.conn.execute("PRAGMA journal_size_limit=67108864")  # 64 MB
         self._upsert_count = 0  # WAL checkpoint cadence counter
         self.last_query_scores: Dict[str, float] = {}  # Retrieval scores from last query
         # Per-tier score breakdown for the last query: {gene_id: {tier_name: score}}.
@@ -391,10 +394,15 @@ class Genome:
 
         # Dedicated read-only connection — WAL allows concurrent readers
         # without blocking the writer. Separate connection = no lock contention.
+        # isolation_level=None makes Python's sqlite3 module skip the implicit
+        # BEGIN around SELECTs. Without it, the first read pins a WAL snapshot
+        # for the lifetime of the process and prevents wal_checkpoint(TRUNCATE)
+        # from advancing — which is the dominant cause of WAL bloat.
         if self.path != ":memory:":
             self._reader = sqlite3.connect(
                 f"file:{self.path}?mode=ro", uri=True,
                 check_same_thread=False, timeout=10,
+                isolation_level=None,
             )
             self._reader.row_factory = sqlite3.Row
             self._reader.execute("PRAGMA busy_timeout=10000")
@@ -3121,6 +3129,7 @@ class Genome:
             self.conn.row_factory = sqlite3.Row
             self.conn.execute("PRAGMA journal_mode=WAL")
             self.conn.execute("PRAGMA busy_timeout=30000")
+            self.conn.execute("PRAGMA journal_size_limit=67108864")  # 64 MB
 
     # ── Close ───────────────────────────────────────────────────────
 
@@ -3140,8 +3149,29 @@ class Genome:
         if mode not in ("PASSIVE", "FULL", "RESTART", "TRUNCATE"):
             mode = "PASSIVE"
         try:
-            self.conn.execute(f"PRAGMA wal_checkpoint({mode})")
-            log.debug("WAL checkpoint (%s) completed", mode)
+            # Best-effort: release the reader's WAL snapshot before checkpointing
+            # so a TRUNCATE can actually advance. Safe no-op when the reader is
+            # already in autocommit mode (isolation_level=None).
+            if self._reader is not None:
+                try:
+                    self._reader.commit()
+                except Exception:
+                    pass
+            row = self.conn.execute(
+                f"PRAGMA wal_checkpoint({mode})"
+            ).fetchone()
+            # Returns (busy, log_pages, checkpointed_pages). busy=1 means a
+            # reader was holding a snapshot and the checkpoint was incomplete.
+            if row and row[0]:
+                log.warning(
+                    "WAL checkpoint (%s) blocked by reader: %d/%d pages flushed",
+                    mode, row[2] or 0, row[1] or 0,
+                )
+            else:
+                log.debug(
+                    "WAL checkpoint (%s) completed: %d pages flushed",
+                    mode, (row[2] if row else 0) or 0,
+                )
         except Exception:
             log.warning("WAL checkpoint (%s) failed", mode, exc_info=True)
 
@@ -3195,6 +3225,7 @@ class Genome:
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute("PRAGMA busy_timeout=30000")
+        self.conn.execute("PRAGMA journal_size_limit=67108864")  # 64 MB
 
         after = os.path.getsize(path) if os.path.exists(path) else 0
         reclaimed = before - after

--- a/tests/test_genome_wal.py
+++ b/tests/test_genome_wal.py
@@ -1,0 +1,76 @@
+"""WAL-mode behavior on the file-backed Genome.
+
+Regression tests for the bloat fix in fix/wal-bloat-reader-snapshot:
+the dedicated read-only connection must not pin a WAL snapshot that
+prevents wal_checkpoint(TRUNCATE) from advancing.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from helix_context.genome import Genome
+from tests.conftest import make_gene
+
+
+def _file_genome(tmp_path) -> Genome:
+    return Genome(path=str(tmp_path / "genome.db"), synonym_map={})
+
+
+class TestWalCheckpointAfterReads:
+    def test_truncate_checkpoint_succeeds_after_reader_select(self, tmp_path):
+        """After a SELECT on the dedicated reader, a TRUNCATE checkpoint
+        must report busy=0 (i.e., the reader did NOT pin a snapshot)."""
+        g = _file_genome(tmp_path)
+        try:
+            g.upsert_gene(make_gene("seed gene"))
+            # First read on the dedicated reader — pre-fix this would
+            # start an implicit transaction that pins WAL frames.
+            g.read_conn.execute("SELECT COUNT(*) FROM genes").fetchone()
+
+            row = g.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            assert row is not None, "wal_checkpoint returned no row"
+            busy, log_pages, ckpt_pages = row
+            assert busy == 0, (
+                f"TRUNCATE checkpoint blocked by reader (busy={busy}); "
+                f"reader's implicit transaction is still pinning the WAL"
+            )
+        finally:
+            g.close()
+
+    def test_journal_size_limit_pragma_applied(self, tmp_path):
+        """The 64MB journal_size_limit must be set on the writer."""
+        g = _file_genome(tmp_path)
+        try:
+            row = g.conn.execute("PRAGMA journal_size_limit").fetchone()
+            assert row is not None
+            assert row[0] == 67108864, (
+                f"expected journal_size_limit=67108864, got {row[0]}"
+            )
+        finally:
+            g.close()
+
+    def test_wal_size_stays_bounded_under_repeated_writes(self, tmp_path):
+        """Sanity: writes + reads + checkpoints keep the WAL file under
+        the configured limit. Pre-fix, the WAL would grow without bound
+        because checkpoints couldn't truncate past the reader snapshot."""
+        g = _file_genome(tmp_path)
+        try:
+            wal_path = str(tmp_path / "genome.db-wal")
+            for i in range(50):
+                g.upsert_gene(make_gene(f"gene number {i}"))
+                # interleave a read so the reader has a fresh statement
+                g.read_conn.execute("SELECT COUNT(*) FROM genes").fetchone()
+                if i % 10 == 9:
+                    g.checkpoint("TRUNCATE")
+            wal_size = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
+            # 1 MB ceiling — generous; pre-fix bloats well past this on
+            # the same workload because the reader pins frames.
+            assert wal_size < 1_000_000, (
+                f"WAL file grew to {wal_size:,} bytes — checkpoint is "
+                f"failing to advance (reader likely still pinning a snapshot)"
+            )
+        finally:
+            g.close()


### PR DESCRIPTION
## Symptom

WAL file (\`genome.db-wal\`) bloats without bound under multi-agent load. Observed by the operator as the WAL file growing into hundreds of MB / GB during normal operation, with progressive slowdown.

## Diagnosis

Three causes in \`helix_context/genome.py\`, in order of contribution:

### 1. Reader connection pins a WAL snapshot for the entire process lifetime

The dedicated read-only connection at [genome.py:395-400](helix_context/genome.py#L395-L400) uses Python sqlite3's default \`isolation_level=\"\"\` (deferred). That wraps every \`SELECT\` in an implicit \`BEGIN\`. The first read on the reader starts a transaction that **never ends** — there's no \`commit()\`/\`rollback()\` on \`self._reader\` anywhere in the 3545-line file except \`close()\` at shutdown.

In WAL mode, an open reader transaction pins the snapshot. \`wal_checkpoint(TRUNCATE)\` cannot advance past it. The codebase already documented this exact failure mode in \`_refresh_snapshot()\` ([genome.py:1044-1058](helix_context/genome.py#L1044-L1058)) — but the method only refreshes the writer connection, not the reader.

**Fix:** \`isolation_level=None\` on the reader. For a read-only connection there's nothing to manage — every \`SELECT\` autocommits and the snapshot releases on completion.

### 2. No \`journal_size_limit\` set

Even when checkpoints DO succeed, SQLite's default behavior is to RESET the WAL file (zero-fill in place) rather than physically truncate it. The file size stays at high-water mark unless capped.

**Fix:** \`PRAGMA journal_size_limit=67108864\` (64MB) applied at all three WAL-mode-set sites.

### 3. \`checkpoint()\` was silently no-op'ing

[genome.py:3127-3146](helix_context/genome.py#L3127-L3146) ran \`PRAGMA wal_checkpoint(MODE)\` and logged success/failure based on whether the call raised. But checkpoint failures from a blocking reader **don't raise** — they return \`(busy=1, log_pages, checkpointed_pages)\`. The old code logged \`\"completed\"\` even when the reader was blocking and nothing flushed.

**Fix:** inspect the return tuple. Warn loudly when \`busy != 0\`. Defensively \`commit()\` the reader before checkpointing as belt-and-suspenders for #1.

## Test coverage

New \`tests/test_genome_wal.py\` (3 tests):
- \`test_truncate_checkpoint_succeeds_after_reader_select\` — asserts \`busy == 0\` after a reader \`SELECT\`. Pre-fix: fails with \`busy == 1\`.
- \`test_journal_size_limit_pragma_applied\` — asserts the 64MB cap is set.
- \`test_wal_size_stays_bounded_under_repeated_writes\` — 50 interleaved writes+reads+checkpoints; asserts WAL stays under 1MB.

All 3 pass. Full \`tests/test_genome.py\` (38 tests) still passes.

## Operational notes

- After merge, on the running server, run \`PRAGMA wal_checkpoint(TRUNCATE)\` once via the existing \`/admin/vacuum\` endpoint or a server restart to clear the existing bloat. The fix prevents new bloat; it does not retroactively shrink the on-disk file.
- Watch for the new \`WAL checkpoint blocked by reader\` warning. It should be rare; if you see it spike, there's another long-lived reader path that wasn't migrated to autocommit.

## Test plan

- [ ] \`pytest tests/test_genome_wal.py\` — 3 passed
- [ ] \`pytest tests/test_genome.py\` — 38 passed (regression baseline)
- [ ] After merge, restart the server and watch \`genome.db-wal\` size over a multi-agent session
- [ ] If WAL still grows, the new \`busy=1\` warning will identify which checkpoint cycle is blocked

## Related

- Operator-reported symptom: \"20-40s delays when multiple agents are interacting + WAL file bloating\"
- Follow-up: GitHub Discussion on SQLite alternatives that scale better for many concurrent agents (separate from this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)