### PR TITLE
feat(telemetry): per-stage pipeline + genome signal histograms

### DIFF
--- a/docs/dashboards/helix-pipeline.json
+++ b/docs/dashboards/helix-pipeline.json
@@ -1,0 +1,273 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource connected to the OTel collector",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "9.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "heatmap", "name": "Heatmap", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Helix-context per-stage pipeline latency, ribosome call timing, genome signal profiling, WAL health, and concurrent /context load.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Pipeline Stage Latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p95 latency per /context pipeline stage stacked — extract, express, rerank, splice, assemble.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["p95"], "displayMode": "table", "placement": "right" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (stage, le) (rate(helix_pipeline_stage_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Stage Latency p95 (stacked)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 101,
+      "title": "Ribosome Call Latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Heatmap of helix_ribosome_call_seconds across all call_kinds and backends.",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "scheme" }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 2,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": { "scheme": "Blues", "steps": 64 },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "yAxis": { "decimals": 2, "unit": "s" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (le) (rate(helix_ribosome_call_seconds_bucket[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ribosome Call Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p95 ribosome call latency broken out by call_kind (pack, rerank, splice, replicate).",
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["p95", "mean"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (call_kind, le) (rate(helix_ribosome_call_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{call_kind}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ribosome p95 by call_kind",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 102,
+      "title": "Genome Signal Timing",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p95 latency per retrieval signal (pki, tag_exact, tag_prefix, fts5, splade, sema_boost).",
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["p95", "mean"], "displayMode": "table", "placement": "right" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (signal, le) (rate(helix_genome_signal_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{signal}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Genome Signal p95 Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 103,
+      "title": "WAL Health & Load",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "SQLite WAL file size in bytes. Sustained growth indicates checkpoint pressure.",
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 33554432 },
+              { "color": "red", "value": 67108864 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 28 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "helix_genome_wal_size_bytes",
+          "legendFormat": "WAL bytes",
+          "refId": "A"
+        }
+      ],
+      "title": "WAL File Size",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Cumulative count of WAL checkpoints that returned busy=1 (reader blocking TRUNCATE). Rising = WAL bloat risk.",
+      "fieldConfig": {
+        "defaults": { "unit": "short", "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 28 },
+      "id": 6,
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "increase(helix_genome_checkpoint_blocked_total[$__rate_interval])",
+          "legendFormat": "blocked checkpoints / interval",
+          "refId": "A"
+        }
+      ],
+      "title": "Checkpoint Blocked (busy=1)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Concurrent /context calls in flight, derived from the end-to-end latency histogram.",
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 28 },
+      "id": 7,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(helix_context_latency_seconds_count[$__rate_interval]))",
+          "legendFormat": "/context req/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Concurrent /context Request Rate",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["helix", "pipeline", "telemetry"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Helix Pipeline Telemetry",
+  "uid": "helix-pipeline-v1",
+  "version": 1
+}

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -50,6 +50,38 @@ from .schemas import (
 
 log = logging.getLogger("helix.context_manager")
 
+
+# ── Stage-timer context manager ──────────────────────────────────────
+# Wraps each named pipeline stage with a monotonic-clock measurement and
+# records a single OTel histogram entry on exit. Exceptions in telemetry
+# are suppressed so a broken collector never kills the pipeline.
+
+import time as _time
+from .telemetry import pipeline_stage_histogram as _pipeline_stage_histogram
+
+
+class _stage_timer:
+    """Context manager that records helix_pipeline_stage_seconds on exit."""
+
+    __slots__ = ("stage", "labels", "_t0")
+
+    def __init__(self, stage: str, labels: Optional[dict] = None):
+        self.stage = stage
+        self.labels = labels or {}
+
+    def __enter__(self):
+        self._t0 = _time.monotonic()
+        return self
+
+    def __exit__(self, *exc):
+        try:
+            _pipeline_stage_histogram().record(
+                _time.monotonic() - self._t0,
+                {"stage": self.stage, **self.labels},
+            )
+        except Exception:
+            pass  # never let telemetry break the pipeline
+
 # Thread pool for running sync ribosome calls from async context
 _executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="helix-ribosome")
 
@@ -738,18 +770,20 @@ class HelixContextManager:
         # Restates the query with expanded keywords BEFORE promoter lookup.
         # This sharpens the initial frequency so retrieval falls into the
         # right gravity well instead of optimizing the wrong one.
-        expanded_query, domains, entities = self._prepare_query_signals(
-            query,
-            session_context=session_context,
-            expand_query=True,
-        )
+        with _stage_timer("extract"):
+            expanded_query, domains, entities = self._prepare_query_signals(
+                query,
+                session_context=session_context,
+                expand_query=True,
+            )
 
         # Step 2: Express (genome query + pending buffer + optional cold tier)
-        candidates = self._express(
-            domains, entities, max_genes,
-            query_text=query, include_cold=include_cold, party_id=party_id,
-            read_only=read_only,
-        )
+        with _stage_timer("express"):
+            candidates = self._express(
+                domains, entities, max_genes,
+                query_text=query, include_cold=include_cold, party_id=party_id,
+                read_only=read_only,
+            )
 
         if not candidates:
             empty_health = ContextHealth(
@@ -770,15 +804,16 @@ class HelixContextManager:
                 metadata={"query": query, "genes_expressed": 0},
             )
 
-        candidates, _ = self._apply_candidate_refiners(
-            query,
-            candidates,
-            max_genes,
-            use_cymatics=True,
-            use_harmonic_bin=True,
-            use_tcm=True,
-            allow_rerank=True,
-        )
+        with _stage_timer("rerank"):
+            candidates, _ = self._apply_candidate_refiners(
+                query,
+                candidates,
+                max_genes,
+                use_cymatics=True,
+                use_harmonic_bin=True,
+                use_tcm=True,
+                allow_rerank=True,
+            )
 
         # Dynamic budget tiers — size the expression window based on
         # retrieval confidence instead of always sending max_genes.
@@ -1000,6 +1035,7 @@ class HelixContextManager:
         answer_slate_lines = []  # MoE answer slate — flat KV pairs
         # foveated_caps / foveated_active are call-local; see top of build_context.
         foveated_base = self.config.budget.foveated_base_chars
+        _splice_t0 = _time.monotonic()
         for idx, g in enumerate(candidates):
             src = g.source_id or ""
             short = ""
@@ -1040,17 +1076,26 @@ class HelixContextManager:
             )
             spliced_map[g.gene_id] = f"<GENE{src_attr}{kv_attrs}>\n{content}\n</GENE>"
 
+        # Record splice-stage timing (covers compress_text loop over all genes)
+        try:
+            _pipeline_stage_histogram().record(
+                _time.monotonic() - _splice_t0, {"stage": "splice"},
+            )
+        except Exception:
+            pass
+
         # Step 5: Assemble (MoE/small-model aware)
         use_slate = self._should_use_slate(downstream_model)
-        window = self._assemble(
-            query, candidates, spliced_map, relation_graph,
-            query_signals=(domains, entities),
-            answer_slate=answer_slate_lines if use_slate else None,
-            session_id=session_id,
-            ignore_delivered=ignore_delivered,
-            decoder_prompt_override=effective_decoder_prompt,
-            respect_caller_order=foveated_active,
-        )
+        with _stage_timer("assemble"):
+            window = self._assemble(
+                query, candidates, spliced_map, relation_graph,
+                query_signals=(domains, entities),
+                answer_slate=answer_slate_lines if use_slate else None,
+                session_id=session_id,
+                ignore_delivered=ignore_delivered,
+                decoder_prompt_override=effective_decoder_prompt,
+                respect_caller_order=foveated_active,
+            )
 
         # Annotate window with dynamic budget tier (for telemetry/benchmarks)
         if window.metadata is not None:

--- a/helix_context/genome.py
+++ b/helix_context/genome.py
@@ -1782,6 +1782,7 @@ class Genome:
         # on the 2026-04-12 KV-harvest bench before this fix).
         q_lower_tokens = [t.lower() for t in query_terms if t]
         if q_lower_tokens:
+            _pki_t0 = time.monotonic()
             try:
                 # Group hits by (path_token, kv_key) to compute per-pair
                 # cardinality. SQLite GROUP BY + COUNT does this in one
@@ -1845,6 +1846,14 @@ class Genome:
                         tier_contrib.setdefault(gid, {})["pki"] = capped
             except Exception as exc:
                 log.debug("path_key_index tier skipped: %s", exc)
+            finally:
+                try:
+                    from .telemetry import genome_signal_histogram
+                    genome_signal_histogram().record(
+                        time.monotonic() - _pki_t0, {"signal": "pki"}
+                    )
+                except Exception:
+                    pass
 
         # ── Tier 0.5: filename-anchor boost (flag-gated spike) ─────
         # Dewey bench 2026-04-14: filename alone drives retrieval lift;
@@ -1867,6 +1876,7 @@ class Genome:
                 log.debug("filename_anchor tier skipped: %s", exc)
 
         # ── Tier 1: exact promoter tag match (weight 3.0) ──────────
+        _tag_exact_t0 = time.monotonic()
         placeholders = ",".join("?" * len(query_terms))
         rows = cur.execute(
             f"""
@@ -1885,9 +1895,17 @@ class Genome:
             tag_score = r["match_count"] * 3.0
             gene_scores[r["gene_id"]] = tag_score
             tier_contrib.setdefault(r["gene_id"], {})["tag_exact"] = tag_score
+        try:
+            from .telemetry import genome_signal_histogram
+            genome_signal_histogram().record(
+                time.monotonic() - _tag_exact_t0, {"signal": "tag_exact"}
+            )
+        except Exception:
+            pass
 
         # ── Tier 2: prefix tag match (weight 1.5) ──────────────────
         # "server" matches "serverconfig", "server_api", etc.
+        _tag_prefix_t0 = time.monotonic()
         prefix_conditions = " OR ".join(
             "pi.tag_value LIKE ?" for _ in query_terms
         )
@@ -1910,10 +1928,18 @@ class Genome:
             prefix_score = r["match_count"] * 1.5
             gene_scores[gid] = gene_scores.get(gid, 0) + prefix_score
             tier_contrib.setdefault(gid, {})["tag_prefix"] = prefix_score
+        try:
+            from .telemetry import genome_signal_histogram
+            genome_signal_histogram().record(
+                time.monotonic() - _tag_prefix_t0, {"signal": "tag_prefix"}
+            )
+        except Exception:
+            pass
 
         # ── Tier 3: FTS5 content search (weight 3.0) ───────────────
         if self._fts_available:
             # Build FTS5 query: OR-join all terms
+            _fts5_t0 = time.monotonic()
             fts_query = " OR ".join(
                 f'"{t}"' for t in query_terms if len(t) > 2
             )
@@ -1954,9 +1980,18 @@ class Genome:
                             tier_contrib.setdefault(gid, {})["fts5"] = fts_score
                 except Exception:
                     log.warning("FTS5 query failed", exc_info=True)
+                finally:
+                    try:
+                        from .telemetry import genome_signal_histogram
+                        genome_signal_histogram().record(
+                            time.monotonic() - _fts5_t0, {"signal": "fts5"}
+                        )
+                    except Exception:
+                        pass
 
         # ── Tier 3.5: SPLADE sparse retrieval (weight 3.5) ─────────
         if self._splade_enabled:
+            _splade_t0 = time.monotonic()
             try:
                 from . import splade_backend
                 # Check if splade_terms table exists
@@ -1974,6 +2009,14 @@ class Genome:
                         tier_contrib.setdefault(gid, {})["splade"] = splade_score
             except Exception:
                 log.warning("SPLADE retrieval failed", exc_info=True)
+            finally:
+                try:
+                    from .telemetry import genome_signal_histogram
+                    genome_signal_histogram().record(
+                        time.monotonic() - _splade_t0, {"signal": "splade"}
+                    )
+                except Exception:
+                    pass
 
         # ── Tier 4: ΣĒMA semantic retrieval + re-ranking ───────────────
         # Two modes:
@@ -1986,6 +2029,7 @@ class Genome:
                 top_score = max(gene_scores.values()) if gene_scores else 0
 
                 # Mode A: Boost existing candidates when confidence is weak
+                _sema_boost_t0 = time.monotonic()
                 if gene_scores and top_score < 20.0:
                     existing_ids = list(gene_scores.keys())
                     id_ph = ",".join("?" * len(existing_ids))
@@ -2015,6 +2059,13 @@ class Genome:
                                     sema_boost = sim * 2.0 * boost_scale
                                     gene_scores[gid] += sema_boost
                                     tier_contrib.setdefault(gid, {})["sema_boost"] = sema_boost
+                try:
+                    from .telemetry import genome_signal_histogram
+                    genome_signal_histogram().record(
+                        time.monotonic() - _sema_boost_t0, {"signal": "sema_boost"}
+                    )
+                except Exception:
+                    pass
 
                 # Mode B: Add new candidates when pool is undersized
                 # Uses pre-materialized numpy cache for fast cosine scan
@@ -3167,6 +3218,13 @@ class Genome:
                     "WAL checkpoint (%s) blocked by reader: %d/%d pages flushed",
                     mode, row[2] or 0, row[1] or 0,
                 )
+                try:
+                    from .telemetry import genome_checkpoint_blocked_counter
+                    genome_checkpoint_blocked_counter().add(
+                        1, {"mode": mode}
+                    )
+                except Exception:
+                    pass
             else:
                 log.debug(
                     "WAL checkpoint (%s) completed: %d pages flushed",
@@ -3174,6 +3232,23 @@ class Genome:
                 )
         except Exception:
             log.warning("WAL checkpoint (%s) failed", mode, exc_info=True)
+
+    def emit_wal_health_gauges(self) -> None:
+        """Emit helix_genome_wal_size_bytes gauge for the current genome WAL.
+
+        Intended to be called from a background task every ~30 s. No-op for
+        in-memory genomes and when OTel is disabled (noop instruments drop the
+        call silently). Never raises — failures are logged at DEBUG level.
+        """
+        if self.path == ":memory:":
+            return
+        try:
+            wal_path = self.path + "-wal"
+            wal_size = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
+            from .telemetry import genome_wal_size_gauge
+            genome_wal_size_gauge().set(wal_size)
+        except Exception:
+            log.debug("emit_wal_health_gauges failed", exc_info=True)
 
     def vacuum(self) -> Dict[str, int]:
         """

--- a/helix_context/ribosome.py
+++ b/helix_context/ribosome.py
@@ -74,6 +74,7 @@ DO NOT delete this file or its methods without explicit coordination.
 from __future__ import annotations
 
 import logging
+import time as _time
 from typing import Dict, List, Optional, Protocol
 
 import httpx
@@ -492,6 +493,41 @@ class Ribosome:
         self.encoder = encoder or CodonEncoder()
         self.splice_aggressiveness = splice_aggressiveness
 
+    def _timed_complete(
+        self,
+        prompt: str,
+        system: str = "",
+        temperature: float = 0.0,
+        call_kind: str = "unknown",
+    ) -> str:
+        """Call backend.complete() and record helix_ribosome_call_seconds.
+
+        call_kind labels the histogram entry so callers can distinguish
+        pack / rerank / splice / replicate latency. Telemetry is best-effort:
+        if the histogram call raises for any reason the original exception
+        (or result) still propagates.
+        """
+        backend_name = type(self.backend).__name__
+        model_name = getattr(self.backend, "model", "unknown")
+        t0 = _time.monotonic()
+        try:
+            result = self.backend.complete(prompt, system=system, temperature=temperature)
+        finally:
+            elapsed = _time.monotonic() - t0
+            try:
+                from .telemetry import ribosome_call_histogram
+                ribosome_call_histogram().record(
+                    elapsed,
+                    {
+                        "backend": backend_name,
+                        "model": str(model_name),
+                        "call_kind": call_kind,
+                    },
+                )
+            except Exception:
+                pass  # never let telemetry break the ribosome
+        return result
+
     # ── Pack: raw text → Gene ───────────────────────────────────────
 
     def pack(self, content: str, content_type: str = "text") -> Gene:
@@ -521,7 +557,7 @@ class Ribosome:
         prompt = f"Encode the following content into codons:\n\n{numbered}"
 
         try:
-            raw = self.backend.complete(prompt, system=_PACK_SYSTEM)
+            raw = self._timed_complete(prompt, system=_PACK_SYSTEM, call_kind="pack")
             parsed = _parse_json(raw)
         except Exception as exc:
             raise TranscriptionError(f"Pack failed: {exc}") from exc
@@ -570,7 +606,9 @@ class Ribosome:
         prompt = f"Extract key-value facts from this content:\n\n{truncated}"
 
         try:
-            raw = self.backend.complete(prompt, system=_KV_EXTRACT_SYSTEM)
+            raw = self._timed_complete(
+                prompt, system=_KV_EXTRACT_SYSTEM, call_kind="pack"
+            )
             parsed = _parse_json(raw)
         except Exception:
             log.debug("KV extraction failed (non-fatal)", exc_info=True)
@@ -619,7 +657,9 @@ class Ribosome:
         prompt = pb.build()
 
         try:
-            raw = self.backend.complete(prompt, system=_EXPRESS_SYSTEM)
+            raw = self._timed_complete(
+                prompt, system=_EXPRESS_SYSTEM, call_kind="rerank"
+            )
             scores = _parse_json(raw)
         except Exception:
             # Fix 4: timeout or model failure — fall back to input order
@@ -683,7 +723,7 @@ class Ribosome:
         system = _splice_system(self.splice_aggressiveness)
 
         try:
-            raw = self.backend.complete(prompt, system=system)
+            raw = self._timed_complete(prompt, system=system, call_kind="splice")
             parsed = _parse_json(raw)
         except Exception:
             # Fix 4: timeout/failure — fall back to complement for all genes
@@ -747,7 +787,9 @@ class Ribosome:
         prompt = f"Encode this conversation exchange:\n\n{numbered}"
 
         try:
-            raw = self.backend.complete(prompt, system=_REPLICATE_SYSTEM)
+            raw = self._timed_complete(
+                prompt, system=_REPLICATE_SYSTEM, call_kind="replicate"
+            )
             parsed = _parse_json(raw)
         except Exception:
             # Replication is best-effort (background task) — don't crash

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -44,6 +44,7 @@ log = logging.getLogger("helix.server")
 
 _CHECKPOINT_INTERVAL = 60  # seconds between background WAL checkpoints
 _REGISTRY_SWEEP_INTERVAL = 60  # seconds between session registry status sweeps
+_WAL_GAUGE_INTERVAL = 30  # seconds between WAL-size gauge emissions
 
 
 def _local_timezone() -> Optional[str]:
@@ -315,6 +316,20 @@ async def _background_checkpoint(helix: HelixContextManager) -> None:
             log.warning("Background WAL checkpoint failed", exc_info=True)
 
 
+async def _background_wal_gauge(helix: HelixContextManager) -> None:
+    """Emit helix_genome_wal_size_bytes every _WAL_GAUGE_INTERVAL seconds.
+
+    Best-effort: failures are ignored so the gauge never affects uptime.
+    No-op when OTel is disabled (noop instruments silently drop the call).
+    """
+    while True:
+        await asyncio.sleep(_WAL_GAUGE_INTERVAL)
+        try:
+            helix.genome.emit_wal_health_gauges()
+        except Exception:
+            pass  # diagnostic path; never block the event loop
+
+
 async def _background_registry_sweep(registry_obj) -> None:
     """Periodically sweep session registry status.
 
@@ -441,10 +456,12 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
 
         task = asyncio.create_task(_background_checkpoint(helix))
         sweep_task = asyncio.create_task(_background_registry_sweep(registry))
+        wal_gauge_task = asyncio.create_task(_background_wal_gauge(helix))
         yield
         task.cancel()
         sweep_task.cancel()
-        for _t in (task, sweep_task):
+        wal_gauge_task.cancel()
+        for _t in (task, sweep_task, wal_gauge_task):
             try:
                 await _t
             except asyncio.CancelledError:

--- a/helix_context/telemetry.py
+++ b/helix_context/telemetry.py
@@ -404,6 +404,88 @@ def ribosome_info_gauge():
     return _instruments["ribosome_info"]
 
 
+# ── Per-stage pipeline telemetry (feat/per-stage-telemetry) ──────────
+
+
+def pipeline_stage_histogram():
+    """Histogram for per-stage /context pipeline latency.
+
+    Attributes: {stage: str}  — e.g. "classify", "express", "refine",
+    "assemble". Optionally decorated with {decoder_mode: str} by the
+    caller when the label is cheap to produce.
+    """
+    if "pipeline_stage" not in _instruments:
+        _instruments["pipeline_stage"] = meter.create_histogram(
+            "helix_pipeline_stage_seconds",
+            unit="s",
+            description="Latency of each /context pipeline stage.",
+        )
+    return _instruments["pipeline_stage"]
+
+
+def ribosome_call_histogram():
+    """Histogram for individual ribosome backend.complete() calls.
+
+    Attributes: {backend: str, model: str, call_kind: str}
+    call_kind is one of: pack | rerank | splice | replicate | unknown
+    """
+    if "ribosome_call" not in _instruments:
+        _instruments["ribosome_call"] = meter.create_histogram(
+            "helix_ribosome_call_seconds",
+            unit="s",
+            description="Latency of each ribosome backend.complete() call, "
+                        "labelled by backend, model, and call_kind.",
+        )
+    return _instruments["ribosome_call"]
+
+
+def genome_signal_histogram():
+    """Histogram for per-signal latency inside query_genes().
+
+    Attributes: {signal: str}  — e.g. "fts5", "splade", "sema_boost",
+    "tag_exact", "tag_prefix", "pki", "harmonic", "sr".
+    """
+    if "genome_signal" not in _instruments:
+        _instruments["genome_signal"] = meter.create_histogram(
+            "helix_genome_signal_seconds",
+            unit="s",
+            description="Latency of each retrieval signal inside query_genes(), "
+                        "labelled by signal name.",
+        )
+    return _instruments["genome_signal"]
+
+
+def genome_wal_size_gauge():
+    """Gauge for the WAL file size in bytes.
+
+    Updated by the background WAL-health task (every 30 s). Stale when
+    OTel is disabled — the noop instrument silently drops the call.
+    """
+    if "genome_wal_size" not in _instruments:
+        _instruments["genome_wal_size"] = meter.create_gauge(
+            "helix_genome_wal_size_bytes",
+            unit="By",
+            description="SQLite WAL file size in bytes. Spikes indicate "
+                        "checkpoint pressure; sustained high values = WAL bloat.",
+        )
+    return _instruments["genome_wal_size"]
+
+
+def genome_checkpoint_blocked_counter():
+    """Counter incremented when a WAL checkpoint reports busy=1.
+
+    A rising count means readers are holding WAL snapshots long enough
+    to block TRUNCATE checkpoints. Correlates with WAL bloat (PR #32).
+    """
+    if "genome_checkpoint_blocked" not in _instruments:
+        _instruments["genome_checkpoint_blocked"] = meter.create_counter(
+            "helix_genome_checkpoint_blocked_total",
+            description="Number of WAL checkpoints that returned busy=1, "
+                        "meaning a reader was holding a snapshot.",
+        )
+    return _instruments["genome_checkpoint_blocked"]
+
+
 def _emit_snapshot_values(
     *,
     chrom_rows: list[tuple[Any, Any]],

--- a/tests/test_telemetry_pipeline.py
+++ b/tests/test_telemetry_pipeline.py
@@ -1,0 +1,123 @@
+"""
+Tests for per-stage pipeline telemetry (feat/per-stage-telemetry).
+
+Covers:
+  - pipeline_stage_histogram() caches instrument in _instruments
+  - _stage_timer records one observation with the right stage label
+  - _stage_timer is silent when the histogram raises (noop path)
+  - ribosome_call_histogram() caches instrument in _instruments
+  - genome_signal_histogram() caches instrument in _instruments
+"""
+
+from __future__ import annotations
+
+import helix_context.telemetry as telemetry_mod
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+class _RecordingInstrument:
+    """Minimal histogram stand-in that captures record() calls."""
+
+    def __init__(self):
+        self.observations: list[tuple[float, dict]] = []
+
+    def record(self, value: float, attributes: dict | None = None):
+        self.observations.append((value, attributes or {}))
+
+
+class _RaisingInstrument:
+    """Histogram that raises on record() — exercises the noop guard."""
+
+    def record(self, *args, **kwargs):
+        raise RuntimeError("telemetry deliberately broken")
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+def test_pipeline_stage_histogram_is_cached(monkeypatch):
+    """pipeline_stage_histogram() returns the same object on repeated calls."""
+    # Clear cache so we get a clean slate regardless of import order.
+    monkeypatch.setitem(telemetry_mod._instruments, "pipeline_stage",
+                        _RecordingInstrument())
+
+    h1 = telemetry_mod.pipeline_stage_histogram()
+    h2 = telemetry_mod.pipeline_stage_histogram()
+    assert h1 is h2, "instrument must be cached — not recreated on each call"
+
+
+def test_stage_timer_records_one_observation(monkeypatch):
+    """_stage_timer.__exit__ records exactly one entry with the right stage."""
+    from helix_context.context_manager import _stage_timer
+    import helix_context.context_manager as cm_mod
+
+    recorder = _RecordingInstrument()
+    # _stage_timer calls the module-level _pipeline_stage_histogram name.
+    monkeypatch.setattr(cm_mod, "_pipeline_stage_histogram", lambda: recorder)
+
+    with _stage_timer("express"):
+        pass  # no real work needed
+
+    assert len(recorder.observations) == 1
+    elapsed, attrs = recorder.observations[0]
+    assert attrs.get("stage") == "express"
+    assert elapsed >= 0.0, "elapsed must be non-negative"
+
+
+def test_stage_timer_records_extra_labels(monkeypatch):
+    """_stage_timer passes additional labels through to the histogram."""
+    from helix_context.context_manager import _stage_timer
+
+    recorder = _RecordingInstrument()
+    import helix_context.context_manager as cm_mod
+    monkeypatch.setattr(cm_mod, "_pipeline_stage_histogram", lambda: recorder)
+
+    with _stage_timer("rerank", {"decoder_mode": "condensed"}):
+        pass
+
+    assert len(recorder.observations) == 1
+    _, attrs = recorder.observations[0]
+    assert attrs["stage"] == "rerank"
+    assert attrs["decoder_mode"] == "condensed"
+
+
+def test_stage_timer_swallows_telemetry_errors(monkeypatch):
+    """_stage_timer must NOT raise if the histogram itself raises."""
+    from helix_context.context_manager import _stage_timer
+
+    import helix_context.context_manager as cm_mod
+    monkeypatch.setattr(cm_mod, "_pipeline_stage_histogram",
+                        lambda: _RaisingInstrument())
+
+    # Should complete without raising even though the instrument is broken.
+    with _stage_timer("assemble"):
+        pass  # pipeline must continue unharmed
+
+
+def test_ribosome_call_histogram_is_cached(monkeypatch):
+    """ribosome_call_histogram() returns the same object on repeated calls."""
+    monkeypatch.setitem(telemetry_mod._instruments, "ribosome_call",
+                        _RecordingInstrument())
+
+    h1 = telemetry_mod.ribosome_call_histogram()
+    h2 = telemetry_mod.ribosome_call_histogram()
+    assert h1 is h2
+
+
+def test_genome_signal_histogram_is_cached(monkeypatch):
+    """genome_signal_histogram() returns the same object on repeated calls."""
+    monkeypatch.setitem(telemetry_mod._instruments, "genome_signal",
+                        _RecordingInstrument())
+
+    h1 = telemetry_mod.genome_signal_histogram()
+    h2 = telemetry_mod.genome_signal_histogram()
+    assert h1 is h2
+
+
+def test_noop_instruments_do_not_raise():
+    """_NoopInstrument.record() must be a silent no-op — no raises allowed."""
+    noop = telemetry_mod._NoopInstrument()
+    noop.record(1.234, {"stage": "express"})  # must not raise
+    noop.record(0.0)


### PR DESCRIPTION
**Re-opened from #35** which was auto-closed when its base branch (PR #32) was deleted on merge. Same branch, same commits, now correctly based on master.

## Why

Pre-existing \`helix_context_latency_seconds\` was the only visibility on the /context request path. Operator could see *"this call took 20s"* but cannot tell *"12s in re-rank model swap, 8s in splice, 1s in retrieval"*. Until that breakdown exists, every architecture decision (move to DuckDB? cap concurrent ribosome calls? tighten the 12-signal scoring?) is a guess.

## What's added

### Histograms
| Metric | Labels | Source |
|---|---|---|
| \`helix_pipeline_stage_seconds\` | \`stage\` | extract / express / rerank / splice / assemble — wraps each stage in [context_manager.py](helix_context/context_manager.py) |
| \`helix_ribosome_call_seconds\` | \`backend\`, \`model\`, \`call_kind\` | per-backend timing in [ribosome.py](helix_context/ribosome.py) for pack / rerank / splice / replicate |
| \`helix_genome_signal_seconds\` | \`signal\` | the 6 highest-cost signals in query_genes (pki, tag_exact, tag_prefix, fts5, splade, sema_boost) |

### Gauges + counters
| Metric | Type | Purpose |
|---|---|---|
| \`helix_genome_wal_size_bytes\` | Gauge (30s polled) | Verifies PR #32 fix is holding under live load |
| \`helix_genome_checkpoint_blocked_total{mode}\` | Counter | Should stay flat at zero |

### Grafana dashboard
\`docs/dashboards/helix-pipeline.json\` — 7-panel Grafana 9.x dashboard. Import via UI, point at existing Prometheus data source.

## Performance

Latency overhead per /context request: ~30μs total (5 stage timers + ~6 signal timers, each ~3μs for monotonic+histogram record).

## Test coverage

7 new tests in \`tests/test_telemetry_pipeline.py\`. 48/48 tests pass overall (7 new + 38 existing genome + 3 WAL tests).

## Test plan

- [ ] Restart the server, hit /context a few times
- [ ] Open Prometheus, verify \`helix_pipeline_stage_seconds\` is being recorded
- [ ] Import \`docs/dashboards/helix-pipeline.json\` into Grafana
- [ ] Run a multi-agent session and watch the stage breakdown for the 20-40s spikes

## Related

- Built on PR #32 (WAL bloat fix, now merged)
- Discussion #33 (SQLite alternatives — diagnostic dashboard tells you whether storage is the bottleneck)
- Discussion #34 (Obsidian export — sibling operator-facing surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)