### PR TITLE
docs: add stage 2-7 retrieval-fix specs

### DIFF
--- a/docs/specs/2026-05-08-stage-2-dense-recall.md
+++ b/docs/specs/2026-05-08-stage-2-dense-recall.md
@@ -1,0 +1,207 @@
+# Stage 2 — Dense as First-Class Recall
+
+Plan: helix-context retrieval-fix, Stage 2 of 6 (council 2026-05-08). Depends on Stage 1 for measurement; independently mergeable code-side.
+
+## 1. Goals + non-goals
+
+**Goals.** Promote BGE-M3 dense retrieval from a 12-candidate re-ranker to a parallel first-class recall source returning top-K=500 over the full 18.9k-gene corpus. Restore full 1024-dim BGE-M3 vectors. Decouple `pool_size` (recall breadth) from `max_genes` (final cut). Keep retrieval LLM-free, flat-numpy, and back-compat with `query_genes_ann` callers.
+
+**Non-goals.** RRF / score fusion (Stage 3). Threshold recalibration (Stage 4). HNSW / sqlite-vec / USearch (later, if scan latency exceeds budget at >100k genes).
+
+## 2. Surface area
+
+| File:line | Change |
+|---|---|
+| `helix_context/genome.py:451-477` (genes DDL) | Add `embedding_dense_v2 BLOB` column (alter-block at lines 490-503 pattern). |
+| `helix_context/genome.py:369-374` (Genome `__init__` config wires) | Read new `dense_pool_size` config; keep existing keys; emit deprecation warn. |
+| `helix_context/genome.py:2516-2521` (`_get_dense_codec`) | Pass `dim=1024` (new default); reuse instance. |
+| `helix_context/genome.py:2523-2600` (`query_genes_ann`) | Refactor: split pool/cut, fan out lexical + dense in parallel, union, body-fetch once. |
+| `helix_context/genome.py` (new method) | `query_genes_dense_recall(query, *, k=500, party_id, read_only) -> List[tuple[str, float]]`. |
+| `helix_context/genome.py` (new attr in `__init__`) | `self._dense_matrix: np.ndarray | None`, `self._dense_matrix_ids: list[str] | None`, `self._dense_matrix_lock: threading.Lock`. |
+| `helix_context/genome.py` (new method) | `_load_dense_matrix(force=False)` — bulk-read v2 BLOBs into fp32 (n,1024). |
+| `helix_context/genome.py` (existing inserts) | Hook `_invalidate_dense_matrix()` after every gene insert/update path. |
+| `helix_context/bgem3_codec.py:17` | Default `dim=1024`. |
+| `helix_context/bgem3_codec.py:53-58` | Drop `vec[:self.dim]` truncation when `dim==raw_dim`; keep renormalize. |
+| `scripts/backfill_bgem3_v2.py` (new) | Re-encode all genes at 1024-dim, write BLOB to `embedding_dense_v2`. |
+| `scripts/bench_dense_recall_latency.py` (new) | p50/p95 micro-bench for matmul scan. |
+| `helix.toml:250-257` | Add `dense_pool_size = 500`, `dense_embedding_dim = 1024`; comment-mark `ann_similarity_threshold` as needing Stage-4 recalibration. |
+| `tests/test_dense_recall.py` (new) | Tests enumerated in §9. |
+
+## 3. Storage migration
+
+**Strategy: parallel column, not in-place.** Keep `embedding_dense TEXT` (JSON, 256-dim) intact during the transition. Add `embedding_dense_v2 BLOB` (raw little-endian fp32, `dim*4` bytes). When v2 is fully populated, retrieval code reads v2 only. The legacy column is dropped in a follow-up release once a snapshot rotation has confirmed no rollback need.
+
+**Why BLOB.** 18.9k × 1024 × 4 = 77.6 MiB raw vs ~600 MiB JSON-encoded text. Parsing 600 MiB of JSON on cold start is the dominant cost we are removing — BLOB → `np.frombuffer` is zero-copy.
+
+**SQL migration (executed by `_init_db` + idempotent `ALTER` block, mirroring lines 490-503):**
+
+```sql
+ALTER TABLE genes ADD COLUMN embedding_dense_v2 BLOB;
+CREATE INDEX IF NOT EXISTS idx_genes_dense_v2_hot
+    ON genes(gene_id) WHERE embedding_dense_v2 IS NOT NULL AND chromatin < 2;
+```
+
+The partial index streams hot-tier (chromatin < HETEROCHROMATIN) populated rows during the partial-rollout window without a table scan. Heterochromatin (chromatin=2) genes are intentionally excluded — they remain reachable via the separate `query_cold_tier` path.
+
+**Backfill (`scripts/backfill_bgem3_v2.py`)** mirrors `backfill_bgem3.py` but:
+- Initialises `BGEM3Codec(dim=1024)`.
+- Encodes `(content or "")[:2000]` as `task="passage"`.
+- Writes `vec.astype('<f4').tobytes()` into `embedding_dense_v2`.
+- Idempotent: `WHERE embedding_dense_v2 IS NULL`. Re-running is a no-op once complete.
+- Batched commit every 100 rows, identical to existing script.
+
+The May-8 snapshot is invalidated by design — operators run the backfill once after pulling Stage 2.
+
+## 4. In-memory vector matrix
+
+**Layout.** `self._dense_matrix: np.ndarray` of shape `(n_genes, 1024)`, dtype `float32`, C-contiguous. Sister array `self._dense_matrix_ids: list[str]` parallel to row index. Both held on the `Genome` instance.
+
+**Lazy-load contract.** Built on first call to `query_genes_dense_recall`. Loader pseudocode:
+
+```python
+with self._dense_matrix_lock:
+    if self._dense_matrix is not None: return
+    rows = read_conn.execute(
+        "SELECT gene_id, embedding_dense_v2 FROM genes "
+        "WHERE embedding_dense_v2 IS NOT NULL "
+        "AND chromatin < ?",
+        (HETEROCHROMATIN,)  # = 2
+    ).fetchall()
+    ids, blobs = zip(*[(r["gene_id"], r["embedding_dense_v2"]) for r in rows])
+    buf = b"".join(blobs)
+    mat = np.frombuffer(buf, dtype="<f4").reshape(len(ids), self._dense_embedding_dim)
+    self._dense_matrix = np.ascontiguousarray(mat)  # decouple from buffer lifetime
+    self._dense_matrix_ids = list(ids)
+```
+
+**Hot-tier only.** Dense recall scans hot-tier (chromatin < HETEROCHROMATIN) genes only — matches the existing hot-tier convention at [genome.py:1135](../../helix_context/genome.py#L1135) and [:1182-1184](../../helix_context/genome.py#L1182-L1184). Cold-tier genes are reachable via the separate `query_cold_tier()` path. Stage 7 surfaces cold-tier matches as `MissBlock(reason="cold", refresh_targets=[...])` rather than silently filtering them — see Stage 7 §6.
+
+**Invalidation.** Coverage-based + count-based. After every insert/update path (ingest, replicate, consolidate) call `self._invalidate_dense_matrix()` which sets `_dense_matrix=None`. Rebuild is full, not incremental — at 78 MiB and 18.9k rows, full rebuild is ≤ 200 ms and triggered only on first query after an ingest batch. (Incremental append is a future optimisation if ingest QPS rises.) An explicit refresh tick on `/admin/refresh` also calls `_invalidate_dense_matrix(force=True)`.
+
+**Fallback.** If v2 coverage is partial (`count(v2) < 0.95 * count(genes)`), `query_genes_dense_recall` logs a one-time warn and returns `[]`; callers degrade to lexical-only.
+
+## 5. New recall function signature
+
+```python
+def query_genes_dense_recall(
+    self,
+    query: str,
+    *,
+    k: int = 500,
+    party_id: Optional[str] = None,
+    read_only: bool = False,
+) -> List[tuple[str, float]]:
+    """Top-K dense recall over the full corpus. ID + cosine only.
+
+    Does NOT load gene bodies. Body load happens in query_genes_ann via
+    a single batched `_load_genes_by_ids`.
+    """
+```
+
+Body. Encode query (BGE-M3 query task, full 1024-dim). Ensure matrix loaded. Compute `sims = self._dense_matrix @ query_vec` (vectors are L2-normalised, so dot = cosine). `top_idx = np.argpartition(-sims, k)[:k]`; sort that slice descending; map indices to ids. `party_id` filtering applies post-rank against the per-gene `party_id` column (cheap dict lookup against an in-memory id→party map cached alongside the matrix).
+
+## 6. Pool/cut separation in `query_genes_ann`
+
+**New signature** (additive — old positional `max_genes` preserved):
+
+```python
+def query_genes_ann(
+    self,
+    query: str,
+    threshold: float | None = None,
+    max_genes: int | None = None,
+    min_genes: int | None = None,
+    domains: list[str] | None = None,
+    entities: list[str] | None = None,
+    party_id: Optional[str] = None,
+    use_harmonic: bool = True,
+    use_sr: Optional[bool] = None,
+    use_entity_graph: Optional[bool] = None,
+    read_only: bool = False,
+    *,
+    pool_size: int | None = None,   # NEW
+) -> List[Gene]: ...
+```
+
+**Body sketch.**
+
+1. Resolve `pool_size = pool_size or self._dense_pool_size` (default 500 when dense enabled, else falls back to `max_genes` for back-compat).
+2. **Parallel recall** (sequential calls; "parallel" = independent sources, both feed pool):
+   - `lex_candidates = self.query_genes(domains, entities, max_genes=pool_size, ...)` — returns up to `pool_size` Genes by lexical/promoter/harmonic/SR scoring.
+   - `dense_pairs = self.query_genes_dense_recall(query, k=pool_size, party_id=party_id, read_only=read_only)` — returns up to `pool_size` `(gene_id, cosine)` pairs. Returns `[]` when `dense_embedding_enabled=False`.
+3. **Union** by gene_id. For ranking inside this stage: keep dense cosine where present; lexical-only candidates get `sim = threshold - 0.01` (preserves existing min_genes-fill behavior for un-embedded genes). **Stage 3 will replace this with RRF — out of scope here.**
+4. Sort by sim descending, `result_ids = [...][:max_genes]` after applying min_genes / threshold logic identical to current lines 2594-2599.
+5. Single batched body load via `_load_genes_by_ids(result_ids)` preserving rank order. Lexical Genes from step 2a are reused (no re-fetch) for ids already materialised.
+
+`min_genes` / `threshold` semantics unchanged. Dense candidates that didn't make the lexical cut are still subject to the same threshold gate.
+
+## 7. Codec change
+
+`bgem3_codec.py`:
+
+- Line 17: `def __init__(self, dim: int = 1024, ...)` — flip default.
+- Lines 53-54: drop the `vec = vec[:self.dim]` line **when `dim == raw_dim`**. Keep a guard `if self.dim < vec.shape[0]: vec = vec[:self.dim]` so future Matryoshka-sanctioned dims (1024/768/512) still work, but 256 is no longer the path. Renormalize unchanged.
+- `sentence_transformers` branch (line 50): `normalize_embeddings=True` is already correct for 1024-d.
+- Add a one-time warn in `_load` when `self.dim not in (1024, 768, 512)`: `"Non-Matryoshka dim=%d may produce degenerate cosine geometry"`.
+
+## 8. Threshold deferral
+
+Existing `ann_similarity_threshold = 0.35` was calibrated against 256-dim collapsed geometry. At 1024-dim, random-pair cosine drops materially; the absolute threshold becomes invalid. Stage 2 does **not** recalibrate.
+
+Stage 2 emits a **single warn** at Genome init when `dense_embedding_enabled=True` AND v2 coverage > 0:
+
+```python
+log.warning(
+    "ann_similarity_threshold=%.3f is calibrated for dim=256; "
+    "v2 vectors are dim=%d. Threshold recalibration is Stage 4. "
+    "Recall pool is independent of threshold.",
+    self._ann_threshold, self._dense_embedding_dim,
+)
+```
+
+Threshold still gates the final cut in `query_genes_ann` to preserve current behavior — under-tuned threshold may over-include, but `max_genes` is the hard cap, so blast radius is bounded.
+
+## 9. Test plan
+
+`tests/test_dense_recall.py`:
+
+- `test_dense_recall_finds_needle_outside_top12_lexical` — seed corpus with 1 needle gene whose content shares only synonyms (not surface tokens) with query; verify `query_genes_dense_recall(k=500)` returns the needle, AND that `query_genes(max_genes=12)` does NOT.
+- `test_query_genes_ann_pool_size_independent_of_max_genes` — assert `len(union of lex+dense)` reaches ≥ 100 with `pool_size=500` even when `max_genes=12`. Final return ≤ 12.
+- `test_codec_full_1024_dim_on_encode` — `BGEM3Codec().encode("hello", "passage")` returns len 1024; norm ≈ 1.0; random-pair cosine on 1k pairs has mean < 0.10 (regression guard against the dim=256 collapse).
+- `test_v2_blob_roundtrip_matches_json` — encode same passage, write JSON via legacy path and BLOB via v2 path, decode both, assert `np.allclose` within fp32 epsilon.
+- `test_backfill_v2_idempotent` — run `backfill_bgem3_v2.py` twice; second run touches 0 rows; matrix shape unchanged.
+- `test_dense_matrix_invalidation_after_insert` — call recall, insert gene, call recall again, assert new gene appears in pool.
+
+## 10. Back-compat
+
+`query_genes_ann` keeps positional `(query, threshold, max_genes, min_genes, ...)` order. `pool_size` is **kw-only**. When `dense_embedding_enabled=False`, `pool_size` defaults to `max_genes` (current behavior — lexical-only, no dense pass). When `True`, default 500. Existing callers in `context_manager.py`, `server.py`, and tests work unmodified. Legacy `embedding_dense` (TEXT JSON) column is read by no code path after this stage but stays in the schema for one release.
+
+## 11. Latency budget + measurement
+
+**Target.** Flat `np.dot(matrix, q)` at (18934, 1024) fp32, contiguous: ~78 MiB streamed. Numpy with OpenBLAS / MKL: 3-7 ms on a modern CPU; 10-15 ms on older laptops without BLAS. Encode cost (BGE-M3 query, single text, CPU) dominates at 30-80 ms — already present in current pipeline, so net Δ vs current is the matmul + argpartition + body-fetch difference.
+
+**Bench.** `scripts/bench_dense_recall_latency.py`:
+- 50-query warm-up, 200-query measured.
+- Reports p50 / p95 / p99 for: (a) matmul scan only, (b) full `query_genes_dense_recall`, (c) full `query_genes_ann` with `pool_size=500`.
+- Compares against `query_genes_ann` baseline at `dense_pool_size=12` (current behavior).
+- Pass criterion: full `query_genes_ann` p95 ≤ baseline + 20 ms.
+
+## 12. Acceptance criteria
+
+1. `bench_n1000` reports `located_n1000 ≥ 60%` with Stage 2 alone (i.e., no RRF / no threshold recalib). Current 13.8% at 12-candidate dense re-rank.
+2. `/context` endpoint p95 latency at corpus=18.9k does not exceed current p95 by more than 20 ms.
+3. `tests/` pass (mock + live).
+4. `backfill_bgem3_v2.py` completes on a fresh `genomes/main/genome.db` clone and reports 100% v2 coverage.
+5. No new ribosome / LLM calls on the `/context` path (auditable via existing OTel `tier_fired_counter`).
+
+## 13. Out of scope
+
+- **Stage 3:** RRF (Reciprocal Rank Fusion) over `(lex_score, dense_cosine)` replacing the `threshold - 0.01` placeholder.
+- **Stage 4:** Margin-over-random threshold recalibration at 1024-dim. Likely lands at ~0.55-0.65 cosine but will be measured.
+- **Stage 5+:** sqlite-vec / USearch / HNSW. Triggered when corpus exceeds ~100k or scan p95 exceeds 25 ms.
+- Dropping legacy `embedding_dense TEXT` column (deferred one release).
+- Per-gene party-aware matrix sharding (single-tenant assumption holds at current scale).
+
+---
+
+**Key files referenced:** `helix_context/genome.py` lines 369-374, 451-477, 490-503, 2516-2600; `helix_context/bgem3_codec.py` lines 17, 49-58; `scripts/backfill_bgem3.py` (template for v2); `helix.toml` lines 250-257.

--- a/docs/specs/2026-05-08-stage-3-rrf-fusion.md
+++ b/docs/specs/2026-05-08-stage-3-rrf-fusion.md
@@ -1,0 +1,174 @@
+# Stage 3 — Reciprocal Rank Fusion (RRF)
+
+Plan: helix-context retrieval-fix, Stage 3 of 6 (council 2026-05-08). Depends on Stage 2 (dense as a tier) for the dense participation in RRF.
+
+## 1. Goals + non-goals
+
+**Goals.** Replace the additive `gene_scores[gid] += tier_score` accumulator in `query_genes()` with rank-level Reciprocal Rank Fusion (Cormack 2009). Per-tier scores are non-commensurate (FTS5 negative-bm25, BGE cosine ∈ [-1,1], promoter exact ∈ {0, 3.0}, harmonic ∈ {0..3}, filename_anchor 4.0/match, etc.); their sum is mathematically meaningless and currently lets one over-scaled tier dominate. RRF is invariant to scale. Stack with Stages 1+2 to hit ≥75% located_n1000 retrieval@1.
+
+**Non-goals.** No threshold recalibration of TIGHT/FOCUSED/BROAD floors (Stage 4). No per-classifier floors (Stage 4). No new tiers. No LLM in the fusion path. No change to candidate-generation order or BM25 pre/post-filter logic. No change to `query_genes_ann()` outer wrapper.
+
+## 2. Surface area
+
+| File | Lines | Change |
+|---|---|---|
+| `helix_context/genome.py` | 1815–1816 | Initialize `Fuser` alongside `gene_scores` dict |
+| `helix_context/genome.py` | 1851–2380 | Each tier writes `fuser.add_tier(...)` and continues to populate `gene_scores`+`tier_contrib` for telemetry/back-compat |
+| `helix_context/genome.py` | 2384–2386 | When `fusion_mode=="rrf"`, replace `last_query_scores` with fused scores |
+| `helix_context/genome.py` | 2387–2407 | Telemetry block stays; reads raw `tier_contrib` (unchanged) |
+| `helix_context/genome.py` | 2453–2454 | `ranked_ids = fuser.top_k(limit)` when `fusion_mode=="rrf"` |
+| `helix_context/fusion.py` | new | `Fuser` class |
+| `helix.toml` | new key in `[retrieval]` | `fusion_mode = "additive"` |
+| `helix_context/config.py` | TOML loader | Parse `fusion_mode`, default `"additive"` |
+| `tests/test_fusion_rrf.py` | new | Unit + regression tests |
+
+## 3. Tier inventory (exhaustive)
+
+Every site that writes `gene_scores[gid] +=` or `gene_scores[gid] =` in `query_genes()`:
+
+| Tier name | Source lines | Current score range | Weight knob | RRF | Post-multiplier |
+|---|---|---|---|---|---|
+| `pki` (path-key compound) | 1851–1942 | 0.05 .. 12.0 (PKI_BASE/card, capped) | `PKI_BASE=10.0`, `PKI_FLOOR=2.0` literals | yes | `pki_weight = 1.0` (new) |
+| `filename_anchor` | 1944–1962 | weight × match_count (4.0/match) | `filename_anchor_weight = 4.0` | yes | `filename_anchor_weight = 4.0` (reuse) |
+| `tag_exact` | 1964–1991 | match_count × 3.0 | hardcoded 3.0 | yes | `tag_exact_weight = 3.0` (new, defaults to 3.0) |
+| `tag_prefix` | 1993–2025 | match_count × 1.5 | hardcoded 1.5 | yes | `tag_prefix_weight = 1.5` (new) |
+| `fts5` | 2027–2079 | min(-rank, 6.0) | hardcoded cap 6.0 | yes | `fts5_weight = 3.0` (new) |
+| `splade` | 2081–2110 | min(score, 20)·3.5/20 | hardcoded 3.5 | yes | `splade_weight = 3.5` (new) |
+| `sema_boost` | 2122–2152 | sim·2.0·boost_scale (≈0..2) | hardcoded 2.0 | **no** (gate-only re-rank, not a recall tier) | n/a — keep additive, applied AFTER RRF as tiebreaker |
+| `sema_cold` | 2161–2198 | sim·3.0 (only when pool undersized) | hardcoded 3.0 | yes (when it fires) | `sema_cold_weight = 3.0` (new) |
+| `lex_anchor` (IDF) | 2205–2239 | min(idf·1.5, 3.0), summed across terms | hardcoded 1.5/3.0 | yes | `lex_anchor_weight = 1.5` (new) |
+| `authority_*` (source/domain/recency) | 1657–1726 (called 2242) | 0.5–4.0 stacked | hardcoded | **no** — flat boost on existing pool, applied AFTER RRF |
+| `harmonic` | 2244–2277 | min(links·1.0, 3.0) | hardcoded 1.0/cap 3.0 | yes | `harmonic_weight = 1.0` (new), cap stays |
+| `sr` (Successor Repr.) | 2279–2301 | sr_boost output (≤ sr_cap=3.0) | `sr_weight = 1.5`, `sr_cap = 3.0` | yes | `sr_weight = 1.5` (reuse) |
+| `entity_graph` | 2303–2328 | 0.5/match, cap 2.0 | hardcoded 1.0·0.5 | yes | `entity_graph_weight = 0.5` (new) |
+| `party_attr` | 2330–2344 | flat +0.5 | hardcoded | **no** — applied AFTER RRF as flat additive |
+| `access_rate` | 2346–2370 | 0.05 .. 0.25 | hardcoded | **no** — explicit tiebreaker, applied AFTER RRF |
+| `dense` (Stage 2) | new (Stage 2 spec) | cosine ∈ [-1,1], top-500 | `dense_weight = 1.0` (new) | yes | `dense_weight = 1.0` |
+
+**Rule of thumb.** Recall/discovery tiers participate in RRF. Re-rank/tiebreaker/policy boosts (sema_boost gate, authority, party, access_rate) stay additive on top of the fused score so the user's "is this gene authoritative?" semantics survive unchanged.
+
+## 4. RRF formula and parameters
+
+For each gene `d` and each participating tier `t`:
+```
+score(d) = Σ_{t ∈ tiers}  weight_t · 1 / (k + rank_t(d))
+```
+where `rank_t(d)` is `d`'s 1-based rank in tier `t`'s descending-score-ordered list (genes not in tier `t` contribute 0). Constants:
+
+- `k = 60` (Cormack default; configurable as `[retrieval] rrf_k`).
+- `weight_t` from helix.toml (post-multipliers above).
+- **Ties.** Stable rank-by-(score desc, gene_id asc). Genes with bitwise-equal float scores get adjacent ranks (NOT shared rank — keeps RRF strictly monotone in input order).
+- **Float tiers** (FTS5 BM25, dense cosine, SEMA cosine): rank by raw score descending.
+- **Count tiers** (tag_exact, tag_prefix, filename_anchor): rank by match_count descending; ties broken by gene_id.
+
+## 5. Implementation shape
+
+New file `helix_context/fusion.py`:
+
+```python
+class Fuser:
+    def __init__(self, k: int = 60):
+        self._k = k
+        self._scores: dict[str, float] = {}
+
+    def add_tier(self, name: str, ranked_ids: list[str], weight: float) -> None:
+        """ranked_ids must already be in descending tier-score order."""
+        if weight == 0.0 or not ranked_ids:
+            return
+        for rank, gid in enumerate(ranked_ids, start=1):
+            self._scores[gid] = self._scores.get(gid, 0.0) + weight / (self._k + rank)
+
+    def top_k(self, n: int) -> list[tuple[str, float]]:
+        return sorted(self._scores.items(), key=lambda x: (-x[1], x[0]))[:n]
+
+    def scores(self) -> dict[str, float]:
+        return dict(self._scores)
+```
+
+In `query_genes()`, each tier now collects `(gid, raw_score)` pairs locally, sorts them descending, and calls `fuser.add_tier(name, [gid for gid, _ in pairs], weight=cfg.<tier>_weight)`. The existing `gene_scores[gid] += raw_score` and `tier_contrib[gid][name] = raw_score` writes stay (they feed telemetry and the additive fallback). At the sort site (line 2454):
+
+```python
+if self._fusion_mode == "rrf":
+    fused = fuser.top_k(limit)
+    ranked_ids = [gid for gid, _ in fused]
+    self.last_query_scores = dict(fused)
+else:
+    ranked_ids = sorted(gene_scores, key=gene_scores.get, reverse=True)[:limit]
+```
+
+Authority/party/access_rate post-additives (re-rank class) apply to `last_query_scores` AFTER RRF when `fusion_mode=="rrf"`, preserving their original purpose.
+
+## 6. Per-tier telemetry preservation
+
+`tier_contribution_histogram()` and `tier_fired_counter()` must keep observing **raw pre-RRF** scores so panels remain interpretable. The existing emit block at lines 2387–2407 reads `tier_contrib[gid][tier_name]` (raw scores) and is unchanged. Each tier still writes its raw score to `tier_contrib` *before* calling `fuser.add_tier(...)`. **Single emit point** stays at line 2392; do not move it. Add a parallel `rrf_fused_score_histogram` (new, gated on `fusion_mode=="rrf"`) emitting the post-fusion score per gene for the new "RRF distribution" panel.
+
+## 7. Config flag
+
+```toml
+[retrieval]
+fusion_mode = "additive"   # "additive" | "rrf"
+rrf_k = 60
+# Post-multipliers (mostly defaulted to current implicit weights):
+fts5_weight = 3.0
+splade_weight = 3.5
+tag_exact_weight = 3.0
+tag_prefix_weight = 1.5
+sema_cold_weight = 3.0
+lex_anchor_weight = 1.5
+harmonic_weight = 1.0
+entity_graph_weight = 0.5
+dense_weight = 1.0
+pki_weight = 1.0
+# filename_anchor_weight, sr_weight already exist — reused as-is.
+```
+
+**Deprecation timeline.** v(N): ship `fusion_mode = "additive"` default. v(N+1): flip default to `"rrf"`. v(N+2): remove additive code path. Document in this spec doc.
+
+## 8. Tied-tier semantics
+
+When two tiers both rank gene G at rank 1, RRF awards `weight_a/(60+1) + weight_b/(60+1)`. **Independent contribution per tier.** No max, no min, no per-gene cap. This is the math working as intended: agreement across tiers is the strongest signal RRF can express. Tied-tier covered by unit test `test_rrf_tier_independence`.
+
+## 9. Score-ratio compatibility (TIGHT/FOCUSED/BROAD)
+
+`context_manager.py` lines 976–984 compare `top_score` against `TIGHT_SCORE_FLOOR=5.0` and `FOCUSED_SCORE_FLOOR=2.5`. Under RRF the score scale collapses to roughly `Σ_tier weight/(k+1) ≈ (3+3.5+3+1.5+...)/61 ≈ 0.3` max. **Keeping these floors hardcoded would force every query to BROAD.**
+
+**Decision: defer retune to Stage 4.** Stage 3 ships with a transitional bypass: when `fusion_mode == "rrf"`, `context_manager` reads `top_score / mean_score` ratio only (which IS scale-invariant) and skips the absolute-floor gates. Add `if self.genome._fusion_mode == "rrf": skip_absolute_floors = True` at `context_manager.py:976`. Stage 4 will introduce empirically-fitted RRF floors (target table: TIGHT≥0.10, FOCUSED≥0.05) after a 100-query distribution sweep.
+
+Hand-off note: "Stage 4 owns absolute floor recalibration. Until then, RRF mode operates on ratio gates only."
+
+## 10. Test plan
+
+In `tests/test_fusion_rrf.py`:
+
+- `test_rrf_pool_dominates_when_dense_alone_misses_lexical_match` — dense ranks gene A at 1, FTS ranks B at 1, A at 2; assert B > A only if FTS weight > dense weight; assert tie-breakable by k.
+- `test_rrf_with_zero_weights_disables_tier` — set `fts5_weight=0`; assert FTS-only candidates absent from output.
+- `test_rrf_preserves_filename_anchor_winners` — replay 2026-04-22 Dewey axis-2 corpus; assert filename-anchored gene at rank 1 (regression for +12pp result).
+- `test_fusion_mode_additive_unchanged` — back-compat: bench 50 known queries under `fusion_mode="additive"`; assert ranked_ids identical to pre-Stage-3 baseline (snapshot test).
+- `test_rrf_tier_independence` — two tiers both rank G at rank 1; assert score = `2·w/(k+1)`.
+- `test_rrf_telemetry_emits_raw_pre_rrf` — record observations to a fake meter; assert raw bm25/cosine values surface, not RRF fractions.
+
+## 11. Migration validation
+
+A/B sweep on `genome-bench-N1000.db` (located_n1000 set, ≈200 queries):
+- Run A: `fusion_mode="additive"` with current weights (baseline).
+- Run B: `fusion_mode="rrf"` with all weights preserved as post-multipliers.
+- Metric: retrieval@1, retrieval@5, retrieval@20.
+- **Pass:** retrieval@1 lift ≥ +15pp.
+- **Soft-fail (investigate, do not merge):** lift < +5pp — likely a weight-mapping bug; suspect filename_anchor or PKI mass mis-weighted under RRF rather than abandon the approach.
+- Bench harness: `benchmarks/bench_skill_activation.py --fusion-mode rrf` (add CLI flag).
+
+## 12. Acceptance criteria
+
+- located_n1000 retrieval@1 ≥ 75% with Stages 1+2+3 stacked (current baseline 13.8%).
+- Per-query RRF overhead ≤ 2ms (one `Fuser` instance, ≤ 12 `add_tier` calls of ≤ 500 ids each, single sort at end — well within budget).
+- All unit tests in §10 pass.
+- Telemetry panels for raw per-tier scores unchanged (visual diff).
+- `fusion_mode="additive"` is byte-identical to pre-Stage-3 ranking on snapshot queries.
+
+## 13. Out of scope
+
+- Threshold recalibration for TIGHT/FOCUSED/BROAD absolute floors (Stage 4).
+- Per-classifier (`caller_model_class`) floor tables (Stage 5).
+- Learned weight fitting (would require `cwola_validated` labels — Stage 6+).
+- Replacing the BM25 shortlist post-filter with an RRF cutoff (separate spec).
+- Migrating `query_genes_ann()` thresholding to RRF space (Stage 4 with the floors).

--- a/docs/specs/2026-05-08-stage-4-threshold-calibration.md
+++ b/docs/specs/2026-05-08-stage-4-threshold-calibration.md
@@ -1,0 +1,271 @@
+# Stage 4 — Calibrated Thresholds (per-classifier + margin-over-random)
+
+Plan: helix-context retrieval-fix, Stage 4 of 6 (council 2026-05-08). Depends on Stages 2+3 (score scale stable post-RRF + 1024-dim dense).
+
+## 1. Goals + non-goals
+
+**Goals.** Replace two hand-picked constants with reproducible, data-derived calibrations: (a) the absolute ANN cosine cutoff in `genome.py:371`, and (b) the global confidence floors in `context_manager.py:946-989`. After Stages 2 (1024-dim restore) and 3 (RRF fusion), both are stale. Stage 4 produces a `scripts/calibrate_thresholds.py` artifact that re-derives both from a genome snapshot + bench JSON, persists provenance, and exposes it via `/health` and `/context`.
+
+**Non-goals.** No new query classes, no LLM calls, no changes to retrieval signal mix (Stages 2/3), no `caller_model_class` (Stage 5), no know/miss block (Stage 6).
+
+## 2. Surface area
+
+| File | Lines | Change |
+|---|---|---|
+| `helix_context/genome.py` | 371 | Read `ann_threshold` from new `genome_calibration` table when mode=margin_over_random |
+| `helix_context/genome.py` | ~452 (DDL) | New `CREATE TABLE genome_calibration` |
+| `helix_context/context_manager.py` | 946-989 | Per-classifier floor lookup; pass `cls` from upstream classifier |
+| `helix_context/context_manager.py` | 1094-1096 | `alpha = floors.foveated_alpha(cls)` |
+| `helix_context/config.py` | TOML loader | New `[abstain]`, `[abstain.<cls>]`, extended `[retrieval]` keys |
+| `helix.toml` | 250-257 | `ann_threshold_mode`, `ann_threshold_sigma_multiplier`; `[abstain]` block |
+| `helix_context/server.py` | `/health`, `/context` handlers | Emit calibration provenance |
+| `scripts/calibrate_thresholds.py` | NEW | CLI driver |
+| `tests/test_calibration.py` | NEW | Unit + property tests |
+
+## 3. Margin-over-random ANN threshold
+
+**Algorithm (deterministic, seeded).**
+
+```
+INPUT: genome.db, dim (1024 post-Stage-2), N=10_000, seed=42
+1. SELECT gene_id FROM genes WHERE embedding_dense_v2 IS NOT NULL
+2. rng = numpy.random.default_rng(seed)
+3. ids = rng.choice(all_ids, size=2*N, replace=True).reshape(N, 2)
+4. For each (a, b) in ids where a != b:
+     v_a, v_b = np.frombuffer(BLOB)  # already L2-normalized at index time
+     cos[i] = float(np.dot(v_a, v_b))
+5. mu, sigma = float(cos.mean()), float(cos.std(ddof=1))
+6. threshold = mu + sigma_mult * sigma   # default sigma_mult=3.0
+7. UPSERT INTO genome_calibration (key, value_json, computed_at) VALUES
+     ('ann_threshold', json{'value':threshold,'mu':mu,'sigma':sigma,
+       'N':N,'dim':dim,'sigma_mult':3.0,'seed':42}, now())
+```
+
+**DDL.**
+```sql
+CREATE TABLE IF NOT EXISTS genome_calibration (
+  key TEXT PRIMARY KEY,
+  value_json TEXT NOT NULL,
+  computed_at TEXT NOT NULL,    -- ISO8601 UTC
+  source TEXT                   -- 'calibrate_thresholds.py vX'
+);
+```
+
+Genome `query_genes()` reads `ann_threshold` once at first call (cache on `self`), invalidated on `set_replication_manager` rotation. If the row is missing AND `mode=margin_over_random`, log warning and fall back to the legacy absolute value from helix.toml.
+
+## 4. Per-classifier confidence floors
+
+**Inputs.** `located_n1000.json` rows carry `gene_id` (planted ground-truth) plus the response's `agent.score_top` and the candidate list. We re-classify each row's `query` through `classify_query` to populate `cls`, then split each cls into hits (`gene_id` appears in retrieved set) vs misses.
+
+**Percentile choices.**
+- `abstain_top` = **p85** of MISS scores per cls — score-below-this is dominated by failures (15% false-abstain budget).
+- `focused_top` = **p25** of HIT scores per cls — 75% of true hits clear it.
+- `tight_top` = **p60** of HIT scores per cls — top-confidence band only.
+
+Reasoning: abstain at the upper tail of misses (cheap to be wrong: re-engages BROAD); tight at the lower-middle of hits (expensive to be wrong: drops 9 candidates). Asymmetric percentiles bias toward recall.
+
+**Default-class fanout (from `query_classifier.py:130-179`).**
+
+| cls | assembly_max_genes_cap | abstain_top | focused_top | tight_top | foveated_alpha |
+|---|---|---|---|---|---|
+| arithmetic | 2 | p85_miss | p25_hit | p60_hit | 1.6 (sharp — only 2 genes ever) |
+| factual | 5 | p85_miss | p25_hit | p60_hit | 1.4 |
+| procedural | 6 | p85_miss | p25_hit | p60_hit | 0.9 |
+| multi_hop | 8 | p85_miss | p25_hit | p60_hit | 0.6 (flat — distribute budget) |
+| default | (unset) | p85_miss | p25_hit | p60_hit | 1.0 |
+
+Numeric values are **derived** at calibration time per genome+bench. The α column ships as defaults; the script also emits suggested α from observed mean compression-ratio per cls (out of scope to retune α automatically — manual review).
+
+## 5. Calibration script
+
+**CLI.**
+```
+scripts/calibrate_thresholds.py
+  --genome PATH                   # required, sqlite path
+  --bench PATH                    # located_n1000.json
+  --output-toml PATH              # default: stdout
+  --output-report PATH            # default: calibration_report.json
+  --sigma-mult FLOAT              # default 3.0
+  --random-pairs INT              # default 10000
+  --seed INT                      # default 42
+  --abstain-pct FLOAT             # default 85.0
+  --focused-pct FLOAT             # default 25.0
+  --tight-pct FLOAT               # default 60.0
+  --write-db / --no-write-db      # default --write-db (UPSERT genome_calibration)
+  --dry-run                       # print only, no DB write, exit 0
+```
+
+**stdout (TOML snippet).**
+```toml
+[retrieval]
+ann_threshold_mode = "margin_over_random"
+ann_threshold_sigma_multiplier = 3.0
+# computed: mu=0.018 sigma=0.131 N=10000 dim=1024 -> 0.411
+
+[abstain]
+mode = "per_classifier"
+
+[abstain.factual]
+abstain_top = 0.42
+focused_top = 0.71
+tight_top = 1.18
+
+[abstain.multi_hop]
+abstain_top = 0.38
+focused_top = 0.55
+tight_top = 0.92
+# ... arithmetic, procedural, default
+```
+
+**`calibration_report.json` schema.**
+```json
+{
+  "$schema": "https://helix-context.dev/schemas/calibration_report.v1.json",
+  "version": 1,
+  "computed_at": "2026-05-08T14:32:00Z",
+  "genome": {"path": "...", "sha256": "...", "gene_count": 18934, "dim": 1024},
+  "bench": {"path": "...", "rows": 1000, "harness_version": 2},
+  "ann": {
+    "mu": 0.018, "sigma": 0.131, "N": 10000, "seed": 42,
+    "sigma_mult": 3.0, "threshold": 0.411
+  },
+  "classifiers": {
+    "factual": {
+      "n_total": 412, "n_hit": 358, "n_miss": 54,
+      "hit_score_p25": 0.71, "hit_score_p60": 1.18,
+      "miss_score_p85": 0.42,
+      "floors": {"abstain_top": 0.42, "focused_top": 0.71, "tight_top": 1.18}
+    },
+    "multi_hop": {"...": "..."}, "arithmetic": {"...": "..."},
+    "procedural": {"...": "..."}, "default": {"...": "..."}
+  },
+  "warnings": ["arithmetic: n_total=8 < 30, floors marked low_confidence"]
+}
+```
+
+Any cls with `n_total < 30` emits a warning and copies `default` floors instead.
+
+## 6. helix.toml schema additions
+
+```toml
+[retrieval]
+ann_threshold_mode = "absolute"            # "absolute" | "margin_over_random"  (default: absolute, back-compat)
+ann_threshold_sigma_multiplier = 3.0       # only read when mode=margin_over_random
+# ann_similarity_threshold stays as the absolute fallback / legacy value
+
+[abstain]
+mode = "global"                            # "global" | "per_classifier"  (default: global)
+# Global mode: existing TIGHT_SCORE_FLOOR=5.0, FOCUSED_SCORE_FLOOR=2.5 remain hard-coded constants.
+
+[abstain.factual]
+abstain_top = 0.42
+focused_top = 0.71
+tight_top = 1.18
+foveated_alpha = 1.4
+
+[abstain.multi_hop]
+abstain_top = 0.38
+focused_top = 0.55
+tight_top = 0.92
+foveated_alpha = 0.6
+
+[abstain.arithmetic]
+foveated_alpha = 1.6
+# ...
+[abstain.procedural]
+foveated_alpha = 0.9
+[abstain.default]
+foveated_alpha = 1.0
+```
+
+`mode="global"` preserves Stage-3 behavior exactly. Flipping to `"per_classifier"` requires every emitted `cls` to have a block; missing → loader raises `ConfigError`.
+
+## 7. Per-classifier foveated_alpha
+
+`HelixContextManager` already receives `ClassifierResult` upstream. At line 1094, replace `alpha=self.config.budget.foveated_alpha` with a lookup helper:
+
+```python
+def _alpha_for_cls(self, cls: str) -> float:
+    if self.config.abstain.mode == "per_classifier":
+        return self.config.abstain.per_class[cls].foveated_alpha
+    return self.config.budget.foveated_alpha
+```
+
+Threaded through `_compute_foveated_caps(n, alpha=...)` unchanged. Window metadata records `foveated_alpha_source: "per_classifier:factual"` for telemetry.
+
+## 8. Wire-through points
+
+- **`context_manager.py:946-989`** — replace `FOCUSED_SCORE_FLOOR_FOR_ABSTAIN=2.5`, `TIGHT_SCORE_FLOOR=5.0`, `FOCUSED_SCORE_FLOOR=2.5` with `floors = self._floors_for(cls)`. The three checks become `top_score < floors.abstain_top`, `top_score >= floors.tight_top`, `top_score >= floors.focused_top`. Ratio gates (1.8, 3.0) untouched — they're scale-free.
+- **`genome.py:371`** — `self._ann_threshold` initialised from helix.toml as today; `query_genes()` calls `self._effective_ann_threshold()` which checks `mode` and reads `genome_calibration` row. Cached after first read.
+- **Classifier output already flows in** via the existing injection-router path; just persist `result.cls` onto the active query context for the budget block to read.
+
+## 9. Provenance in /health and /context
+
+**`/health`** adds:
+```json
+"calibration": {
+  "ann_threshold": 0.411,
+  "ann_threshold_mode": "margin_over_random",
+  "ann_threshold_provenance": {"mu": 0.018, "sigma": 0.131, "N": 10000, "dim": 1024},
+  "abstain_mode": "per_classifier",
+  "computed_at": "2026-05-08T14:32:00Z",
+  "calibration_age_days": 0
+}
+```
+
+**`/context` response** — add to existing `agent` dict:
+```json
+"calibration_age_days": 0,
+"calibration_stale": false        // true if age > 30
+```
+
+When stale, also add a `warnings: ["calibration_stale"]` entry. Loader logs WARNING at startup if age > 30 days.
+
+## 10. Test plan
+
+```
+tests/test_calibration.py
+
+test_calibrate_threshold_outputs_margin_over_random_value
+  Build 50-gene fixture genome with dim=64 random unit vectors.
+  Run calibrate(genome, N=1000). Assert |mu - 0| < 0.05, threshold = mu+3sigma,
+  threshold < 1.0.
+
+test_per_classifier_abstain_factual_tighter_than_multi_hop
+  Synthesize bench JSON: factual rows hit at score 0.7, multi_hop hit at 0.4.
+  Run calibrator. Assert floors.factual.tight_top > floors.multi_hop.tight_top.
+
+test_calibration_report_jsonschema_validates
+  Run calibrator on fixture, validate report against
+  schemas/calibration_report.v1.json with jsonschema.validate(...)
+
+test_global_mode_preserves_legacy_behavior
+  ContextManager(config(abstain.mode="global")). Inject scored candidates with
+  top_score=4.9, ratio=2.5. Assert tier="focused" (matches pre-Stage-4 5.0 floor).
+
+test_property_random_genome_threshold_rejects_99pct (hypothesis)
+  @given dim in [128, 1024], n_genes in [200, 5000]:
+    Build genome of unit-Gaussian vectors. Calibrate.
+    Sample 5000 fresh random pairs. Assert >= 0.99 fall below threshold.
+
+test_floor_lookup_falls_back_to_default_when_cls_missing
+test_calibration_age_warning_on_stale_db (mock now() to 31 days ahead)
+test_genome_calibration_table_upsert_idempotent
+```
+
+Mock-only; no live Ollama. Add `tests/fixtures/calibration_bench_50.json` minimal.
+
+## 11. Acceptance criteria
+
+- `bench_needle_1000.py` retrieval@1 ≥ **82%** with Stages 1+2+3+4 stacked (vs current 13.8% at thr=0.30).
+- Per-classifier abstain rate on factual queries ≤ **5%** (current implicit ~95% — 5.0 floor unreachable post-RRF).
+- `mode="global"` regression diff vs pre-Stage-4 head ≤ **±1 row** out of 1000 on the same bench.
+- `genome_calibration` UPSERT round-trips: `calibrate → reopen → /health` returns identical provenance.
+- Property test passes ≥ 50 hypothesis examples.
+
+## 12. Out of scope
+
+- `caller_model_class` adaptive sizing (Stage 5).
+- Know/miss negative-evidence block (Stage 6).
+- Auto-recalibration cron / scheduled refresh.
+- Per-classifier α auto-tuning beyond defaults.

--- a/docs/specs/2026-05-08-stage-5-caller-model-class.md
+++ b/docs/specs/2026-05-08-stage-5-caller-model-class.md
@@ -1,0 +1,176 @@
+# Stage 5 — `caller_model_class` opt-in render branch
+
+Plan: helix-context retrieval-fix, Stage 5 of 6 (council 2026-05-08). Layered on Stages 1-4; generic branch is regression-locked to pre-Stage-5 output.
+
+## 1. Goals + non-goals
+
+**Goals.**
+- Stop hurting frontier callers (Claude Opus 4.7, GPT-5, Gemini 3 Pro) with foveated rank-reversal and 20-entry slate truncation.
+- Give small-MoE callers a JSON-shaped, character-bounded slate so attention-routing locks survive budget enforcement.
+- Cross the classifier axis with the model-class axis without collapsing them.
+
+**Non-goals.**
+- No User-Agent / model-string auto-detection (caller opts in).
+- No second endpoint, no second packet schema. One `/context`, branches inside `build_context`.
+- No LLM in the retrieval path. Stage 5 is rule-table only.
+- No know/miss block (Stage 6).
+
+## 2. Surface area
+
+| File | Lines | Change |
+|---|---|---|
+| `helix_context/schemas.py` | end of file | new `CallerModelClass` str-Enum + `CALLER_MODEL_CLASS_DEFAULT="generic"` |
+| `helix_context/server.py` | 772–870 | parse `caller_model_class` from request, validate, pass through |
+| `helix_context/server.py` | 569–571 | thread param into `build_context_async` for `/v1/chat/completions` path too |
+| `helix_context/context_manager.py` | `build_context` signature | new kwarg `caller_model_class: str = "generic"` |
+| `helix_context/context_manager.py` | 680–694 (`_should_use_slate`) | extend: `caller_model_class=="small_moe"` forces True; `=="frontier"` forces False |
+| `helix_context/context_manager.py` | 1089–1103 (foveated apply) | gate: `frontier` skips reversal entirely |
+| `helix_context/context_manager.py` | 1117–1130 (slate population) | branch on class for ordering + JSON shape |
+| `helix_context/context_manager.py` | 2173–2189 (slate cap) | replace `unique_slate[:20]` with char-bounded greedy fill |
+| `helix_context/legibility.py` | 122–157 (`format_gene_header`) | suppress headers when class is `small_moe` (token cost > legibility benefit at 4B) |
+| `helix_context/query_classifier.py` | 113–179 | `decoder_mode` lookup table replaces hard-coded values; new `resolve_decoder_mode(cls, caller_model_class)` |
+| `bench/bench_needle_1000.py` | argparse | `--caller-model-class {generic,small_moe,frontier}` |
+| `tests/test_caller_model_class.py` | NEW | per §10 |
+| `helix_context/telemetry.py` | OTel span emit | new attribute + counter |
+
+## 3. Wire-format addition
+
+Pydantic enum in `schemas.py`:
+
+```python
+class CallerModelClass(str, Enum):
+    generic   = "generic"
+    small_moe = "small_moe"
+    frontier  = "frontier"
+```
+
+`/context` request adds optional `caller_model_class: CallerModelClass = "generic"`. Unknown string → 400 with allowed list (mirrors `response_mode` validation at server.py:846). Echoed back at `response.metadata.caller_model_class` for debugging. The `/v1/chat/completions` proxy path passes whatever the body sets, defaulting `"generic"` (preserves today's behavior for Continue).
+
+## 4. Behavior matrix
+
+Rows = caller_model_class, columns = behavior knobs. **`generic` row is the regression baseline — every cell equals today's hard-coded behavior.**
+
+| | foveated | slate emitted | slate_format | slate_bound | assembly_cap | decoder_mode_default | legibility_headers | candidate_order |
+|---|---|---|---|---|---|---|---|---|
+| **generic** | ON if `budget_tier=="broad"` and `foveated_enabled` | iff `_should_use_slate()` (server MoE flag OR small downstream) | `\n`-joined raw KV lines | **20 entries** (status quo) | `classifier.assembly_max_genes_cap` | per classifier (table §6 `generic` column) | ON when `legibility_on` | reversed if foveated active, else forward |
+| **small_moe** | ON (always, regardless of `budget_tier`) | always ON | **JSON object** `<helix:slate>{...}</helix:slate>` | **1500 chars** (config: `slate_char_budget`) | `min(classifier_cap, 4)` | per classifier (table §6 `small_moe` column) | OFF (suppressed — 4B doesn't need them, costs ~80 tok/gene) | reversed (small models genuinely benefit from recency) |
+| **frontier** | **OFF** (skip reversal entirely) | OFF | n/a | n/a | `max(12, classifier_cap*2)` | per classifier (table §6 `frontier` column) | ON | **forward (rank 1 first)** — narrative-coherence ordering |
+
+Notes on cells:
+- `frontier × foveated = OFF` is the load-bearing change. Council seat 4's ~14% → 60%+ frontier-hit-rate jump.
+- `small_moe × foveated = ON always` (not just `broad`): small models always benefit from recency on the gene that holds the answer.
+- `frontier × assembly_cap = max(12, classifier_cap*2)` because frontier callers have 200k+ context and the classifier caps were tuned for 4B prompt windows.
+- `small_moe × candidate_order` stays reversed even though foveated is on, because the slate is the primary surface for small_moe and the prose tail is secondary.
+
+## 5. Slate format change
+
+Today: `"\n".join(unique_slate[:20])` at context_manager.py:2181. Entry-bounded cap silently drops the answer KV when the genome surfaces >20 KVs, and breaks MoE attention-routing because flat newlines have no structural lock.
+
+**New (small_moe branch only):**
+
+```
+<helix:slate>{"k1":"v1","k2":"v2",...}</helix:slate>
+```
+
+- Char-bounded, default budget `1500` (config key `budget.slate_char_budget`). Counted as the rendered string including braces, quotes, commas, and the wrapper tag — i.e., what the model actually sees.
+- Greedy-fill ordered by per-KV score. Gemini's `_best_first` sort at context_manager.py:1121 is preserved as the source order.
+- Each KV is parsed as `key=value` (existing `g.key_values` shape). On parse failure, key=`"kv{idx}"`, value=raw line.
+- Keys de-duped (first-write-wins; later duplicates dropped silently).
+- **Truncation rule:** when adding a KV would exceed budget, truncate that KV's *value* to fit (minimum 8 chars retained — if can't fit, drop the entry and continue). Do NOT silently stop iterating — a low-rank short KV can still fit after a high-rank long one was truncated.
+- JSON encoding: `json.dumps(d, ensure_ascii=False, separators=(",", ":"))` — compact, no whitespace, MoE attention-friendly.
+- `generic` and `frontier` branches: slate_format unchanged (newline-joined); for `frontier` the slate is suppressed entirely.
+
+## 6. Cross-product with classifier (decoder_mode resolution)
+
+Replace hard-coded `decoder_mode=` literals in `query_classifier.py:131–175` with a lookup. Classifier returns `cls` only; `resolve_decoder_mode(cls, caller_model_class)` is called by `build_context` after both signals are known.
+
+15-cell table. **Bold cells** differ from generic. Columns are `caller_model_class`.
+
+| classifier.cls \ class | generic | small_moe | frontier |
+|---|---|---|---|
+| `arithmetic` | `minimal` | **`answer_slate_only`** | **`minimal`** (same as generic — frontier handles arithmetic with tiny context) |
+| `factual` | `condensed` | **`answer_slate_only`** | **`condensed`** (same — wh-question stays tight) |
+| `procedural` | `full` | **`condensed_with_slate`** | **`full`** |
+| `multi_hop` | `full` | **`condensed_with_slate`** (full is too long for 4B) | **`full`** |
+| `default` | (None — falls back to `self._decoder_prompt`) | **`condensed_with_slate`** | (None — falls back, same as generic) |
+
+Mode definitions (existing prompts in `helix_context/decoder_prompts.py`, plus two new):
+- `answer_slate_only` (NEW for small_moe×short-answer): the JSON slate is the *entire* decoder context, no `<expressed_context>` block. ~150 tokens.
+- `condensed_with_slate` (NEW): `<helix:slate>` followed by the condensed decoder prompt. Slate first so attention locks before prose.
+- `minimal`, `condensed`, `full`: existing.
+
+## 7. Default / legacy preservation
+
+Regression table (column = today's literal in `query_classifier.py`). `generic` column of §6 must equal column 2 below cell-for-cell:
+
+| classifier.cls | today's hard-coded `decoder_mode` (lines) | §6 `generic` cell |
+|---|---|---|
+| arithmetic | `"minimal"` (138) | `minimal` ✓ |
+| factual | `"condensed"` (149) | `condensed` ✓ |
+| procedural | `"full"` (163) | `full` ✓ |
+| multi_hop | `"full"` (174) | `full` ✓ |
+| default | `None` (113, _DEFAULT) | None ✓ |
+
+Test `test_generic_branch_byte_identical_to_pre_stage5_output` (§10) is the live enforcement.
+
+## 8. Foveated gating logic
+
+`context_manager.py:1089` becomes:
+
+```python
+# Stage 5 (2026-05-08): frontier callers skip foveated reversal.
+# Long-context attention expects narrative-coherence (rank-1-first) order;
+# reversal degrades retrieval. See docs/specs/2026-05-08-stage-5-caller-model-class.md §4.
+if (
+    caller_model_class != "frontier"
+    and budget_tier == "broad"
+    and self.config.budget.foveated_enabled
+    and len(candidates) > 1
+):
+    caps = _compute_foveated_caps(...)
+    candidates = list(reversed(candidates))
+    foveated_caps = list(reversed(caps))
+    foveated_active = True
+```
+
+For `small_moe`, the `budget_tier == "broad"` precondition is dropped (foveated always-on). Implementation: a small `_foveated_should_run(caller_model_class, budget_tier, cfg)` helper avoids nesting two new branches in the existing block.
+
+## 9. Bench harness change
+
+`bench/bench_needle_1000.py` accepts `--caller-model-class {generic,small_moe,frontier}` (default `generic`). Value passed in the `/context` POST body. Run output filename includes the class: `n1000_results_{class}_{timestamp}.json`.
+
+Expected outcome: `located_n1000` with `frontier` produces a substantially higher retrieval rate than `small_moe` on the same retrieval pipeline. This is informative, not a bug — frontier's forward-order, foveated-off, larger-cap branch is genuinely better for frontier consumers.
+
+## 10. Test plan
+
+`tests/test_caller_model_class.py` (mock tests, no Ollama):
+
+1. `test_caller_model_class_default_is_generic` — POST `/context` without the field; assert request handled, response metadata echoes `"generic"`.
+2. `test_frontier_skips_foveated` — monkeypatch `_compute_foveated_caps` to record calls; with `caller_model_class="frontier"` and `budget_tier="broad"`, assert zero calls AND `candidates` is in forward order at splice time.
+3. `test_small_moe_emits_json_slate` — assert decoder prompt contains `<helix:slate>{` and the rendered slate parses as JSON.
+4. `test_slate_char_bounded_not_entry_bounded` — feed 50 KVs, set `slate_char_budget=400`, assert >20 entries can fit if short, and total rendered length ≤ 400 + wrapper-tag chars.
+5. `test_decoder_mode_lookup_table_complete` — iterate the 15-cell cross-product; assert `resolve_decoder_mode(cls, class)` returns the table value for every cell.
+6. `test_generic_branch_byte_identical_to_pre_stage5_output` — run a 100-query golden set against pre-Stage-5 git ref (recorded to `tests/golden/pre_stage5_responses.jsonl`); diff every response byte-for-byte.
+
+Plus reuse: existing foveated/slate tests run unchanged with default class.
+
+## 11. Telemetry
+
+- OTel span `helix.context` gains attribute `helix.caller_model_class` (string).
+- New counter `helix_context_calls_by_class{class="generic|small_moe|frontier"}` incremented once per `/context` call.
+- Existing latency histogram (server.py:1097) gains the `class` label so frontier/small_moe regressions are visible separately.
+
+## 12. Acceptance criteria
+
+- `located_n1000` retrieval@1 with `caller_model_class="frontier"` ≥ **90%** (Stages 1+2+3+4+5 stacked, frontier branch).
+- `located_n1000` with `caller_model_class="small_moe"` ≥ **70% retrieval AND ≥ 50% answered** (small models extract from JSON slate where they failed on flat newlines).
+- `generic` branch byte-identical to pre-Stage-5 output on the 100-query golden set (test 6).
+- All existing tests green; no perf regression on `bench_needle_1000.py --caller-model-class generic` vs main (±2% p95 latency).
+
+## 13. Out of scope
+
+- Top-level know/miss block (Stage 6).
+- Live model-class detection from User-Agent or `model` field — explicitly rejected; opt-in only.
+- New decoder-mode prompts beyond `answer_slate_only` and `condensed_with_slate`.
+- Per-class foveated alpha tuning (current `α` reused for `small_moe`; `frontier` doesn't apply foveated at all).
+- Telemetry-driven autotuning of `slate_char_budget`.

--- a/docs/specs/2026-05-08-stage-6-know-miss-blocks.md
+++ b/docs/specs/2026-05-08-stage-6-know-miss-blocks.md
@@ -1,0 +1,230 @@
+# Stage 6 — Machine-Tagged `know` / `miss` Surface for `/context`
+
+Plan: helix-context retrieval-fix, Stage 6 of 6 (council 2026-05-08). Independent of Stages 2-4; can land any time after Stage 1.
+
+## 1. Goals + non-goals
+
+**Goals.** Promote retrieval outcome from prose-in-`expressed_context` and scattered-`notes[]` strings to a top-level, machine-tagged contract on every `/context` and `/context/packet` response. Frontier agents must be able to deterministically branch know vs. go without parsing English.
+
+**Non-goals.** No LLM in the decision path. No new retrieval signals — Stage 6 only re-surfaces what Stages 1–5 already compute. No MCP tool wiring (consumers register grep/rag/web themselves). No removal of existing fields — purely additive.
+
+## 2. Surface area
+
+| File | Lines | Change |
+|---|---|---|
+| `helix_context/schemas.py` | end of file | Add `KnowBlock`, `MissBlock`; add `know`/`miss` fields to `ContextWindow.metadata`-mirror or as siblings (see §5) |
+| `helix_context/context_manager.py` | 185 | New constants `_NO_MATCH_TAG_*` for tagged refusal tokens |
+| `helix_context/context_manager.py` | 1869–1908 (`_build_abstain_window`) | Replace `_ABSTAIN_MARKER` byte and stamp `miss` into `metadata` |
+| `helix_context/context_packet.py` | 241–272 (`_coordinate_signals`) | Expose tuple result up to caller for `KnowBlock.coordinate_confidence` |
+| `helix_context/context_packet.py` | 484–506 | Keep `notes.append(...)` strings; additionally stamp packet-level `know`/`miss` |
+| `helix_context/server.py` | 974–1001 (`agent.recommendation`) | Add `"escalate"`; lift `know`/`miss` from `window.metadata` to top-level response |
+| `helix_context/server.py` | 1103 (`/context/packet`) | Same lift on the packet response |
+| `helix_context/server.py` | 1178 (`/context/refresh-plan`) | Pass-through `miss` if present (it implies a refresh plan anyway) |
+| `helix_context/know_calibration.py` | new | Loads `[know]` table from `helix.toml`; pure functions, no I/O at call time |
+| `scripts/calibrate_know_confidence.py` | new | Stage §11 calibrator |
+| `tests/test_know_miss_block.py` | new | Stage 6 contract tests |
+
+## 3. New schema — `KnowBlock`
+
+```python
+# schemas.py
+from typing import Literal, Optional
+from pydantic import BaseModel, Field
+
+class KnowBlock(BaseModel):
+    """Top-level 'we found it' contract. Emitted iff retrieval cleared
+    the FOCUSED floor AND coordinate_confidence is above floor.
+    Mutually exclusive with MissBlock."""
+    found: Literal[True] = True
+    confidence: float = Field(ge=0.0, le=1.0)        # calibrated, see below
+    top_score: float                                  # raw fused top-1
+    score_gap: float                                  # raw (top1 - top2), NOT ratio
+    lexical_dense_agree: bool                         # top BM25 == top dense top-K∩
+    gene_id_match: Optional[str] = None               # beacon, see §8
+    coordinate_confidence: float = Field(ge=0.0, le=1.0)  # promoted, see §9
+```
+
+**Calibration of `confidence`.** A logistic over four normalized features (parameters fit by §11 from `located_n1000`):
+
+```
+z   = β0
+    + β1 * tanh(top_score / s_ref)        # squashes raw fused score
+    + β2 * tanh(score_gap   / g_ref)      # raw subtraction, not ratio
+    + β3 * (1.0 if lexical_dense_agree else 0.0)
+    + β4 * coordinate_confidence          # already in [0,1]
+confidence = 1.0 / (1.0 + exp(-z))
+```
+
+`s_ref`, `g_ref`, and the four `β` coefficients live in `[know]` of `helix.toml`. Defaults shipped in code (cold-start) until calibration runs: `β = (-2.0, +2.0, +1.5, +0.7, +1.8)`, `s_ref = 1.0`, `g_ref = 0.5`. These defaults intentionally produce `confidence ≈ 0.5` at boundary cases — a `know` block is only emitted when `confidence >= know.emit_floor` (default `0.55`); below that we fall through to `MissBlock(reason="sparse")`.
+
+**Stage 7 extension (forthcoming).** Stage 7 adds `freshness_min` (the worst per-gene decay score across top-K) as a fifth feature β5 with default ≈ +1.5. The logistic becomes 5-feature; `know` cannot be emitted if the top-1 gene's source is stale. This is required because the current `_compute_health` averages decay scores ([context_manager.py:2315](../../helix_context/context_manager.py#L2315)), masking a stale needle when fresh padding accompanies it. Stage 6 ships with the 4-feature logistic; Stage 7 retunes via the same calibration script.
+
+## 4. New schema — `MissBlock`
+
+```python
+class MissBlock(BaseModel):
+    """Top-level 'we did NOT find it' contract. Emitted on ABSTAIN,
+    on denatured genome, on sub-floor sparse retrieval, or on a
+    promoter-tag whiff. Mutually exclusive with KnowBlock."""
+    miss: Literal[True] = True
+    reason: Literal["abstain", "denatured", "sparse", "no_promoter_match"]
+    top_score: float
+    ratio: float                                      # top/2nd (matches existing metadata.ratio)
+    escalate_to: list[Literal["grep", "rag", "web", "ask_human"]]
+    do_not_answer_from_genome: Literal[True] = True
+```
+
+**`escalate_to` population (rule-based, ordered).** Decided in `_pick_escalation(query, reason)`; first matching rule wins, results deduped:
+
+1. **Code-shaped query** (matches `r"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]"` OR contains `def `, `class `, `import `, `function ` OR ≥1 `path_token` resembling a filename `.py|.ts|.go|.rs|.md`) → `["grep", "rag"]`.
+2. **Entity-shaped query** (extract_query_signals returns ≥1 entity AND no code shape) and `reason == "no_promoter_match"` → `["rag", "web"]`.
+3. **Reason `denatured`** (genome inconsistent) → `["grep", "ask_human"]` — don't trust RAG over a denatured corpus, but local grep still works.
+4. **Reason `abstain` and short query (≤3 tokens)** → `["ask_human", "rag"]` — ambiguity.
+5. **Default fallback** → `["rag"]`.
+
+`do_not_answer_from_genome` is a `Literal[True]` so the field's *presence* is the signal — agents don't compare strings.
+
+**Stage 7 extension (forthcoming).** Stage 7 adds three new reasons to the `Literal[...]`: `"stale"` (gene retrieved successfully but source mtime > last_verified_at), `"cold"` (heterochromatin match — gene exists but isn't safe to act on without re-warming), `"superseded"` (claims_graph has a successor edge from a newer gene). All three use a different routing — `agent.recommendation="refresh"` (new sixth value), and a new required field `refresh_targets: list[str]` (file paths or URLs to re-fetch before retrying). Stage 6 ships with the four reasons above; Stage 7 extends without breaking back-compat (consumers parse the union, new reasons fall through unknown→escalate for legacy clients).
+
+## 5. ContextResponse top-level addition
+
+`/context` and `/context/packet` JSON responses gain **exactly one** of two sibling keys at the top level (alongside `expressed_context`, `agent`, `metadata`):
+
+```json
+{ "know": { "...": "..." } }    // or
+{ "miss": { "...": "..." } }
+```
+
+**Discriminator (server-side, single source of truth).** Computed once in a new helper `helix_context/know_decision.py::decide_know_or_miss(window, packet_signals) -> KnowBlock | MissBlock`:
+
+- `window.context_health.status == "abstain"` → `MissBlock(reason="abstain")`.
+- `window.context_health.status == "denatured"` → `MissBlock(reason="denatured")`.
+- `genes_expressed == 0` AND not abstain → `MissBlock(reason="no_promoter_match")`.
+- Else compute `confidence`. If `confidence < know.emit_floor` → `MissBlock(reason="sparse")`. Else → `KnowBlock(...)`.
+
+Server lifts the result to the top of the response dict. Schema invariant enforced by a `model_validator` on a thin `ContextResponseEnvelope` wrapper used by both routes: exactly one of `know`/`miss` is non-null.
+
+## 6. `expressed_context` byte change
+
+Replace `_ABSTAIN_MARKER` (currently `"(no relevant context found in genome)"` at `context_manager.py:185`) with three sibling tagged tokens, selected by reason:
+
+```
+<helix:no_match reason="abstain"          do_not_answer="true"/>
+<helix:no_match reason="denatured"        do_not_answer="true"/>
+<helix:no_match reason="sparse"           do_not_answer="true"/>
+<helix:no_match reason="no_promoter_match" do_not_answer="true"/>
+```
+
+Exact format: lowercase tag `helix:no_match`, attributes in fixed order (`reason` then `do_not_answer`), self-closing `/>`, no whitespace inside. Constants in `context_manager.py`: `_NO_MATCH_TAG = '<helix:no_match reason="{reason}" do_not_answer="true"/>'`. `_ABSTAIN_MARKER` is **kept** as a deprecated alias re-pointed at `_NO_MATCH_TAG.format(reason="abstain")` for one release; existing tests assert via the constant, so they migrate transparently.
+
+## 7. `agent.recommendation` extension
+
+Add `"escalate"` to the existing set (`server.py:975–986`). Mapping additions:
+
+- `health.status == "abstain"` → `recommendation = "escalate"`, hint = `"Genome has no usable signal for this query. Use external retrieval (grep / RAG / web)."`
+- `health.status == "denatured"` keeps `"reread_raw"` (unchanged).
+- New: when `miss` block present AND query is code-shaped → `recommendation = "escalate"`, `escalate_to` mirrored from `MissBlock`.
+
+The existing four values (`trust`, `verify`, `refresh`, `reread_raw`) remain valid; `escalate` is the fifth, and is the *only* value that may co-exist with a `miss` block.
+
+## 8. `gene_id_match` beacon rules
+
+Populate `KnowBlock.gene_id_match` with the matched token (string), or leave `None`. Implemented in `context_packet.py::_gene_id_beacon(query, top_gene)`:
+
+- Tokenize the query with `extract_query_signals` (existing).
+- For the top-1 gene only:
+  - Compute `file_tokens(top_gene.source_id)` and `path_tokens(top_gene.source_id)` (both already exist).
+  - If any query token is in `file_tokens(...)` → set `gene_id_match` to that token. Filename match wins.
+  - Else if any query token is in `path_tokens(...)` AND that token has length ≥ 4 (avoid `src`, `lib`, `app`) → set `gene_id_match` to that token.
+- **Exact, case-insensitive equality only.** No prefix match, no substring match, no edit distance, no synonym expansion.
+
+False-positive cost > false-negative cost: a wrong beacon causes the frontier model to lock in a wrong answer; a missing beacon merely lowers `confidence` and the agent still gets the gene.
+
+## 9. `coordinate_confidence` promotion
+
+Today `context_packet.py:484–506` appends `f"coordinate_confidence={x:.2f}..."` strings to `packet.notes`. Migration:
+
+1. Keep all existing `notes.append(...)` calls verbatim — humans read them.
+2. Add `packet._coordinate_confidence: float` (set on the packet by the builder) and `packet._file_coverage: float`. Underscore-prefixed because they are computation byproducts, not part of the wire schema; the wire schema gets them via `KnowBlock`.
+3. The know/miss decider reads these from the packet (or, for `/context`, recomputes them from `window.expressed_gene_ids` via the same `_coordinate_signals`).
+
+## 10. Test plan (`tests/test_know_miss_block.py`)
+
+- `test_know_block_emitted_when_found_and_high_confidence` — seed planted gene, query its filename, assert `know.found=True`, `know.confidence > 0.7`, `know.gene_id_match == "<filename_token>"`, `miss is None`.
+- `test_miss_block_emitted_on_abstain` — abstain manager fixture, assert `miss.reason == "abstain"`, `miss.do_not_answer_from_genome is True`, `know is None`, `escalate_to` non-empty.
+- `test_gene_id_match_beacon_only_on_exact_filename_match` — three subcases: (a) exact filename token match → set; (b) substring `"manage"` vs file `"context_manager.py"` → `None`; (c) folder-only match `"src"` → `None` (length filter).
+- `test_expressed_context_has_no_match_tag_on_miss` — assert `expressed_context == '<helix:no_match reason="abstain" do_not_answer="true"/>'` exactly.
+- `test_agent_recommendation_escalate_on_code_shaped_miss` — abstain with query `"def parse_promoter"`, assert `agent.recommendation == "escalate"` and `miss.escalate_to == ["grep", "rag"]`.
+- `test_no_block_when_neither_found_nor_abstain` — **edge case spec.** Score above ABSTAIN floor but `confidence < know.emit_floor` (e.g., low `coordinate_confidence`, no agreement, score just clears floor). The discriminator emits `MissBlock(reason="sparse")` — never neither, never both. Test asserts exactly that: response has `miss`, not `know`, and `expressed_context` carries the populated genes (because we did retrieve, just weakly) plus the `<helix:no_match reason="sparse"/>` token *appended* (not replacing) so the agent still sees the weak hits but is told to escalate.
+
+## 11. Confidence calibration
+
+`scripts/calibrate_know_confidence.py`:
+
+1. Load `located_n1000` ground truth (Stage 1 bench output).
+2. For each row, invoke `/context` against the locked-in fixture genome and record `(top_score, score_gap, lexical_dense_agree, file_cov, planted_gene_id == retrieved_top1)`.
+3. Fit `sklearn.linear_model.LogisticRegression(penalty="l2", C=1.0)` on the four features → `(planted == top1)` label. Extract `β` and intercept.
+4. Pick `s_ref = median(top_score)`, `g_ref = median(score_gap)` from the calibration set so `tanh(...)` saturates around the typical scale.
+5. Pick `know.emit_floor` as the precision-95 operating point on the held-out 20% split.
+6. Write to `helix.toml`:
+
+```toml
+[know]
+emit_floor = 0.55
+s_ref = 1.0
+g_ref = 0.5
+betas = [-2.0, 2.0, 1.5, 0.7, 1.8]   # [intercept, top, gap, agree, coord]
+calibrated_at = "2026-05-08T..."
+calibrated_on_n = 800
+```
+
+Loader in `helix_context/know_calibration.py`; pure functions; falls back to defaults on missing/malformed table with a `log.warning`.
+
+## 12. Frontier agent prompt-template (load-bearing)
+
+Without this, a frontier model will paper over `do_not_answer_from_genome=true` by falling back to its training prior. The contract is load-bearing only if the agent's system prompt teaches it to honor the tag. Recommended fragment, shipped in `docs/agent-sdk-fragment.md` and importable as a constant `helix_context.agent_prompt.HELIX_NO_MATCH_FRAGMENT`:
+
+```
+HELIX KNOW/MISS CONTRACT
+========================
+The retrieval layer (helix-context) returns one of two structured blocks
+on every /context call:
+
+  • know { found, confidence, gene_id_match, ... } — retrieval succeeded;
+    the expressed_context bytes ARE grounded; you may answer from them.
+
+  • miss { reason, escalate_to, do_not_answer_from_genome:true, ... } —
+    retrieval did NOT find it. The expressed_context will contain a
+    <helix:no_match reason="..." do_not_answer="true"/> tag. When you
+    see this tag OR a `miss` block:
+
+      1. DO NOT answer from the genome content.
+      2. DO NOT fall back to your training prior to fabricate an answer.
+      3. Emit a tool call from `escalate_to` (in order):
+           - "grep"      → local repo grep / file_search MCP tool
+           - "rag"       → external RAG / docs index
+           - "web"       → web search
+           - "ask_human" → ask the operator
+      4. Only after the escalation tool returns, compose your reply.
+
+If both `know` and `miss` are absent (legacy server), treat the response
+as `know` with confidence=0.5 — but log a warning, your server is stale.
+
+Compliance is non-negotiable: confabulating an answer when miss is
+present is a contract violation, scored as a hard failure in eval.
+```
+
+Deliberately uses imperative, numbered, short sentences. The "scored as a hard failure" sentence is the highest-leverage line; small/medium frontier models comply more readily when given an explicit eval framing.
+
+## 13. Acceptance criteria
+
+On `located_n1000` with Stages 1–5 stacked:
+
+- (a) ≥ 99% of retrieval-success rows emit a `know` block with `confidence > 0.7`.
+- (b) 100% of retrieval-miss rows emit a `miss` block with `len(escalate_to) >= 1`.
+- (c) 0 rows emit both blocks. Enforced by the response-envelope validator at runtime (raises 500 on violation; integration tests assert it never raises).
+- (d) Offline frontier-agent eval (mocked tool layer): with §12 system-prompt fragment, the agent issues a tool call from `escalate_to` instead of answering on ≥ 95% of `miss` rows. Eval harness in `scripts/eval_agent_compliance.py`; fails the build below 95%.
+
+## 14. Out of scope
+
+Actual MCP tool wiring for `grep`/`rag`/`web`/`ask_human` — consumers register their own tools. Helix only signals which class of tool to invoke. Also out: backfilling the contract onto `/v1/chat/completions` (the OpenAI-compat proxy is a separate surface; that's a future stage).

--- a/docs/specs/2026-05-08-stage-7-freshness-gate.md
+++ b/docs/specs/2026-05-08-stage-7-freshness-gate.md
@@ -1,0 +1,319 @@
+# Stage 7 — Freshness Gate on `know`: Stale / Cold / Superseded Demotion
+
+Plan: helix-context retrieval-fix, Stage 7 of 6+1 (council 2026-05-08, two-reviewer convergence add-on). Layered on Stage 6's `know`/`miss` contract; closes the "high-confidence retrieval of stale source" gap. Stage 6 already pre-declared the β5 logistic slot, the three new `MissBlock.reason` values, and `agent.recommendation="refresh"` — Stage 7 fills them in.
+
+## 1. Goals + non-goals
+
+**Goals.**
+- A `know` block can only be emitted when the top-1 gene's underlying source is fresh enough to act on.
+- Stale, cold-tier-only, and superseded top-1 results downgrade to `MissBlock(reason ∈ {stale, cold, superseded})` carrying `refresh_targets`.
+- Replace `mean(decay_score)` health math with three signals so a stale needle is no longer masked by fresh padding.
+- New `agent.recommendation="refresh"` distinguishes "re-fetch then come back" from `"escalate"`.
+- Surface heterochromatin SEMA hits as `MissBlock(reason="cold")` instead of dropping them silently.
+
+**Non-goals.**
+- No LLM in the freshness path (ribosome stays disabled).
+- No KnowBlock/MissBlock redesign — extend Stage 6 additively.
+- No hash-based revalidation; MVP is mtime + URL delegation to `/consolidate`.
+- No auto-consolidation triggered by stale detection.
+- No multi-version / point-in-time genome queries.
+
+## 2. Surface area
+
+| File | Lines | Change |
+|---|---|---|
+| `helix_context/context_manager.py` | 2255–2349 | Rewrite `_compute_health`: add freshness_min/top1/weighted; new `status="stale"` rule (§3) |
+| `helix_context/context_manager.py` | 2446–2470 | Populate three new ContextHealth fields; back-compat shim sets `freshness=freshness_weighted` |
+| `helix_context/context_manager.py` | `build_context` near know/miss decide | Call freshness pipeline before `decide_know_or_miss` |
+| `helix_context/schemas.py` | 165–195 (`ContextHealth`) | Add `freshness_min`, `freshness_top1`, `freshness_weighted` (Optional[float]) |
+| `helix_context/schemas.py` | Stage-6 `MissBlock` | Extend `reason` to add `stale|cold|superseded`; add `refresh_targets: list[str]` |
+| `helix_context/schemas.py` | Stage-6 `KnowBlock` | Add `soft_stale: bool = False` |
+| `helix_context/genome.py` | 471, 499 | `last_verified_at REAL` already in DDL — confirm; no new column |
+| `helix_context/genome.py` | 1465–1500 (insert path) | Set `last_verified_at = now` on ingest if caller passed None |
+| `helix_context/genome.py` | new method | `mark_verified(gene_ids, ts, *, read_only)` — no-op when read_only=True |
+| `helix_context/genome.py` | 490+ migration block | `CREATE INDEX IF NOT EXISTS idx_genes_supersedes ON genes(supersedes) WHERE supersedes IS NOT NULL` |
+| `helix_context/freshness.py` | new | `revalidate_source`, `revalidate_and_mark`, `check_superseded`; in-memory mtime cache (60s TTL) |
+| `helix_context/know_decision.py` | Stage 6 helper | Three new gates (§7, §8); β5 plumbed in (§10) |
+| `helix_context/know_calibration.py` | Stage 6 helper | Logistic extended to 5 features; default `β5 = +1.5` |
+| `helix_context/server.py` | 974–1001 | Route MissBlock(stale/cold/superseded) → `recommendation="refresh"`; soft-stale on KnowBlock → `"refresh"` |
+| `helix_context/legibility.py` | Stage-6 fragment | Append `HELIX_REFRESH_FRAGMENT` (§12) |
+| `tests/test_freshness_gate.py` | new | §13 cases |
+
+## 3. `_compute_health` rewrite
+
+Replace the `mean(decay_score)` block at `context_manager.py:2313–2317` with three signals computed in one pass over score-desc-ordered candidates:
+
+```python
+if candidates:
+    decays = [float(g.epigenetics.decay_score or 0.0) for g in candidates]
+    freshness_min = min(decays)
+    freshness_top1 = decays[0]
+    raw_scores = [max(scores_map.get(g.gene_id, 0.0), 0.0) for g in candidates]
+    s_total = sum(raw_scores) or 1.0
+    weights = [s / s_total for s in raw_scores]
+    freshness_weighted = sum(w * d for w, d in zip(weights, decays))
+else:
+    freshness_min = freshness_top1 = freshness_weighted = 0.0
+```
+
+**Status rule** (replaces the `freshness < 0.4` line at 2342):
+
+```
+if genes_expressed > 0 and (freshness_top1 < 0.4 or freshness_weighted < 0.5):
+    status = "stale"
+elif ellipticity >= 0.7: status = "aligned"
+elif ellipticity >= 0.3: status = "sparse"
+else:                    status = "denatured"
+```
+
+`freshness_top1 < 0.4` catches "the gene we'd answer from is stale". `freshness_weighted < 0.5` catches "score-weighted neighborhood is stale" — padding genes only contribute proportional to their score share, so 11 cap-fillers can no longer mathematically mask a stale needle.
+
+**Back-compat shim.** `ContextHealth.freshness` (the only field external callers read) becomes `freshness_weighted` so it stays meaningful (a stale top-1 will pull it down) without renaming. New three fields are additive. The `status` string vocabulary (`aligned|sparse|stale|denatured`) is unchanged so OTel dashboards do not break.
+
+## 4. `genes.last_verified_at` — already exists, wire writers
+
+DDL inspection: `last_verified_at REAL` is already at `genome.py:471` and ALTER-block `:499`. **No column add required.** Stage 7 only ensures it is populated:
+
+- **On ingest** (`genome.py:1465–1500`): if `gene.last_verified_at is None`, set to `now()` before INSERT. `provenance.py:394` already does this on the provenance path; mirror into bare-insert.
+- **On `/consolidate`** (`server.py:2300+`): the existing UPDATE adds `last_verified_at = now()`.
+- **On successful retrieval-time mtime check** (§5): `genome.mark_verified([gene_id], now_ts, read_only=read_only)` — gated; no-op under read_only.
+- **Semantics.** `NULL` = "freshness unknown" (legacy rows). `decide_know_or_miss` treats NULL as **neutral**: confidence reduced via β5, but `know` still emittable on a strong score gap. Test `test_unknown_freshness_treated_as_neither_fresh_nor_stale` enforces.
+
+No migration needed; existing snapshots already have the column. Stage-1 read_only contract preserved because `mark_verified` gates on it.
+
+## 5. Per-gene source revalidation contract
+
+New module `helix_context/freshness.py`:
+
+```python
+def revalidate_source(
+    gene: Gene,
+    *,
+    mtime_cache: dict[str, tuple[float, float]],   # source_path -> (mtime, cached_at)
+    now_ts: float,
+    cache_ttl_s: float = 60.0,
+) -> Literal["fresh", "stale", "missing", "unknown"]:
+    """Compare on-disk mtime to gene.last_verified_at.
+
+    Decision matrix:
+      source_path is None                         -> "unknown"
+      source_path is URL (scheme://...)           -> "unknown"  (URL flow delegated to /consolidate)
+      file does not exist                         -> "missing"
+      gene.last_verified_at is None               -> "unknown"
+      mtime <= last_verified_at                   -> "fresh"
+      mtime  > last_verified_at                   -> "stale"
+    """
+```
+
+**Cache.** Keyed on `source_path`, value `(mtime, cached_at)`. Skip `os.stat` when `now_ts - cached_at < cache_ttl_s`. TTL=60s. Lives on `HelixContextManager` (per-batch state, not Genome). Evicted on `/admin/refresh`.
+
+**read_only contract (Stage 1 boundary).** mtime cache is in-memory — populating it is NOT a genome mutation, so read_only callers MAY update the cache. They MUST NOT call `genome.mark_verified` (writes the column):
+
+```python
+def revalidate_and_mark(genome, gene, *, mtime_cache, now_ts, read_only):
+    status = revalidate_source(gene, mtime_cache=mtime_cache, now_ts=now_ts)
+    if status == "fresh" and not read_only:
+        genome.mark_verified([gene.gene_id], now_ts, read_only=False)
+    return status
+```
+
+Under `read_only=True`, "fresh" is reported for the turn but the column is not bumped; the next non-read-only call re-stats (within 60s, served from cache) and writes through.
+
+**Where called.** In `build_context` after candidates are ranked but before `decide_know_or_miss` — only the top-K shown to the agent (default top-3, configurable as `freshness.revalidation_topk`). Bulk revalidation of all 500 pool candidates is out of scope. Latency: 3 stat calls × ~100µs warm = sub-millisecond.
+
+## 6. Cold-tier surfacing
+
+`query_cold_tier` already exists (`genome.py:1248`) but is not wired into the hot path. New helper `_cold_tier_peek(query, k=3)` in `context_manager.py`:
+
+**Trigger condition.**
+```
+genes_expressed < 3
+AND health.status != "abstain"
+AND not classifier.disable_cold_tier
+```
+
+If trigger fires, call `genome.query_cold_tier(query, k=3, min_cosine=0.4)`. Threshold 0.4 is tighter than the function default (0.15): cold peek competes with `MissBlock(reason="sparse")` and we want it only on real archived hits.
+
+**Translation to `refresh_targets`.** For each cold gene returned, take `gene.epigenetics.source_path or gene.source_id`. Emit:
+
+```python
+MissBlock(
+    reason="cold",
+    refresh_targets=[g.epigenetics.source_path or g.source_id for g in cold_hits],
+    top_score=top_cold_cosine, ratio=1.0,
+    escalate_to=[],
+)
+```
+
+Cold matches are NOT auto-promoted to hot tier — the agent re-ingests by re-reading the source. Preserves the LLM-free design pillar.
+
+## 7. Supersession check
+
+`check_superseded(genome, gene) -> Optional[str]`. Two source paths exist:
+
+**Path A — gene-level pointer.** `genes.supersedes TEXT` at `genome.py:473` is "this gene replaces ...". Reverse lookup ("who replaces me?"):
+
+```sql
+SELECT gene_id, source_id FROM genes WHERE supersedes = ? LIMIT 1
+```
+
+If a row exists, return `successor.source_id`.
+
+**Path B — claim-edge chain.** `claims_graph.latest_in_chain` walks `claim_edges` for `supersedes` edges. For each top-1's claim_id, if `latest_in_chain != claim_id`, the head's gene's `source_id` is the successor.
+
+**Stage 7 ships Path A only.** Path A is one indexed query; Path B is recursive walk plus claim→gene mapping. Add `idx_genes_supersedes` index in §2's migration. Path B is flagged Stage 7+1 if the bench surfaces gene rows whose `supersedes IS NULL` but a claim chain exists.
+
+**Wiring** — called from `decide_know_or_miss` against top-1 only:
+
+```python
+successor_source = check_superseded(genome, top1)
+if successor_source:
+    return MissBlock(
+        reason="superseded",
+        refresh_targets=[successor_source],
+        top_score=top_score, ratio=ratio, escalate_to=[],
+    )
+```
+
+## 8. `MissBlock.reason` extension + `refresh_targets`
+
+Final Stage 7 schema:
+
+```python
+class MissBlock(BaseModel):
+    miss: Literal[True] = True
+    reason: Literal[
+        "abstain", "denatured", "sparse", "no_promoter_match",   # Stage 6
+        "stale", "cold", "superseded",                           # Stage 7
+    ]
+    top_score: float
+    ratio: float
+    escalate_to: list[Literal["grep", "rag", "web", "ask_human"]] = Field(default_factory=list)
+    refresh_targets: list[str] = Field(default_factory=list)     # NEW
+    do_not_answer_from_genome: Literal[True] = True
+```
+
+**Field invariants** (pydantic `model_validator`):
+- `reason in {"stale","cold","superseded"}` ⇒ `len(refresh_targets) >= 1` AND `escalate_to == []`.
+- `reason in {"abstain","denatured","sparse","no_promoter_match"}` ⇒ `refresh_targets == []` AND `len(escalate_to) >= 1`.
+- The two lists are mutually exclusive (one populated, one empty).
+
+**JSON shape** (sibling of Stage 6 `know` key):
+
+```json
+{ "miss": {
+    "miss": true, "reason": "stale",
+    "top_score": 0.83, "ratio": 1.42,
+    "escalate_to": [],
+    "refresh_targets": ["F:/Projects/helix-context/helix_context/config.py"],
+    "do_not_answer_from_genome": true
+} }
+```
+
+`refresh_targets` are absolute file paths or fully-qualified URLs — same shape `RefreshTarget.source_id` carries (§11).
+
+## 9. `agent.recommendation = "refresh"`
+
+Sixth value, distinct from `"escalate"`. Rules append to Stage 6 at `server.py:974–1001`:
+
+| Block | Condition | recommendation |
+|---|---|---|
+| `MissBlock(stale)` | top1 mtime > last_verified_at | `"refresh"` |
+| `MissBlock(cold)` | cold-peek hit, no hot match | `"refresh"` |
+| `MissBlock(superseded)` | top1 has successor gene | `"refresh"` |
+| `MissBlock(abstain/denatured/sparse/no_promoter_match)` | (Stage 6) | `"escalate"` |
+| `KnowBlock` AND `freshness_min < 0.5` AND `freshness_top1 >= 0.5` | soft-stale | `"refresh"` + `KnowBlock.soft_stale=true` |
+| `KnowBlock` otherwise | normal | `"trust"`/`"verify"` |
+
+Soft-stale-on-know is the one place a `know` block requests refresh: top-1 fresh (safe to act), but supporting context stale. `KnowBlock.soft_stale: bool = False` carries the signal; legacy parsers ignore it.
+
+## 10. KnowBlock confidence formula extension (β5)
+
+Stage 6 4-feature logistic becomes 5-feature:
+
+```
+z = β0
+  + β1 * tanh(top_score / s_ref)
+  + β2 * tanh(score_gap / g_ref)
+  + β3 * (1.0 if lexical_dense_agree else 0.0)
+  + β4 * coordinate_confidence
+  + β5 * freshness_min                       # NEW
+confidence = 1.0 / (1.0 + exp(-z))
+```
+
+`freshness_min` from §3, in `[0,1]`. **Default `β5 = +1.5`**. When all candidates' `last_verified_at IS NULL`, `freshness_min` falls back to `decay_score` (non-zero for legacy rows). Calibration via existing `scripts/calibrate_know_confidence.py` — gains a fifth coefficient column; CLI unchanged. Pre-calibration on `located_n1000`: planted-stale needles (`freshness_min ≈ 0.1`) drive `confidence < emit_floor` → fall through to `MissBlock(reason="stale")`.
+
+## 11. Integration with `/context/refresh-plan`
+
+Stage 7 `MissBlock(stale)` carries `refresh_targets: list[str]`; existing `/context/refresh-plan` returns `list[RefreshTarget]` where `source_id` is the equivalent string. Round-trip:
+
+| `MissBlock` | `RefreshTarget` | Notes |
+|---|---|---|
+| `refresh_targets[i]` | `source_id` | Direct equivalence |
+| (inferred from scheme) | `target_kind` | `"file"` if no scheme, else `"url"` |
+| `reason` | `reason` | `stale`→`stale_mtime`, `cold`→`cold_tier`, `superseded`→`superseded_by_successor` |
+| `1.0 - freshness_min` | `priority` | Higher = more urgent |
+
+Adapter `MissBlock.to_refresh_targets() -> list[RefreshTarget]` lives in `schemas.py`. `/context/refresh-plan` wire format at `server.py:1174` is unchanged.
+
+## 12. Frontier agent prompt-template extension
+
+Append `HELIX_REFRESH_FRAGMENT` to Stage 6's `HELIX_NO_MATCH_FRAGMENT`:
+
+```
+If `recommendation` is "refresh" (NOT "escalate"):
+  Stage 7 contract — the genome found a candidate but the underlying
+  source is stale, archived, or superseded.
+
+  1. DO NOT answer from the genome content (still binding).
+  2. Read each path in `refresh_targets` from disk, OR fetch each URL.
+     - "stale": file mtime moved past last verification — re-read.
+     - "cold":  archived match — re-read to re-warm hot tier.
+     - "superseded": a newer source replaces the queried one.
+  3. After fetching, re-call /context with the same query.
+  4. The next response will reflect the refreshed state.
+
+"refresh" means "the answer is here, just out of date — fetch and retry."
+"escalate" means "the answer is NOT here — go ask elsewhere."
+These are distinct branches. Do not conflate them.
+```
+
+Identical imperative-numbered tone to Stage 6's fragment. Concatenated into the system-prompt prefix when `caller_model_class != "small_moe"`; small_moe gets a 1-line summary to preserve tokens.
+
+## 13. Test plan
+
+`tests/test_freshness_gate.py` (mock-only):
+
+- `test_freshness_top1_dominates_padding` — top-1 decay=0.1, 11 padding decay=1.0 → `status="stale"` (regression vs current `mean → "aligned"`).
+- `test_compute_health_back_compat_freshness_field` — `health.freshness == freshness_weighted`, reflects stale top-1 (< 0.5).
+- `test_cold_tier_peek_emits_miss_cold` — heterochromatin cosine > 0.4, zero hot matches → `MissBlock(cold)` with correct `refresh_targets`.
+- `test_supersession_downgrades_top1` — plant G2 with `supersedes=G1`, query retrieves G1 → `MissBlock(superseded)`, `refresh_targets=[G2.source_id]`.
+- `test_revalidate_caches_mtime_60s_ttl` — two calls within 60s = one `os.stat`; +61s = two.
+- `test_read_only_does_not_write_last_verified_at` — `read_only=True` mtime-pass call leaves DB column unchanged; `read_only=False` advances it.
+- `test_unknown_freshness_treated_as_neither_fresh_nor_stale` — `last_verified_at IS NULL`, decay=0.9, strong gap → KnowBlock emitted (not downgraded), confidence reduced vs known-fresh.
+- `test_soft_stale_know_block_recommends_refresh` — top-1 decay=0.95, ranks 2–5 decay=0.2 → KnowBlock with `soft_stale=true`, `recommendation="refresh"`.
+- `test_refresh_targets_required_for_stale_cold_superseded` — pydantic validator blocks `reason="stale"` + `refresh_targets=[]` with `ValidationError`.
+
+Reuses Stage 6 fixtures.
+
+## 14. Acceptance criteria
+
+- On `located_n1000` with planted-stale needles (mtime artificially aged so `freshness_min < 0.4` for planted top-1): **≥ 95%** emit `MissBlock(reason="stale")`. Bench flag `--plant-stale 0.05` ages 5% of needles.
+- 11 fresh padding genes around a stale needle does **NOT** flip status from `"stale"` to `"aligned"` (regression vs `mean(decay)` math).
+- Cold-tier visibility: corpus with 5% heterochromatin matches → **≥ 90%** of heterochromatin-only-match queries emit `MissBlock(reason="cold")` with non-empty `refresh_targets`, instead of `MissBlock(reason="sparse")`.
+- Generic branch byte-compat: `health.freshness` shifts to `freshness_weighted`, equals `mean(decay)` exactly when all weights are equal — verify on the 100-query golden set.
+- All Stage 1–6 tests stay green; `pytest tests/ -m "not live" -v` exits 0.
+
+## 15. Out of scope
+
+- Hash-based revalidation (`content_hash` exists; mtime is cheaper and sufficient for MVP).
+- URL revalidation logic itself (delegated to `/consolidate`).
+- Auto-consolidation triggered by stale detection (would write in the read flow — violates Stage 1's read_only contract).
+- Per-tenant freshness policies (party-aware mtime tolerances).
+- Multi-version / point-in-time genome queries.
+- Path B supersession via `claim_edges` chains.
+- Auto-retuning of `β5` outside the existing Stage 6 calibration script.
+
+---
+
+**Surface-area summary:** 1 health-math rewrite, 1 new freshness module, 2 schema extensions (additive), 3 know/miss decision branches, 1 prompt fragment appended, 1 test file. Zero new columns, zero new endpoints, zero LLM calls. Headline behavioral change: a stale top-1 needle can no longer produce a `KnowBlock`.


### PR DESCRIPTION
Companion design records for the 6 remaining stages of the 7-stage retrieval-fix plan. Stage 1's spec landed with #45; these are the rest:

- Stage 2 (#46): dense recall as first-class tier
- Stage 3 (#55): RRF fusion replacing additive gene_scores
- Stage 4 (#56): calibrated thresholds (margin-over-random + per-classifier floors)
- Stage 5 (#47): caller_model_class render branches
- Stage 6 (#48): machine-tagged know/miss contract for /context
- Stage 7 (#51): freshness gate (stale/cold/superseded demotion)

Includes the post-write amendments applied during the council review:
- Stage 1 read-only contract scope sentence + response_mode=packet regression test
- Stage 2 chromatin filter clause in dense recall SQL + matrix loader
- Stage 6 forward-pointing notes about Stage 7's freshness extension and `MissBlock.reason` extension

Pure docs commit; no code changes.