### PR TITLE
docs: post-7-stage initiative — SETUP / TROUBLESHOOTING / API / runbooks / config (closes #8 + #59)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,308 @@
+# helix-context — environment variable reference
+#
+# Copy to `.env` and source before running helix:
+#   set -a; source .env; set +a                # bash / WSL
+#   for /F "tokens=*" %i in (.env) do set %i   # cmd
+#
+# Vars marked [REQUIRED] must be set; others are optional with sensible
+# defaults. [DARK-SHIP] = wired but off-by-default (Phase 2 / experimental).
+# [TEST-ONLY] = used by benchmarks/tests only, not server runtime.
+# [LEGACY] = back-compat alias kept for older clients; prefer the modern name.
+#
+# Verified by grep against helix_context/, scripts/, benchmarks/, and the
+# launcher .bat files on 2026-05-10. File:line citations on each var.
+
+
+# ─── Attribution (4-layer identity contract) ─────────────────────────────────
+# These tag every gene the server writes for cross-machine federation.
+# See FEDERATION_LOCAL.md and helix_context/server.py:_resolve_default_attribution.
+
+# HELIX_ORG: organization slug — top of the 4-layer attribution stack.
+# Falls back to "local" when unset. Set per shell to group machines under
+# a common operator (e.g. "swiftwing", "acme").                  [OPTIONAL]
+HELIX_ORG=local
+# src: helix_context/server.py:139, helix_context/mcp_server.py:277
+
+# HELIX_DEVICE: device/PC label in the federation stack. Doubles as the
+# hardware picker for ribosome inference: auto | cuda | rocm | mps | cpu.
+# When unset, server falls back to HELIX_PARTY then socket.gethostname().
+# Override one-shot via HELIX_DEVICE=cpu to force CPU on a GPU box.   [OPTIONAL]
+HELIX_DEVICE=auto
+# src: helix_context/hardware.py:40, helix_context/server.py:145, helix_context/mcp_server.py:279
+
+# HELIX_USER: human operator handle (the "who is at the keyboard" layer).
+# Falls back to getpass.getuser() when unset. Distinct from HELIX_AGENT — a
+# user can run multiple agents (laude/raude/taude) from one login.   [OPTIONAL]
+HELIX_USER=
+# src: helix_context/server.py:161, helix_context/mcp_server.py:283
+
+# HELIX_AGENT: AI persona writing genes (laude / raude / taude / gemini /
+# openwebui / etc). When unset, ingests are tagged "manual / no AI persona."
+# Pre-4-layer code overloaded this as the user handle; the server still
+# honors that legacy fallback when only HELIX_AGENT is set.          [OPTIONAL]
+HELIX_AGENT=
+# src: helix_context/server.py:153, helix_context/mcp_server.py:285
+
+# HELIX_AGENT_KIND: agent vendor/family axis — e.g. "claude-code", "gemini",
+# "ollama-chat", "vscode". Falls back to HELIX_MCP_HOST when omitted.
+# Drives dashboard chip rendering and capability tags.               [OPTIONAL]
+HELIX_AGENT_KIND=
+# src: helix_context/mcp_server.py:288, helix_context/mcp_server.py:969
+
+# HELIX_PARTY_ID: party/device identifier for CWoLa session attribution and
+# session-registry presence. Resolution order: HELIX_PARTY_ID > HELIX_DEVICE
+# > HELIX_PARTY > socket.gethostname(). Set in helix.toml [server] also.   [OPTIONAL]
+HELIX_PARTY_ID=
+# src: helix_context/mcp_server.py:135, helix_context/mcp_server.py:280
+
+# HELIX_MCP_HANDLE: stable handle for one MCP session in the live registry.
+# Convention: laude (Claude Code), raude (claude.ai), taude (Cursor),
+# gemini (Gemini CLI), openwebui (Open WebUI). Defaults to "mcp-<pid>"
+# when unset — unique per process but anonymous.                     [OPTIONAL]
+HELIX_MCP_HANDLE=
+# src: helix_context/mcp_server.py:119, helix_context/mcp_server.py:966
+
+# HELIX_MCP_HOST: MCP host/tool family — used as a capability tag
+# ("host:claude-code") on the live registry chip. Defaults to "unknown"
+# when unset, which the launcher heuristically remaps via VSCODE_PID
+# / CURSOR_TRACE_ID detection.                                       [OPTIONAL]
+HELIX_MCP_HOST=
+# src: helix_context/mcp_server.py:968, helix_context/launcher/ide_fingerprint.py:37
+
+# HELIX_PARTY: legacy alias for HELIX_DEVICE / HELIX_PARTY_ID. Still read
+# for back-compat with pre-4-layer clients. Prefer HELIX_PARTY_ID.   [LEGACY]
+HELIX_PARTY=
+# src: helix_context/server.py:146, helix_context/mcp_server.py:281
+
+
+# ─── Server / config ─────────────────────────────────────────────────────────
+
+# HELIX_CONFIG: path to helix.toml. Default is "helix.toml" in cwd.   [OPTIONAL]
+HELIX_CONFIG=helix.toml
+# src: helix_context/config.py:521
+
+# HELIX_GENOME_PATH: SQLite genome path — overrides [genome].path in
+# helix.toml. Use with HELIX_USE_SHARDS=1 for a routing DB.           [OPTIONAL]
+HELIX_GENOME_PATH=
+# src: helix_context/config.py:611
+
+# HELIX_SERVER_UPSTREAM: OpenAI-compatible upstream URL (Ollama / OpenAI /
+# headroom). Overrides [server].upstream. Set automatically when the
+# launcher routes through headroom.                                   [OPTIONAL]
+HELIX_SERVER_UPSTREAM=
+# src: helix_context/config.py:616, helix_context/launcher/app.py:328
+
+# HELIX_SERVER_UPSTREAM_TIMEOUT: seconds for upstream chat completions.
+# Overrides [server].upstream_timeout. Float.                         [OPTIONAL]
+HELIX_SERVER_UPSTREAM_TIMEOUT=
+# src: helix_context/config.py:618
+
+# HELIX_TZ: IANA timezone for the /context timestamp_local field
+# (e.g. 'America/Los_Angeles', 'Europe/Berlin'). Falls back to system tz.  [OPTIONAL]
+HELIX_TZ=
+# src: helix_context/server.py:85
+
+# HELIX_MCP_URL: helix HTTP base URL the MCP shim talks to.           [OPTIONAL]
+HELIX_MCP_URL=http://127.0.0.1:11437
+# src: helix_context/mcp_server.py:108
+
+# HELIX_MCP_TIMEOUT: per-request timeout (seconds) for the MCP shim.  [OPTIONAL]
+HELIX_MCP_TIMEOUT=30
+# src: helix_context/mcp_server.py:109
+
+# HELIX_MCP_LOG_LEVEL: logging level for the MCP shim process.        [OPTIONAL]
+HELIX_MCP_LOG_LEVEL=INFO
+# src: helix_context/mcp_server.py:1020
+
+# HELIX_URL: legacy MCP base URL. Read by helix_context/mcp/server.py
+# (the deprecated stdio shim) and benchmark scripts. Prefer HELIX_MCP_URL. [LEGACY]
+HELIX_URL=http://127.0.0.1:11437
+# src: helix_context/mcp/server.py:45, helix_context/vault/cli.py:18
+
+# HELIX_TIMEOUT: legacy MCP timeout. Prefer HELIX_MCP_TIMEOUT.        [LEGACY]
+HELIX_TIMEOUT=30
+# src: helix_context/mcp/server.py:46
+
+
+# ─── Observability ───────────────────────────────────────────────────────────
+
+# HELIX_OBSERVABILITY: master switch for the native observability sidecar
+# (Prometheus, Tempo, Loki, Grafana, OTel Collector). Set to 0 / false / no
+# / off to skip. Default ON when unset.                               [OPTIONAL]
+HELIX_OBSERVABILITY=1
+# src: helix_context/launcher/app.py:432
+
+# HELIX_OTEL_ENABLED: turn on OTel SDK init in the FastAPI server.
+# Default "0" (off). Set "1" to emit traces/metrics to the collector. [OPTIONAL]
+HELIX_OTEL_ENABLED=1
+# src: helix_context/telemetry.py:117
+
+# HELIX_OTEL_ENDPOINT: OTLP gRPC endpoint for the collector.          [OPTIONAL]
+HELIX_OTEL_ENDPOINT=localhost:4317
+# src: helix_context/telemetry.py:149
+
+# HELIX_OTEL_INSECURE: "1" for plain gRPC (dev-local), "0" for TLS.   [OPTIONAL]
+HELIX_OTEL_INSECURE=1
+# src: helix_context/telemetry.py:150
+
+# HELIX_OTEL_SAMPLER_RATIO: trace sampler 0.0-1.0. 1.0 = sample every span. [OPTIONAL]
+HELIX_OTEL_SAMPLER_RATIO=1.0
+# src: helix_context/telemetry.py:152
+
+# HELIX_OTEL_REDACT_QUERY: "1" hashes raw query strings in spans
+# (privacy default). Set "0" to ship raw queries — local dev only.    [OPTIONAL]
+HELIX_OTEL_REDACT_QUERY=1
+# src: helix_context/telemetry.py:77
+
+
+# ─── Headroom integration (proxy + dashboard) ────────────────────────────────
+
+# HELIX_HEADROOM_ENABLED: master switch — overrides [headroom].enabled
+# in helix.toml. Truthy ⇒ launcher adopts/spawns headroom on start.   [OPTIONAL]
+HELIX_HEADROOM_ENABLED=
+# src: helix_context/launcher/app.py:567
+
+# HELIX_HEADROOM_AUTOSTART: spawn headroom proxy if nothing is already
+# running on the configured port. Truthy ⇒ autostart.                 [OPTIONAL]
+HELIX_HEADROOM_AUTOSTART=
+# src: helix_context/launcher/app.py:566
+
+# HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO: auto-route helix's OpenAI-compatible
+# chat upstream through headroom only when the upstream is non-local.
+# Local Ollama stays direct; remote providers gain headroom's proxy layer. [OPTIONAL]
+HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=
+# src: helix_context/launcher/app.py:544
+
+# HELIX_DISABLE_HEADROOM: kill-switch for A/B benchmarking — bypass the
+# headroom bridge entirely. Truthy ⇒ headroom hooks return None.      [OPTIONAL]
+HELIX_DISABLE_HEADROOM=
+# src: helix_context/headroom_bridge.py:52
+
+
+# ─── Feature toggles ─────────────────────────────────────────────────────────
+
+# HELIX_BUDGET_ZONE: enable the 2026-04-14 budget-zone gene-cap spike.
+# Clamps max_genes based on caller's incoming prompt token count.
+# Zones (128k window): <25% none, 25-40% cap 12, 40-60% cap 6,
+# 60-80% cap 3, 80%+ cap 1. Truthy ⇒ on.                              [OPTIONAL]
+HELIX_BUDGET_ZONE=1
+# src: helix_context/budget_zone.py:48
+
+# HELIX_FILENAME_ANCHOR_ENABLED: Tier 0.5 filename-anchor scoring —
+# boost candidates whose filename stem matches a query term. Off by
+# default to preserve existing tier behaviour.                        [OPTIONAL]
+HELIX_FILENAME_ANCHOR_ENABLED=
+# src: helix_context/filename_anchor.py:134, helix_context/context_manager.py:460
+
+# HELIX_LAYERED_FINGERPRINTS: Phase 2 claims-layer fingerprints (issue #8).
+# Off by default. Set "1" to write the layered fingerprint table.     [DARK-SHIP]
+HELIX_LAYERED_FINGERPRINTS=0
+# src: helix_context/genome.py:2848
+
+# HELIX_USE_SHARDS: open the genome via the sharded routing adapter
+# instead of the single-file SQLite path. Off by default until cutover. [DARK-SHIP]
+HELIX_USE_SHARDS=
+# src: helix_context/shard_router.py:243, helix_context/sharding.py:299
+
+# HELIX_WALKING_TIEBREAK: opt-in associative-graph ordering for
+# tied-score retrieval. A/B benchmarking flag.                        [DARK-SHIP]
+HELIX_WALKING_TIEBREAK=
+# src: helix_context/tie_break.py:42
+
+# HELIX_ABSTAIN_DISABLE: kill-switch for the abstain-tier (BROAD takes
+# negative space). Set "1" to force off even when helix.toml enables it.   [OPTIONAL]
+HELIX_ABSTAIN_DISABLE=
+# src: helix_context/context_manager.py:1036
+
+# HELIX_LAUNCHER_UPDATE_CHECK: 0 / false / no / off disables the
+# launcher's periodic pip-update check. Default ON.                   [OPTIONAL]
+HELIX_LAUNCHER_UPDATE_CHECK=1
+# src: helix_context/launcher/update_check.py:85
+
+
+# ─── mem_sync (background ingest daemon) ─────────────────────────────────────
+
+# HELIX_MEM_SYNC_URL: helix base URL for the mem_sync daemon's HTTP client.
+# Falls back to [mem_sync].helix_url in helix.toml.                   [OPTIONAL]
+HELIX_MEM_SYNC_URL=
+# src: scripts/run_mem_sync.py:73
+
+# HELIX_MEM_SYNC_INTERVAL: poll interval (seconds) between ingests.   [OPTIONAL]
+HELIX_MEM_SYNC_INTERVAL=
+# src: scripts/run_mem_sync.py:77
+
+# HELIX_MEM_SYNC_DIRS: pathsep-separated list of dirs to watch.       [OPTIONAL]
+HELIX_MEM_SYNC_DIRS=
+# src: scripts/run_mem_sync.py:80
+
+
+# ─── Bench / test-only ───────────────────────────────────────────────────────
+
+# HELIX_MODEL: downstream model id for benchmark scripts (qwen3:4b /
+# qwen3:8b / gemma4:e4b / etc). Not read by the server runtime.       [TEST-ONLY]
+HELIX_MODEL=
+# src: benchmarks/bench_needle.py:268, benchmarks/bench_needle_1000.py:61
+
+# HELIX_BENCH_REQUIRE_BM25_PARITY: gate the rag-vs-helix composition
+# bench on BM25 parity with the reference set.                        [TEST-ONLY]
+HELIX_BENCH_REQUIRE_BM25_PARITY=0
+# src: benchmarks/bench_helix_rag_composition.py:768
+
+# HELIX_SKIP_MONITOR: opt out of bench_needle_1000's monitor sidecar. [TEST-ONLY]
+HELIX_SKIP_MONITOR=
+# src: benchmarks/bench_needle_1000.py:867
+
+# HELIX_FUSION_MODE_LABEL: label tag for skill-activation bench rows. [TEST-ONLY]
+HELIX_FUSION_MODE_LABEL=additive
+# src: benchmarks/bench_skill_activation.py:287
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Consumed-by index (one-line summary per var)
+#
+#   HELIX_ABSTAIN_DISABLE              context_manager._build_abstain_signal kill-switch
+#   HELIX_AGENT                        ingest attribution AI agent handle
+#   HELIX_AGENT_KIND                   agent family axis (claude-code / gemini / ...)
+#   HELIX_BENCH_REQUIRE_BM25_PARITY    bench_helix_rag_composition.py gate
+#   HELIX_BUDGET_ZONE                  budget_zone.is_enabled — gene-cap spike
+#   HELIX_CONFIG                       helix.toml path
+#   HELIX_DEVICE                       hardware picker + device attribution
+#   HELIX_DISABLE_HEADROOM             headroom_bridge kill-switch (A/B)
+#   HELIX_FILENAME_ANCHOR_ENABLED      filename_anchor.is_enabled — Tier 0.5 toggle
+#   HELIX_FUSION_MODE_LABEL            bench_skill_activation row label
+#   HELIX_GENOME_PATH                  genome.path override
+#   HELIX_HEADROOM_AUTOSTART           launcher autostart override
+#   HELIX_HEADROOM_ENABLED             launcher headroom master switch
+#   HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO conditional upstream route through headroom
+#   HELIX_LAUNCHER_UPDATE_CHECK        launcher self-update check toggle
+#   HELIX_LAYERED_FINGERPRINTS         genome.py Phase 2 claims layer toggle
+#   HELIX_MCP_HANDLE                   live MCP session handle for registry presence
+#   HELIX_MCP_HOST                     MCP host/tool-family capability tag
+#   HELIX_MCP_LOG_LEVEL                MCP shim logging level
+#   HELIX_MCP_TIMEOUT                  MCP shim per-request timeout
+#   HELIX_MCP_URL                      MCP shim → helix HTTP base URL
+#   HELIX_MEM_SYNC_DIRS                mem_sync watch_dirs override
+#   HELIX_MEM_SYNC_INTERVAL            mem_sync poll interval
+#   HELIX_MEM_SYNC_URL                 mem_sync helix base URL
+#   HELIX_MODEL                        bench downstream model id
+#   HELIX_OBSERVABILITY                native observability sidecar opt-out
+#   HELIX_ORG                          attribution org id
+#   HELIX_OTEL_ENABLED                 OTel SDK init switch
+#   HELIX_OTEL_ENDPOINT                OTLP gRPC endpoint
+#   HELIX_OTEL_INSECURE                OTLP plain-gRPC switch
+#   HELIX_OTEL_REDACT_QUERY            hash query strings in spans
+#   HELIX_OTEL_SAMPLER_RATIO           trace sampler ratio
+#   HELIX_PARTY                        legacy alias for HELIX_DEVICE / HELIX_PARTY_ID
+#   HELIX_PARTY_ID                     CWoLa party id + session attribution
+#   HELIX_SERVER_UPSTREAM              OpenAI-compatible upstream URL override
+#   HELIX_SERVER_UPSTREAM_TIMEOUT      upstream chat-completions timeout
+#   HELIX_SKIP_MONITOR                 bench_needle_1000 monitor opt-out
+#   HELIX_TIMEOUT                      legacy MCP timeout
+#   HELIX_TZ                           /context timestamp_local timezone
+#   HELIX_URL                          legacy MCP base URL
+#   HELIX_USE_SHARDS                   sharded genome adapter switch
+#   HELIX_USER                         human participant handle
+#   HELIX_WALKING_TIEBREAK             walking-tiebreak A/B flag
+#
+# (no HELIX_*_TOKEN / *_SECRET / *_KEY / *_API_KEY are read by the codebase
+#  — admin-endpoint auth is not implemented as of 2026-05-10).

--- a/README.md
+++ b/README.md
@@ -6,173 +6,143 @@
 [![LLM-free pipeline](https://img.shields.io/badge/pipeline-LLM--free-brightgreen.svg)](docs/architecture/PIPELINE_LANES.md)
 [![Paper: Agentome](https://img.shields.io/badge/paper-Agentome-purple.svg)](https://mbachaud.substack.com/p/agentome)
 
-A context-index engine for LLM agents. Helix retrieves, weighs, and compresses your codebase into a context window — **without a single LLM call on the retrieval path.**
+**Genome-based context compression for local LLMs, with a machine-tagged know/miss agent contract.**
 
-**28.7× token savings on production workloads** · GPQA diamond +4 pp accuracy with context on · 5.4× median across 15 query types
+Coordinate-index engine for LLM agents. Helix retrieves, weighs, and compresses your codebase into a context window — without a single LLM call on the retrieval path.
 
----
+## At a glance
 
-## Benchmarks
+- **Compression**: collapses ~9k tokens of raw working set into a ~600 effective-token assembled context (28.7× headline on production workloads, 5.4× median across 15 query shapes).
+- **Agent contract**: every `/context` response carries a top-level `know{}` (grounded, you may answer) or `miss{}` (`do_not_answer_from_genome:true`, plus `escalate_to` tools or `refresh_targets` paths). Stale `know` blocks downgrade to `miss(reason="stale"|"cold"|"superseded")` via the Stage 7 freshness gate.
+- **LLM-free retrieval**: `/context` runs spaCy NER, SQLite FTS5 BM25, BGE-M3 dense recall, RRF fusion, Howard-2005 TCM, and Hebbian co-activation — zero ribosome calls. The only LLM call is downstream at `/v1/chat/completions`.
+- **Three install paths**: compact tray flow (`start-helix-tray.bat`) for the daily driver, proxy-only for `OPENAI_BASE_URL` redirection, agent-SDK fragment for frontier-model integration.
 
-> ⚙️ **Hardware:** Ryzen 7 5800x · 48 GB DDR4 · RTX 3080 Ti 12 GB VRAM · 2× 1 TB NVMe · open case, reactive fan curves · model: **gemma4:e4b** (Ollama) · genome: 18,547 genes
+### Quick navigation
 
-| Query | Type | Helix tokens | RAG baseline | Savings |
-|---|---|---|---|---|
-| "How does helix handle WAL checkpoints?" | mechanism-internal | 279 | 8,000 | **28.7×** |
-| "What does the access-rate tiebreaker do?" | operational rule | 394 | 8,000 | **20.3×** |
-| "What port does the helix proxy listen on?" | point-fact lookup | 399 | 8,000 | **20.1×** |
-| "What is the role of the harmonic_links table?" | data structure purpose | 753 | 8,000 | **10.6×** |
-| "What does path_key_index store?" | data structure purpose | 1,023 | 8,000 | **7.8×** |
-| "How does the density gate work?" | conceptual system | 2,971 | 8,000 | **2.7×** |
-
-*RAG baseline: top-5 chunks × 1,500 tokens + 500 overhead = 8,000 tokens/query (Pinecone/LangChain defaults). Full bench: [`benchmarks/bench_rag_vs_sike_tokens.py`](benchmarks/bench_rag_vs_sike_tokens.py) — rerun yourself.*
-
-**GPQA diamond accuracy — gemma4:e4b, N=100:**
-OFF baseline: **22%** → Helix ON: **26%** **(+4 pp)** · Source: [`benchmarks/bench_aa_suite.py`](benchmarks/bench_aa_suite.py)
-
----
-
-## Pipeline
-
-```mermaid
-%%{init: {"theme": "dark"}}%%
-flowchart TD
-    classDef cpu   fill:#1e3a5f,stroke:#3b82f6,color:#93c5fd
-    classDef llm   fill:#2d1b69,stroke:#7c3aed,color:#c4b5fd
-    classDef store fill:#14532d,stroke:#16a34a,color:#86efac
-    classDef gate  fill:#431407,stroke:#c2410c,color:#fdba74
-    classDef surf  fill:#0c4a6e,stroke:#0284c7,color:#7dd3fc
-
-    subgraph INGEST["⬛  INGEST  —  LLM-free"]
-        direction LR
-        SRC["📁 Source\ngit · S3 · local\nfiles / conversations"]:::cpu
-        TAG["🏷️ CpuTagger\nspaCy NER · key-value\nchromosome codons\nintent classification"]:::cpu
-        GATE["🔬 Density Gate\nchromatin tier\nOPEN → EUCHROMATIN → HETERO"]:::gate
-        DB[("🧬 Genome\nSQLite · 18.5 K genes\npromoter index · FTS5\nentity graph · harmonic links")]:::store
-        SRC --> TAG --> GATE --> DB
-    end
-
-    subgraph RETRIEVAL["⬛  RETRIEVAL  —  LLM-free · 9-tier fusion scorer"]
-        direction LR
-        QRY["❓ Query\n/context  /context/packet"]:::cpu
-        CLF["🎯 Classifier\nfactual · procedural\nmulti_hop · default\nassembly cap 2–8 genes"]:::cpu
-        BM["🔍 BM25 pre-filter\nFTS5 top-200\nIDF-discriminated pool"]:::cpu
-        TIERS["📊 9-Tier Fusion\n① PKI path-key IDF\n② filename anchor\n③ exact promoter tag\n④ prefix tag\n⑤ FTS5 BM25\n⑥ SPLADE sparse\n⑦ ΣĒMA 20-dim cosine\n⑧ harmonic co-activation\n⑨ SR future-occupancy"]:::cpu
-        CONF{"📐 Confidence tier\nratio = top ÷ mean"}:::gate
-        T3["TIGHT · 3 genes\nratio ≥ 3.0"]:::cpu
-        F6["FOCUSED · 6 genes\nratio ≥ 1.8"]:::cpu
-        B12["BROAD · 12 genes\nweak signal"]:::cpu
-        QRY --> CLF --> BM --> TIERS --> CONF
-        CONF --> T3 & F6 & B12
-    end
-
-    subgraph EXPRESSION["⬛  EXPRESSION  —  LLM-free"]
-        direction LR
-        SPL["✂️ Splice\nKompress 5× avg\nfoveated rank-proportional\nreorder: lost-in-middle fix"]:::cpu
-        ASM["📦 Assemble\ndecoder prompt +\n&lt;GENE&gt; blocks +\nanswer slate"]:::cpu
-        SPL --> ASM
-    end
-
-    subgraph OUT["OUTPUT SURFACES"]
-        direction LR
-        CTX["📄 /context\nexpressed_context\nContextHealth metadata"]:::surf
-        PKT["📬 /context/packet\ngene_id + source_id\nverdict: verified · stale_risk\n· needs_refresh + refresh_targets"]:::surf
-        ASM --> CTX
-        ASM --> PKT
-    end
-
-    subgraph LLM["⚡  SINGLE LLM CALL"]
-        ANS["🤖 /v1/chat/completions\nClaude · Gemini · local"]:::llm
-        CTX --> ANS
-    end
-
-    DB --> RETRIEVAL
-    T3 & F6 & B12 --> EXPRESSION
-```
-
-*Dark-shipped features (entity graph Tier 5b, sub-query decomposition, BGE-M3 ANN) are omitted. See [`docs/architecture/DIMENSIONS.md`](docs/architecture/DIMENSIONS.md) for the full dimension inventory.*
-
-<details>
-<summary>▶ Terminal walkthrough — launcher startup + first query</summary>
-
-**Part 1 — Launch**
-
-```
-$ helix-launcher
-
-[00:00.1]  helix-launcher v0.5.0
-[00:00.2]  config: helix.toml
-[00:00.3]  genome: genomes/main/genome.db  (18,547 genes · 5.0× compression)
-[00:00.8]  starting helix server on :11437 ...
-[00:01.4]  ✓  helix server      http://127.0.0.1:11437
-[00:01.6]  starting observability stack ...
-[00:02.1]  ✓  otel collector    :4317
-[00:02.4]  ✓  prometheus        :9090
-[00:02.9]  ✓  loki              :3100
-[00:03.3]  ✓  grafana           :3000  →  http://localhost:3000
-[00:03.4]  tray icon ready — right-click for controls
-```
-
-**Part 2 — First retrieval query**
-
-```bash
-curl -s http://127.0.0.1:11437/context \
-  -H "Content-Type: application/json" \
-  -d '{"query": "what port does helix use"}' \
-  | python -m json.tool
-```
-
-```json
-{
-  "expressed_context": "<GENE src=\"helix.toml\" facts=\"port=11437\">\nThe helix proxy server listens on port 11437.\n</GENE>\n...",
-  "genes_expressed": 5,
-  "budget_tier": "focused",
-  "context_health": {
-    "retrieval_rate": 1.0,
-    "top_score": 8.3,
-    "score_ratio": 4.1
-  }
-}
-```
-
-Token cost: **399 tokens** delivered to the LLM vs 8,000 for a naive RAG top-5 pass — **20.1× savings.**
-
-</details>
-
----
+- [Setup guide](docs/SETUP.md) — extras matrix, OS-specific install paths, calibration runbook
+- [Troubleshooting](docs/TROUBLESHOOTING.md) — common errors and recovery
+- [`/context` API reference](docs/api/context-endpoint.md) — request/response schema, render branches, field-by-field
+- [Operator runbooks](docs/operator-runbooks.md) — backfill, calibrate, consolidate, vacuum
+- [Config reference](docs/config-reference.md) — every key in `helix.toml`
+- [Agent SDK integration](docs/agent-sdk-fragment.md) — frontier prompt fragment + compliance eval
+- [Environment variables](.env.example) — runtime overrides
 
 ## Quick Start
 
 ```bash
-# 1 — Install
-pip install "helix-context[all]"
+# 1. Install
+pip install -e ".[all,launcher,otel]"
+python -m spacy download en_core_web_sm
 
-# 2 — Launch  (Windows · Linux/macOS: use helix-launcher)
+# 2. Pull a small model for the ribosome (optional — disabled by default)
+ollama pull gemma3:e4b
+
+# 3. Start the proxy
+python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11437
+
+# 4. Or, daily-driver tray (Windows):
 start-helix-tray.bat
-helix-status            # confirm :11437 is responding
 
-# 3 — Seed your project
-helix ingest ./my-project
+# 5. Seed your genome (one-time)
+python examples/seed_genome.py path/to/your/docs/
 
-# 4 — Test retrieval
-curl http://localhost:11437/context \
-  -H "Content-Type: application/json" \
-  -d '{"query": "what is the main entry point?"}'
+# 6. Post-merge: backfill 1024-dim BGE-M3 vectors for Stage 2 dense recall
+python scripts/backfill_bgem3_v2.py genomes/main/genome.db
 ```
 
-### Native observability (default)
+For full options including the extras matrix, see [docs/SETUP.md](docs/SETUP.md).
 
-Canonical path: the tray (`start-helix-tray.bat`) manages the native OpenTelemetry
-binaries in `tools/native-otel/` automatically. A balloon notification confirms
-the sidecar is running. To opt out: `HELIX_OBSERVABILITY=0 start-helix-tray.bat`.
+## Pipeline
 
-> **Advanced — Docker stack:** if you prefer a full Docker-compose observability
-> stack (Prometheus, Tempo, Loki, Grafana), see
-> [deploy/otel/README.md](deploy/otel/README.md).
+A transparent OpenAI-compatible proxy that intercepts LLM requests and injects compressed context from a persistent SQLite genome. Six stages per turn, all LLM-free except step 4 splice (optional ribosome) and the downstream completion call:
 
-### MCP setup (Claude Code / Cursor / Continue)
+- **0a. Classify** — rule-based query classifier picks decoder mode + assembly cap (no model call).
+- **1. Extract** — heuristic keyword extraction from query (no model call).
+- **2. Express** — SQLite promoter-tag lookup + BGE-M3 dense recall + synonym expansion + co-activation. Ranks candidates via Reciprocal Rank Fusion over `{dense, FTS5, promoter, harmonic, SR}` when `[retrieval] fusion_mode = "rrf"` (default `"additive"`, see Gotchas).
+- **3. Re-rank** — small CPU model scores candidates for relevance.
+- **4. Splice** — small CPU model trims introns, keeps exons (batched single call; optional).
+- **5. Assemble** — join spliced parts, enforce token budget, wrap in tags. The Stage 7 health pass downgrades to `MissBlock(reason="stale")` when the top-1 source mtime exceeds `last_verified_at`.
+- **6. Replicate** — pack query + response into the genome (background).
 
-Add to `~/.claude/settings.json` (or your IDE's MCP config):
+→ Swim-lane reference: [`docs/architecture/PIPELINE_LANES.md`](docs/architecture/PIPELINE_LANES.md)
+→ Retrieval dimensions: [`docs/architecture/DIMENSIONS.md`](docs/architecture/DIMENSIONS.md)
+
+## Agent integration
+
+Every `/context` response carries one of two top-level blocks:
+
+- **`know { found, confidence, gene_id_match, ... }`** — retrieval succeeded; the `expressed_context` bytes are grounded. The agent may answer from them.
+- **`miss { reason, escalate_to | refresh_targets, do_not_answer_from_genome:true }`** — retrieval did NOT find it (or found it but it is stale, cold, or superseded). The agent should NOT answer from the genome; it should call an escalation tool from `escalate_to` (`grep | rag | web | ask_human`) or refetch from `refresh_targets`.
+
+To make a frontier model honor the contract, prepend the helix-context prompt fragment to your system prompt:
+
+```python
+from helix_context.agent_prompt import full_fragment
+
+system_prompt = full_fragment() + "\n\n" + your_existing_system_prompt
+```
+
+Without the fragment, frontier models will paper over `do_not_answer_from_genome` and confabulate. See [docs/agent-sdk-fragment.md](docs/agent-sdk-fragment.md) for the full template, the `<helix:no_match/>` token semantics, and the compliance eval recipe.
+
+### Caller model class
+
+`/context` accepts an optional `caller_model_class: "generic" | "small_moe" | "frontier"` field that selects the render branch:
+
+- **`frontier`** (Claude Opus, GPT-5, Gemini 3 Pro): forward rank-1-first ordering, larger assembly cap, full decoder mode.
+- **`small_moe`** (qwen3:4b, gemma3:e4b): foveated reverse-rank order, JSON-shaped char-bounded answer slate, condensed decoder.
+- **`generic`** (default): regression-locked byte-identical to pre-Stage-5 behavior.
+
+See [docs/api/context-endpoint.md §7](docs/api/context-endpoint.md) for the full behavior matrix.
+
+## Surfaces and endpoints
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /context` | know/miss + `expressed_context` (primary integration). |
+| `POST /context/packet` | Agent-safe bundle: `verified` / `stale_risk` / `refresh_targets`. |
+| `POST /context/refresh-plan` | `refresh_targets` only — reread plan, no evidence items. |
+| `POST /fingerprint` | Navigation-first payload (scores + metadata, no body). |
+| `POST /consolidate` | Rewrite stale gene bodies from their source fingerprints (Stage 7 counterpart to `refresh_targets`). |
+| `POST /sessions/register` | Register an agent participant (taude / laude / …) for attribution. |
+| `POST /admin/refresh` | Force a retrieval-layer refresh (admin only). |
+| `POST /admin/vacuum` | Reclaim SQLite pages after compaction (admin only). |
+| `POST /ingest` | Add a document or exchange to the genome. |
+| `GET /stats` | Genome metrics + compression ratio. |
+| `GET /health` | Ribosome model, gene count, upstream URL, **calibration provenance** (Stage 4). |
+| `POST /v1/chat/completions` | OpenAI-compatible proxy with automatic context injection. |
+
+→ Full endpoint reference: [`docs/api/endpoints.md`](docs/api/endpoints.md) and [`docs/api/context-endpoint.md`](docs/api/context-endpoint.md)
+→ MCP tool schemas: [`docs/api/mcp-tools.md`](docs/api/mcp-tools.md)
+
+**Two surfaces, two caller types:**
+
+| | `/context` | `/context/packet` |
+| --- | --- | --- |
+| Returns | Assembled compressed window | Pointer + verdict + refresh plan |
+| LLM reads? | Directly | No — agent fetches if needed |
+| Verdict emitted? | Top-level `know` / `miss` | First-class: `verified / stale_risk / needs_refresh` |
+| Best for | Chat clients, Continue | MCP agents, programmatic use |
+
+## Continue IDE Integration
+
+Add to `~/.continue/config.yaml`:
+
+```yaml
+models:
+  - name: Helix (Local)
+    provider: openai
+    model: gemma3:e4b           # or whatever is loaded in Ollama
+    apiBase: http://127.0.0.1:11437/v1
+    apiKey: EMPTY
+    roles: [chat]
+    defaultCompletionOptions:
+      contextLength: 128000     # Helix handles compression downstream
+      maxTokens: 4096
+```
+
+### MCP setup (Claude Code / Cursor / Claude Desktop)
+
+Add to `~/.claude/settings.json`:
 
 ```json
 {
@@ -181,7 +151,9 @@ Add to `~/.claude/settings.json` (or your IDE's MCP config):
       "command": "python",
       "args": ["-m", "helix_context.mcp_server"],
       "cwd": "/absolute/path/to/your/project",
-      "env": { "HELIX_MCP_URL": "http://127.0.0.1:11437" }
+      "env": {
+        "HELIX_MCP_URL": "http://127.0.0.1:11437"
+      }
     }
   }
 }
@@ -194,39 +166,18 @@ ANTHROPIC_BASE_URL=http://localhost:11437 claude
 OPENAI_BASE_URL=http://localhost:11437/v1 your-app
 ```
 
----
-
-## How It Works
-
-**The entire retrieval and weighing path is LLM-free** — spaCy NER, Howard 2005 TCM, Stachenfeld SR, Werman W1, Hebbian co-activation. Pure CPU math from ingest to expressed context. The only LLM call in the whole system is at `/v1/chat/completions`. This matters for latency (sub-second retrieval), cost (no token spend on the retrieval path), and determinism.
-
-**Two surfaces for two caller types:**
-
-| | `/context` | `/context/packet` |
-|---|---|---|
-| Returns | Assembled compressed window | Pointer + verdict + refresh plan |
-| LLM reads? | Directly | No — agent fetches if needed |
-| Verdict emitted? | Via `ContextHealth` | First-class: `verified / stale_risk / needs_refresh` |
-| Use for | Chat clients, Continue | MCP agents, tool use, programmatic decisions |
-
-→ [PIPELINE_LANES.md](docs/architecture/PIPELINE_LANES.md) · [DIMENSIONS.md](docs/architecture/DIMENSIONS.md) · [Agentome paper](https://mbachaud.substack.com/p/agentome)
-
----
-
-## Configuration
+## Genome management
 
 ### Genome path
 
-Set `path` in `[genome]` to move the database to any drive or directory:
+Set `path` in `[genome]` to a file or directory:
 
 ```toml
 [genome]
 path = "genomes/main/genome.db"   # relative to helix run directory
-# Put this on your fastest NVMe for best ingest throughput
+# Put this on your fastest NVMe for best ingest throughput.
 # Example: path = "D:/helix/genome.db"
 ```
-
-### Running multiple projects
 
 One helix instance per genome — each reads its own `helix.toml`. Use the `helix_context.hgt` Python API to share genes across instances (Horizontal Gene Transfer).
 
@@ -244,42 +195,28 @@ cp genomes/main/genome.db backups/genome-$(date +%Y%m%d).db
 Copy-Item genomes\main\genome.db backups\genome-$(Get-Date -Format yyyyMMdd).db
 ```
 
-*A built-in backup manager with configurable paths and interval is on the roadmap.*
-
-### DAL — source content fetching
+### DAL — source-content fetching
 
 `/context/packet` returns `source_id` pointers. Callers resolve them to bytes via the DAL:
 
 ```python
 from helix_context.adapters.dal import DAL
 
-dal = DAL()                              # file + HTTP built-in
-dal.register("s3", my_s3_fetcher)       # register additional schemes
+dal = DAL()                          # file + HTTP built-in
+dal.register("s3", my_s3_fetcher)    # register additional schemes
 text, meta = dal.fetch("s3://bucket/schema.json")
 ```
 
----
+### Native observability (default)
 
-## API Reference
+The tray (`start-helix-tray.bat`) manages the native OpenTelemetry binaries in `tools/native-otel/` automatically. A balloon notification confirms the sidecar is running. To opt out: `HELIX_OBSERVABILITY=0 start-helix-tray.bat`.
 
-| Endpoint | Description |
-|---|---|
-| `POST /context` | Retrieve and assemble compressed context |
-| `POST /context/packet` | Retrieve pointer + verdict (agent-safe) |
-| `POST /ingest` | Add a document or exchange to the genome |
-| `GET /stats` | Genome size, compression ratio, tier metrics |
-| `GET /fingerprint` | Navigation-first retrieval (scores + metadata) |
-| `POST /v1/chat/completions` | OpenAI-compatible proxy with automatic context injection |
-
-→ Full endpoint reference: [`docs/api/endpoints.md`](docs/api/endpoints.md)
-→ MCP tool schemas: [`docs/api/mcp-tools.md`](docs/api/mcp-tools.md)
-
----
+> **Advanced — Docker stack:** if you prefer a full Docker-compose observability stack (Prometheus, Tempo, Loki, Grafana), see [deploy/otel/README.md](deploy/otel/README.md).
 
 ## Architecture
 
-| Doc | What it covers |
-|---|---|
+| Doc | Topic |
+| --- | --- |
 | [PIPELINE_LANES.md](docs/architecture/PIPELINE_LANES.md) | Swim-lane reference: ingest, context, packet, fingerprint flows |
 | [DIMENSIONS.md](docs/architecture/DIMENSIONS.md) | The 9 retrieval dimensions — schema, data, bench status |
 | [LAUNCHER.md](docs/architecture/LAUNCHER.md) | Supervisor, tray, observability stack lifecycle |
@@ -287,12 +224,49 @@ text, meta = dal.fetch("s3://bucket/schema.json")
 | [OBSERVABILITY.md](docs/architecture/OBSERVABILITY.md) | Prometheus metrics, Grafana dashboards, alert rules |
 | [KNOWLEDGE_GRAPH.md](docs/architecture/KNOWLEDGE_GRAPH.md) | Entity graph, harmonic links, co-activation |
 
----
+## Gotchas
+
+- **Model swap latency**: the ribosome (small model) and the generation model share Ollama. Use `keep_alive = "30m"` in helix.toml to pin the ribosome in memory.
+- **Synonym map is critical**: if queries return "no relevant context", check that query keywords map to the promoter tags the ribosome assigned. Add synonyms in `[synonyms]` of helix.toml.
+- **Short content may fail ingestion**: the ribosome struggles with very short inputs (<200 chars). Pad with context or combine small files before ingesting.
+- **`genome.db` persists**: delete it to start fresh. It auto-creates on first use.
+- **Continue Agent mode**: use Chat mode, not Agent mode. The proxy does not handle tool routing.
+- **`know`/`miss` block requires the agent prompt fragment** to be honored — without it, frontier models confabulate. Import `helix_context.agent_prompt.full_fragment()` and prepend it to your system prompt.
+- **Stage 2 backfill is a one-time post-merge action** — `embedding_dense_v2 IS NULL` until you run `scripts/backfill_bgem3_v2.py`. Symptom: `/context` retrieval rate plateaus low; check coverage via `sqlite3 genome.db "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"`.
+- **Default `[retrieval] fusion_mode = "additive"` is back-compat**; flip to `"rrf"` after running `scripts/calibrate_thresholds.py` so the absolute-floor gates do not strand every query in BROAD.
+- **Default `[abstain].mode = "global"` is back-compat**; flip to `"per_classifier"` after calibration to use the bench-derived floors.
+
+## Testing
+
+```bash
+# All mock tests (no Ollama needed, ~6s)
+python -m pytest tests/ -m "not live" -v
+
+# Live tests (requires Ollama running)
+python -m pytest tests/ -m live -v -s
+
+# Full suite
+python -m pytest tests/ -v
+```
+
+The 7-stage retrieval-fix added Stage-by-Stage contract tests:
+`tests/test_dense_recall.py` (Stage 2), `tests/test_fusion_rrf.py` (Stage 3),
+`tests/test_calibration.py` (Stage 4), `tests/test_caller_model_class.py` (Stage 5),
+`tests/test_know_miss_block.py` (Stage 6), `tests/test_freshness_gate.py` (Stage 7).
 
 ## Acknowledgments
 
-Built on: [spaCy](https://spacy.io/) NER · [Howard 2005](https://doi.org/10.1037/0033-295X.112.3.559) TCM · [Stachenfeld 2017](https://www.nature.com/articles/nn.4650) SR · SQLite FTS5 BM25 · [Kompress](https://huggingface.co/chopratejas/kompress-base) compression
+Built on: [spaCy](https://spacy.io/) NER · [Howard 2005](https://doi.org/10.1037/0033-295X.112.3.559) TCM · [Stachenfeld 2017](https://www.nature.com/articles/nn.4650) SR · SQLite FTS5 BM25 · [Kompress](https://huggingface.co/chopratejas/kompress-base) · [Headroom](https://github.com/chopratejas/headroom)
 
-## License
+Licensed under [Apache-2.0](LICENSE). See [NOTICE](NOTICE) for third-party attributions.
 
-Apache 2.0 — see [LICENSE](LICENSE).
+## Further reading
+
+- [Setup guide](docs/SETUP.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [`/context` API reference](docs/api/context-endpoint.md)
+- [Operator runbooks](docs/operator-runbooks.md)
+- [Config reference](docs/config-reference.md)
+- [Agent SDK integration](docs/agent-sdk-fragment.md)
+- [Environment variables](.env.example)
+- [Agentome paper](https://mbachaud.substack.com/p/agentome)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,704 @@
+# Helix Context — Setup Guide
+
+## What this guide covers
+
+This document is the canonical install path for `helix-context`. It walks
+through three workflows: the daily-driver tray flow (Windows-first, runs
+the supervisor + native observability sidecar + headroom proxy + tray
+icon), the proxy-only flow (a headless `/context` server suitable for
+servers and CI), and the agent-SDK flow (consuming `/context` and
+`/context/packet` from a Claude Code or other MCP-aware agent). Section 3
+is the extras decision matrix that tells you which `pip install` extras
+to add for the features you want; the rest of the guide cross-references
+that table. Sections 5 and 6 cover silent-failure modes and the post-2026-05-10
+operator actions required for the 7-stage retrieval-fix.
+
+If you only want a one-line install, the README's Quick Start
+(`pip install "helix-context[all]"` then `start-helix-tray.bat`) is correct
+but skips every nuance — every operator who has hit a `/context` empty-result
+problem ended up reading this file.
+
+## Prerequisites
+
+- **Python 3.11–3.13.** The wheel classifies these three versions in
+  [`pyproject.toml`](../pyproject.toml) lines 21–23. Python 3.14 works in
+  practice today but is not classified — `torch` and `pystray` wheel
+  availability tends to drift behind upstream Python releases by a few
+  months, so 3.14 may force you to build one of those from source. If
+  you have a choice, pin 3.12 or 3.13.
+- **Ollama** (latest stable), reachable at `http://localhost:11434`.
+  Helix uses Ollama as its default chat upstream and as the optional
+  ribosome backend. Verify with `curl -s http://localhost:11434/api/tags`
+  — the response must be JSON, not a connection-refused.
+- **SQLite with FTS5.**
+  - Windows + Linux: bundled with the Python `sqlite3` module that ships
+    with CPython 3.11+. Nothing to install.
+  - **macOS: the system SQLite that ships with Apple Python often lacks
+    FTS5.** Install a current SQLite via Homebrew and ensure your Python
+    links the brewed copy:
+
+    ```bash
+    brew install sqlite
+    # If using pyenv, rebuild your Python so its sqlite3 picks up brew:
+    LDFLAGS="-L$(brew --prefix sqlite)/lib" \
+    CPPFLAGS="-I$(brew --prefix sqlite)/include" \
+    PYTHON_CONFIGURE_OPTS="--enable-loadable-sqlite-extensions" \
+    pyenv install 3.12.7
+    ```
+
+    Verify FTS5 is available:
+
+    ```bash
+    python -c "import sqlite3; conn = sqlite3.connect(':memory:'); \
+      conn.execute('CREATE VIRTUAL TABLE t USING fts5(x)'); print('ok')"
+    ```
+
+    If that prints anything other than `ok`, FTS5 is not linked.
+    Without FTS5 the BM25 tier (Tier 5 of the 9-tier fusion scorer)
+    is unavailable and `helix ingest` will fail at gene-table init.
+- **Disk.** A full `pip install -e ".[all]"` pulls roughly 2 GB —
+  dominated by `torch`, `sentence-transformers`, `headroom-ai`, and
+  `tree-sitter` parser binaries. The lean proxy-only path
+  (`embeddings,cpu`) is roughly 150 MB. The genome itself grows linearly
+  with corpus size; an 18.5k-gene main genome is ~250 MB on disk.
+
+## Extras decision matrix
+
+Helix ships a wide pyproject extras surface. Most operators install
+exactly two or three extras, not `[all]`. The table below maps each
+extra to the runtime feature it gates and a "install when" trigger.
+Source: [`pyproject.toml`](../pyproject.toml) `[project.optional-dependencies]`
+block, lines 39–113.
+
+| Extra | What it enables | Install when |
+|---|---|---|
+| `accel` ([`pyproject.toml:43`](../pyproject.toml)) | `orjson` fast-path for JSON encode/decode on the `/context` and `/ingest` paths. | Optional perf boost — small but always-on. |
+| `embeddings` ([`pyproject.toml:44`](../pyproject.toml)) | `numpy` + `sentence-transformers`. Powers the SEMA codec (MiniLM 20-dim sparse projection used for cold-tier retrieval) and the BGE-M3 dense recall path. | Semantic retrieval enabled — required for Tier 7 (`ΣĒMA cosine`) and Stage 2 dense recall. |
+| `cpu` ([`pyproject.toml:45`](../pyproject.toml)) | `spacy>=3.7` for ingest-time NER. | `[ingestion] backend = "cpu"` — this is the **default** ingest backend. If you are doing any ingestion at all, install this extra. |
+| `mcp` ([`pyproject.toml:49`](../pyproject.toml)) | `mcp>=1.0` Python SDK for the MCP shim. Required for `python -m helix_context.mcp_server`. | You are integrating with Claude Code, Cursor, Continue, Claude Desktop, or any other MCP host. |
+| `nli` ([`pyproject.toml:54`](../pyproject.toml)) | `torch>=2.0` + `transformers>=4.30` standalone — the path used when `[ribosome] backend = "deberta"` for cross-encoder rerank or relation-graph NLI. | You explicitly flipped `[ribosome] backend = "deberta"` in `helix.toml`. If you have `embeddings` already, sentence-transformers transitively pulls torch — you only need this extra for the standalone deberta-only path. |
+| `otel` ([`pyproject.toml:57`](../pyproject.toml)) | OpenTelemetry SDK + OTLP gRPC exporter + FastAPI instrumentation. Emits metrics, traces, and logs to the OTel collector at `localhost:4317`. | **Silently required by `start-helix-tray.bat`**, which sets `HELIX_OTEL_ENABLED=1` unconditionally. Without this extra the helix server starts and serves `/context`, but emits no telemetry — Grafana dashboards will be empty. See section 5. |
+| `launcher` ([`pyproject.toml:62`](../pyproject.toml)) | `jinja2`, `psutil`, `platformdirs`, `py-cpuinfo`. The `helix-launcher` and `helix-status` console scripts. | Tray / supervisor flow — required by every flow that uses `start-helix-tray.bat`, `setup-helix.bat`, `backend-with-otel.bat`, or `launcher-with-otel.bat`. |
+| `launcher-native` ([`pyproject.toml:63`](../pyproject.toml)) | Everything in `launcher` plus `pywebview`. Adds the native-window dashboard (`helix-launcher --native`) instead of opening the dashboard in a browser tab. | You want a native desktop window UI but cannot or will not install LGPL dependencies. |
+| `launcher-tray` ([`pyproject.toml:70`](../pyproject.toml)) | Everything in `launcher` plus `pystray>=0.19` + `Pillow>=10` + `pywin32` (Windows only). Enables the system-tray icon with start/stop/restart, "Open Grafana", and "Open Prometheus" menu items. | **Canonical daily-driver flow.** Note: `pystray` is **LGPL-3** licensed. Helix itself stays Apache-2.0-clean because `launcher-tray` is a runtime-only optional dep — the helix-context wheel does not bundle pystray. If LGPL is a license concern for your distribution, install `launcher-native` instead. |
+| `ast` ([`pyproject.toml:75`](../pyproject.toml)) | `tree-sitter` core + parsers for Python, Rust, JavaScript, TypeScript. Used by the code-aware ingest path to extract function/class boundaries for promoter tagging. | You ingest source code (not just docs / markdown / conversations). |
+| `scorerift` ([`pyproject.toml:82`](../pyproject.toml)) | The `scorerift` companion package (CD spectroscope bridge). Powers ScoreRift dimensions in the audit pipeline. | You are running the ScoreRift integration. Most operators do not need this. |
+| `codec` ([`pyproject.toml:85`](../pyproject.toml)) | `headroom-ai[proxy,code]>=0.5.21` — Tejas Chopra's CPU-resident semantic compression proxy + dashboard. | You want the Headroom dashboard at `http://127.0.0.1:8787/dashboard` and the tray's "Open Headroom Dashboard" + Start/Restart/Stop menu items. The launcher adopts an already-running headroom proxy on its configured port; otherwise it spawns one. See `[headroom]` in [`helix.toml`](../helix.toml) lines 163–169. |
+| `dev` ([`pyproject.toml:86`](../pyproject.toml)) | `pytest`, `pytest-asyncio`, `numpy`, `spacy>=3.7`, `hypothesis>=6.0`. | You are a contributor running the test suite. Not for production. |
+| `all` ([`pyproject.toml:90`](../pyproject.toml)) | The full feature surface **minus** `dev` (contributor-only) and **minus** `launcher-tray` (LGPL). Includes `accel`, `embeddings`, `cpu`, `mcp`, `nli`, `otel`, `launcher`, `launcher-native`, `ast`, `codec`. Does NOT include `scorerift` (separate package). | Convenience for "I want everything Apache-2.0-clean and don't care about disk." Pulls ~2 GB. Install `[all,launcher-tray]` if you also want the tray. |
+
+A few notes on the matrix that have bitten operators:
+
+- `[all]` does **not** include `[launcher-tray]`. If you `pip install "helix-context[all]"` then run `start-helix-tray.bat`, the tray icon will not appear and the launcher falls back to the native window or browser. Add `,launcher-tray` explicitly if you want the tray.
+- `[all]` does **not** include `[scorerift]`. ScoreRift is a separate companion package and stays opt-in.
+- `[embeddings]` transitively pulls `torch`. If you do not need semantic retrieval, you do not need torch — skip this extra and accept that Tier 7 (ΣĒMA cosine) and Stage 2 dense recall will be no-ops.
+- `[codec]` pulls `headroom-ai` which itself has nontrivial dependencies. Only install if you want the Headroom proxy lifecycle.
+
+## Install workflows
+
+### Daily-driver tray flow (Windows-first, recommended)
+
+This is what most operators run on a workstation. It launches the
+supervisor, the native observability sidecar (Prometheus + Tempo + Loki +
+Grafana + OTel collector — managed binaries, not Docker), the helix
+backend on `:11437`, and the system-tray icon.
+
+```bash
+pip install -e ".[all,launcher,launcher-tray,otel]"
+```
+
+`[all]` already includes `launcher` and `otel`, but listing them
+explicitly documents intent and makes the line copy-paste safe even if
+the `all` bundle composition changes.
+
+Then run the one-time setup (creates desktop / start-menu shortcuts and
+optionally brings up the observability stack):
+
+```cmd
+setup-helix.bat
+```
+
+`setup-helix.bat` is a thin wrapper that delegates to
+`deploy\windows\setup-helix.ps1`. Useful flags from the wrapper:
+
+- `setup-helix.bat -WithObservability` — also docker-compose up the
+  Grafana + Prometheus + OTel stack (advanced; the default native sidecar
+  path already covers this).
+- `setup-helix.bat -NoShortcuts` — headless install, no `.lnk` creation.
+- `setup-helix.bat -SkipPipInstall` — refresh shortcuts without
+  reinstalling the package.
+
+Then daily-launch via:
+
+```cmd
+start-helix-tray.bat
+```
+
+What that batch file does (from
+[`start-helix-tray.bat`](../start-helix-tray.bat)):
+
+- Sets `HELIX_OTEL_ENABLED=1`, `HELIX_OTEL_ENDPOINT=localhost:4317`,
+  `HELIX_OTEL_INSECURE=1`, `HELIX_OTEL_SAMPLER_RATIO=1.0`.
+- Sets `HELIX_BUDGET_ZONE=1` (2026-04-14 spike — clamps `max_genes`
+  based on caller's prompt-token-zone).
+- Defaults `HELIX_USER=max` if unset (you should override this).
+- Sets `HELIX_HEADROOM_ENABLED=1` and `HELIX_HEADROOM_AUTOSTART=1` (only
+  effective if `[codec]` is installed).
+- Sets `HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=1` so non-local upstreams
+  auto-route through Headroom.
+- Spawns `python -m helix_context.launcher.app --tray --grafana-url
+  http://localhost:3000/d/helix-overview/helix-overview --prometheus-url
+  http://localhost:9090/graph` in `/B` (no new window) mode.
+
+Verify it's up:
+
+```bash
+helix-status
+curl -s http://127.0.0.1:11437/health | python -m json.tool
+```
+
+The tray icon's right-click menu surfaces Start / Stop / Restart, "Open
+Grafana", "Open Prometheus", and (when Headroom is installed and
+enabled) "Open Headroom Dashboard" + Start / Restart / Stop Headroom.
+
+**Linux / macOS variant.** No `start-helix-tray.sh` exists yet
+(non-docs follow-up tracked in issue #59). For now, on Linux/macOS, run
+the launcher directly:
+
+```bash
+HELIX_OTEL_ENABLED=1 \
+HELIX_OTEL_ENDPOINT=localhost:4317 \
+HELIX_OTEL_INSECURE=1 \
+HELIX_OTEL_SAMPLER_RATIO=1.0 \
+HELIX_BUDGET_ZONE=1 \
+HELIX_HEADROOM_ENABLED=1 \
+HELIX_HEADROOM_AUTOSTART=1 \
+helix-launcher --tray \
+  --grafana-url "http://localhost:3000/d/helix-overview/helix-overview" \
+  --prometheus-url "http://localhost:9090/graph"
+```
+
+If `pystray` cannot bind a tray icon on your desktop environment (some
+Wayland sessions, some headless macOS setups), the launcher falls back
+to the native pywebview window if `[launcher-native]` is installed, or
+opens the dashboard in a browser tab.
+
+### Proxy-only flow (no tray, no observability)
+
+This is the canonical headless deployment — a server that exposes
+`/context`, `/context/packet`, `/ingest`, `/stats`, `/health`, and the
+OpenAI-compatible `/v1/chat/completions` proxy on `:11437`, with no tray
+icon, no supervisor, no observability sidecar. Roughly 150 MB on disk.
+
+```bash
+pip install -e ".[embeddings,cpu]"
+```
+
+Add `,mcp` if you also want `python -m helix_context.mcp_server` (MCP
+stdio shim) on the same install. Add `,otel` if you have an external OTel
+collector you want to export to.
+
+```bash
+python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11437
+```
+
+> **Note.** The internal ASGI module is `helix_context._asgi`. The
+> `start-helix-tray.bat` flow goes through the launcher's
+> `HelixSupervisor` which spawns its own uvicorn — this direct command
+> is for headless servers and CI where the supervisor adds no value.
+> An equivalent, also-supported entry-point is
+> `python -m uvicorn helix_context.server:app` — that path exists in
+> [`backend-with-otel.bat`](../backend-with-otel.bat) line 10.
+
+Verify it's up:
+
+```bash
+curl -s http://127.0.0.1:11437/health | python -m json.tool
+curl -s -X POST http://127.0.0.1:11437/context \
+  -H "Content-Type: application/json" \
+  -d '{"query":"hello"}' | python -m json.tool
+```
+
+This flow expects the genome to live at the path configured in
+[`helix.toml`](../helix.toml) line 127 (`[genome] path =
+"genomes/main/genome.db"`). Override with `HELIX_GENOME_PATH=/abs/path`
+or by editing the TOML.
+
+### Agent-SDK flow
+
+When Helix is consumed *as a context source* by another agent (Claude
+Code via MCP, Continue via OpenAI-compat, Cursor, a custom Claude
+Agent SDK app, etc.), the install is the same as the proxy-only flow.
+The extra step is teaching the *consuming* agent to honor the Stage 6
+KnowBlock / MissBlock contract.
+
+Install:
+
+```bash
+pip install -e ".[embeddings,cpu,mcp]"
+```
+
+Run the proxy:
+
+```bash
+python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11437
+```
+
+Then inject the `<helix:no_match/>` and `know` / `miss` contract into
+the agent's system prompt. The fragment is exported from
+`helix_context.agent_prompt.HELIX_NO_MATCH_FRAGMENT` for programmatic
+inclusion, and documented in plain text at
+[`docs/agent-sdk-fragment.md`](agent-sdk-fragment.md).
+
+For Claude Code / MCP, register the helix MCP shim in
+`~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "helix-context": {
+      "command": "python",
+      "args": ["-m", "helix_context.mcp_server"],
+      "cwd": "/absolute/path/to/your/project",
+      "env": {
+        "HELIX_MCP_URL": "http://127.0.0.1:11437",
+        "HELIX_AGENT": "your-agent-handle",
+        "HELIX_USER": "your-handle",
+        "HELIX_PARTY_ID": "your-machine-name"
+      }
+    }
+  }
+}
+```
+
+For an Open WebUI or other OpenAPI host that wraps MCP via mcpo:
+
+```cmd
+start-helix-mcpo.bat
+```
+
+That file (see [`start-helix-mcpo.bat`](../start-helix-mcpo.bat)) waits
+for the helix backend to answer `/health`, then runs
+`mcpo --port 8788 -- python -m helix_context.mcp_server`. Requires
+`pip install mcpo` in the same env. The default port is `8788`,
+overridable via `HELIX_MCPO_PORT`. Identity defaults are set defensively
+so multi-agent sessions don't collide on `HELIX_AGENT=laude` (Claude
+Code's default) — see lines 28–41 of the bat file.
+
+The agent itself **must** import the prompt fragment. Without it, a
+capable model paints over `do_not_answer_from_genome=true` and answers
+from its training prior — which is scored as a hard failure in offline
+eval. See [`docs/agent-sdk-fragment.md`](agent-sdk-fragment.md) for the
+full contract.
+
+## Implicit requirements
+
+The following are silent-failure modes — helix starts, `/context`
+returns 200, but quality is degraded or telemetry is missing. Each one
+has bitten at least one operator.
+
+### spaCy NER model
+
+The `[cpu]` extra installs the spaCy *library*, not the *model*. After
+installing `[cpu]`:
+
+```bash
+python -m spacy download en_core_web_sm
+```
+
+Without the model, the `CpuTagger` ingest path silently falls back to a
+keyword-only tagger. Promoter tags become coarser, NER nodes in the
+entity graph are absent, and `/context` retrieval quality on
+entity-bearing queries degrades by 10–30 percentage points depending on
+corpus.
+
+### Ollama version + reachability
+
+Helix does not ship Ollama. The default upstream is
+`http://localhost:11434` (configured in [`helix.toml`](../helix.toml)
+line 142, `[server] upstream`). Verify reachability:
+
+```bash
+curl -s http://localhost:11434/api/tags
+```
+
+The response must be a JSON object with a `models` array. If the server
+is not reachable, `/v1/chat/completions` proxy requests fail
+end-to-end, and **`/context` returns an empty `expressed_context` with
+no warning** when the ribosome backend is set to `"ollama"` (which is
+the default placeholder, even when ribosome is disabled — see
+[`helix.toml`](../helix.toml) lines 21–22).
+
+If you want to use a different upstream (e.g., a remote Ollama, a
+LiteLLM proxy, an OpenAI-compatible endpoint), set
+`HELIX_SERVER_UPSTREAM=http://...` or edit `[server] upstream` in
+`helix.toml`.
+
+Recommended models for the chat upstream:
+
+```bash
+ollama pull gemma4:e4b      # default for benchmarks; ~5 GB
+ollama pull qwen3:4b         # alternative; ~3 GB, holds VRAM well
+ollama pull gemma4:e2b       # small, fast; ~2 GB — good for ribosome backend if enabled
+```
+
+### Headroom first-run model download
+
+If `[codec]` is installed and `HELIX_HEADROOM_ENABLED=1` (which
+`start-helix-tray.bat` sets unconditionally on line 60), the headroom
+proxy downloads its ModernBERT ONNX model on the **first**
+`/v1/chat/completions` call. The download is roughly 200 MB and adds
+20–60 seconds of cold-start latency to that first request, which the
+caller experiences as a hung response.
+
+Pre-warm before exposing the proxy to users:
+
+```bash
+python -c "from headroom_ai import preload; preload()"
+```
+
+The model caches under `~/.cache/headroom/`. Subsequent boots are
+near-instant.
+
+### OTel exporter
+
+`start-helix-tray.bat` line 17 sets `HELIX_OTEL_ENABLED=1`. The helix
+server reads that env var at boot and tries to construct an OTLP
+exporter. If the `[otel]` extra is **not** installed, the server logs a
+single WARN line on boot and continues serving — but emits no metrics,
+no traces, no structured logs. Grafana dashboards will be empty.
+
+Verify the exporter is wired:
+
+```bash
+curl -s http://127.0.0.1:11437/health | python -m json.tool
+```
+
+Look for the `observability.exporter` field. Expected values:
+
+- `"otlp_grpc"` — `[otel]` installed and OTLP exporter built.
+- `"noop"` — `HELIX_OTEL_ENABLED=1` but `[otel]` not installed.
+  Grafana will be empty until you add the extra.
+- absent / `null` — `HELIX_OTEL_ENABLED` is not set or is `0`. This is
+  the intended state for the proxy-only flow.
+
+If the field shows `"noop"` and you want telemetry, run
+`pip install -e ".[otel]"` and restart the tray.
+
+## Post-install operator actions for the 7-stage retrieval-fix
+
+The 7-stage retrieval-fix landed 2026-05-10 (PRs #45, #46, #47, #48,
+#51, #55, #56). It introduced new schema, scripts, and config knobs
+that need explicit operator action after `pip install -e .[...]`. These
+actions are idempotent; running them twice is a no-op once they
+converge.
+
+### One-time backfill of full-1024-dim BGE-M3 vectors
+
+Stage 2 promoted BGE-M3 dense retrieval from a 12-candidate re-ranker
+to a parallel first-class recall source over the full corpus, and
+restored the full 1024-dim Matryoshka representation (the previous
+256-dim truncation collapsed random-pair cosine to ~0.6). To use the
+new path, every gene's `embedding_dense_v2` BLOB column must be
+populated.
+
+```bash
+python scripts/backfill_bgem3_v2.py path/to/genome.db
+```
+
+If you omit the path argument, the script reads `[genome] path` from
+`helix.toml`. The script is idempotent: rows already populated with a
+non-NULL fp32 BLOB of the expected length are skipped. Runtime
+estimate from
+[`scripts/backfill_bgem3_v2.py`](../scripts/backfill_bgem3_v2.py) lines
+22–24:
+
+- ~30–90 minutes on CPU `sentence-transformers` BGE-M3 at 18.9k genes.
+- ~5–15 minutes with `FlagEmbedding` + GPU.
+
+Recommended runbook from the same script (lines 15–20):
+
+1. Make a snapshot copy of `genomes/main/genome.db` first.
+2. Run the script against the copy. Verify it reports `coverage=100%`.
+3. Hot-swap the populated DB into place during a maintenance window.
+4. Stage 4 follows: recalibrate `ann_similarity_threshold` at dim=1024.
+
+After backfill, flip dense recall on by editing
+[`helix.toml`](../helix.toml):
+
+```toml
+[retrieval]
+dense_embedding_enabled = true     # was false (line 255)
+dense_embedding_dim = 1024         # default; do not change
+dense_pool_size = 500              # default
+```
+
+Without the backfill, `query_genes_dense_recall` logs a one-time WARN
+and returns `[]`, falling back to lexical-only retrieval (degraded but
+not broken). See spec
+[`docs/specs/2026-05-08-stage-2-dense-recall.md`](specs/2026-05-08-stage-2-dense-recall.md)
+§4 for the exact fallback contract.
+
+### Threshold calibration (optional, recommended after backfill)
+
+Stage 4 replaces the legacy hard-coded `TIGHT_SCORE_FLOOR=5.0`,
+`FOCUSED_SCORE_FLOOR=2.5`, `abstain=2.5` constants with per-classifier
+floors derived from a margin-over-random distribution. Default mode is
+`"global"` (byte-identical to pre-Stage-4 behavior); to consume the
+new path you run the calibration script and flip
+`[abstain] mode = "per_classifier"`.
+
+```bash
+python scripts/calibrate_thresholds.py \
+    --genome genomes/main/genome.db \
+    --bench results/located_n1000.json
+```
+
+The script samples random gene pairs from the genome's
+`embedding_dense_v2` BLOBs, computes a `mu + sigma_mult * sigma` ANN
+cosine cutoff (margin-over-random), and segments
+`agent.score_top` distributions by classifier class. It outputs:
+
+- A TOML snippet with `[retrieval]` overrides and per-classifier
+  `[abstain.<cls>]` blocks. Paste these into your `helix.toml`.
+- `calibration_report.json` with full provenance.
+- An UPSERT into the `genome_calibration` table when `--write-db`
+  (default).
+
+After pasting, flip the mode in `helix.toml`:
+
+```toml
+[abstain]
+mode = "per_classifier"   # was "global" (line 432)
+
+[abstain.default]         # required when mode = "per_classifier"
+abstain_top = 0.40
+focused_top = 0.65
+tight_top = 1.10
+foveated_alpha = 1.0
+```
+
+Other classes (`factual`, `multi_hop`, `arithmetic`, `procedural`) may
+be omitted — runtime falls back to `[abstain.default]`. Without
+`[abstain.default]`, the config loader raises `ConfigError` at boot.
+
+Also flip the ANN threshold mode if you want margin-over-random:
+
+```toml
+[retrieval]
+ann_threshold_mode = "margin_over_random"   # was "absolute" (line 267)
+```
+
+The runtime then reads the persisted threshold from `genome_calibration`
+and falls back to `ann_similarity_threshold` (with a one-time WARN) if
+the row is missing. See
+[`docs/specs/2026-05-08-stage-4-threshold-calibration.md`](specs/2026-05-08-stage-4-threshold-calibration.md)
+§3 + §6.
+
+### Confidence calibration (optional, recommended after Stage 1 bench output exists)
+
+Stage 6 introduces the KnowBlock / MissBlock contract on `/context` and
+`/context/packet` — every retrieval emits exactly one of two top-level
+blocks. The `[know]` table in [`helix.toml`](../helix.toml) lines
+313–343 ships ship-time defaults that work on a generic corpus; the
+calibration step refits the four logistic coefficients from a labeled
+bench run.
+
+Prerequisite: a JSONL file from a Stage 1 bench run (the output of
+`benchmarks/located_n1000.py`).
+
+```bash
+python scripts/calibrate_know_confidence.py \
+    --input results/located_n1000.jsonl \
+    --out helix.toml
+```
+
+The script refits `[know].betas`, `s_ref`, `g_ref`, and `emit_floor`
+to the operator's corpus. It uses `scikit-learn` for logistic
+regression when the package is importable; otherwise it falls back to
+the pure-Python gradient descent in
+`helix_context.know_calibration.fit_betas_from_features`. To use the
+faster path:
+
+```bash
+pip install scikit-learn
+```
+
+(There is no `[calibration]` extra in `pyproject.toml` today — sklearn
+is intentionally a soft-optional. Issue #59 flagged this as a possible
+future extra.)
+
+After running, the `[know]` block in `helix.toml` is rewritten in place.
+Spec:
+[`docs/specs/2026-05-08-stage-6-know-miss-blocks.md`](specs/2026-05-08-stage-6-know-miss-blocks.md)
+§3, §11.
+
+### Idempotency and re-runs
+
+All three calibration runs are idempotent. Re-run after corpus changes
+that materially shift the gene-pair cosine distribution or the
+classifier-segmented score distribution. Typical triggers:
+
+- A new ingest batch that adds more than ~20% of total gene count.
+- A schema migration that changes the BGE-M3 codec version.
+- A bench discipline change (different `located_n1000` sampling).
+
+A no-op re-run after no corpus change writes the same numbers and
+costs a few minutes — there is no harm in including these in a
+periodic pipeline.
+
+## Environment variables
+
+Helix reads roughly two dozen `HELIX_*` environment variables. The
+table below is a one-line summary of the load-bearing ones. Full
+documentation belongs in `.env.example` (cross-link below).
+
+| Variable | Purpose |
+|---|---|
+| `HELIX_ORG` | Organization tag for 4-layer federation attribution. |
+| `HELIX_DEVICE` | Machine identifier for CWoLa + session registry. |
+| `HELIX_USER` | Operator handle. Defaults to `"max"` in `start-helix-tray.bat` if unset. |
+| `HELIX_AGENT` | Persona writing genes (e.g., `laude`, `raude`, `taude`, `gemini`). If unset, ingests tag as "manual". |
+| `HELIX_AGENT_KIND` | Tool-kind stamp (e.g., `claude-code`, `ollama-chat`). |
+| `HELIX_PARTY_ID` | Multi-tenant party tag. Falls back to `[session] default_party_id` in `helix.toml`. |
+| `HELIX_MCP_HANDLE` | Session-registry handle for the MCP host process. Disambiguates Claude Code / OpenWebUI / etc. on shared machines. |
+| `HELIX_MCP_HOST` | MCP host kind (`ollama-chat`, `claude-desktop`, `cursor`, etc.). |
+| `HELIX_MCP_URL` | URL where the helix backend is listening (default `http://127.0.0.1:11437`). |
+| `HELIX_CONFIG` | Path to the TOML config file. Default: `helix.toml` in the helix run directory. |
+| `HELIX_GENOME_PATH` | Override `[genome] path` from CLI / env. |
+| `HELIX_USE_SHARDS` | Enable phase-2 shard router. |
+| `HELIX_SERVER_UPSTREAM` | Override `[server] upstream`. Set automatically by the launcher when Headroom auto-routing is in effect. |
+| `HELIX_SERVER_UPSTREAM_TIMEOUT` | Per-request timeout (float, seconds) for proxied calls to the upstream model server. |
+| `HELIX_OTEL_ENABLED` | Set to `1` to enable OpenTelemetry. Set unconditionally by `start-helix-tray.bat`. Requires the `[otel]` extra. |
+| `HELIX_OTEL_ENDPOINT` | OTLP gRPC endpoint. Default `localhost:4317`. |
+| `HELIX_OTEL_INSECURE` | `1` for plaintext gRPC (default for local sidecar). |
+| `HELIX_OTEL_SAMPLER_RATIO` | Trace sampling ratio (0.0–1.0). Default `1.0` in the tray flow. |
+| `HELIX_OTEL_REDACT_QUERY` | Redact query text from emitted traces (privacy). |
+| `HELIX_OBSERVABILITY` | Set to `0` to skip the native observability sidecar. Useful when you're using the Docker compose stack at `deploy/otel/` or want no observability at all. |
+| `HELIX_HEADROOM_ENABLED` | `1` to wire the Headroom proxy lifecycle into the launcher. |
+| `HELIX_HEADROOM_AUTOSTART` | `1` to spawn a fresh headroom child if no existing proxy is found on the configured port. |
+| `HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO` | `1` to auto-route non-local upstreams through Headroom. |
+| `HELIX_DISABLE_HEADROOM` | Hard kill switch. Overrides every other Headroom toggle. |
+| `HELIX_BUDGET_ZONE` | `1` to enable the budget-zone gene-cap clamp (clamps `max_genes` based on caller's prompt-token-zone). Set by `start-helix-tray.bat`. |
+| `HELIX_DEVICE` | Device picker for hardware-aware codec/rerank: `auto \| cuda \| rocm \| mps \| cpu`. Default `auto`. |
+| `HELIX_FILENAME_ANCHOR_ENABLED` | Override `[retrieval] filename_anchor_enabled`. |
+| `HELIX_ABSTAIN_DISABLE` | `1` forces `[budget] abstain_enabled = false` without redeploy. |
+| `HELIX_NO_MATCH_FRAGMENT` | Override the no-match prompt fragment text. Default lives in `helix_context.agent_prompt`. |
+| `HELIX_REFRESH_FRAGMENT` | Override the refresh prompt fragment text. |
+| `HELIX_TIMEOUT` | Default per-request timeout for the helix client SDK. |
+| `HELIX_TZ` | Timezone for log timestamps. |
+| `HELIX_URL` | Default URL for client SDK callers. |
+| `HELIX_LAYERED_FINGERPRINTS` | Enable layered fingerprint payloads in `/fingerprint`. |
+| `HELIX_FORMAT_VERSION` | Output format version pin (for reproducible bench runs). |
+| `HELIX_LAUNCHER_UPDATE_CHECK` | `0` to disable the launcher's update check. |
+| `HELIX_CODEGRAPH_PATH` | Path to a code graph database (optional). |
+| `HELIX_EMBED_CODEGRAPH` | Enable code graph embedding generation. |
+| `HELIX_WALKING_TIEBREAK` | Tiebreaker selection for walking retrieval (research-bench only). |
+
+For the full list with default values and load order, see
+[`.env.example`](../.env.example) (planned follow-up — issue #59
+tracks adding it). Until that file lands, the canonical source is the
+`os.environ.get(...)` calls in `helix_context/config.py`,
+`helix_context/launcher/app.py`, and `helix_context/server.py`.
+
+## Uninstall / cleanup
+
+A clean uninstall has three steps. Each step is independent — you may
+keep the Python package installed but delete the genome, or vice versa.
+
+### 1. Remove the Python package
+
+```bash
+pip uninstall helix-context
+```
+
+If you used an editable install (`pip install -e .`), this removes
+the `.egg-link` and console scripts (`helix`, `helix-launcher`,
+`helix-status`, `helix-vault`) but leaves the source tree intact.
+
+### 2. Delete the per-user state directory
+
+```bash
+# Linux / macOS
+rm -rf ~/.helix/
+
+# Windows (PowerShell)
+Remove-Item -Recurse -Force "$env:USERPROFILE\.helix"
+```
+
+This directory holds the supervisor's PID files and Unix sockets, the
+tray's state JSON, the launcher's update-check cache, and any
+session-registry metadata. Deleting it forces a fresh launcher boot;
+no genes are lost (genes live in `genomes/`).
+
+### 3. Delete the genome(s)
+
+```bash
+# All genomes
+rm -rf genomes/
+
+# Specific shard only
+rm -rf genomes/main/
+```
+
+Genomes are SQLite `.db` files (plus their `-wal` and `-shm`
+companions). They are durable data — back them up before deleting if
+you might need them again.
+
+### 4. Headroom cache (optional)
+
+If `[codec]` is installed, the headroom proxy caches downloaded
+ModernBERT ONNX weights under:
+
+```bash
+# Linux / macOS
+rm -rf ~/.cache/headroom/
+
+# Windows
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\headroom"
+```
+
+(Path may differ — `headroom-ai` uses `platformdirs` for cache
+discovery. Check `python -c "import platformdirs;
+print(platformdirs.user_cache_dir('headroom'))"` for your platform's
+exact path.)
+
+### 5. Native observability sidecar binaries (optional)
+
+If you used `start-helix-tray.bat` and let it install the native OTel
+binaries:
+
+```bash
+# Linux / macOS
+rm -rf tools/native-otel/
+
+# Windows
+Remove-Item -Recurse -Force tools\native-otel
+```
+
+The launcher's first-run install lives there. Reinstall via
+`scripts/install-native-observability.ps1` (Windows) or
+`scripts/install-native-observability.sh` (Linux/macOS).
+
+## Cross-links
+
+- [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — recurring failure
+  modes, including symptom → fix tables for empty `/context`,
+  spaCy-model-missing, OTel-noop, Headroom-cold-start, and FTS5-not-linked.
+- [`docs/api/context-endpoint.md`](api/context-endpoint.md) —
+  `/context` request/response reference, including `caller_model_class`
+  (Stage 5) and the `know` / `miss` block contract (Stage 6 / 7).
+- [`docs/operator-runbooks.md`](operator-runbooks.md) — full
+  calibration + backfill procedures, with timing and rollback steps.
+- [`docs/config-reference.md`](config-reference.md) — every
+  `helix.toml` section, every env-var override, every default value.
+- [`docs/agent-sdk-fragment.md`](agent-sdk-fragment.md) — the
+  prompt-template fragment teaching frontier agents to honor
+  `do_not_answer_from_genome=true` and the `<helix:no_match/>` tag.
+- [`docs/architecture/LAUNCHER.md`](architecture/LAUNCHER.md) —
+  supervisor + tray + observability stack lifecycle.
+- [`docs/architecture/OBSERVABILITY.md`](architecture/OBSERVABILITY.md)
+  — Prometheus metrics, Grafana dashboards, alert rules.
+- [`deploy/otel/README.md`](../deploy/otel/README.md) — Docker compose
+  observability stack (advanced; the default native sidecar covers most
+  cases).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,834 @@
+# Troubleshooting
+
+This guide collects the failure modes that recur across user reports
+and git history for `helix-context`. Each section follows a fixed
+shape: **Symptom**, **Cause**, **Fix**, **Verify**, **Prevention**.
+
+Sections are ordered by observed frequency in the issue tracker. If
+you only have a minute, scan the symptom headers first — most users
+land on the right section in a single hop.
+
+> Conventions used below: shell snippets are bash unless noted; on
+> Windows use the equivalent `PowerShell` form (`$env:VAR=...` for
+> env vars, `Get-Process` for `lsof`, etc.). Paths are written with
+> forward slashes. The default proxy port is `11437`; the default
+> launcher UI port is `11438`. Both are configurable in `helix.toml`
+> under `[server]` and via `--port` on the launcher CLI.
+
+---
+
+## Server will not start: port 11437 is already in use
+
+**Symptom.** `python -m uvicorn helix_context.server:app --port 11437`
+exits with `OSError: [Errno 98] Address already in use` (POSIX) or
+`OSError: [WinError 10048] Only one usage of each socket address ...`
+(Windows). The launcher variant raises:
+
+```
+SupervisorError: Port 127.0.0.1:11437 is already in use by a
+non-helix process. Free the port or change --helix-port.
+```
+
+**Cause.** Another process is already bound to `127.0.0.1:11437`. The
+launcher's supervisor (`helix_context/launcher/supervisor.py:281-319`)
+will quietly *adopt* an orphan helix on that port if it can identify
+its command line, but a non-helix listener (an old Ollama instance, a
+dev script, a different Python venv) can only be cleared manually.
+
+**Fix.**
+
+1. Identify the listener.
+
+   - Linux / macOS:
+     ```bash
+     lsof -nP -iTCP:11437 -sTCP:LISTEN
+     ```
+   - Windows (PowerShell):
+     ```powershell
+     Get-NetTCPConnection -LocalPort 11437 | Select-Object OwningProcess
+     Get-Process -Id <pid>
+     ```
+
+2. If it is a stray helix process from a prior session:
+   ```bash
+   kill <pid>          # POSIX
+   taskkill /F /PID <pid>   # Windows
+   ```
+   Confirm the port frees up before retrying.
+
+3. If you cannot free port 11437, change the helix port. Edit
+   `helix.toml`:
+   ```toml
+   [server]
+   port = 11537
+   ```
+   Then update every client (Continue config `apiBase`, the MCP
+   server `HELIX_MCP_URL`, `helix_context.adapters.retriever` callers
+   — see `helix_context/config.py:175-179` for the default and the
+   list of touched modules).
+
+4. Restart helix:
+   ```bash
+   python -m uvicorn helix_context.server:app --host 127.0.0.1 --port 11537
+   ```
+
+**Verify.** From a second shell:
+```bash
+curl -s http://127.0.0.1:11537/health | python -m json.tool
+```
+Expected: a JSON object with `"genome_genes": <int>` and
+`"upstream_url": "http://localhost:11434"`. A `Connection refused`
+means the server did not bind; re-check step 1.
+
+**Prevention.** Use the launcher (`start-helix-tray.bat` /
+`python -m helix_context.launcher.app`) instead of bare `uvicorn`. The
+launcher auto-adopts an orphan helix on the same port instead of
+crashing — see `helix_context/launcher/supervisor.py:288-312`. If you
+do drive uvicorn directly, always Ctrl+C cleanly so the lifespan
+shutdown at `helix_context/server.py:679-743` runs.
+
+---
+
+## Server will not start: missing extras
+
+**Symptom.** `pip install -e .` succeeds but `python -m uvicorn
+helix_context.server:app` fails on import with one of:
+
+```
+ImportError: No module named 'sentence_transformers'
+ImportError: No module named 'spacy'
+ImportError: No module named 'tree_sitter'
+ImportError: cannot import name 'CpuTagger' from 'helix_context'
+```
+
+**Cause.** The base `helix-context` wheel ships only the proxy spine
+(`fastapi`, `uvicorn`, `httpx`, `pydantic`, `filelock`). All
+encoders, taggers, the launcher, and the codec live behind optional
+extras declared in `pyproject.toml` lines 38-97. The package
+`__init__.py:24-39` soft-imports `CpuTagger` and `SemaCodec` so the
+import does not crash, but downstream features silently degrade. The
+proxy itself, however, requires `embeddings` for the SEMA cache.
+
+**Fix.**
+
+1. Pick the extras that match your deployment:
+
+   ```bash
+   # Proxy + ingestion only (lean ~150 MB):
+   pip install -e ".[embeddings,cpu]"
+
+   # Proxy + launcher + tray (most desktops):
+   pip install -e ".[embeddings,cpu,launcher,launcher-tray]"
+
+   # Everything (~2 GB; pulls torch + headroom + tree-sitter):
+   pip install -e ".[all]"
+   ```
+
+2. Download the spaCy model used by the CPU tagger
+   (`helix_context/tagger.py:56-57`):
+   ```bash
+   python -m spacy download en_core_web_sm
+   ```
+
+3. Restart the server.
+
+**Verify.**
+```bash
+python -c "import helix_context; print(helix_context.CpuTagger)"
+```
+Expected: `<class 'helix_context.tagger.CpuTagger'>`. A `None` means
+the `spacy` extra is missing or `en_core_web_sm` is not installed.
+
+**Prevention.** Use the one-click installers — `setup-helix.bat` on
+Windows runs `deploy/windows/setup-helix.ps1`, which pins the
+correct extras for the platform. For headless servers, pin the extras
+in your project's lockfile so CI matches production.
+
+---
+
+## Server will not start: helix.toml is malformed
+
+**Symptom.** Server logs:
+```
+helix.toml is malformed (Expected '=' after a key in a key/value pair (at line 47, column 12)) — using defaults
+```
+or, for the per-classifier abstain block:
+```
+ConfigError: [abstain].mode='per_classifier' requires an
+[abstain.default] block (loader §6); none found.
+```
+
+**Cause.** The TOML loader at `helix_context/config.py:528-533` falls
+back to `HelixConfig()` defaults on a `tomllib.TOMLDecodeError` and
+emits a single `log.error` line. Defaults bind to port 11437 with
+`genome.path = "genome.db"` (relative to cwd) and Ollama at
+`http://localhost:11434` — which is rarely what an operator tuning
+`helix.toml` expects. The Stage 4 `ConfigError` at
+`helix_context/config.py:751-756` is harder: the loader raises and the
+server refuses to start because the per-classifier abstain mode has
+no default block to fall back to. See
+`helix_context/exceptions.py:37-43`.
+
+**Fix.**
+
+1. Validate the TOML manually:
+   ```bash
+   python -c "import tomllib; tomllib.load(open('helix.toml','rb'))"
+   ```
+   Any traceback points at the first malformed line.
+
+2. Common gotchas:
+
+   - **Lists must use brackets.** `replicas = path1, path2` is
+     invalid; use `replicas = ["path1", "path2"]`.
+   - **Sub-tables follow their parent.** `[abstain.default]` must come
+     after the last `[abstain]` table key, not interleaved with
+     `[server]`.
+   - **`[ribosome] device` is deprecated.** The loader at
+     `helix_context/config.py:822-834` warns "deprecated" + "override"
+     when both `[ribosome] device` and `[hardware] device` are set.
+     Move the value to `[hardware]`.
+
+3. If using `[abstain].mode = "per_classifier"`, add the required
+   default block (see `helix.toml:459-463` for an example):
+   ```toml
+   [abstain.default]
+   abstain_top = 0.40
+   focused_top = 0.65
+   tight_top = 1.10
+   foveated_alpha = 1.0
+   ```
+
+4. Restart the server.
+
+**Verify.**
+```bash
+python -c "from helix_context.config import load_config; \
+  cfg = load_config(); \
+  print(cfg.server.host, cfg.server.port, cfg.genome.path)"
+```
+Expected: the values from `helix.toml`, not the
+`(127.0.0.1, 11437, genome.db)` defaults.
+
+**Prevention.** Keep `helix.toml` under version control and run the
+one-line validator above as a pre-commit check. The repo's
+`helix.toml` doubles as a worked example with inline comments — diff
+against it after every upgrade.
+
+---
+
+## Ollama is unreachable / wrong base_url / model not pulled
+
+**Symptom.** `/health` returns `{"upstream_reachable": false, "detail":
+"ConnectError: [Errno 111] Connection refused"}`. Chat requests
+return `httpx.ConnectError` or HTTP 502 from `/v1/chat/completions`.
+The server log shows:
+```
+TranscriptionError: Ribosome model call failed entirely
+```
+when the ribosome is enabled (`helix_context/exceptions.py:29-30`).
+
+**Cause.** The proxy's upstream probe at
+`helix_context/server.py:492-532` tries `/api/tags`, `/v1/models`, and
+`/health` in order; if all three fail it returns
+`{"reachable": false, "detail": <last_error>}`. Any of three things
+break it:
+
+1. Ollama is not running.
+2. `[server] upstream` (or the `HELIX_SERVER_UPSTREAM` env override at
+   `config.py:616-617`) points to the wrong host/port.
+3. The ribosome model in `[ribosome] model` is configured but has not
+   been pulled, so Ollama 404s on the first generation call.
+
+**Fix.**
+
+1. Confirm Ollama is up:
+   ```bash
+   curl -s http://localhost:11434/api/tags
+   ```
+   The response must be JSON. A connection-refused means Ollama is
+   not running — start it with `ollama serve`.
+
+2. Confirm the upstream URL helix is using:
+   ```bash
+   curl -s http://127.0.0.1:11437/health | python -c \
+     "import sys, json; d=json.load(sys.stdin); \
+      print(d['upstream_url'], d.get('upstream_reachable'))"
+   ```
+
+3. If the URL is wrong, fix `helix.toml`:
+   ```toml
+   [server]
+   upstream = "http://localhost:11434"
+   ```
+   Or set the env override:
+   ```bash
+   export HELIX_SERVER_UPSTREAM="http://localhost:11434"
+   ```
+
+4. Pull the ribosome model and the chat model:
+   ```bash
+   ollama pull gemma4:e2b      # ribosome (helix.toml [ribosome] model)
+   ollama pull gemma4:e4b      # chat
+   ```
+
+5. Restart helix.
+
+**Verify.**
+```bash
+curl -s http://127.0.0.1:11437/health
+```
+Expected: `"upstream_reachable": true` with a `probe` field naming the
+endpoint that succeeded (typically `/api/tags`).
+
+**Prevention.** Pin `keep_alive = "30m"` in `[ribosome]` (already the
+default in `helix.toml:26`) so the model stays resident. If your
+launcher routes the chat upstream through Headroom, note that
+`helix_context/launcher/app.py:287-338` rewrites `HELIX_SERVER_UPSTREAM`
+to the Headroom port automatically; check `/health` after toggling
+`[headroom] enabled` to confirm the URL you expect.
+
+---
+
+## Tray icon is missing on Linux or macOS
+
+**Symptom.** `start-helix-tray.bat` (or the equivalent `python -m
+helix_context.launcher.app --tray` invocation) exits with:
+```
+--tray requires pystray + Pillow. Install with:
+pip install helix-context[launcher-tray]
+```
+or, on Linux specifically: the launcher starts, the dashboard works,
+but no system-tray icon appears in the panel.
+
+**Cause.** Two layered reasons:
+
+1. **License-driven exclusion.** `pystray` is LGPL-3, so the
+   `helix-context` core wheel does not bundle it (see
+   `helix_context/launcher/tray.py:19-25`). It only installs when you
+   opt in via the `launcher-tray` extra, declared in
+   `pyproject.toml:70-77`. The fail-fast at
+   `helix_context/launcher/app.py:530-535` triggers when `pystray` or
+   `Pillow` is missing.
+
+2. **Linux desktop compatibility.** `pystray` uses `AppIndicator3` on
+   GNOME and `Xlib` elsewhere. GNOME 3.26+ removed the legacy
+   StatusNotifier protocol — without the
+   `gnome-shell-extension-appindicator` extension installed, the icon
+   exists but never renders. Wayland-only sessions on Sway / Hyprland
+   need a third-party tray (`waybar`, `swaync`) bridging
+   StatusNotifier.
+
+**Fix.**
+
+1. Install the extra:
+   ```bash
+   pip install "helix-context[launcher-tray]"
+   ```
+
+2. On GNOME (Ubuntu 22.04+, Fedora 38+):
+   ```bash
+   sudo apt install gnome-shell-extension-appindicator   # Debian/Ubuntu
+   sudo dnf install gnome-shell-extension-appindicator    # Fedora
+   gnome-extensions enable ubuntu-appindicators@ubuntu.com
+   ```
+   Log out and back in.
+
+3. On macOS, no extra system packages are needed; the icon lives in
+   the menu bar. If it does not appear, check
+   `~/.helix/launcher/launcher.log` for `pystray` import errors —
+   typically a Pillow ABI mismatch on Python 3.14 (see the wheel
+   mismatch section below).
+
+4. Re-run with the tray flag:
+   ```bash
+   python -m helix_context.launcher.app --tray
+   ```
+
+**Verify.**
+```bash
+python -c "from helix_context.launcher.tray import is_tray_available; \
+  print(is_tray_available())"
+```
+Expected: `True`. A `False` means `pystray` or `PIL` is still not
+importable in the active Python environment.
+
+**Prevention.** If the tray is core to your workflow, document the
+GNOME extension prerequisite alongside the install instructions.
+Headless servers do not need the tray — drop `--tray` and run the
+launcher in dashboard-only mode.
+
+---
+
+## genome.db is locked
+
+**Symptom.** Ingestion or `/context` requests fail with:
+```
+sqlite3.OperationalError: database is locked
+```
+Often correlated with multiple helix processes pointed at the same
+`genome.db`, or with a long-running write script (`scripts/ingest_*.py`,
+the backfill scripts) running while the server is up.
+
+**Cause.** `genome.db` is opened in WAL mode at
+`helix_context/genome.py:468-475`. WAL allows concurrent readers, but
+SQLite still serializes writers. A 30-second `busy_timeout` is set
+(`genome.py:471`), so genuine contention only surfaces above that
+threshold. The most common triggers in practice:
+
+1. Two helix uvicorn processes binding the same `genome.path` — only
+   the first one's write lock survives; the second times out.
+2. A backfill script (`scripts/backfill_*.py`) writing while the
+   server still holds a long-lived read connection. The reader at
+   `genome.py:499-508` uses `isolation_level=None` to avoid pinning
+   WAL snapshots, but third-party scripts may not.
+3. WAL not checkpointed before a snapshot copy — the `.db` file is
+   stale even though `.db-wal` has the latest writes.
+
+**Fix.**
+
+1. Stop every helix process pointing at the same DB:
+   ```bash
+   ps aux | grep "helix_context._asgi"     # POSIX
+   tasklist | findstr python                # Windows
+   ```
+   Kill all but one.
+
+2. Force a WAL checkpoint via the admin endpoint
+   (`helix_context/server.py:2876-2880`):
+   ```bash
+   curl -X POST "http://127.0.0.1:11437/admin/checkpoint?mode=TRUNCATE"
+   ```
+   Expected response: `{"checkpointed": true, "mode": "TRUNCATE"}`.
+
+3. If you need to inspect or copy `genome.db`, do it after
+   step 2 — the `.db-wal` file should now be empty or absent.
+
+4. For long-running backfill scripts, run them against a snapshot
+   copy first, verify, then hot-swap during a maintenance window
+   instead of writing to the live DB.
+
+**Verify.**
+```bash
+sqlite3 genomes/main/genome.db "PRAGMA journal_mode; \
+  SELECT COUNT(*) FROM genes;"
+```
+Expected: `wal` followed by an integer gene count. If the `SELECT`
+hangs, another writer is still holding the lock.
+
+**Prevention.** One server per `genome.db`. If you need a side
+deployment, set `HELIX_GENOME_PATH=genomes/side/genome.db` (see
+`helix_context/config.py:611-612`) so the side server uses a separate
+file. The lifespan shutdown at `server.py:717` runs
+`checkpoint("TRUNCATE")` automatically, so always Ctrl+C cleanly.
+
+---
+
+## Frontier model returns plausible-but-wrong answers when /context indicates a miss
+
+**Symptom.** Claude Opus / GPT-5 / Gemini 3 Pro receives a `/context`
+response with `miss { do_not_answer_from_genome: true }` and a
+`<helix:no_match reason="..."/>` token in `expressed_context`, but
+answers from training prior anyway.
+
+**Cause.** The agent's system prompt does not import the
+helix-context know/miss contract fragment. Without explicit rules
+teaching the model to honor the `do_not_answer_from_genome` flag and
+call an escalate tool, it falls back to its training prior to
+fabricate an answer. The contract is load-bearing only when the agent
+prompt teaches it.
+
+The Stage 6 spec (`docs/specs/2026-05-08-stage-6-know-miss-blocks.md`
+§12) is explicit about this: the runtime envelope validator in
+`helix_context/schemas.py:521-600` rejects malformed `MissBlock`s
+server-side, but the prompt-level contract that turns
+`do_not_answer_from_genome=True` into actual escalation is the
+caller's responsibility. The compiled fragment lives at
+`helix_context/agent_prompt.py:25-92`.
+
+**Fix.**
+
+1. In your agent SDK setup, prepend
+   `helix_context.agent_prompt.HELIX_NO_MATCH_FRAGMENT` (or the
+   combined `full_fragment()`) to the system prompt:
+
+   ```python
+   from helix_context.agent_prompt import (
+       HELIX_NO_MATCH_FRAGMENT,
+       HELIX_REFRESH_FRAGMENT,
+       full_fragment,
+   )
+
+   system_prompt = full_fragment() + "\n\n" + your_existing_system_prompt
+   ```
+
+2. Register escalation tools (`grep` / `rag` / `web` / `ask_human`)
+   so the model has somewhere to route to. Helix only signals which
+   CLASS of tool to invoke; you implement the tool itself. The
+   permitted set is enforced at
+   `helix_context/schemas.py:564-569` (`ESCALATE_TARGETS`).
+
+3. Ensure your agent has a tool-call-before-answer loop: when `miss`
+   is present (or the `<helix:no_match/>` tag appears in
+   `expressed_context`), the model emits a tool call from the
+   `escalate_to` list, waits for the result, then composes the reply.
+
+4. Distinguish `recommendation = "escalate"` from
+   `recommendation = "refresh"` — the Stage 7 fragment at
+   `helix_context/agent_prompt.py:59-82` covers refresh semantics.
+   Refresh means "the answer is here, just out of date — fetch and
+   retry"; escalate means "the answer is NOT here — go ask
+   elsewhere". Conflating them defeats the contract.
+
+**Verify.** Run a query you know is NOT in the genome (e.g., a
+synthetic UUID). Expected: the agent emits a tool call (grep / rag /
+web), not an answer. Inspect via your agent's trace, or run the
+offline compliance harness:
+```bash
+python scripts/eval_agent_compliance.py --jsonl <your_trace.jsonl>
+```
+The Stage 6 spec recommends a >=95% compliance bar.
+
+**Prevention.** Add a unit test that mocks `/context` returning a
+`MissBlock` and asserts the agent issues a tool call. Wire the
+fragment injection into your agent SDK boot path so it cannot be
+forgotten — the runtime contract is enforced server-side, the prompt
+contract is enforced only by you.
+
+---
+
+## Dense recall returns nothing / /context retrieval rate plateaus low
+
+**Symptom.** `bench_needle_1000.py` retrieval rate stays under 30%;
+`/context` debug logs show
+`query_genes_dense_recall: empty matrix, falling back to lexical-only`.
+The genome was ingested before the 7-stage merge, or pulled but never
+backfilled.
+
+**Cause.** Stage 2's backfill was not run after pulling the 7-stage
+merge. The `embedding_dense_v2 BLOB` column is empty; the in-memory
+dense matrix loader at `helix_context/genome.py` returns `[]` and
+emits a one-time WARN. Stage 2 promoted dense from a 12-candidate
+re-ranker to a parallel first-class recall source returning top-K=500
+over the full corpus (spec
+`docs/specs/2026-05-08-stage-2-dense-recall.md` §1). Without the v2
+column populated, dense recall silently degrades to lexical-only.
+
+**Fix.**
+
+1. Stop helix:
+   ```bash
+   _stop_bench_helix.bat       # Windows bench helper
+   # Or Ctrl+C the uvicorn process
+   ```
+
+2. Snapshot-copy `genomes/main/genome.db` to a working location:
+   ```bash
+   cp genomes/main/genome.db genomes/main/genome.db.backfill-working
+   ```
+
+3. Run the backfill:
+   ```bash
+   python scripts/backfill_bgem3_v2.py \
+     genomes/main/genome.db.backfill-working
+   ```
+   Wall-clock estimate: ~30-90 min on CPU sentence-transformers
+   BGE-M3, ~5-15 min on GPU (FlagEmbedding). Idempotent and
+   resumable: rows with a non-NULL v2 BLOB are skipped (script
+   header at `scripts/backfill_bgem3_v2.py:1-22`).
+
+4. Verify the script ends with `coverage=100.00%`.
+
+5. Hot-swap the populated DB into place during a maintenance window:
+   ```bash
+   mv genomes/main/genome.db genomes/main/genome.db.pre-backfill
+   mv genomes/main/genome.db.backfill-working genomes/main/genome.db
+   ```
+
+6. Restart helix.
+
+**Verify.**
+```bash
+sqlite3 genomes/main/genome.db \
+  "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL;"
+sqlite3 genomes/main/genome.db "SELECT COUNT(*) FROM genes;"
+```
+Expected: both counts are equal. A delta means the backfill is
+incomplete — re-run step 3.
+
+**Prevention.** After every helix-context upgrade, check the
+changelog for new backfill operator actions. The post-merge runbook
+lives in `docs/operator-runbooks.md`; new backfills are also called
+out in the corresponding stage spec under `docs/specs/`.
+
+---
+
+## SQLite FTS5 missing on macOS
+
+**Symptom.** First helix start (or the first `/ingest` call) raises:
+```
+sqlite3.OperationalError: no such module: fts5
+```
+The server log records "FTS5 not available — content search disabled"
+at `helix_context/genome.py:803`. Tier 3 (full-text content match)
+silently drops out of the 9-tier fusion ranker.
+
+**Cause.** Apple's bundled CPython on Big Sur and later links against
+a stripped system SQLite that omits FTS5 and JSON1. Homebrew's
+SQLite ships FTS5, but `pyenv install` does not pick it up unless you
+explicitly point it at the brewed copy. Linux distros and Windows do
+not hit this — CPython 3.11+ wheels for those platforms bundle a
+recent SQLite with FTS5 enabled.
+
+**Fix.**
+
+1. Install Homebrew SQLite:
+   ```bash
+   brew install sqlite
+   ```
+
+2. Rebuild your Python (or install a fresh one) with the brewed
+   SQLite linked in. For pyenv:
+   ```bash
+   LDFLAGS="-L$(brew --prefix sqlite)/lib" \
+   CPPFLAGS="-I$(brew --prefix sqlite)/include" \
+   PYTHON_CONFIGURE_OPTS="--enable-loadable-sqlite-extensions" \
+   pyenv install 3.12.7
+   pyenv shell 3.12.7
+   ```
+
+3. Re-create the venv and reinstall helix:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e ".[embeddings,cpu]"
+   ```
+
+4. Restart helix.
+
+**Verify.**
+```bash
+python -c "import sqlite3; \
+  c = sqlite3.connect(':memory:'); \
+  c.execute('CREATE VIRTUAL TABLE t USING fts5(x)'); \
+  print('ok')"
+```
+Expected: `ok`. Anything else means FTS5 is still not linked. See
+`docs/SETUP.md:33-56` for the same recipe with extra context.
+
+**Prevention.** On macOS, never use the system Python (`/usr/bin/python3`)
+for helix. Use pyenv, conda, or Homebrew Python — all of them link
+against a current SQLite with FTS5. Pin the Python version in your
+project README so contributors do not regress.
+
+---
+
+## Python 3.14 wheel mismatches for torch / pystray
+
+**Symptom.** `pip install -e ".[all]"` fails on a 3.14 venv with one
+of:
+```
+ERROR: Could not find a version that satisfies the requirement torch
+ERROR: Failed building wheel for pystray
+ImportError: dynamic module does not define module export function (PyInit__C)
+```
+Or the install completes but `python -c "import torch"` segfaults at
+import.
+
+**Cause.** PyTorch and `pystray` (with its Pillow dependency) lag
+upstream Python by months. CPython 3.14 ships in February 2026; at
+the time of the 7-stage merge their wheel matrices target 3.11-3.13.
+`pyproject.toml:10` declares `requires-python = ">=3.11"`, but the
+classifier list (lines 21-23) only certifies 3.11-3.13. See
+`docs/SETUP.md:23-28` for the same warning.
+
+**Fix.**
+
+1. Install Python 3.12 or 3.13 alongside your existing 3.14:
+   ```bash
+   pyenv install 3.13.1   # POSIX
+   # Or: download an installer from python.org for Windows
+   ```
+
+2. Create a fresh venv on 3.13:
+   ```bash
+   python3.13 -m venv .venv-313
+   source .venv-313/bin/activate     # POSIX
+   .venv-313\Scripts\activate.bat    # Windows
+   ```
+
+3. Reinstall helix-context:
+   ```bash
+   pip install -e ".[all]"
+   ```
+
+4. If you must stay on 3.14, install only the extras with binary
+   wheels available:
+   ```bash
+   pip install -e ".[embeddings,cpu]"   # no torch, no pystray
+   ```
+   The proxy and CPU encoders work; the launcher tray and DeBERTa
+   rerank backend will not.
+
+**Verify.**
+```bash
+python --version
+python -c "import torch; print(torch.__version__)"
+python -c "import pystray; print(pystray.__version__)"
+```
+Expected: a Python version line in the 3.11-3.13 range, then a
+`torch` and `pystray` version with no segfault. On 3.14, expect at
+least one of the latter two to fail or be missing.
+
+**Prevention.** Pin the supported Python range in your project
+README. The `.python-version` file (used by pyenv) is a good lock
+mechanism. CI matrices should test against the lowest-supported
+version (3.11) and the recommended one (3.13) until upstream wheels
+catch up.
+
+---
+
+## spaCy NER model not downloaded — ingestion falls back, /context quality degrades silently
+
+**Symptom.** `/ingest` POSTs succeed but ingested gene quality drops
+visibly: tag set is sparse, entity-graph (`[ingestion] entity_graph =
+true`) edges fail to populate, and `/context` retrieval rate on
+entity-heavy queries falls. The server log shows a single
+`OSError: [E050] Can't find model 'en_core_web_sm'` at first ingest
+and then nothing further.
+
+**Cause.** `helix_context/tagger.py:52-64` lazy-loads
+`en_core_web_sm` on first use. The package `__init__.py:24-28`
+soft-imports `CpuTagger` so an `ImportError` at module load does not
+crash the server, but a missing *model* is a runtime error inside
+`_get_nlp()` and surfaces only when ingestion actually runs. The
+tagger has no graceful regex fallback — when the spaCy load fails,
+the call stack unwinds and that ingest gene gets none of the NER /
+noun-chunk enrichment, dropping its tag count.
+
+**Fix.**
+
+1. Install the model:
+   ```bash
+   python -m spacy download en_core_web_sm
+   ```
+   This pulls ~12 MB and writes into the active venv's
+   `site-packages/en_core_web_sm/`.
+
+2. Restart helix. The tagger's `_nlp` cache is process-local; in-flight
+   workers will not pick up a freshly downloaded model.
+
+3. Re-ingest any documents that were ingested while the model was
+   missing:
+   ```bash
+   python scripts/docs_tidy_reingest.py <path>
+   ```
+   Or use the `/admin/refresh` endpoint to trigger a retrieval-layer
+   refresh after re-ingest.
+
+**Verify.**
+```bash
+python -c "import spacy; \
+  nlp = spacy.load('en_core_web_sm'); \
+  doc = nlp('helix-context fronts Ollama at localhost:11434.'); \
+  print([(e.text, e.label_) for e in doc.ents])"
+```
+Expected: a non-empty list of entities (at minimum a `PRODUCT` /
+`ORG` hit). A blank `[]` or an `OSError` means the model is missing
+from this venv.
+
+**Prevention.** Wire the model download into your install script.
+For pip-only installs, append the download line to your project's
+post-install step:
+```bash
+pip install "helix-context[cpu]" && python -m spacy download en_core_web_sm
+```
+Production deployments should bake the model into the container
+image so cold starts do not race the network.
+
+---
+
+## Calibration drift — per_classifier mode with stale floors
+
+**Symptom.** The Stage 4 calibrated floors in `helix.toml`
+(`[abstain.factual]`, `[abstain.multi_hop]`, etc.) were generated
+weeks ago against a different genome snapshot. `/context` now
+abstains on queries it used to answer (or vice versa). Bench
+retrieval rates drift while no code has changed.
+
+**Cause.** `[abstain].mode = "per_classifier"` reads per-classifier
+floors from the `[abstain.<cls>]` blocks and uses them as hard
+gates. Those floors are calibrated empirically by
+`scripts/calibrate_thresholds.py` from a bench JSONL of located
+queries — if the genome has grown (or shifted in topic mix) since
+the calibration run, the score distribution shifts too, and the old
+floors no longer reflect reality. The loader at
+`helix_context/config.py:718-757` accepts the stale values without
+warning; only the bench tells you they are wrong. There is no
+auto-recalibration.
+
+**Fix.**
+
+1. Regenerate the located bench:
+   ```bash
+   python benchmarks/bench_needle_1000.py \
+     --genome genomes/main/genome.db \
+     --output results/located_n1000.jsonl
+   ```
+
+2. Recalibrate (script header at
+   `scripts/calibrate_thresholds.py:1-25`):
+   ```bash
+   python scripts/calibrate_thresholds.py \
+     --input results/located_n1000.jsonl \
+     --genome genomes/main/genome.db \
+     --output-toml helix.toml.calibrated
+   ```
+
+3. Diff the new floors against the live ones:
+   ```bash
+   diff helix.toml helix.toml.calibrated
+   ```
+   Review every `abstain_top` / `focused_top` / `tight_top` change —
+   floors that drift by >0.10 are suspicious; check the bench's hit /
+   miss distribution for the affected classifier class.
+
+4. Replace the `[abstain.*]` blocks in the live `helix.toml` with the
+   recalibrated values. Restart helix.
+
+5. If you want to fall back to the global mode while you investigate:
+   ```toml
+   [abstain]
+   mode = "global"
+   ```
+   This restores the legacy hard-coded floors
+   (`TIGHT_SCORE_FLOOR=5.0`, `FOCUSED_SCORE_FLOOR=2.5`, abstain at
+   `2.5`) — pre-Stage-4 behavior byte-for-byte (see comment at
+   `helix.toml:421-432`).
+
+**Verify.** Compare retrieval rate before and after on the same
+bench:
+```bash
+python benchmarks/bench_needle_1000.py \
+  --genome genomes/main/genome.db \
+  --report
+```
+Expected: retrieval rate within 1-2 pp of the figure recorded the
+last time the floors were calibrated. A larger gap means the genome
+has shifted enough to warrant a recalibration cadence (monthly is a
+reasonable default).
+
+**Prevention.** Recalibrate after any of: large ingestion run,
+shard split, ribosome model change, or fusion-mode flip
+(additive ↔ rrf). Pin the calibration JSONL alongside the floors so
+reviewers can see what data the threshold was fit against.
+
+---
+
+## When to file an issue
+
+If your symptom does not match any section above and `/health`
+reports `genome_genes > 0` and `upstream_reachable = true`, file an
+issue: <https://github.com/SwiftWing21/helix-context/issues>. Include
+`/health`, `/stats`, the relevant log lines, and your `helix.toml`
+with secrets redacted.

--- a/docs/api/context-endpoint.md
+++ b/docs/api/context-endpoint.md
@@ -1,0 +1,817 @@
+# `/context` endpoint reference
+
+This document is the schema-level reference for the `/context` family of
+endpoints exposed by `helix-context`. It supersedes the two-paragraph
+treatment in [`docs/api/endpoints.md`](endpoints.md) and is the canonical
+contract for frontier-agent and small-MoE callers integrating against the
+post-2026-05-10 7-stage retrieval-fix surface.
+
+All file references link to the helix-context repository. Pydantic models
+are at [`helix_context/schemas.py`](../../helix_context/schemas.py); route
+handlers are at [`helix_context/server.py`](../../helix_context/server.py).
+
+---
+
+## 1. Overview
+
+`POST /context` is the primary read endpoint for an LLM agent. The agent
+sends a query string; helix-context runs its retrieval pipeline against the
+local genome (SQLite) and returns a structured envelope containing either
+(a) a `know` block with grounded `expressed_context` bytes the agent may
+answer from, or (b) a `miss` block whose `reason` field tells the agent how
+to recover (escalate to a tool, refresh a stale source, ask a human).
+
+The contract is the **know-vs-go** split: every response has exactly one of
+the two top-level keys non-null. There is no third "maybe" branch — the
+discriminator at
+[`helix_context/know_decision.py:304`](../../helix_context/know_decision.py#L304)
+collapses every retrieval outcome onto one of the two blocks. Frontier
+agents are expected to branch on the structured tag instead of parsing
+prose out of `expressed_context`.
+
+Callers:
+
+- **MCP hosts** (Claude Code, Cursor, Continue) using `mcp__helix-context__helix_context`.
+- **Frontier-agent SDKs** (Claude Opus, GPT-5, Gemini 3 Pro) that want
+  retrieval-augmented context with a load-bearing refusal contract.
+- **Small-MoE proxies** (qwen3:4b, gemma4:e4b) that need a JSON answer slate
+  the model's attention can lock onto.
+- **Bench harnesses** running `bench_needle_1000.py` with `--axis located`.
+
+The endpoint is LLM-free: no model is invoked inside the retrieval path.
+All structured signals (`confidence`, `coordinate_confidence`,
+`freshness_min`, `lexical_dense_agree`) are computed by deterministic
+SQL-and-numpy code from the post-fusion score map.
+
+---
+
+## 2. Request body
+
+`POST /context` accepts a JSON object. All fields are optional except
+`query`. Fields marked **(verified)** are read by
+[`server.py:1010-1170`](../../helix_context/server.py#L1010);
+fields documented from `_request_read_only` are at
+[`server.py:1000-1008`](../../helix_context/server.py#L1000).
+
+| Field | Type | Default | Semantics |
+|---|---|---|---|
+| `query` | `str` | — | **Required.** Natural-language query or locator. Empty/whitespace-only string returns 400 (`server.py:1082`). |
+| `session_id` | `str \| null` | synthesized | Session attribution for CWoLa logging. When `null` and `synthetic_session_enabled` is on, the server synthesizes `"syn_<sha1(client_ip:bucket_ts)>[:12]"` (`server.py:1056-1067`). |
+| `party_id` | `str \| null` | `config.session.default_party_id` | Trust identity. Defaults to the configured party when `null`. |
+| `caller_model_class` | `"generic" \| "small_moe" \| "frontier"` | `"generic"` | **Stage 5.** Render-branch selector. Unknown values return 400 (`server.py:1135-1142`). The `generic` branch is regression-locked byte-identical to pre-Stage-5 output. See §7 for the behavior matrix. Wire enum at [`schemas.py:692-696`](../../helix_context/schemas.py#L692). |
+| `clean` | `bool` | `false` | **Stage 1.** When true: (a) implies `read_only=true` (`server.py:1008`); (b) calls `helix.reset_session_state()` to clear per-session caches before the request runs (`server.py:1075-1079`). Used by synthetic benches to isolate from prior state. |
+| `read_only` | `bool \| null` | `null` | Explicit override. When non-null, takes precedence over `clean`'s implicit value (`_request_read_only` at `server.py:1000`). When true: no genome learning, no `touch_genes`, no `link_coactivated`, no harmonic/relation writes. Mtime cache may still update (in-memory; not a genome write). |
+| `response_mode` | `"continue" \| "packet"` | `"continue"` | When `"packet"`, the route delegates to `build_context_packet` and returns a `ContextPacket`-shaped payload instead of the Continue-compatible envelope (`server.py:1090-1111`). Other values return 400. |
+| `format` | `str \| null` | — | Legacy alias for `response_mode`. Ignored when `response_mode` is set; otherwise its value is used (`server.py:1019`). |
+| `include_cold` | `bool \| null` | (config flag) | Cold-tier override. `null` defers to config (`config.budget.cold_tier_enabled`). `true` forces cold-tier ON for this request; `false` forces it OFF (`server.py:1027-1029`). |
+| `prompt_tokens` | `int \| null` | `null` | Budget-zone hint. The `/context` route has no `messages[]`, so callers must supply the prompt-token count explicitly to enable zone-cap behavior. Missing => treated as clean/no-cap (`server.py:1147-1152`). |
+| `decoder_mode` | `"full" \| "condensed" \| "minimal" \| "none" \| null` | resolved | Per-request decoder override. Other values are ignored and the classifier-resolved mode wins (`server.py:1116-1120`). |
+| `verbose` | `bool` | `false` | When true, citations gain `domains` / `entities` and `agent` gains `tier_contributions` / `tier_totals` (`server.py:1264-1273`, `1358-1379`). |
+| `session_context` | `dict \| null` | `null` | Editor context: `{"active_project": str, "active_files": list[str], "active_projects": list[str]}`. Plumbed through to the path_key_index tier so PKI can fire on `(project, key)` pairs even when the query string itself is short. |
+| `task_type` | `str` | `"explain"` | Only consumed when `response_mode == "packet"`; selects the packet builder's task profile (`server.py:1103`). |
+| `max_genes` | `int` | `config.budget.max_genes_per_turn` | Only consumed when `response_mode == "packet"`. Clamped to `[1, 32]` (`server.py:1095`). |
+| `ignore_delivered` | `bool` | `false` | Bypasses the session working-set elision so already-delivered genes can re-fire (used by benches and smoke tests, `server.py:1157`). |
+
+### 2.1 Example request
+
+```json
+{
+  "query": "What is the cold_start_threshold value in helix-context/helix_context/config.py?",
+  "caller_model_class": "frontier",
+  "session_id": "taude-2026-05-10-001",
+  "party_id": "max@local",
+  "clean": false,
+  "prompt_tokens": 18000,
+  "session_context": {
+    "active_project": "helix-context",
+    "active_files": ["helix_context/config.py", "helix.toml"]
+  }
+}
+```
+
+---
+
+## 3. Response — `know` branch
+
+When the discriminator returns a `KnowBlock`, the response top-level is:
+
+```json
+{
+  "know": { ... },
+  "name": "Helix Genome Context",
+  "description": "12 genes expressed, 3.4x compression, health=aligned (Δε=0.91)",
+  "content": "<expressed_context>...</expressed_context>",
+  "context_health": { ... },
+  "agent": { ... }
+}
+```
+
+`miss` is **not** present in this branch (it is omitted, not `null`). The
+envelope validator at
+[`schemas.py:665-674`](../../helix_context/schemas.py#L665) raises
+`ValueError` if both keys are set or both omitted.
+
+### 3.1 `know: KnowBlock`
+
+Defined at [`schemas.py:490-518`](../../helix_context/schemas.py#L490).
+`extra="forbid"` — additional keys are a hard error.
+
+| Field | Type | Constraint | Source |
+|---|---|---|---|
+| `found` | `Literal[True]` | always `true` | discriminator |
+| `confidence` | `float` | `[0.0, 1.0]` | 5-feature logistic, see §3.1.1 |
+| `top_score` | `float` | unconstrained | rank-1 fused retrieval score |
+| `score_gap` | `float` | unconstrained | `top1 - top2` (raw subtraction, NOT ratio) |
+| `lexical_dense_agree` | `bool` | — | `True` if lexical-cluster top-K and dense-cluster top-K share at least one gene_id (k=3); see [`know_decision.py:237-297`](../../helix_context/know_decision.py#L237) |
+| `gene_id_match` | `str \| null` | — | Beacon: query token that exactly (case-insensitive) matches a top-1 file or path token. `null` when no match. See §3.1.2. |
+| `coordinate_confidence` | `float` | `[0.0, 1.0]` | Blend of folder + file-grain query/source agreement; computed by `context_packet._coordinate_confidence` |
+| `soft_stale` | `bool` | default `false` | **Stage 7.** `True` when top-1 is fresh enough to act on, but `freshness_min < 0.5` indicates lower-ranked supporting genes are stale. Drives `agent.recommendation = "refresh"` even though the agent may answer from the genome. |
+
+#### 3.1.1 Confidence formula (Stage 6 + Stage 7)
+
+The 5-feature logistic at
+[`know_calibration.py`](../../helix_context/know_calibration.py)
+(plumbed from `decide_know_or_miss` at
+[`know_decision.py:433`](../../helix_context/know_decision.py#L433)):
+
+```
+z = β0
+  + β1 * tanh(top_score / s_ref)
+  + β2 * tanh(score_gap / g_ref)
+  + β3 * (1.0 if lexical_dense_agree else 0.0)
+  + β4 * coordinate_confidence
+  + β5 * freshness_min                       # Stage 7
+confidence = 1.0 / (1.0 + exp(-z))
+```
+
+Cold-start defaults shipped in code: `β = (-2.0, +2.0, +1.5, +0.7, +1.8, +1.5)`,
+`s_ref = 1.0`, `g_ref = 0.5`. A `KnowBlock` is only emitted when
+`confidence >= know.emit_floor` (default `0.55`); below that the
+discriminator falls through to `MissBlock(reason="sparse")`.
+
+`freshness_min` falls back to `decay_score` when `last_verified_at IS NULL`
+on legacy rows. When `freshness_min` is `None` (no candidates), the term
+is treated as neutral (β5 contribution zero).
+
+#### 3.1.2 `gene_id_match` beacon rules
+
+Implemented at
+[`know_decision.py:157-211`](../../helix_context/know_decision.py#L157).
+Filename match wins over path match. Path-token match requires the
+matched token's length `>= 4` AND it must not be in the
+`{"src","lib","app","bin","var","tmp","out"}` blocklist. Equality is
+exact and case-insensitive only — no prefix, no substring, no edit
+distance, no synonym expansion. Asymmetric cost: a wrong beacon makes
+the frontier model lock in a wrong answer; a missing beacon merely
+lowers `confidence`.
+
+#### 3.1.3 Example `know` payload
+
+```json
+{
+  "know": {
+    "found": true,
+    "confidence": 0.83,
+    "top_score": 0.92,
+    "score_gap": 0.41,
+    "lexical_dense_agree": true,
+    "gene_id_match": "config.py",
+    "coordinate_confidence": 0.78,
+    "soft_stale": false
+  }
+}
+```
+
+---
+
+## 4. Response — `miss` branch
+
+When the discriminator returns a `MissBlock`, the response top-level is:
+
+```json
+{
+  "miss": { ... },
+  "name": "Helix Genome Context",
+  "description": "0 genes expressed, 0.0x compression, health=abstain (Δε=0.00)",
+  "content": "<expressed_context><helix:no_match reason=\"abstain\" do_not_answer=\"true\"/></expressed_context>",
+  "context_health": { ... },
+  "agent": { ... }
+}
+```
+
+### 4.1 `miss: MissBlock`
+
+Defined at [`schemas.py:521-642`](../../helix_context/schemas.py#L521).
+`extra="forbid"`.
+
+| Field | Type | Constraint | Source |
+|---|---|---|---|
+| `miss` | `Literal[True]` | always `true` | discriminator |
+| `reason` | `str` | one of `MISS_REASONS` (see §4.2) | `_validate_reason_and_escalate` model_validator |
+| `top_score` | `float` | — | rank-1 fused retrieval score (may be 0.0 on `no_promoter_match`) |
+| `ratio` | `float` | — | `top1 / top2` (matches existing `metadata.ratio`) |
+| `escalate_to` | `list[str]` | each in `ESCALATE_TARGETS` | populated for escalate-class reasons (see §4.2); empty for refresh-class |
+| `refresh_targets` | `list[str]` | — | populated for refresh-class reasons; empty for escalate-class |
+| `do_not_answer_from_genome` | `Literal[True]` | always `true` | load-bearing contract bit; agents MUST honor it |
+
+### 4.2 Reason vocabulary
+
+`MISS_REASONS` is a `tuple[str, ...]` at
+[`schemas.py:457-466`](../../helix_context/schemas.py#L457).
+Order matters for clients that index into the tuple:
+
+```python
+MISS_REASONS = (
+    "abstain",            # Stage 6 — escalate
+    "denatured",          # Stage 6 — escalate
+    "sparse",             # Stage 6 — escalate
+    "no_promoter_match",  # Stage 6 — escalate
+    "stale",              # Stage 7 — refresh
+    "cold",               # Stage 7 — refresh
+    "superseded",         # Stage 7 — refresh
+)
+```
+
+`ESCALATE_TARGETS` is a `tuple[str, ...]` at
+[`schemas.py:478-483`](../../helix_context/schemas.py#L478):
+
+```python
+ESCALATE_TARGETS = ("grep", "rag", "web", "ask_human")
+```
+
+The model validator at
+[`schemas.py:557-601`](../../helix_context/schemas.py#L557) enforces:
+
+- `reason in {"stale","cold","superseded"}` ⇒
+  `len(refresh_targets) >= 1` AND `escalate_to == []`.
+- `reason in {"abstain","denatured","sparse","no_promoter_match"}` ⇒
+  `refresh_targets == []` AND `len(escalate_to) >= 1`.
+
+A construction violating either invariant raises `ValueError` at
+pydantic-validate time.
+
+### 4.3 Reason → behavior mapping
+
+| `reason` | Class | Discriminator branch | `escalate_to` populated by | `refresh_targets` source | `agent.recommendation` |
+|---|---|---|---|---|---|
+| `abstain` | escalate | `health.status == "abstain"` | `_pick_escalation(query, "abstain")` | `[]` | `"escalate"` |
+| `denatured` | escalate | `health.status == "denatured"` | `_pick_escalation(query, "denatured")` | `[]` | `"escalate"` |
+| `no_promoter_match` | escalate | `genes_expressed == 0` and not abstain | `_pick_escalation(query, "no_promoter_match")` | `[]` | `"escalate"` |
+| `sparse` | escalate | `confidence < emit_floor` (and no cold-tier hits) | `_pick_escalation(query, "sparse")` | `[]` | `"escalate"` |
+| `stale` | refresh | top-1 mtime > `last_verified_at` | `[]` | `[top_gene.source_id]` | `"refresh"` |
+| `cold` | refresh | sparse fallthrough but cold-tier peek surfaced hits | `[]` | `[g.source_path or g.source_id for g in cold_hits]` | `"refresh"` |
+| `superseded` | refresh | top-1 has a successor row via `genes.supersedes` | `[]` | `[successor.source_id]` | `"refresh"` |
+
+### 4.4 `escalate_to` ordering rules
+
+`_pick_escalation` at
+[`know_decision.py:96-139`](../../helix_context/know_decision.py#L96).
+First matching rule wins; results deduped while preserving order:
+
+1. **Code-shaped query** (matches `[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]` OR
+   contains `def`/`class`/`import`/`function`/`fn`/`let`/`var`/`const`
+   keyword OR has a filename extension token like `.py|.ts|.go|.rs|.md|...`)
+   → `["grep", "rag"]`.
+2. **Entity-shape + `no_promoter_match`** (≥1 entity, no code shape) →
+   `["rag", "web"]`.
+3. **`denatured` corpus** → `["grep", "ask_human"]`.
+4. **`abstain` + short query (≤3 tokens)** → `["ask_human", "rag"]`.
+5. **Default fallback** → `["rag"]`.
+
+The list always contains at least one tool — escalate-class reasons with
+empty `escalate_to` would fail the model validator.
+
+### 4.5 Example `miss` payloads
+
+Escalate-class (abstain on a code-shaped query):
+
+```json
+{
+  "miss": {
+    "miss": true,
+    "reason": "abstain",
+    "top_score": 0.0,
+    "ratio": 0.0,
+    "escalate_to": ["grep", "rag"],
+    "refresh_targets": [],
+    "do_not_answer_from_genome": true
+  }
+}
+```
+
+Refresh-class (stale top-1):
+
+```json
+{
+  "miss": {
+    "miss": true,
+    "reason": "stale",
+    "top_score": 0.83,
+    "ratio": 1.42,
+    "escalate_to": [],
+    "refresh_targets": ["F:/Projects/helix-context/helix_context/config.py"],
+    "do_not_answer_from_genome": true
+  }
+}
+```
+
+Refresh-class (cold-tier fallback):
+
+```json
+{
+  "miss": {
+    "miss": true,
+    "reason": "cold",
+    "top_score": 0.42,
+    "ratio": 1.0,
+    "escalate_to": [],
+    "refresh_targets": [
+      "F:/Projects/helix-context/helix_context/freshness.py"
+    ],
+    "do_not_answer_from_genome": true
+  }
+}
+```
+
+---
+
+## 5. Mutual exclusivity invariant
+
+Exactly one of `know` and `miss` is non-null on every well-formed
+response. The invariant is enforced by the
+`ContextResponseEnvelope._exactly_one` model validator at
+[`schemas.py:665-674`](../../helix_context/schemas.py#L665):
+
+```python
+@model_validator(mode="after")
+def _exactly_one(self) -> "ContextResponseEnvelope":
+    if (self.know is None) == (self.miss is None):
+        raise ValueError(
+            "ContextResponseEnvelope: exactly one of know/miss must "
+            "be set (got "
+            f"know={'set' if self.know is not None else 'None'}, "
+            f"miss={'set' if self.miss is not None else 'None'})"
+        )
+    return self
+```
+
+A construction with both blocks present or both absent raises
+`ValueError` at pydantic-validate time, which the route surfaces as a
+500 (the test suite asserts it never fires under correct flow). Clients
+that read both keys defensively MUST treat "both set" or "both absent"
+as a server bug, not as a fall-through case.
+
+---
+
+## 6. `expressed_context` token taxonomy
+
+The `content` field of the response contains the assembled
+`expressed_context` string — typically wrapped in
+`<expressed_context>...</expressed_context>` tags. Three special
+inline tokens may appear:
+
+### 6.1 `<helix:no_match/>` — Stage 6 miss token
+
+Self-closing tag injected by `_no_match_token` at
+[`context_manager.py:221-236`](../../helix_context/context_manager.py#L221).
+Lowercase tag name, attributes in fixed order (`reason` then
+`do_not_answer`), no whitespace inside the tag, `do_not_answer="true"`
+literal:
+
+```
+<helix:no_match reason="abstain"           do_not_answer="true"/>
+<helix:no_match reason="denatured"         do_not_answer="true"/>
+<helix:no_match reason="sparse"            do_not_answer="true"/>
+<helix:no_match reason="no_promoter_match" do_not_answer="true"/>
+<helix:no_match reason="stale"             do_not_answer="true"/>
+<helix:no_match reason="cold"              do_not_answer="true"/>
+<helix:no_match reason="superseded"        do_not_answer="true"/>
+```
+
+**Implementation note:** the `_no_match_token` helper currently only
+formats the four Stage-6 reasons (abstain, denatured, sparse,
+no_promoter_match); an unknown reason falls back to the abstain form
+(`context_manager.py:233-236`). The Stage-7 reasons (`stale`, `cold`,
+`superseded`) are surfaced via `MissBlock.reason` and
+`agent.recommendation = "refresh"` rather than a distinct
+`expressed_context` byte. Clients should branch on the structured
+`miss.reason` field, not on the `<helix:no_match/>` reason attribute.
+
+### 6.2 `<helix:slate>` — Stage 5 small-MoE answer slate
+
+Injected by `_render_small_moe_slate` at
+[`context_manager.py:288-342`](../../helix_context/context_manager.py#L288).
+Char-bounded JSON KV pack, default budget 1500 chars (config key
+`budget.slate_char_budget`). Compact JSON (`separators=(",", ":")`,
+`ensure_ascii=False`); keys deduped first-write-wins:
+
+```
+<helix:slate>{"port":"11437","model":"qwen3:4b","cold_start_threshold":"0.62"}</helix:slate>
+```
+
+Empty form when no KV fits the budget:
+
+```
+<helix:slate>{}</helix:slate>
+```
+
+The slate is emitted only when `caller_model_class == "small_moe"` (or
+the legacy MoE flag fires); for `frontier` callers the slate is
+suppressed entirely (see §7).
+
+### 6.3 Decoder-mode templates that embed the slate
+
+When `decoder_mode == "answer_slate_only"` (small_moe × arithmetic /
+factual) or `decoder_mode == "condensed_with_slate"` (small_moe ×
+procedural / multi_hop / default), the rendered prompt template
+substitutes `{answer_slate}` with the rendered `<helix:slate>` string
+and emits the result — there is no distinct `<helix:answer_slate>` tag.
+Templates at
+[`context_manager.py:176-192`](../../helix_context/context_manager.py#L176).
+
+### 6.4 Per-gene legibility headers
+
+When legibility headers are enabled, each delivered gene is preceded by
+a single bracketed line emitted by `format_gene_header` at
+[`legibility.py:122-157`](../../helix_context/legibility.py#L122):
+
+```
+[gene=<short_id> <symbol> fired=<tier1>:<score1>,... <chars→compressed>]
+```
+
+`<symbol>` is one of `◆ / ◇ / ·` (z-normalized confidence). Tier slice
+caps at top-3 by default. Size form is `<raw>→<compressed>c` when the
+splice trimmed the gene, else `<n>c`. Headers are suppressed for
+`small_moe` callers (cost > benefit at 4B params; see Stage 5 spec §4).
+
+---
+
+## 7. `caller_model_class` rendering matrix
+
+Ported from Stage 5 spec §4. Rows = `caller_model_class`, columns =
+behavior knob. The `generic` row equals pre-Stage-5 hard-coded behavior
+cell-for-cell (regression-locked by
+`test_generic_branch_byte_identical_to_pre_stage5_output`).
+
+| Knob | `generic` | `small_moe` | `frontier` |
+|---|---|---|---|
+| **foveated** | ON if `budget_tier=="broad"` AND `foveated_enabled` | ON always (regardless of `budget_tier`) | **OFF** (skip reversal entirely) |
+| **slate emitted** | iff `_should_use_slate()` (legacy MoE flag OR small downstream model) | always ON | OFF |
+| **slate format** | `\n`-joined raw KV lines | **JSON object** `<helix:slate>{...}</helix:slate>` | n/a |
+| **slate bound** | 20 entries (status quo) | **1500 chars** (config: `slate_char_budget`) | n/a |
+| **assembly cap** | `classifier.assembly_max_genes_cap` | `min(classifier_cap, 4)` | `max(12, classifier_cap*2)` |
+| **decoder mode default** | per classifier (§8 `generic` column) | per classifier (§8 `small_moe` column) | per classifier (§8 `frontier` column) |
+| **legibility headers** | ON when `legibility_on` | OFF (suppressed) | ON |
+| **candidate order** | reversed if foveated active, else forward | reversed (small models benefit from recency) | **forward (rank 1 first)** — narrative coherence |
+
+Rationale for the load-bearing cells:
+
+- `frontier × foveated = OFF`: long-context attention expects rank-1-first
+  narrative-coherence ordering; reversal degrades retrieval. Council
+  seat 4's frontier-hit-rate jump from ~14% to 60%+ depends on this.
+- `frontier × assembly_cap = max(12, classifier_cap*2)`: frontier
+  callers have 200k+ context and the classifier caps were tuned for
+  4B-parameter prompt windows.
+- `small_moe × foveated = ON always` (not just `broad`): small models
+  always benefit from recency on the gene that holds the answer.
+- `small_moe × slate_format = JSON`: flat newlines have no structural
+  lock for MoE attention routing; JSON braces give the model a fixed
+  attention sink.
+
+---
+
+## 8. `decoder_mode` resolution table
+
+Ported from Stage 5 spec §6. Resolved by
+`query_classifier.resolve_decoder_mode(cls, caller_model_class)` after
+both signals are known. Cells in **bold** differ from the `generic`
+column.
+
+| `classifier.cls` \ class | `generic` | `small_moe` | `frontier` |
+|---|---|---|---|
+| `arithmetic` | `minimal` | **`answer_slate_only`** | `minimal` |
+| `factual` | `condensed` | **`answer_slate_only`** | `condensed` |
+| `procedural` | `full` | **`condensed_with_slate`** | `full` |
+| `multi_hop` | `full` | **`condensed_with_slate`** | `full` |
+| `default` | `None` (falls back to `self._decoder_prompt`) | **`condensed_with_slate`** | `None` (falls back, same as `generic`) |
+
+Mode definitions (templates at
+[`context_manager.py:176-202`](../../helix_context/context_manager.py#L176)):
+
+- `minimal`, `condensed`, `full`, `none`, `moe`: existing pre-Stage-5
+  templates.
+- `answer_slate_only` (NEW for small_moe × short-answer): the JSON
+  slate is the **entire** decoder context, no `<expressed_context>`
+  block. ~150 tokens.
+- `condensed_with_slate` (NEW): `<helix:slate>` first (so attention
+  locks before prose), then the condensed decoder prompt.
+
+---
+
+## 9. Other endpoints
+
+Detailed only at the request-shape and pointer level; for response
+schemas, follow the route handler line numbers.
+
+### 9.1 `POST /context/packet` — agent-safe evidence packet
+
+Handler: [`server.py:1461-1544`](../../helix_context/server.py#L1461).
+Request fields: `query` (required), `task_type` (default `"explain"`),
+`max_genes` (default 8, clamped to `[1, 32]`), `clean`, `read_only`,
+`include_raw` (default `false` — when true, item content is the full
+gene body instead of the 280-char ribosome-compressed thumbnail),
+`max_item_chars` (per-item cap when `include_raw`).
+Response is a `ContextPacket` dict (see
+[`schemas.py:245-272`](../../helix_context/schemas.py#L245)) with
+`know` / `miss` lifted to the top of the dict, plus
+`response_mode: "packet"`. Includes `verified`, `stale_risk`,
+`contradictions`, `refresh_targets` (as `RefreshTarget` rows),
+`coordinate_confidence`, `file_coverage`, and `notes`.
+
+### 9.2 `POST /context/refresh-plan` — refresh-only convenience
+
+Handler: [`server.py:1546-1593`](../../helix_context/server.py#L1546).
+Thin wrapper over `get_refresh_targets`; returns
+`{"query", "task_type", "refresh_targets": [RefreshTarget...],
+"response_mode": "refresh_plan"}`. Useful when the caller already has
+the content cached and only needs to decide which sources to reread.
+Honors `clean` / `read_only` identically to `/context`.
+
+### 9.3 `POST /fingerprint` — navigation-first payload
+
+Handler: [`server.py:1595-1825`](../../helix_context/server.py#L1595).
+Request fields: `query` (required), `profile`
+(`"fast" | "balanced" | "quality"`, default from
+`config.context.fingerprint_mode_profile`), `include_cold`,
+`session_context`, `clean`, `max_results` (clamped to `[1, 200]`),
+`score_floor` (final post-refiner score threshold), `party_id`.
+Returns tier-score breakdowns per candidate gene (`gene_id`, `score`,
+`preview`, `path`, `source`, `domains`, `entities`, `chromatin`,
+`tier_contributions`) plus accounting fields (`evaluated_total`,
+`above_floor_total`, `returned`, `filtered_by_floor`,
+`truncated_by_cap`) and a `response_hint` string.
+
+### 9.4 `POST /consolidate` — session memory consolidation
+
+Handler: [`server.py:2672-2690`](../../helix_context/server.py#L2672).
+No request body. Distills the session buffer into consolidated
+knowledge genes, extracting only new facts, decisions, and
+discoveries. Returns `{"facts_extracted": int, "gene_ids":
+list[str]}`. On error returns 500 with `{"error": ..., "facts_extracted":
+0, "gene_ids": []}`.
+
+### 9.5 `POST /sessions/register` — participant registration
+
+Handler: [`server.py:2239-2320`](../../helix_context/server.py#L2239).
+Required body fields: `party_id`, `handle` (both must be non-null
+strings, ≥3 chars, no NULL bytes). Optional: `workspace`, `pid`,
+`capabilities`, `metadata`, `display_name`, `agent_kind`, `mcp_host`,
+`ide_detected`, `ide_detection_via`, `model_id`. Trust-on-first-use
+for `party_id`. Returns `{"participant_id", "party_id",
+"registered_at", "heartbeat_interval_s", "ttl_s"}`.
+
+### 9.6 `POST /admin/refresh` — reopen genome connection
+
+Handler: [`server.py:2805-2810`](../../helix_context/server.py#L2805).
+No body. Reopens the genome connection so external changes
+(deletions, thinning) become visible. Returns
+`{"refreshed": true, "genes": <new_count>}`.
+
+### 9.7 `POST /admin/vacuum` — reclaim SQLite pages
+
+Handler: [`server.py:2812-2828`](../../helix_context/server.py#L2812).
+No body. Runs SQLite `VACUUM` to compact the genome file after
+thinning, compaction, or large-scale deletions. Blocks all writers
+during the operation — run during maintenance windows. Returns
+`{"ok": true, ...}` with before/after sizes; on failure returns 500
+with `{"ok": false, "error": str}`.
+
+### 9.8 `GET /health` — readiness + provenance
+
+Handler: [`server.py:2694-2788`](../../helix_context/server.py#L2694).
+Returns `status` (`"ok" | "degraded"`), `message`, `ribosome` model,
+`ribosome_backend`, `ribosome_configured_backend`, `ribosome_cost_class`,
+`genes` (total count), `upstream` URL, `upstream_reachable`, a
+`hardware` block (device, vram, fallback state), a `calibration` block
+(`ann_threshold_mode`, `abstain_mode`, `abstain_classes`, optional
+`ann_threshold` provenance dict), and a `checks` block.
+
+### 9.9 `GET /stats` — genome metrics
+
+Handler: [`server.py:1829-1838`](../../helix_context/server.py#L1829).
+Returns `helix.stats()` — genome metrics, compression ratio, per-tier
+counters. Cheap synchronous DB read; safe to poll.
+
+---
+
+## 10. Client examples
+
+### 10.1 Frontier agent (Claude Opus 4.7 / GPT-5 / Gemini 3 Pro)
+
+```python
+import httpx
+from helix_context.agent_prompt import full_fragment
+
+SYSTEM_PROMPT = full_fragment() + "\n\nYou are a coding assistant ..."
+
+def ask_with_helix(user_query: str) -> str:
+    with httpx.Client(timeout=30.0) as client:
+        r = client.post(
+            "http://127.0.0.1:11437/context",
+            json={
+                "query": user_query,
+                "caller_model_class": "frontier",
+                "session_id": "frontier-agent-001",
+                "party_id": "max@local",
+                "prompt_tokens": 18000,
+            },
+        )
+        r.raise_for_status()
+        env = r.json()
+
+    if "know" in env:
+        know = env["know"]
+        if know["confidence"] > 0.7:
+            # High-confidence retrieval. Inject the expressed_context
+            # bytes into the LLM call alongside the system prompt.
+            return call_llm(
+                system=SYSTEM_PROMPT,
+                context=env["content"],
+                user=user_query,
+            )
+        # Low-confidence know — answer but flag uncertainty.
+        return call_llm(
+            system=SYSTEM_PROMPT,
+            context=env["content"],
+            user=user_query,
+            instruction="Note any uncertainty in your answer.",
+        )
+
+    if "miss" in env:
+        miss = env["miss"]
+        # Honor do_not_answer_from_genome=true. Route on reason.
+        if miss["reason"] in ("stale", "cold", "superseded"):
+            for path in miss["refresh_targets"]:
+                refresh_source(path)              # re-read from disk
+            return ask_with_helix(user_query)     # retry once after refresh
+        # Escalate-class — pick the first tool from escalate_to.
+        first_tool = miss["escalate_to"][0]
+        return route_to_tool(first_tool, user_query)
+
+    raise RuntimeError("Helix returned neither know nor miss — server bug")
+```
+
+The system prompt MUST include the `HELIX_NO_MATCH_FRAGMENT` /
+`HELIX_REFRESH_FRAGMENT` text from
+[`helix_context/agent_prompt.py`](../../helix_context/agent_prompt.py)
+(or equivalently, the markdown at
+[`docs/agent-sdk-fragment.md`](../agent-sdk-fragment.md)) — without it,
+a frontier model will paper over `do_not_answer_from_genome=true` by
+falling back to its training prior. The "scored as a hard failure in
+the offline eval" sentence is the highest-leverage line.
+
+### 10.2 Small-MoE proxy (qwen3:4b / gemma4:e4b)
+
+```python
+import httpx
+import json
+import re
+
+_SLATE_RE = re.compile(r"<helix:slate>(.*?)</helix:slate>", re.DOTALL)
+
+def small_moe_lookup(user_query: str) -> dict | None:
+    with httpx.Client(timeout=30.0) as client:
+        r = client.post(
+            "http://127.0.0.1:11437/context",
+            json={
+                "query": user_query,
+                "caller_model_class": "small_moe",
+                "session_id": "qwen3-4b-proxy-001",
+            },
+        )
+        r.raise_for_status()
+        env = r.json()
+
+    if "miss" in env:
+        # Small-MoE callers can't usefully escalate; surface to operator.
+        return None
+
+    # Parse the JSON answer slate out of expressed_context. The slate is
+    # the primary surface for small_moe callers; the prose tail is
+    # secondary. Decoder modes "answer_slate_only" /
+    # "condensed_with_slate" guarantee the slate is present.
+    m = _SLATE_RE.search(env["content"])
+    if m is None:
+        return None
+    try:
+        return json.loads(m.group(1))
+    except json.JSONDecodeError:
+        return None
+
+# Caller does: kv = small_moe_lookup("cold_start_threshold")
+# kv == {"cold_start_threshold": "0.62", ...}
+```
+
+Decoder mode is selected by the cross-product of classifier output and
+`caller_model_class`; a `factual` query with `caller_model_class=
+"small_moe"` resolves to `answer_slate_only` (§8). The 1500-char slate
+budget is the contract surface — `slate_char_budget` is configurable
+via `[budget]` in `helix.toml`.
+
+### 10.3 MCP host (Claude Code, Cursor, Continue)
+
+When configured as an MCP server, helix-context exposes
+`mcp__helix-context__helix_context` directly to the host. The default
+`caller_model_class` is `"generic"`, which is byte-identical to
+pre-Stage-5 behavior:
+
+```jsonc
+// Tool call from inside a Claude Code session:
+{
+  "tool": "mcp__helix-context__helix_context",
+  "arguments": {
+    "query": "cold_start_threshold helix.toml",
+    "session_id": "taude-2026-05-10",
+    "party_id": "max@local"
+  }
+}
+```
+
+The MCP adapter at
+[`helix_context/mcp_server.py`](../../helix_context/mcp_server.py)
+forwards the request to `/context` with `caller_model_class` defaulting
+to `"generic"`. Claude Code and Cursor pass the `know` / `miss` blocks
+through verbatim — the host's UI surfaces a "Used: helix-context" tile
+when `know.confidence > 0.7`.
+
+---
+
+## 11. Calibration & freshness contract
+
+The 5-feature confidence logistic (§3.1.1) ships with cold-start
+defaults but is calibrated against bench data via
+`scripts/calibrate_know_confidence.py` (Stage 6 spec §11). Calibrated
+parameters live in `[know]` of `helix.toml`:
+
+```toml
+[know]
+emit_floor = 0.55
+s_ref      = 1.0
+g_ref      = 0.5
+betas      = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]   # [intercept, top, gap, agree, coord, freshness_min]
+calibrated_at = "2026-05-08T..."
+calibrated_on_n = 800
+```
+
+Operator runbook for the recalibration cadence and the
+`bench_needle_1000.py --plant-stale` flag lives at
+[`docs/ops/operator-runbooks.md`](../ops/operator-runbooks.md) — see
+the "Recalibrate know.confidence" section.
+
+The `agent` block in every `/context` response carries
+`ann_threshold_mode` and `abstain_mode` so the agent can see WHICH
+calibration set the response was produced under without an extra
+`/health` roundtrip
+([`server.py:1349-1350`](../../helix_context/server.py#L1349)).
+
+**Freshness signals.** Three fields on `ContextHealth`
+([`schemas.py:182-184`](../../helix_context/schemas.py#L182)) replace
+the single `mean(decay)` value from pre-Stage-7:
+
+- `freshness_min` — min decay across expressed candidates.
+- `freshness_top1` — decay of the top-1 by score.
+- `freshness_weighted` — score-weighted decay sum (also aliased to
+  the back-compat `freshness` field).
+
+Status mapping (see Stage 7 spec §3): `genes_expressed > 0 AND
+(freshness_top1 < 0.4 OR freshness_weighted < 0.5)` ⇒
+`status="stale"` regardless of how many fresh padding genes accompany
+the stale needle.
+
+**Soft-stale on `know`.** When the discriminator emits a `KnowBlock`
+but `freshness_min < 0.5`, `know.soft_stale = true` and
+`agent.recommendation = "refresh"`. The agent MAY answer from the
+genome (top-1 is fresh) AND should plan a refresh of lower-ranked
+supporting genes on its own schedule
+([`server.py:1310-1319`](../../helix_context/server.py#L1310)).
+
+**Refresh tool layer.** `MissBlock.refresh_targets` is the contract
+surface for the agent's refresh tool layer. Each entry is an absolute
+file path or a fully-qualified URL; the adapter
+`MissBlock.to_refresh_targets()` at
+[`schemas.py:608-642`](../../helix_context/schemas.py#L608) converts
+the list to `RefreshTarget` rows for callers that want the wider
+schema (`target_kind`, `priority`, mapped reason). The agent's
+expected loop:
+
+1. Receive `miss` with `recommendation="refresh"`.
+2. For each path in `refresh_targets`: re-read from disk OR fetch URL.
+3. Re-call `/context` with the same query — the next response will
+   reflect the refreshed state.
+
+The `HELIX_REFRESH_FRAGMENT` at
+[`agent_prompt.py:59-82`](../../helix_context/agent_prompt.py#L59)
+codifies the rule "refresh means the answer is here, just out of date —
+fetch and retry; escalate means the answer is NOT here — go ask
+elsewhere." The two are distinct branches and the agent must not
+conflate them.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,1559 @@
+# Configuration Reference
+
+This document is the canonical reference for every section and key in
+`helix.toml`. It tracks the runtime configuration consumed by
+`helix_context/config.py` (the TOML loader) and the post-merge state of
+the 7-stage retrieval-fix initiative landed 2026-05-08 / 2026-05-10.
+
+Every key documented below is verified against `helix.toml` in the
+repository root (the canonical reference) and against the dataclass
+definitions in `helix_context/config.py`. File-line citations use the
+`helix.toml:NN` shorthand.
+
+The configuration file is loaded at process start by
+`helix_context.config.load_config()`. The default lookup order is:
+
+1. Path argument supplied to `load_config(path=...)` (programmatic).
+2. `HELIX_CONFIG` environment variable (process-level override).
+3. `helix.toml` in the current working directory (default).
+
+If no file is found, the loader returns the dataclass defaults baked
+into `helix_context/config.py`. Malformed TOML is logged and falls back
+to the same defaults so the server never blocks on a config typo. Keys
+in a section that the loader does not recognise are surfaced as a
+`WARNING` in the server log via `_warn_unknown` (`helix_context/config.py:500`)
+but do not abort startup.
+
+The order of sections below mirrors the file's top-to-bottom order so
+operators reading along can follow each block in place.
+
+---
+
+## `[ribosome]`
+
+**Purpose.** The ribosome is the optional enrichment layer that runs an
+LLM (Ollama / DeBERTa / LiteLLM / Claude) for ingest-time gene packing,
+background replication, and the default-off Step 0 query intent
+expansion. The 12-tier `/context` retrieval pipeline is **LLM-free** —
+this section configures a separate subsystem against the same genome.
+Leaving `enabled = false` (the design pillar: deterministic,
+auditable, LLM-free retrieval) means `/context` never touches an LLM
+even when other knobs in this section are populated. See
+`helix.toml:1-19` for the design preamble.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `false` | Master opt-in. When `false`, every other key in this section is ignored at runtime; `RibosomeConfig.effective_backend` returns `"disabled"`. The shipped value (`helix.toml:21`). |
+| `backend` | str | `"ollama"` | Legacy/default placeholder. Only `"litellm"` and `"deberta"` are honored when `enabled = true` (see `RibosomeConfig.effective_backend` in `helix_context/config.py:69-80`). `"ollama"` and `"claude"` resolve to `"disabled"` at runtime even when `enabled = true`. The shipped value (`helix.toml:22`). |
+| `model` | str | `"gemma4:e2b"` | Ollama model name for `pack()` and `replicate()` when the ribosome runs against Ollama. ~2GB VRAM footprint. The shipped value (`helix.toml:23`). |
+| `base_url` | str | `"http://localhost:11434"` | Ollama API endpoint. The shipped value (`helix.toml:24`). |
+| `timeout` | float | `120.0` | Per-request timeout in seconds for ribosome calls. Bumped from the 10s code default to 120s for bulk ingestion. The shipped value (`helix.toml:25`). |
+| `keep_alive` | str | `"30m"` | Ollama `keep_alive` directive that pins the ribosome model in VRAM between calls. Critical when the same Ollama instance also serves the chat upstream (model swap latency dominates). The shipped value (`helix.toml:26`). |
+| `warmup` | bool | `false` | Pre-load the ribosome model on server start. Disabled in the shipped file because long-running benches keep the larger generation model resident. The shipped value (`helix.toml:27`). |
+| `query_expansion_enabled` | bool | `false` | Step 0 LLM query-intent expansion (one ribosome call per novel query, LRU-cached). `false` = strictly LLM-free `/context`; the 12 retrieval tiers run on raw query text plus the `[synonyms]` map. Flipping on adds 2-3pp on ambiguous queries at the cost of one ribosome call per request. The shipped value (`helix.toml:28`). |
+| `query_decomposition_enabled` | bool | `false` | Sub-query decomposition (Step 2). Decomposes broad queries into 2-4 point-fact sub-queries via one LLM call. Only fires for `multi_hop` and `default` classifier classes. Requires `query_expansion_enabled = true`. The shipped value (`helix.toml:31`). |
+| `claude_model` | str | `"claude-haiku-4-5-20251001"` | Claude model used when `backend = "claude"`. Code default in `helix_context/config.py:33`. Commented in `helix.toml:38`. |
+| `claude_base_url` | str | `""` | Empty = direct Anthropic API. Set to a proxy URL (e.g., `http://127.0.0.1:8787` for Headroom) to route through a gateway. Code default in `helix_context/config.py:34`. Commented in `helix.toml:39`. |
+| `litellm_model` | str | `"gemini/gemini-2.5-flash"` | LiteLLM model string used when `backend = "litellm"`. Code default in `helix_context/config.py:35`. The commented example `"ollama/gemma4:e2b"` in `helix.toml:40` shows local routing. |
+| `rerank_model_path` | str | `"training/models/rerank"` | DeBERTa rerank head artifact path. Code default only (`helix_context/config.py:36`). |
+| `splice_model_path` | str | `"training/models/splice"` | DeBERTa splice head artifact path. Code default only (`helix_context/config.py:37`). |
+| `splice_threshold` | float | `0.5` | Probability cutoff for the splice head. Code default only (`helix_context/config.py:38`). |
+| `nli_model_path` | str | `"training/models/nli"` | NLI head artifact path. Code default only (`helix_context/config.py:39`). |
+| `nli_splice_bonus` | float | `0.15` | Probability bonus for entailment-linked codons. Code default only (`helix_context/config.py:40`). |
+| `nli_splice_penalty` | float | `0.15` | Probability penalty for alternation-linked codons. Code default only (`helix_context/config.py:41`). |
+| `device` | str | `"auto"` | **DEPRECATED.** Legacy device hint kept for one release. The loader emits a `WARNING` whenever this key is set, urging the operator to move to `[hardware] device`. When both keys are present, `[hardware] device` wins (`helix_context/config.py:817-834`). |
+
+**Example.**
+
+```toml
+[ribosome]
+enabled = false                       # design pillar — leave false for LLM-free /context
+backend = "ollama"                    # placeholder; only "litellm"/"deberta" honored when enabled
+model = "gemma4:e2b"
+base_url = "http://localhost:11434"
+timeout = 120
+keep_alive = "30m"
+warmup = false
+query_expansion_enabled = false
+query_decomposition_enabled = false
+```
+
+**Migration notes.** `[ribosome] device` is deprecated by the
+2026-05-04 hardware-detection PR (#17, merged at `f25211c`). Move to
+`[hardware] device`. The loader emits a `WARNING` with both
+`"deprecated"` and `"override"` substrings whenever the legacy key is
+set, and the warning text is part of the test contract — see
+`tests/test_hardware_overrides_ribosome_device`.
+
+**Cross-refs.** `[hardware]` (device picker), `[budget]` (token caps
+for the ribosome), `helix_context/config.py:24-117` (`RibosomeConfig`
+dataclass), `RibosomeConfig.cost_class` for the surfaced cost-class
+(`local` / `api+paid` / `disabled`) consumed by `/health`.
+
+---
+
+## `[hardware]`
+
+**Purpose.** Device picker and per-model batch-size policy for the
+DeBERTa rerank/splice heads, the SPLADE expander, and the BGE-M3 dense
+recall path. The Stage-2 hardware-detection initiative
+(`docs/archive/specs/2026-05-04-hardware-detection-design.md`) replaced
+ad-hoc `cuda_if_available()` probes with a single auto-picker invoked
+from `hardware.init_from_config()` at server startup.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `device` | str | `"auto"` | Device picker. Accepts `"auto"`, `"cuda"`, `"rocm"`, `"mps"`, `"cpu"`. `"auto"` walks the priority list `cuda -> rocm -> mps -> cpu` and falls back loudly to CPU on probe failure (state surfaced via `/health`). One-shot override via `HELIX_DEVICE=cpu` env var. The shipped value (`helix.toml:47`). |
+| `batch_sizes` | inline-table or str `"auto"` | `{}` (auto) | Per-model batch-size overrides applied on top of the auto-detected VRAM/RAM-aware table in `helix_context/hardware.py`. Empty dict (or the literal string `"auto"`) means "use the table". When provided as a TOML inline table, every key is cast to `int`. The shipped value uses the `"auto"` string sentinel (`helix.toml:52`). Loader normalisation lives in `helix_context/config.py:809-814`. |
+| `low_vram_threshold_gb` | float | `4.0` | Soft warning threshold (GB). VRAM under this tier surfaces a `low_vram` hint via `/health` and a one-time tray balloon. Set `0.0` to disable. The shipped value (`helix.toml:56`). Surfaced for downstream consumers — not consulted by the picker itself. |
+
+**Example.**
+
+```toml
+[hardware]
+device = "auto"
+batch_sizes = "auto"             # equivalent to {}
+low_vram_threshold_gb = 4.0
+
+# Per-model override:
+# batch_sizes = { rerank = 16, splice = 32, splade = 8, nli = 8 }
+```
+
+**Migration notes.** Introduced 2026-05-04 by PR #17
+(`f25211c`, "Hardware detection — Stage 1"). Stage 2 of that
+initiative (MPS+ROCm+CI hardening) is the next merge in flight per the
+session-memory note.
+
+**Cross-refs.** `[ribosome] device` (deprecated; this section
+overrides it), `helix_context/config.py:432-449` (`Hardware`
+dataclass), `helix_context/hardware.py` (auto-detection table),
+`docs/archive/specs/2026-05-04-hardware-detection-design.md` (design
+spec).
+
+---
+
+## `[budget]`
+
+**Purpose.** Token budgets, gene caps, and decoder-mode knobs for the
+`/context` build pipeline. Drives both the dynamic-budget tier
+selector (TIGHT / FOCUSED / BROAD / ABSTAIN) and the per-gene
+character cap inside the foveated splice schedule. Stage-4
+calibration adds a per-classifier override path for `foveated_alpha`
+(see `[abstain]`).
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `ribosome_tokens` | int | `3000` | Fixed decoder prompt budget for the ribosome path. Reserves headroom for the `<helix:slate>` decoder block. The shipped value (`helix.toml:59`). |
+| `expression_tokens` | int | `12000` | Total context budget delivered to the chat upstream. Sized for a 1:10 ratio at 128K context = ~12.8K-token window. The shipped value (`helix.toml:60`). |
+| `max_genes_per_turn` | int | `12` | Hard cap on assembled gene count after refinement. Distinct from the dense recall pool (`[retrieval] dense_pool_size`). The shipped value (`helix.toml:61`). |
+| `max_fingerprints_per_turn` | int | `40` | Cap on fingerprints returned by `POST /fingerprint`. Navigation-first payload, not a frontier width — wider candidate pools still feed the ranker upstream of this cap. The shipped value (`helix.toml:62`). |
+| `splice_aggressiveness` | float | `0.3` | `0.0` = keep all, `1.0` = ruthless trim. Lower preserves more literal detail. Maps onto the cymatics splice resonance threshold via `[cymatics] splice_threshold_scale`. The shipped value (`helix.toml:63`). |
+| `decoder_mode` | str | `"condensed"` | One of `"full"` \| `"condensed"` \| `"minimal"` \| `"none"`. `"none"` saves ~750 tokens for API models that already follow the gene-tag contract. The shipped value (`helix.toml:64`). |
+| `legibility_enabled` | bool | `true` | Sprint-1 legibility pack — emits a one-line metadata header per gene in `expressed_context` (fired tiers, confidence marker, short `gene_id`, raw → compressed char count). Flip to `false` to restore the pre-Sprint-1 plain-dividers format for bench A/B. The shipped value (`helix.toml:70`). |
+| `session_delivery_enabled` | bool | `true` | Sprint-2 working-set register. Tracks delivered genes per session in `session_delivery_log`; re-retrievals replace gene bodies with a pointer stub, eliding token cost on repeats. Synthetic `session_id` fallback (see `[session]`) covers callers that don't supply one. Flip to `false` to restore pre-MVP dark behavior. The shipped value (`helix.toml:77`). |
+| `abstain_enabled` | bool | `true` | Confidence-gated context attachment (ABSTAIN tier). When `true`, `build_context` returns a marker-only `ContextWindow` when post-refinement retrieval is weak on **both** absolute score (`top_score < 2.5`) **and** ratio (`top_score / mean < 1.8`). Skips the 12K-token BROAD fallback so the chat model answers from weights instead of digesting irrelevant noise. `HELIX_ABSTAIN_DISABLE=1` env var forces off without redeploy. Stage-4 (`[abstain].mode = "per_classifier"`) replaces the hard-coded floors with per-class values. The shipped value (`helix.toml:87`). |
+| `foveated_enabled` | bool | `false` | Foveated-splice schedule for the BROAD branch. When `true`, the BROAD branch replaces uniform per-gene compression with a rank-scaled power-law schedule and reverses assembly order so the top-ranked gene lands immediately before the user query. Off by default through the Phase-2 measurement window. The shipped value (`helix.toml:94`). |
+| `foveated_alpha` | float | `1.0` | Power-law exponent for `c_i = max(c_min, c_max · i^(-α))`. `α = 0.5` = gentle decay, `α = 1.0` = harmonic-ish (default), `α = 2.0` = aggressive top-bias. **Stage 4 override:** when `[abstain].mode = "per_classifier"`, this knob is bypassed in favour of `[abstain.<cls>].foveated_alpha` via `HelixContextManager._alpha_for_cls(cls)` (Stage-4 spec §7). Window metadata records `foveated_alpha_source: "per_classifier:<cls>"` for telemetry. The shipped value (`helix.toml:99`). |
+| `foveated_c_min` | float | `0.15` | Rank-N (bottom of BROAD) compression floor. Each gene's effective char cap is `max(foveated_c_min · base, c_i · base)` where `c_i = c_max · i^(-α)`. The shipped value (`helix.toml:103`). |
+| `foveated_base_chars` | int | `1000` | Per-gene char-budget multiplier. `target_chars per gene = int(c_i · foveated_base_chars)`. Default 1000 matches current uniform Step-4 behavior at `c_i = 1.0`. The shipped value (`helix.toml:107`). |
+| `slate_char_budget` | int | `1500` | Stage-5 (2026-05-08) char budget for the `small_moe` JSON answer slate. Counts the rendered string the model actually sees, including the `<helix:slate>...</helix:slate>` wrapper, JSON braces, quotes, commas, and per-KV separators. Generic and frontier branches do not consult this knob. Code default in `helix_context/config.py:139`. |
+| `mode` | str | `"token"` (Headroom only) | **NOTE:** despite appearing in the task spec, `mode` is **not** a `[budget]` key. The token-vs-cache mode lives under `[headroom] mode` (`helix.toml:168`). Documented under `[headroom]` below. |
+
+**Example.**
+
+```toml
+[budget]
+ribosome_tokens = 3000
+expression_tokens = 12000
+max_genes_per_turn = 12
+max_fingerprints_per_turn = 40
+splice_aggressiveness = 0.3
+decoder_mode = "condensed"
+legibility_enabled = true
+session_delivery_enabled = true
+abstain_enabled = true
+foveated_enabled = false
+foveated_alpha = 1.0
+foveated_c_min = 0.15
+foveated_base_chars = 1000
+```
+
+**Migration notes.** `foveated_*` keys are dark on first ship; flip on
+only after the phased α-sweep bench
+(`docs/archive/specs/2026-05-03-foveated-splice-design.md` §6.3,
+§9). Stage-4 calibration script
+(`scripts/calibrate_thresholds.py`) emits per-class `foveated_alpha`
+values that override `budget.foveated_alpha` when
+`[abstain].mode = "per_classifier"`.
+
+**Cross-refs.** `[abstain]` (Stage-4 per-classifier overrides),
+`[cymatics] splice_threshold_scale` (consumes `splice_aggressiveness`),
+`docs/archive/specs/2026-05-02-abstain-tier-design.md` (ABSTAIN tier
+design), `docs/archive/specs/2026-05-03-foveated-splice-design.md`
+(foveated schedule), `helix_context/config.py:120-162`
+(`BudgetConfig`), `helix_context/legibility.py`
+(`legibility_enabled`), `helix_context/session_delivery.py`
+(`session_delivery_enabled`).
+
+---
+
+## `[session]`
+
+**Purpose.** CWoLa label-logger session and party fallback. Without
+these defaults, clients that omit `session_id` / `party_id` log NULL
+into `cwola_log`, which causes `sweep_buckets` to treat every row as
+Bucket A (no re-query detectable without a session) and breaks CWoLa
+training. The synthetic fallback generates a deterministic
+`session_id` from `(client_ip, time_window)` so bursts of traffic from
+the same operator group into coherent sessions for bucket assignment.
+Fixed 2026-04-13. See `cwola.py` and
+`docs/archive/FUTURE/STATISTICAL_FUSION.md` §C2.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `default_party_id` | str | `"default"` | Attribution fallback when the request omits `party_id` and no `HELIX_PARTY_ID` env var or header is set. The shipped value (`helix.toml:117`). |
+| `synthetic_session_window_s` | int | `300` | Time window (seconds) over which same-IP requests are grouped into one synthetic session. 5 minutes by default. The shipped value (`helix.toml:118`). |
+| `synthetic_session_enabled` | bool | `true` | Master switch for synthetic-session attribution. Flip to `false` to restore the prior NULL-session behavior (not recommended — re-introduces the always-Bucket-A bug). The shipped value (`helix.toml:119`). |
+
+**Example.**
+
+```toml
+[session]
+default_party_id = "default"
+synthetic_session_window_s = 300
+synthetic_session_enabled = true
+```
+
+**Cross-refs.** `helix_context/config.py:221-236` (`SessionConfig`),
+`docs/archive/FUTURE/STATISTICAL_FUSION.md` §C2 (CWoLa framework),
+`cwola.py` (`sweep_buckets` consumer).
+
+---
+
+## `[genome]`
+
+**Purpose.** SQLite genome path, compaction cadence, replication
+shape. The 2026-04-16 fresh-rebuild swapped to `genomes/main/` as the
+phase-2 sharding root; future shards land at `genomes/reference/`,
+`genomes/agent/`, etc. Phase-1 cutover disables replicas pending the
+shard router.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `path` | str | `"genome.db"` (code default) / `"genomes/main/genome.db"` (shipped) | SQLite database path for the primary (master) genome. Override via `HELIX_GENOME_PATH` env var (loader honors this even when the section is absent — `helix_context/config.py:611-612`). The shipped value (`helix.toml:127`). |
+| `compact_interval` | float | `3600.0` | Seconds between source-change checks. Hourly default. Compaction only detects source-file changes (mtime vs `last_accessed`); irrelevant data is handled by splice (intron / exon) at expression time. The shipped value (`helix.toml:128`). |
+| `cold_start_threshold` | int | `10` | Genes needed before history stripping kicks in (Fix 3). Below this count, the system retains all retrieval history to avoid pathological cold-start behavior. The shipped value (`helix.toml:129`). |
+| `replicas` | array<str> | `[]` | Read-only clone paths for the replica fan-out. Empty during phase-1 cutover; will re-enable alongside the shard router in phase 2 (sharding changes the replication shape). The shipped value (`helix.toml:132`). |
+| `replica_sync_interval` | int | `100` | Sync replicas every N inserts. The shipped value (`helix.toml:133`). |
+
+**Example.**
+
+```toml
+[genome]
+path = "genomes/main/genome.db"
+compact_interval = 3600
+cold_start_threshold = 10
+replicas = []
+replica_sync_interval = 100
+```
+
+**Migration notes.** No time-based decay. Genes never expire.
+2026-04-16 rebuild migrated from `F:/Projects/helix-context/genome.db`
+(old master) and `C:/helix-cache/genome.db` (old replica with
+backfill) to the new `genomes/` folder. `HELIX_GENOME_PATH` env var
+overrides this path so sharded vs monolithic servers can coexist on
+different ports without duplicating `helix.toml`.
+
+**Cross-refs.** `helix_context/config.py:165-171` (`GenomeConfig`),
+`docs/archive/FUTURE/GENOME_SHARDING.md` (phase-2 sharding plan).
+
+---
+
+## `[server]`
+
+**Purpose.** HTTP server and chat-upstream wiring for the
+OpenAI-compatible proxy. Helix front-ends Ollama (or any
+OpenAI-compatible upstream) at `127.0.0.1:11437` by default.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `host` | str | `"127.0.0.1"` | HTTP bind address. The shipped value (`helix.toml:139`). |
+| `port` | int | `11437` | HTTP listen port. The shipped value (`helix.toml:140`). |
+| `upstream` | str | `"http://localhost:11434"` | Chat upstream URL (OpenAI-compatible). Default points at Ollama. Override via `HELIX_SERVER_UPSTREAM` env var (`helix_context/config.py:616-617`). The shipped value (`helix.toml:141`). |
+| `upstream_timeout` | float | `180.0` | Per-request timeout (seconds) for proxied requests to the chat upstream. Bumped from 120s on 2026-05-02 — observed Proxy-500s on slow `gemma4:e4b` GPQA queries at ~125s; 180s gives long-tail generation room without letting truly stuck requests hang. Override via `HELIX_SERVER_UPSTREAM_TIMEOUT` env var. Code default in `helix_context/config.py:179`. Commented in `helix.toml:142`. |
+
+**Example.**
+
+```toml
+[server]
+host = "127.0.0.1"
+port = 11437
+upstream = "http://localhost:11434"
+# upstream_timeout = 180
+```
+
+**Cross-refs.** `helix_context/config.py:174-179` (`ServerConfig`),
+env overrides at `helix_context/config.py:614-625`.
+
+---
+
+## `[headroom]`
+
+**Purpose.** Optional Headroom proxy lifecycle controls — launcher
+only. Headroom (`https://github.com/chopratejas/headroom`) is a
+separate process serving a compression proxy + dashboard at
+`http://{host}:{port}/dashboard`. When `enabled = true`, the launcher
+adopts an existing process if one is already listening on `port`
+(adopted process survives launcher Quit) and otherwise spawns a fresh
+child. The tray menu surfaces "Open Headroom Dashboard" and
+Start/Restart/Stop entries.
+
+Requires `pip install "helix-context[codec]"` (pulls
+`headroom-ai[proxy]`).
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `false` (code) / `true` (shipped) | Master switch. `false` = launcher does nothing. The shipped value (`helix.toml:164`). |
+| `autostart` | bool | `true` | When `enabled`: adopt if running, spawn if not. Set `false` for menu-only mode. The shipped value (`helix.toml:165`). |
+| `host` | str | `"127.0.0.1"` | Headroom bind address. The shipped value (`helix.toml:166`). |
+| `port` | int | `8787` | Headroom proxy port. The shipped value (`helix.toml:167`). |
+| `mode` | str | `"token"` | One of `"token"` (compression-first) or `"cache"` (prefix-cache-stable). Passed through as `--mode` to the Headroom child. The shipped value (`helix.toml:168`). |
+| `dashboard_path` | str | `"/dashboard"` | URL path appended to `http://{host}:{port}` for the tray-menu link. The shipped value (`helix.toml:169`). |
+
+**Example.**
+
+```toml
+[headroom]
+enabled = true
+autostart = true
+host = "127.0.0.1"
+port = 8787
+mode = "token"
+dashboard_path = "/dashboard"
+```
+
+**Cross-refs.** `helix_context/config.py:413-429` (`HeadroomConfig`).
+
+---
+
+## `[ingestion]`
+
+**Purpose.** Selects the encoder backend that turns raw content into
+genes during `POST /ingest`. The phased rollout (Phase 2 SPLADE,
+Phase 3 cross-encoder rerank, Phase 4 ColBERT, Phase 5 entity-graph)
+is governed by per-feature flags in this section.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `backend` | str | `"ollama"` (code) / `"cpu"` (shipped) | Encoder backend. One of `"ollama"` (LLM, slow), `"cpu"` (spaCy + regex, fast), `"hybrid"`. The shipped value (`helix.toml:172`). |
+| `splade_enabled` | bool | `false` (code) / `true` (shipped) | Phase-2 SPLADE sparse expansion at index time. Adds expanded sparse vectors that feed Tier-FTS5 / SPLADE retrieval at query time. The shipped value (`helix.toml:173`). |
+| `rerank_model` | str | `""` (code) / `"cross-encoder/ms-marco-MiniLM-L-6-v2"` (shipped) | Phase-3 pretrained cross-encoder HF model ID. The shipped value (`helix.toml:174`). |
+| `rerank_enabled` | bool | `false` | Phase-3 cross-encoder reranking on the post-shortlist candidate set. The shipped value (`helix.toml:175`). |
+| `colbert_enabled` | bool | `false` | Phase-4 ColBERT late-interaction tier (optional). The shipped value (`helix.toml:176`). |
+| `entity_graph` | bool | `false` (code) / `true` (shipped) | Phase-5 entity-based co-activation links. Index-time flag — gates the construction of the `entity_co_activation` table consumed by `[retrieval] entity_graph_retrieval_enabled` at query time. The shipped value (`helix.toml:177`). |
+
+**Example.**
+
+```toml
+[ingestion]
+backend = "cpu"
+splade_enabled = true
+rerank_model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+rerank_enabled = false
+colbert_enabled = false
+entity_graph = true
+```
+
+**Cross-refs.** `helix_context/config.py:182-190`
+(`IngestionConfig`).
+
+---
+
+## `[context]`
+
+**Purpose.** Retrieval-time behavior for `context_manager`. The
+cold-tier knobs were added 2026-04-10 (C.2 of the B->C migration).
+Cold-tier is the opt-in retrieval path that consults heterochromatin
+genes via SEMA cosine similarity, returning their preserved content
+(only possible after C.1 made `compress_to_heterochromatin`
+non-destructive).
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `cold_tier_enabled` | bool | `false` | Master opt-in for cold-tier fallthrough. The shipped value (`helix.toml:195`). |
+| `cold_tier_min_hot_genes` | int | `0` | Fall through to cold-tier when hot returns at most this many genes. `0` = only on empty hot results. The shipped value (`helix.toml:196`). |
+| `cold_tier_k` | int | `3` | Maximum cold-tier genes to retrieve per query. The shipped value (`helix.toml:197`). |
+| `cold_tier_min_cosine` | float | `0.15` | SEMA cosine floor (sparse 20-dim — see `Genome.query_cold_tier`). Tuning matters: too high (e.g., `0.25`) means cold-tier returns nothing on real NIAH queries. `0.15` is calibrated to surface matches in the noise floor. The shipped value (`helix.toml:198`). |
+| `fingerprint_mode_profile` | str | `"balanced"` | One of `"fast"` \| `"balanced"` \| `"quality"` for `POST /fingerprint` and `POST /debug/preview`. The shipped value (`helix.toml:199`). Lower-cased by the loader (`helix_context/config.py:649`). |
+
+**Example.**
+
+```toml
+[context]
+cold_tier_enabled = false
+cold_tier_min_hot_genes = 0
+cold_tier_k = 3
+cold_tier_min_cosine = 0.15
+fingerprint_mode_profile = "balanced"
+```
+
+**Cross-refs.** `helix_context/config.py:193-206`
+(`ContextConfig`), `Genome.query_cold_tier` (consumer).
+
+---
+
+## `[cymatics]`
+
+**Purpose.** Frequency-domain re-rank + splice. CPU math that
+replaces LLM splice calls with spectral analysis over per-gene
+fingerprint vectors. Blends as a bonus (max 0.5), not a primary
+ranker.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `true` | Master switch. The shipped value (`helix.toml:202`). |
+| `n_bins` | int | `256` | Spectrum resolution (256 bins = <2KB per spectrum). The shipped value (`helix.toml:203`). |
+| `peak_width` | float | `3.0` | Gaussian peak width. Overridden at runtime by Q-factor derived from `[budget] splice_aggressiveness`. The shipped value (`helix.toml:204`). |
+| `splice_threshold_scale` | float | `0.7` | Maps `[budget] splice_aggressiveness` (0-1) to the spectral resonance threshold. Code default only (`helix_context/config.py:215`). |
+| `use_embeddings` | bool | `false` | Use `Gene.embedding` when populated (requires `sentence-transformers`). The shipped value (`helix.toml:205`). |
+| `harmonic_links` | bool | `true` | Compute weighted co-activation edges between expressed genes (feeds Tier-5 harmonic boost). The shipped value (`helix.toml:206`). |
+| `distance_metric` | str | `"cosine"` | One of `"cosine"` (weighted dot) or `"w1"` (Werman 1986 circular Wasserstein-1; Singh 2020 CMD). Lower-cased by the loader (`helix_context/config.py:663`). The shipped value (`helix.toml:207`). |
+
+**Example.**
+
+```toml
+[cymatics]
+enabled = true
+n_bins = 256
+peak_width = 3.0
+use_embeddings = false
+harmonic_links = true
+distance_metric = "cosine"
+```
+
+**Cross-refs.** `helix_context/config.py:209-218`
+(`CymaticsConfig`).
+
+---
+
+## `[classifier]`
+
+**Purpose.** Upstream rule-based query classifier and injection
+router. Contributes a decoder-mode hint and an assembly-stage
+gene-count cap to `build_context()`. Drives the per-classifier
+abstain-floor lookup when `[abstain].mode = "per_classifier"`.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `true` | Master switch. When `false`, the classifier path is bypassed and `build_context` falls back to the global `[budget]` knobs. The shipped value (`helix.toml:214`). |
+
+**Example.**
+
+```toml
+[classifier]
+enabled = true
+```
+
+**Cross-refs.** `helix_context/config.py:376-384`
+(`ClassifierConfig`),
+`docs/archive/specs/2026-04-29-query-classifier-injection-router-design.md`,
+`[abstain]` (per-classifier floors keyed by classifier output).
+
+---
+
+## `[retrieval]`
+
+**Purpose.** The big one. Configures every recall and rerank tier in
+`Genome.query_genes()` and the new Stage-2 / Stage-3 / Stage-4 paths
+(dense recall, RRF fusion, margin-over-random ANN threshold). Every
+RRF tier weight is a post-multiplier applied to `1 / (k + rank)`; the
+weights below preserve the implicit weights baked into the legacy
+additive accumulator so `fusion_mode = "rrf"` is a clean rank-fusion
+swap, not a re-tuning.
+
+The full Stage-3 tier inventory (which tiers participate in RRF and
+which stay additive) lives in
+`docs/specs/2026-05-08-stage-3-rrf-fusion.md` §3.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `sr_enabled` | bool | `false` (code) / `true` (shipped) | Tier-5.5 Successor Representation (Stachenfeld 2017). γ-discounted future-occupancy boost over the co-activation graph. Lazy on-demand SR rows via truncated power series. The shipped value (`helix.toml:219`). |
+| `sr_gamma` | float | `0.85` | Discount factor (5-10 hop horizon at 0.9). The shipped value (`helix.toml:220`). |
+| `sr_k_steps` | int | `4` | Power-series truncation depth (caps runaway propagation). The shipped value (`helix.toml:221`). |
+| `sr_weight` | float | `1.5` | Per-gene SR contribution multiplier. Reused as the Stage-3 RRF post-multiplier for the `sr` tier. The shipped value (`helix.toml:222`). |
+| `sr_cap` | float | `3.0` | Maximum per-gene SR boost (matches harmonic cap). The shipped value (`helix.toml:223`). |
+| `ray_trace_theta` | bool | `false` | Theta alternation (Wang/Foster/Pfeiffer 2020). Fore/aft ray-trace sampling biased by the current TCM velocity vector. Dark ship — requires TCM velocity input (Sprint-3 item). The shipped value (`helix.toml:226`). |
+| `theta_weight` | float | `1.0` | Softmax temperature on `v · gene_input_vector`. The shipped value (`helix.toml:227`). |
+| `seeded_edges_enabled` | bool | `false` | Sprint-4 seeded co-activation edges with Hebbian evidence decay. Three-class edge provenance (`seeded` / `co_retrieved` / `cwola_validated`) with Laplace-smoothed `co_count` vs `miss_count` per edge. Dark ship — flip to start evidence accumulation. The shipped value (`helix.toml:229`). |
+| `seeded_edge_weight` | float | `1.0` | Base weight stamped at seed insertion. The shipped value (`helix.toml:230`). |
+| `filename_anchor_enabled` | bool | `false` (code) / `true` (shipped) | Tier-0.5 filename-anchor (2026-04-15 Dewey-pivot spike). Boosts genes whose `filename_stem` matches a query term. Dewey bench showed filename alone outperforms the full project + module + filename bag by 24pp. Override: `HELIX_FILENAME_ANCHOR_ENABLED=1`. The shipped value (`helix.toml:235`). |
+| `filename_anchor_weight` | float | `4.0` | Per-match boost. Tier-1 exact-tag is `3.0` for reference; this tier intentionally outranks it. Reused as the Stage-3 RRF post-multiplier. The shipped value (`helix.toml:236`). |
+| `bm25_shortlist_enabled` | bool | `false` (code) / `true` (shipped) | BM25 shortlist post-filter (2026-04-22, research-review Pareto move 1). When enabled, `query_genes` restricts its final ranking to genes that cleared a BM25 / FTS5 top-N pass — other tiers still accumulate scores, but candidates BM25 would never surface are dropped before the sort. Post-filter by design (isolates the ranking-set hypothesis from the candidate-generation optimisation). The shipped value (`helix.toml:240`). |
+| `bm25_shortlist_size` | int | `50` | BM25 top-N kept in the final ranking. The shipped value (`helix.toml:241`). |
+| `bm25_prefilter_enabled` | bool | `false` | BM25 pre-filter — fires **before** tier scoring (vs the post-filter shortlist). Enable for A/B against `bm25_shortlist`; disable shortlist when using this. The shipped value (`helix.toml:244`). |
+| `bm25_prefilter_size` | int | `200` | BM25 top-N fed into tier scoring. The shipped value (`helix.toml:245`). |
+| `entity_graph_retrieval_enabled` | bool | `false` | Tier-5b entity graph co-occurrence boost (Step 3C, 2026-05-08). Genes sharing entity nodes with query terms get a score boost proportional to entity overlap. Requires `[ingestion] entity_graph = true` at index time. The shipped value (`helix.toml:249`). |
+| `dense_embedding_enabled` | bool | `false` | Step-4 BGE-M3 dense vectors (2026-05-08). Master switch for the Stage-2 dense recall path. The shipped value (`helix.toml:255`). |
+| `dense_embedding_dim` | int | `1024` | BGE-M3 Matryoshka dim. **Stage 2 (2026-05-08): default raised from 256 → 1024.** `dim = 256` collapsed random-pair cosine to ~0.6, sabotaging absolute-threshold semantics. Stage 4 will recalibrate `ann_similarity_threshold` at 1024-d. Codec emits a one-time WARN when `dim not in (1024, 768, 512)`. The shipped value (`helix.toml:256`). |
+| `ann_similarity_threshold` | float | `0.35` | Legacy / fallback ANN cosine threshold. Used when `ann_threshold_mode = "absolute"` (default), and as the fallback when `mode = "margin_over_random"` and the calibration row is missing (one-time WARN). The shipped value (`helix.toml:257`). |
+| `ann_threshold_min_genes` | int | `1` | Floor on the ANN dynamic-cut count (always return at least this many). The shipped value (`helix.toml:258`). |
+| `ann_threshold_max_genes` | int | `12` | Ceiling on the ANN dynamic-cut count (the final cut, not the recall pool — see `dense_pool_size`). The shipped value (`helix.toml:259`). |
+| `ann_threshold_mode` | str | `"absolute"` | **NEW (Stage 4, 2026-05-08).** One of `"absolute"` (default — keeps Stage-3 behavior byte-for-byte: `query_genes_ann` uses `ann_similarity_threshold`) or `"margin_over_random"` (reads the persisted threshold from the `genome_calibration` table populated by `scripts/calibrate_thresholds.py`; falls back to `ann_similarity_threshold` with a one-time WARN when the row is missing). The shipped value (`helix.toml:267`). Spec: `docs/specs/2026-05-08-stage-4-threshold-calibration.md` §3 + §6. |
+| `ann_threshold_sigma_multiplier` | float | `3.0` | **NEW (Stage 4).** `μ + N·σ` over random pairs. Only consulted when `ann_threshold_mode = "margin_over_random"`. The shipped value (`helix.toml:268`). |
+| `dense_pool_size` | int | `500` | **NEW (Stage 2, 2026-05-08).** Dense recall pool width — decoupled from `ann_threshold_max_genes` (the final cut). 500 hits ~3% of an 18.9k-corpus per spec §4. Resolves at the top of `query_genes_ann` via `pool_size = pool_size or self._dense_pool_size` (Stage-2 spec §6). When dense is disabled, falls back to `max_genes` for back-compat. The shipped value (`helix.toml:269`). |
+| `fusion_mode` | str | `"additive"` | **NEW (Stage 3, 2026-05-08).** One of `"additive"` (default for one release — legacy `gene_scores += tier_score` accumulator path) or `"rrf"` (Reciprocal Rank Fusion via `helix_context/fusion.py:Fuser`; final sort uses fused scores). Per-tier weights below are RRF post-multipliers. Spec: `docs/specs/2026-05-08-stage-3-rrf-fusion.md`. The shipped value (`helix.toml:278`). |
+| `rrf_k` | int | `60` | Cormack 2009 default. Used in `score(d) = Σ weight_t · 1/(k + rank_t(d))`. The shipped value (`helix.toml:279`). |
+| `fts5_weight` | float | `3.0` | RRF post-multiplier for the `fts5` tier. Preserves the current FTS5 implicit cap. The shipped value (`helix.toml:280`). |
+| `splade_weight` | float | `3.5` | RRF post-multiplier for the `splade` tier. Preserves the current SPLADE cap. The shipped value (`helix.toml:281`). |
+| `tag_exact_weight` | float | `3.0` | RRF post-multiplier for `tag_exact` (Tier-1 weight × match_count). The shipped value (`helix.toml:282`). |
+| `tag_prefix_weight` | float | `1.5` | RRF post-multiplier for `tag_prefix` (Tier-2 weight × match_count). The shipped value (`helix.toml:283`). |
+| `sema_cold_weight` | float | `3.0` | RRF post-multiplier for `sema_cold` (cold-start `sim · 3.0` multiplier). The shipped value (`helix.toml:284`). |
+| `lex_anchor_weight` | float | `1.5` | RRF post-multiplier for `lex_anchor` (current `idf · 1.5`, capped at 3.0). The shipped value (`helix.toml:285`). |
+| `harmonic_weight` | float | `1.0` | RRF post-multiplier for `harmonic` (per-link weight, cap stays at 3.0). The shipped value (`helix.toml:286`). |
+| `entity_graph_weight` | float | `0.5` | RRF post-multiplier for `entity_graph` (Tier-5b implicit `1.0 · 0.5`). The shipped value (`helix.toml:287`). |
+| `dense_weight` | float | `1.0` | RRF post-multiplier for the Stage-2 `dense` tier. The shipped value (`helix.toml:288`). |
+| `pki_weight` | float | `1.0` | RRF post-multiplier for the path-key-index (`pki`) tier. The shipped value (`helix.toml:289`). |
+
+**Stage-3 RRF tier inventory (additive vs RRF participants).** Per
+`docs/specs/2026-05-08-stage-3-rrf-fusion.md` §3, recall/discovery
+tiers participate in RRF; re-rank/tiebreaker/policy boosts stay
+additive on top of the fused score so the operator's "is this gene
+authoritative?" semantics survive unchanged. The split:
+
+| Tier | RRF participant? | Weight knob |
+|---|---|---|
+| `pki` (path-key compound) | yes | `pki_weight` |
+| `filename_anchor` | yes | `filename_anchor_weight` (reused) |
+| `tag_exact` | yes | `tag_exact_weight` |
+| `tag_prefix` | yes | `tag_prefix_weight` |
+| `fts5` | yes | `fts5_weight` |
+| `splade` | yes | `splade_weight` |
+| `sema_cold` | yes (only when fires) | `sema_cold_weight` |
+| `lex_anchor` (IDF) | yes | `lex_anchor_weight` |
+| `harmonic` | yes | `harmonic_weight` (cap stays at 3.0) |
+| `sr` (Successor Repr.) | yes | `sr_weight` (reused) |
+| `entity_graph` | yes | `entity_graph_weight` |
+| `dense` (Stage 2) | yes | `dense_weight` |
+| `sema_boost` (gate-only re-rank) | **no** — tiebreaker, applied AFTER RRF | n/a |
+| `authority_*` (source/domain/recency) | **no** — flat boost on existing pool | n/a |
+| `party_attr` | **no** — flat additive AFTER RRF | n/a |
+| `access_rate` | **no** — explicit tiebreaker AFTER RRF | n/a |
+
+**Example.**
+
+```toml
+[retrieval]
+# Tier 5.5 Successor Representation
+sr_enabled = true
+sr_gamma = 0.85
+sr_k_steps = 4
+sr_weight = 1.5
+sr_cap = 3.0
+# Theta alternation (dark)
+ray_trace_theta = false
+theta_weight = 1.0
+# Seeded edges (dark)
+seeded_edges_enabled = false
+seeded_edge_weight = 1.0
+# Tier 0.5 filename anchor
+filename_anchor_enabled = true
+filename_anchor_weight = 4.0
+# BM25 shortlist
+bm25_shortlist_enabled = true
+bm25_shortlist_size = 50
+bm25_prefilter_enabled = false
+bm25_prefilter_size = 200
+# Tier 5b entity graph (dark)
+entity_graph_retrieval_enabled = false
+# Stage 2 dense recall (dark master)
+dense_embedding_enabled = false
+dense_embedding_dim = 1024
+ann_similarity_threshold = 0.35
+ann_threshold_min_genes = 1
+ann_threshold_max_genes = 12
+# Stage 4 threshold mode
+ann_threshold_mode = "absolute"
+ann_threshold_sigma_multiplier = 3.0
+dense_pool_size = 500
+# Stage 3 RRF fusion
+fusion_mode = "additive"
+rrf_k = 60
+fts5_weight = 3.0
+splade_weight = 3.5
+tag_exact_weight = 3.0
+tag_prefix_weight = 1.5
+sema_cold_weight = 3.0
+lex_anchor_weight = 1.5
+harmonic_weight = 1.0
+entity_graph_weight = 0.5
+dense_weight = 1.0
+pki_weight = 1.0
+```
+
+**Migration notes.**
+
+- `fusion_mode` stays `"additive"` for one release. Per
+  `docs/specs/2026-05-08-stage-3-rrf-fusion.md` §7 deprecation
+  timeline: `v(N)` ships additive default; `v(N+1)` flips to `"rrf"`
+  default; `v(N+2)` removes the additive code path.
+- Flipping `fusion_mode` to `"rrf"` requires `[abstain].mode =
+  "per_classifier"` for the floor-driven gates to take effect under
+  RRF score scales. See Stage-3 spec §9 (transitional bypass) — the
+  global hard-coded floors (`5.0` / `2.5`) were calibrated against
+  additive scores and become unreachable post-RRF.
+- `dense_embedding_dim` raised from 256 → 1024 in Stage 2. Existing
+  256-d embeddings on disk continue to load via the codec guard
+  (`bgem3_codec.py:53-54`), but new ingest writes 1024-d vectors. Stage 4
+  recalibrates `ann_similarity_threshold` against the new dim.
+- `ann_threshold_mode = "margin_over_random"` only takes effect after
+  `scripts/calibrate_thresholds.py` has populated the
+  `genome_calibration` table. Missing row → one-time WARN, fallback to
+  `ann_similarity_threshold`.
+
+**Cross-refs.** `helix_context/config.py:239-320`
+(`RetrievalConfig`), `helix_context/fusion.py` (RRF `Fuser`),
+`docs/specs/2026-05-08-stage-2-dense-recall.md`,
+`docs/specs/2026-05-08-stage-3-rrf-fusion.md`,
+`docs/specs/2026-05-08-stage-4-threshold-calibration.md`,
+`scripts/calibrate_thresholds.py` (operator runbook for
+margin-over-random calibration), `[abstain]` (Stage-4 floors that
+replace the global hard-coded `5.0` / `2.5` constants).
+
+---
+
+## `[plr]`
+
+**Purpose.** Stacked PLR (Pairwise Logistic Ranker) query-confidence
+head. Attaches a `plr_confidence` log-odds signal to
+`/context/packet` responses — predicted log-odds that the user will
+re-query within 60s under the training discipline (cos(q_t, q_{t+1})
+filter + 60s window). Higher = more likely to re-query = lower
+confidence in the retrieval.
+
+The current artifact is a **query-quality head**, not the per-(q, g)
+ranker originally described in the spec. Gene ranking stays on the
+fuser (additive or RRF, see `[retrieval] fusion_mode`); this signal
+only feeds the packet / router. See `helix_context/fusion_plr.py`
+docstring and `docs/archive/FUTURE/STATISTICAL_FUSION.md` §C3 addendum
+for the scope trade-off.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `false` | Master switch. Dark by default; bench before flipping. The shipped value (`helix.toml:308`). |
+| `model_path` | str | `"training/models/stacked_plr.joblib"` | Path to the trained artifact. The shipped value (`helix.toml:309`). |
+| `expected_sha256` | str | `""` | Empty = trust the `.sha256` sidecar next to the artifact (written by the trainer). Set a pinned hex digest in `helix.toml` for explicit operator-level pinning; load refuses to proceed unless the artifact's digest matches. The shipped value (`helix.toml:310`). |
+| `high_risk_threshold` | float | `0.5` | Symmetric default. The fuser's `prob_B` is compared against this to emit a coarse "likely-to-re-query" boolean alongside the log-odds. Tune only with bench evidence. The shipped value (`helix.toml:311`). |
+
+**Example.**
+
+```toml
+[plr]
+enabled = false
+model_path = "training/models/stacked_plr.joblib"
+expected_sha256 = ""
+high_risk_threshold = 0.5
+```
+
+**Migration notes.** Train a fresh artifact with:
+
+```bash
+python scripts/pwpc/sprint3.py <windowed_export.json> \
+    --save-model training/models/stacked_plr.joblib \
+    --save-label-set best
+```
+
+**Cross-refs.** `helix_context/config.py:387-410` (`PLRConfig`),
+`helix_context/fusion_plr.py` (consumer),
+`docs/archive/FUTURE/STATISTICAL_FUSION.md` §C3.
+
+---
+
+## `[know]`
+
+**Purpose.** Stage-6 KnowBlock confidence logistic. Maps four (Stage
+6) or five (Stage 7) retrieval signals to a calibrated probability
+that the `/context` retrieval is ground-truth correct:
+
+```
+z = b0
+  + b1 * tanh(top_score / s_ref)
+  + b2 * tanh(score_gap / g_ref)
+  + b3 * (1.0 if lexical_dense_agree else 0.0)
+  + b4 * coordinate_confidence
+  + b5 * freshness_min                  # Stage 7 (NEW)
+confidence = 1 / (1 + exp(-z))
+```
+
+When `confidence >= emit_floor`, a `KnowBlock` is emitted; otherwise
+the decision falls through to `MissBlock(reason="sparse")` (or
+`reason="stale"` under Stage 7's freshness gate).
+
+These are SHIP-TIME defaults. Operator action post-merge:
+
+```bash
+python scripts/calibrate_know_confidence.py \
+    --input results/located_n1000.jsonl \
+    --out helix.toml
+```
+
+Calibration requires Stage 1 (bench axis split) to land first — it
+produces the bench JSONL.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `emit_floor` | float | `0.55` | Probability floor below which a KnowBlock is not emitted; falls through to `MissBlock(reason="sparse")`. The shipped value (`helix.toml:340`). |
+| `s_ref` | float | `1.0` | Feature-scale reference for `tanh(top_score / s_ref)`. Pick `s_ref = median(top_score)` from the calibration set so `tanh(...)` saturates around the typical scale (Stage-6 spec §11). The shipped value (`helix.toml:341`). |
+| `g_ref` | float | `0.5` | Feature-scale reference for `tanh(score_gap / g_ref)`. Pick `g_ref = median(score_gap)` from the calibration set. The shipped value (`helix.toml:342`). |
+| `betas` | array<float> | `[-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]` (code default; 6 coefficients with Stage-7 β5) | Logistic coefficients. Order: `[b0_intercept, b1_top, b2_gap, b3_agree, b4_coord, b5_freshness]`. The shipped `helix.toml:343` value `[-2.0, 2.0, 1.5, 0.7, 1.8]` has only 5 entries (pre-Stage-7 length); the loader emits a `WARNING` and falls back to the 6-element default when length mismatches `1 + N_FEATURES = 6` (`helix_context/know_calibration.py:152-160`). **Operators running Stage 7 must add the 6th coefficient (`+1.5`) or flip to defaults**. Stage 7 added β5 (freshness_min coefficient); calibration script auto-detects the feature count. |
+| `calibrated_at` | str (ISO-8601) | `None` (optional) | Timestamp written by `scripts/calibrate_know_confidence.py` after a fresh calibration run. Optional; `None` means the betas are SHIP-TIME defaults. Not in the shipped `helix.toml`. |
+| `calibrated_on_n` | int | `None` (optional) | Sample count from the calibration set. Written by `scripts/calibrate_know_confidence.py`. Not in the shipped `helix.toml`. |
+
+**Example (post-Stage-7 calibration).**
+
+```toml
+[know]
+emit_floor = 0.55
+s_ref = 1.0
+g_ref = 0.5
+betas = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]   # [intercept, top, gap, agree, coord, freshness]
+calibrated_at = "2026-05-08T18:30:00Z"
+calibrated_on_n = 800
+```
+
+**Migration notes.** The shipped `helix.toml:343` value
+`[-2.0, 2.0, 1.5, 0.7, 1.8]` is 5-element (pre-Stage-7 length).
+After Stage 7, the loader expects 6 entries
+(`1 + N_FEATURES = 1 + 5`). Operators should either re-run the
+calibration script to refresh `[know]` or manually append the Stage-7
+default `+1.5` to the array.
+
+**Cross-refs.** `helix_context/know_calibration.py` (pure-function
+loader; soft-fails to defaults), `helix_context/context_packet.py`
+(`KnowBlock` / `MissBlock` emit path),
+`docs/specs/2026-05-08-stage-6-know-miss-blocks.md` §3, §11,
+`docs/specs/2026-05-08-stage-7-freshness-gate.md` §10,
+`scripts/calibrate_know_confidence.py` (operator runbook).
+
+---
+
+## `[mem_sync]`
+
+**Purpose.** Auto-memory → helix sync. Every `.md` file in a watched
+directory becomes a gene; persona / agent attribution comes from
+`HELIX_AGENT` / `HELIX_USER` env vars on the syncer process. See
+`scripts/run_mem_sync.py`.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `false` | Master switch. Set `true` and run `scripts/run_mem_sync.py`. The shipped value (`helix.toml:349`). |
+| `helix_url` | str | `"http://127.0.0.1:11437"` | Helix server URL — must match `[server] host:port` for the local case. The shipped value (`helix.toml:350`). |
+| `sync_interval_s` | int | `60` | Poll cadence in seconds. Human-speed writes; cheap stat+hash check per file. The shipped value (`helix.toml:351`). |
+| `agent_kind` | str | `"claude-code"` | Stamp written on every ingest; identifies the writer tool for downstream attribution. The shipped value (`helix.toml:352`). |
+| `watch_dirs` | array<str> | `["~/.claude/projects/f--Projects-Education/memory"]` | Directories to watch. `~` is expanded automatically. Add more as needed. The shipped value (`helix.toml:353-355`). |
+
+**Example.**
+
+```toml
+[mem_sync]
+enabled = false
+helix_url = "http://127.0.0.1:11437"
+sync_interval_s = 60
+agent_kind = "claude-code"
+watch_dirs = [
+    "~/.claude/projects/f--Projects-Education/memory",
+]
+```
+
+**Note.** This section is **not** parsed by
+`helix_context/config.py` directly — it is consumed by the standalone
+`scripts/run_mem_sync.py` syncer. The block lives in `helix.toml` for
+single-source-of-truth co-location; the syncer reads its own copy.
+
+**Cross-refs.** `scripts/run_mem_sync.py` (consumer).
+
+---
+
+## `[synonyms]`
+
+**Purpose.** Lightweight synonym map for promoter expansion. Query
+keywords map to a list of synonym tags that the retrieval layer uses
+to broaden tag-exact and tag-prefix matches. Edit-and-restart only —
+read once at process start.
+
+**Schema.**
+
+Each entry is `<query keyword> = [<synonym>, <synonym>, ...]`. There
+are no nested tables. The loader builds `cfg.synonym_map` as a
+`Dict[str, List[str]]` (`helix_context/config.py:867-870`).
+
+**Example (excerpt from the shipped file at `helix.toml:357-398`).**
+
+```toml
+[synonyms]
+slow = ["performance", "latency", "bottleneck", "timeout", "lag"]
+fast = ["performance", "speed", "optimization", "cache"]
+cache = ["redis", "ttl", "invalidation", "cdn", "caching", "eviction"]
+auth = ["jwt", "login", "security", "token", "session", "oauth"]
+helix = ["genome", "ribosome", "codons", "splice", "chromatin", "promoter", "context compression"]
+db = ["database", "sqlite", "postgres", "sql", "query", "schema"]
+api = ["endpoint", "route", "rest", "http", "request", "response"]
+test = ["pytest", "unittest", "mock", "assert", "coverage"]
+deploy = ["docker", "kubernetes", "ci", "cd", "pipeline", "helm"]
+config = ["settings", "toml", "env", "environment", "dotenv"]
+# ... (full set in helix.toml)
+```
+
+**Operator note.** The synonym map is critical. If queries return "no
+relevant context", the most common cause is that query keywords don't
+map to the promoter tags the ingestion layer assigned. Add a synonym
+entry and restart.
+
+**Cross-refs.** `helix_context/config.py:866-870` (loader),
+`helix.toml:357-398` (full shipped map).
+
+---
+
+## `[abstain]`
+
+**Purpose.** **NEW (Stage 4, 2026-05-08)** — per-classifier
+confidence floors. When `mode = "global"` (default), the
+`context_manager` retains the legacy hard-coded
+`TIGHT_SCORE_FLOOR = 5.0` / `FOCUSED_SCORE_FLOOR = 2.5` /
+`abstain = 2.5` constants — pre-Stage-4 behavior byte-for-byte. Flip
+to `"per_classifier"` after running
+`scripts/calibrate_thresholds.py` to consume the emitted
+`[abstain.<cls>]` blocks.
+
+`"per_classifier"` **REQUIRES** an `[abstain.default]` block — the
+loader raises `ConfigError` otherwise (`helix_context/config.py:751-756`).
+Other classes may be omitted; runtime falls back to
+`[abstain.default]` via `AbstainConfig.floors_for(cls)`.
+
+**Top-level keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `mode` | str | `"global"` | One of `"global"` (legacy hard-coded floors) or `"per_classifier"` (consult sub-tables). Invalid values fall back to `"global"` with a `WARNING` (`helix_context/config.py:726-730`). The shipped value (`helix.toml:432`). |
+
+**Sub-tables.** `[abstain.factual]`, `[abstain.multi_hop]`,
+`[abstain.arithmetic]`, `[abstain.procedural]`, `[abstain.default]`.
+Each takes the same four keys (calibrated from `located_n1000.json`
+score distributions per Stage-4 spec §4):
+
+| Sub-table key | Type | Default | Effect |
+|---|---|---|---|
+| `abstain_top` | float | `2.5` | p85 of MISS scores per class — `top_score < abstain_top` triggers the ABSTAIN tier. The cheap-to-be-wrong floor (re-engages BROAD on false-abstain). |
+| `focused_top` | float | `2.5` | p25 of HIT scores per class — `top_score >= focused_top` enters the FOCUSED tier (with ratio gate). |
+| `tight_top` | float | `5.0` | p60 of HIT scores per class — `top_score >= tight_top` enters the TIGHT tier (with ratio gate). The expensive-to-be-wrong floor (drops 9 candidates on false-tighten). |
+| `foveated_alpha` | float | `1.0` | Per-class power-law exponent. Replaces `[budget] foveated_alpha` when `[abstain].mode = "per_classifier"` via `HelixContextManager._alpha_for_cls(cls)` (Stage-4 spec §7). Window metadata records `foveated_alpha_source: "per_classifier:<cls>"` for telemetry. |
+
+**Example (calibrated, post-`scripts/calibrate_thresholds.py`).**
+
+```toml
+[abstain]
+mode = "per_classifier"
+
+[abstain.factual]
+abstain_top = 0.42
+focused_top = 0.71
+tight_top = 1.18
+foveated_alpha = 1.4
+
+[abstain.multi_hop]
+abstain_top = 0.38
+focused_top = 0.55
+tight_top = 0.92
+foveated_alpha = 0.6
+
+[abstain.arithmetic]
+abstain_top = 0.30
+focused_top = 0.60
+tight_top = 1.00
+foveated_alpha = 1.6
+
+[abstain.procedural]
+abstain_top = 0.40
+focused_top = 0.65
+tight_top = 1.10
+foveated_alpha = 0.9
+
+[abstain.default]
+abstain_top = 0.40
+focused_top = 0.65
+tight_top = 1.10
+foveated_alpha = 1.0
+```
+
+**Migration notes.**
+
+- `mode = "global"` preserves Stage-3 behavior byte-for-byte.
+- Flipping to `"per_classifier"` requires `[abstain.default]`; other
+  classes are optional (fall back to default).
+- Calibration percentiles are asymmetric by design: `abstain_top` is
+  the upper tail of misses (recall-biased) while `tight_top` is the
+  lower-middle of hits (precision-biased). See Stage-4 spec §4 for
+  the rationale.
+- Acceptance criterion (Stage-4 spec §11): per-classifier abstain
+  rate on factual queries ≤ 5% (current implicit ~95% — `5.0` floor
+  unreachable post-RRF).
+
+**Cross-refs.** `helix_context/config.py:323-373` (`AbstainConfig`,
+`AbstainClassFloors`, `floors_for`),
+`docs/specs/2026-05-08-stage-4-threshold-calibration.md` §4 + §6,
+`scripts/calibrate_thresholds.py` (operator runbook —
+emits `[abstain.<cls>]` blocks from a `located_n1000.jsonl` bench
+run), `[budget] foveated_alpha` (overridden when
+`mode = "per_classifier"`),
+`[retrieval] fusion_mode` (RRF requires per-class floors per
+Stage-3 spec §9 transitional bypass).
+
+---
+
+## `[vault]` (commented-out template)
+
+**Purpose.** Obsidian-style vault export for operators. v1 ships as a
+read-only export plus diagnostic `/context` traces; curation / inbox
+arrive in v1.1. Off by default; the entire block is commented out in
+the shipped `helix.toml`.
+
+**Keys.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `false` | Master switch. |
+| `path` | str | `"~/.helix/vault"` | Vault root. `~` is expanded automatically. |
+| `party_id` | str | `""` | Empty = use the server's primary party. |
+| `fan_out_threshold` | int | `5000` | Split domain folders above this gene count. |
+| `redact_body` | bool | `false` | Replace gene body with `sha + excerpt`. Recommended for cloud-synced setups. |
+| `stale_threshold` | float | `0.5` | Genes with `live_truth_score < this` go to `_stale/`. |
+
+**`[vault.traces]` sub-table.**
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `enabled` | bool | `true` | Auto-export every `/context` call. |
+| `retention_hours` | int | `48` | Default retention. Set ≥720 for 30-day audit. |
+| `max_retention_hours_hard` | int | `720` | Force-deletes pinned past this. `0` disables. |
+| `max_count` | int | `10000` | Safety cap on burst floods (v1.1: not yet enforced). |
+| `rollup_enabled` | bool | `true` | Roll up traces by shard. |
+| `rollup_shard` | str | `"hour"` | One of `"hour"` \| `"daily"`. |
+| `prune_interval_minutes` | int | `60` | Prune cadence. |
+| `trigger_only` | bool | `false` | Emit only on threshold (v1.1: not yet enforced). |
+
+**Example (uncomment to enable).**
+
+```toml
+[vault]
+enabled = false
+path = "~/.helix/vault"
+fan_out_threshold = 5000
+redact_body = false
+stale_threshold = 0.5
+
+[vault.traces]
+enabled = true
+retention_hours = 48
+max_retention_hours_hard = 720
+max_count = 10000
+rollup_enabled = true
+rollup_shard = "hour"
+prune_interval_minutes = 60
+trigger_only = false
+```
+
+**Cross-refs.** `helix_context/config.py:452-476` (`VaultConfig`,
+`VaultTracesConfig`), `helix.toml:399-419` (commented template).
+
+---
+
+# Configuration loading order
+
+`helix_context.config.load_config()` resolves configuration in this
+priority order (highest priority wins):
+
+1. **Per-call request fields.** Endpoint-specific overrides on the
+   request body (e.g., `caller_model_class` on `/context`,
+   `include_cold` on `/context`, `pool_size` on the dense recall
+   path). Per-call overrides do not mutate the loaded `HelixConfig`.
+2. **Process-level environment variables.** A defined set of `HELIX_*`
+   env vars override loaded values:
+   - `HELIX_CONFIG` — path to the TOML file (defaults to
+     `helix.toml`). Read in
+     `helix_context/config.py:520-521`.
+   - `HELIX_GENOME_PATH` — overrides `[genome] path` after the TOML
+     load. Read in `helix_context/config.py:611-612`.
+   - `HELIX_SERVER_UPSTREAM` — overrides `[server] upstream`. Read in
+     `helix_context/config.py:616-617`.
+   - `HELIX_SERVER_UPSTREAM_TIMEOUT` — overrides `[server]
+     upstream_timeout` (float, ignored on parse error with a
+     `WARNING`). Read in `helix_context/config.py:618-625`.
+   - `HELIX_DEVICE` — one-shot device pin. Consumed by
+     `hardware.init_from_config()`, not the TOML loader directly.
+   - `HELIX_PARTY_ID` — preferred override for `[session]
+     default_party_id` (consumed by request-handling code, not the
+     loader).
+   - `HELIX_USE_SHARDS` — sharded vs monolithic genome routing.
+   - `HELIX_FILENAME_ANCHOR_ENABLED` — one-shot override for
+     `[retrieval] filename_anchor_enabled`.
+   - `HELIX_ABSTAIN_DISABLE` — one-shot override for `[budget]
+     abstain_enabled`.
+3. **TOML file values.** `helix.toml` (or the path in `HELIX_CONFIG`).
+   Loaded once at process start.
+4. **Dataclass defaults.** Every field in `helix_context/config.py`
+   has a typed default. Returned as-is when no file is present
+   (`helix_context/config.py:524-526`).
+
+The loader is **soft-fail** on every section: malformed TOML, unknown
+keys (`_warn_unknown` in `helix_context/config.py:500-512`), or
+malformed values fall back to the dataclass default with a
+`log.warning`. The single hard-fail is `[abstain].mode =
+"per_classifier"` without an `[abstain.default]` block, which raises
+`ConfigError` (`helix_context/config.py:751-756`).
+
+---
+
+# Hot-reload semantics
+
+**Restart-required.** Most sections are read **once** at process
+start. Changes take effect only after restarting the helix-context
+process:
+
+- `[ribosome]`, `[hardware]`, `[server]`, `[genome]`, `[ingestion]`,
+  `[cymatics]`, `[classifier]`, `[plr]`, `[abstain]`, `[mem_sync]`,
+  `[synonyms]`, `[vault]`, `[headroom]`.
+- `[budget]` token caps and `[retrieval]` weights / mode (loaded once
+  into `RetrievalConfig`; not mutated at runtime).
+- `[session]` synthetic-session window.
+
+**Hot-reloaded (per-call).** Some knobs are read on each request:
+
+- `[budget] foveated_alpha`, `[budget] foveated_c_min`,
+  `[budget] foveated_base_chars` — consulted per `/context` call by
+  the foveated splice scheduler (subject to per-classifier overrides
+  from `[abstain]` at query time).
+- `[retrieval] ann_threshold_mode` — checked per
+  `query_genes_ann` invocation; the runtime then either reads the
+  legacy `ann_similarity_threshold` (absolute mode) or queries the
+  `genome_calibration` table (margin-over-random mode).
+- `[retrieval] fusion_mode` — checked per `query_genes` invocation
+  (`fusion_mode == "rrf"` selects the `Fuser` branch; otherwise the
+  legacy additive accumulator).
+
+**Hot-reloaded via `/admin/refresh`.** The retrieval-layer cache
+invalidation surface:
+
+- The `[retrieval]` knobs that are cached at startup (e.g., the
+  `_dense_pool_size` instance attribute) refresh when the
+  retrieval layer reloads.
+- The `genome_calibration` row consumed by `ann_threshold_mode =
+  "margin_over_random"` is read on first `/context` after process
+  start, then cached. **Replication-manager rotation invalidates the
+  cache** (`helix_context/genome.py` `_effective_ann_threshold` —
+  Stage-4 spec §8).
+
+**`[know]` hot-reload.** The `[know]` block is **hot-reloaded** via
+the pure-function loader in `helix_context/know_calibration.py`. The
+calibration table is read on first `/context` after process start and
+cached thereafter; subsequent edits to `[know]` require a
+`/admin/refresh` (or process restart) to invalidate the cache. The
+loader is fail-soft: a missing file, missing `[know]` table, or
+malformed entries log a `WARNING` and return defaults — KnowBlock
+emission continues at the SHIP-TIME operating point until calibration
+runs.
+
+**Operator note.** When in doubt, restart. Hot-reload paths exist for
+the highest-churn knobs (`fusion_mode`, `ann_threshold_mode`,
+`[know]`) but the rest of the surface is start-once.
+
+---
+
+# Default `helix.toml`
+
+The full current `helix.toml` as of 2026-05-10 (post-7-stage merge),
+provided as a copy-paste baseline for new operators. Cross-reference
+the per-section tables above for key-by-key behavior.
+
+```toml
+# ──────────────────────────────────────────────────────────────────────
+# [ribosome] — OPTIONAL ENRICHMENT LAYER. Off the hot path.
+#
+# The 12-tier retrieval pipeline and /context path are LLM-free today.
+# MiniLM (SEMA) and DeBERTa (rerank/splice, when enabled) are encoders/
+# classifiers, not generators. Context assembly is pure Python.
+#
+# The ribosome is only consulted when a ribosome op is EXPLICITLY
+# invoked — ingest-time `pack()`, background `replicate()`, or the
+# (default-off) Step 0 query intent expansion. Leave this section
+# alone and /context never touches an LLM.
+#
+# Think of it as a "subconscious" layer: reflective re-processing
+# during idle, tighter complements, cross-gene pattern noticing with
+# a larger model — separate subsystem against the same genome, not a
+# dependency of the retrieval loop. Partner/vendor eval hook too —
+# Anthropic / Google / etc. can plug a hosted compression model into
+# this seam without forking.
+# ──────────────────────────────────────────────────────────────────────
+[ribosome]
+enabled = false                        # Explicit opt-in. Disabled/legacy ribosome config is ignored unless you turn this on.
+backend = "ollama"                      # Legacy/default placeholder. Only "litellm" and "deberta" are honored when enabled=true.
+model = "gemma4:e2b"                    # Ollama model for pack + replicate (light, ~2GB VRAM)
+base_url = "http://localhost:11434"
+timeout = 120                            # Increased for bulk ingestion
+keep_alive = "30m"                      # keep Ollama model loaded
+warmup = false                          # pre-load Ollama model on server start (disabled for N=1000 bench — qwen3:4b holds VRAM)
+query_expansion_enabled = false         # Step 0 LLM query-intent expansion. false = strictly LLM-free /context (the 12 retrieval tiers never need this). Flip on for an extra 2-3pp on ambiguous queries at the cost of one ribosome call per request.
+# Sub-query decomposition — decomposes broad queries into 3 point-fact sub-queries.
+# Only fires for multi_hop/default classifier class. Requires query_expansion_enabled = true.
+query_decomposition_enabled = false
+
+# Cloud-backend opt-in — keep commented so local stays default.
+# Useful for partner/vendor eval (Anthropic, Google, etc.) plugging a
+# hosted compression/extraction model into the ribosome seam without
+# forking, or for freeing the local GPU during heavy bench runs.
+# backend = "claude"
+# claude_model = "claude-haiku-4-5-20251001"   # haiku = cost-effective bulk; swap to claude-sonnet-4-6 for higher resolution
+# claude_base_url = ""                          # "" = direct Anthropic API; set to a proxy URL (e.g. http://127.0.0.1:8787) to route through a gateway
+# litellm_model = "ollama/gemma4:e2b"           # LiteLLM model string — only used when backend = "litellm"
+
+[hardware]
+# Device picker. "auto" picks best-available (cuda -> rocm -> mps -> cpu).
+# Explicit values fall back loudly to CPU on probe failure; helix never
+# blocks on hardware mismatch -- see /health for fallback state.
+# Override one-shot via HELIX_DEVICE=cpu env var.
+device = "auto"        # auto | cuda | rocm | mps | cpu
+
+# Batch-size policy. "auto" consults the VRAM/RAM-aware table in
+# helix_context/hardware.py. Override per model when tuning:
+#   batch_sizes = { rerank = 16, splice = 32, splade = 8, nli = 8 }
+batch_sizes = "auto"
+
+# Soft-warn threshold. Below this, /health returns a "low_vram" hint and
+# the tray surfaces a one-time balloon. Set to 0 to disable.
+low_vram_threshold_gb = 4.0
+
+[budget]
+ribosome_tokens = 3000                  # fixed decoder prompt
+expression_tokens = 12000               # 1:10 ratio at 128K = ~12.8K total context budget
+max_genes_per_turn = 12
+max_fingerprints_per_turn = 40          # navigation-first fingerprint payload cap (final returned count, not frontier width)
+splice_aggressiveness = 0.3             # 0=keep all, 1=ruthless trim (lower preserves more literal detail)
+decoder_mode = "condensed"              # "full"|"condensed"|"minimal"|"none" (none saves ~750 tokens for API models)
+# Sprint 1 legibility pack (AI-consumer roadmap): emit one metadata line
+# per gene in expressed_context — fired tiers, confidence marker, short
+# gene_id, raw→compressed chars. See helix_context/legibility.py + docs/
+# FUTURE/AI_CONSUMER_ROADMAP_2026-04-14.md. Flip to false to restore
+# plain-dividers format for bench A/B.
+legibility_enabled = true
+# Sprint 2 session working-set register (AI-consumer roadmap): track
+# genes delivered per session so re-retrievals elide repeats with a
+# pointer stub. Enabled 2026-04-19 — MVP writes to session_delivery_log
+# on every /context call (synthetic session_id fallback covers callers
+# that don't supply one). Set to false to restore pre-MVP dark behavior.
+# See helix_context/session_delivery.py.
+session_delivery_enabled = true
+# Confidence-gated context attachment (ABSTAIN tier). When true (default),
+# build_context returns a marker-only ContextWindow when post-refinement
+# retrieval is weak on BOTH absolute score (top_score < 2.5) AND ratio
+# (top_score/mean < 1.8) — the negative space of the TIGHT and FOCUSED
+# tiers. Goal: skip the 12K-token BROAD fallback on queries where helix
+# can't help, so the small model answers from weights instead of digesting
+# irrelevant noise. Set to false to restore the legacy always-inject
+# behavior (BROAD takes the negative space). HELIX_ABSTAIN_DISABLE=1 env
+# var forces off without redeploy. See docs/specs/2026-05-02-abstain-tier-design.md.
+abstain_enabled = true
+# Foveated-splice (BROAD tier only). When True, the BROAD branch of the
+# dynamic-budget tier replaces uniform per-gene compression with a rank-
+# scaled power-law schedule and reverses the assembly order so the top-
+# ranked gene lands immediately before the user query. Off by default for
+# the measurement period — see docs/specs/2026-05-03-foveated-splice-
+# design.md §6.3.
+foveated_enabled = false
+
+# Power-law exponent: c_i = max(c_min, c_max · i^(-α)). α=0.5 = gentle
+# decay, α=1.0 (default) = harmonic-ish, α=2.0 = aggressive top-bias.
+# Bench Phase 2 sweeps {0.5, 1.0, 2.0}; ship the winner.
+foveated_alpha = 1.0
+
+# Rank-N (bottom of BROAD) compression floor. Each gene's effective char
+# cap = max(foveated_c_min · base, c_i · base) where c_i = c_max · i^(-α).
+foveated_c_min = 0.15
+
+# Per-gene char-budget multiplier. target_chars per gene = int(c_i · base).
+# Default 1000 matches current uniform Step 4 behavior at c_i = 1.0.
+foveated_base_chars = 1000
+
+[session]
+# CWoLa session / party fallback. Prior to 2026-04-13 the /context endpoint
+# passed NULL to cwola.log_query when clients didn't supply session_id or
+# party_id — which caused sweep_buckets to treat every row as Bucket A
+# (no re-query detectable without a session), making CWoLa training
+# impossible. See cwola.py + STATISTICAL_FUSION.md §C2.
+# Default party_id for CWoLa / session attribution when no env var or header is set.
+# Operators: set HELIX_PARTY_ID in your environment (preferred) or change this value.
+default_party_id = "default"            # Attribution fallback when the request omits party_id
+synthetic_session_window_s = 300        # 5 min — same-IP requests within this window group into one session
+synthetic_session_enabled = true        # Flip to false to restore prior NULL-session behavior (not recommended)
+
+[genome]
+# 2026-04-16: swapped to fresh-rebuild clean genome. Old paths archived:
+# F:/Projects/helix-context/genome.db   — old master (pre-rebuild)
+# C:/helix-cache/genome.db              — old replica (had backfill)
+# New genomes/ folder is the phase-2 sharding root. main/ is v1's only
+# shard; future shards land as genomes/reference/, genomes/agent/, etc.
+path = "genomes/main/genome.db"
+compact_interval = 3600                 # seconds between source-change checks (hourly)
+cold_start_threshold = 10               # genes needed before history stripping kicks in (Fix 3)
+# Replicas disabled during phase-1 cutover. Will re-enable alongside
+# the shard router in phase 2 (sharding changes the replication shape).
+replicas = []
+replica_sync_interval = 100             # sync replicas every N inserts
+# No time-based decay. Genes never expire.
+# Compaction only detects source file changes (mtime vs last_accessed).
+# Irrelevant data is handled by splice (intron/exon) at expression time.
+
+[server]
+host = "127.0.0.1"
+port = 11437
+upstream = "http://localhost:11434"     # Ollama
+# upstream_timeout = 180                # Default in config.py is 180s. Raise to 240+ for very slow models or large prompts; lower if you want fail-fast.
+
+# ── [headroom] — OPTIONAL PROXY LIFECYCLE (launcher only). ─────────────
+# Headroom (https://github.com/chopratejas/headroom) is a separate
+# process serving a compression proxy + dashboard at
+# http://{host}:{port}/dashboard. The launcher can spawn it as a child
+# at boot (autostart=true) and surface it in the tray menu.
+#
+# When ``enabled=true`` the launcher:
+#   1. Adopts an existing headroom proxy if one is already listening on
+#      ``port`` — no duplicate spawn, and adopted process survives
+#      launcher Quit.
+#   2. Otherwise spawns a fresh headroom child (``autostart=true`` default).
+# the tray gains "Open Headroom Dashboard" + Start/Restart/Stop
+# Headroom menu items.
+# Requires: pip install "helix-context[codec]" (pulls headroom-ai[proxy])
+[headroom]
+enabled = true                          # Master switch; true = tray wires Headroom and adopts/spawns it on launch
+autostart = true                        # When enabled: adopt if running, spawn if not. Set false for menu-only mode.
+host = "127.0.0.1"
+port = 8787                             # Default headroom proxy port
+mode = "token"                          # "token" (compression-first) | "cache" (prefix-cache-stable)
+dashboard_path = "/dashboard"           # Appended to http://{host}:{port} for the tray menu link
+
+[ingestion]
+backend = "cpu"                         # "ollama" (LLM, slow) | "cpu" (spaCy+regex, fast) | "hybrid"
+splade_enabled = true                   # Phase 2: SPLADE sparse expansion at index time
+rerank_model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+rerank_enabled = false                  # Phase 3: enable pretrained cross-encoder reranking
+colbert_enabled = false                 # Phase 4: ColBERT late interaction (optional)
+entity_graph = true                     # Phase 5: entity-based co-activation links
+
+[context]
+# Cold-tier retrieval (C.2 of B->C, 2026-04-10)
+# Heterochromatin-tier genes are demoted by the density gate but their
+# content is preserved (C.1). When this fallthrough fires, /context
+# consults cold-tier genes via SEMA cosine similarity in 20-dim space.
+# Per-request override: `include_cold: true` on the /context body.
+# min_cosine too high (e.g. 0.25) means cold-tier returns nothing on
+# real NIAH queries. 0.15 is calibrated to surface matches in the noise floor.
+cold_tier_enabled = false               # master opt-in
+cold_tier_min_hot_genes = 0             # fall through when hot returns <= this many genes (0 = only on empty)
+cold_tier_k = 3                         # max cold-tier genes per query
+cold_tier_min_cosine = 0.15             # SEMA cosine floor (sparse 20-dim — see comment above)
+fingerprint_mode_profile = "balanced"   # "fast" | "balanced" | "quality" for POST /fingerprint and /debug/preview
+
+[cymatics]
+enabled = true                          # Blended as bonus (0.5 max), not used to re-sort
+n_bins = 256                            # Spectrum resolution (256 bins = <2KB per spectrum)
+peak_width = 3.0                        # Gaussian peak width — overridden by Q-factor from splice_aggressiveness
+use_embeddings = false                  # Use Gene.embedding when populated (requires sentence-transformers)
+harmonic_links = true                   # Compute weighted co-activation edges between expressed genes
+distance_metric = "cosine"              # "cosine" (weighted dot) | "w1" (Werman 1986 circular Wasserstein-1; Singh 2020 CMD)
+
+[classifier]
+# Upstream rule-based query classifier / injection router.
+# When enabled, contributes a decoder-mode hint and an assembly-stage
+# gene-count cap to build_context(). See
+# docs/specs/2026-04-29-query-classifier-injection-router-design.md.
+enabled = true
+
+[retrieval]
+# Tier 5.5 — Successor Representation (Stachenfeld 2017). γ-discounted
+# future-occupancy boost over co-activation graph. Lazy.
+sr_enabled = true                       # Stage-1 bench flip (2026-04-22); research review flagged this as dark-shipped signal-positive
+sr_gamma = 0.85                         # 5-10 hop horizon (Stachenfeld grid-cell sweet spot)
+sr_k_steps = 4                          # Power-series truncation (cap runaway propagation)
+sr_weight = 1.5                         # Per-gene SR contribution multiplier
+sr_cap = 3.0                            # Max per-gene SR boost (matches harmonic cap)
+# Theta alternation (Wang/Foster/Pfeiffer 2020) — bias ray_trace neighbor
+# direction. Fore on even bounces, aft on odd.
+ray_trace_theta = false                 # Dark ship — requires TCM velocity input (Sprint 1 item 3)
+theta_weight = 1.0                      # Softmax temperature on v·gene_input_vector
+# Sprint 4 — seeded co-activation edges (Hebbian dense-rank weighting).
+seeded_edges_enabled = false            # Dark ship — flip to start accumulating co_count / miss_count
+seeded_edge_weight = 1.0                # Base weight stamped at seed insertion
+# Tier 0.5 filename-anchor (2026-04-15 Dewey-pivot spike).
+# Dewey bench 2026-04-14: filename-as-primary-anchor gave +24pp
+# retrieval over full path-token bag. Boosts genes whose filename
+# stem matches a query term. One-shot env var override:
+# HELIX_FILENAME_ANCHOR_ENABLED=1.
+filename_anchor_enabled = true          # Stage-1 bench flip (2026-04-22); +12pp on Dewey axis-2 spike
+filename_anchor_weight = 4.0            # Per-match boost (Tier 1 exact-tag = 3.0 for reference)
+# BM25 shortlist post-filter (2026-04-22, research-review Pareto move 1).
+# When enabled, query_genes restricts final ranking to genes in BM25 top-N.
+# Dark by design — flip on for Stage-2 A/B measurement.
+bm25_shortlist_enabled = true           # Keep on (2026-04-22 sprint): +1/8 ans_full on helix_rag + helix_full_stack, clean attribution
+bm25_shortlist_size = 50
+# BM25 pre-filter — fires BEFORE tier scoring (vs the post-filter shortlist).
+# Enable for A/B against bm25_shortlist. Disable shortlist when using this.
+bm25_prefilter_enabled = false
+bm25_prefilter_size = 200
+# Tier 5b: entity graph co-occurrence boost (Step 3C, 2026-05-08).
+# Genes sharing entity nodes with query terms get a score boost
+# proportional to entity overlap. Dark ship — flip to true for A/B.
+entity_graph_retrieval_enabled = false
+# Step 4 — BGE-M3 dense vectors + ANN threshold-based dynamic gene counts
+# (2026-05-08). Stage 2 (2026-05-08): dim raised to 1024 (full BGE-M3
+# Matryoshka). The dim=256 truncation collapsed random-pair cosine to
+# ~0.6, sabotaging the threshold. Stage 4 will recalibrate
+# ann_similarity_threshold at 1024-dim. Dense pool size decouples recall
+# breadth from the final cut (max_genes).
+dense_embedding_enabled = false
+dense_embedding_dim = 1024
+ann_similarity_threshold = 0.35           # legacy / fallback when calibration row missing
+ann_threshold_min_genes = 1
+ann_threshold_max_genes = 12
+# Stage 4 (2026-05-08): margin-over-random ANN threshold. Spec
+# docs/specs/2026-05-08-stage-4-threshold-calibration.md §3+§6.
+# "absolute" (default) keeps Stage-3 behavior byte-for-byte: query_genes_ann
+# uses ann_similarity_threshold above. Flip to "margin_over_random" after
+# running scripts/calibrate_thresholds.py — the runtime then reads the
+# persisted threshold from genome_calibration. Falls back to
+# ann_similarity_threshold (with one-time WARN) if the row is missing.
+ann_threshold_mode = "absolute"           # "absolute" | "margin_over_random"
+ann_threshold_sigma_multiplier = 3.0      # mu + N*sigma over random pairs
+dense_pool_size = 500
+# Stage 3 (2026-05-08): Reciprocal Rank Fusion. Spec
+# docs/specs/2026-05-08-stage-3-rrf-fusion.md replaces the additive
+# gene_scores += tier_score accumulator with rank-level RRF (Cormack 2009).
+# Default "additive" is byte-identical to pre-Stage-3 behavior. Flip to
+# "rrf" to enable the new path. Per-tier weights below are RRF
+# post-multipliers (preserve current implicit weights).
+# Deprecation timeline: v(N) ships additive default; v(N+1) flips to rrf
+# default; v(N+2) removes the additive code path.
+fusion_mode = "additive"                # "additive" | "rrf"
+rrf_k = 60                              # Cormack 2009 default
+fts5_weight = 3.0                       # current FTS5 cap
+splade_weight = 3.5                     # current SPLADE cap
+tag_exact_weight = 3.0                  # Tier 1 weight × match_count
+tag_prefix_weight = 1.5                 # Tier 2 weight × match_count
+sema_cold_weight = 3.0                  # ΣĒMA cold-start sim multiplier
+lex_anchor_weight = 1.5                 # IDF anchor multiplier
+harmonic_weight = 1.0                   # Tier 5 per-link weight
+entity_graph_weight = 0.5               # Tier 5b entity boost
+dense_weight = 1.0                      # Stage 2 dense recall, RRF participant
+pki_weight = 1.0                        # path-key-index tier, RRF participant
+# Note: filename_anchor_weight (above) and sr_weight (above) are reused.
+
+[plr]
+# Stacked PLR query-confidence head (STATISTICAL_FUSION.md §C3).
+#
+# Attaches a `plr_confidence` log-odds signal to /context/packet responses —
+# predicted log-odds that the user will re-query within 60s under the
+# training discipline (cos(q_t, q_{t+1}) filter + 60s window). Higher =
+# more likely to re-query = lower confidence in the retrieval.
+#
+# The current artifact is a **query-quality head**, not the per-(q, g)
+# ranker originally described in the spec. Gene ranking stays on the
+# additive fuser; this signal only feeds the packet / router.
+# See helix_context/fusion_plr.py docstring for the scope trade-off.
+#
+# Train a fresh artifact with:
+#   python scripts/pwpc/sprint3.py <windowed_export.json> \
+#       --save-model training/models/stacked_plr.joblib --save-label-set best
+enabled = false                         # Dark by default; bench before flipping
+model_path = "training/models/stacked_plr.joblib"
+expected_sha256 = ""                    # Empty = trust the .sha256 sidecar (written by the trainer)
+high_risk_threshold = 0.5               # `prob_B > this` surfaces a coarse "likely-to-re-query" boolean
+
+[know]
+# Stage 6 (2026-05-08) — KnowBlock confidence logistic.
+#
+# Spec: docs/specs/2026-05-08-stage-6-know-miss-blocks.md §3, §11.
+#
+# Maps four retrieval signals to a calibrated probability that the
+# /context retrieval is ground-truth correct:
+#
+#   z = b0 + b1*tanh(top_score / s_ref)
+#          + b2*tanh(score_gap / g_ref)
+#          + b3*lexical_dense_agree
+#          + b4*coordinate_confidence
+#   confidence = 1 / (1 + exp(-z))
+#
+# When confidence >= emit_floor a KnowBlock is emitted; otherwise the
+# decision falls through to MissBlock(reason="sparse").
+#
+# These are SHIP-TIME defaults. Operator action post-merge:
+#   python scripts/calibrate_know_confidence.py \
+#       --input results/located_n1000.jsonl \
+#       --out helix.toml
+# Calibration requires Stage 1 to land first (it produces the bench
+# JSONL).
+#
+# # STAGE-7-EXT: Stage 7 will append b5 (default +1.5) for
+# # freshness_min as the fifth feature; the betas list grows to 6
+# # entries. The calibration script auto-detects the feature count.
+emit_floor      = 0.55
+s_ref           = 1.0
+g_ref           = 0.5
+betas           = [-2.0, 2.0, 1.5, 0.7, 1.8]
+
+[mem_sync]
+# Auto-memory → helix sync. Every .md file in a watched dir becomes a
+# gene; persona/agent attribution comes from HELIX_AGENT / HELIX_USER
+# env vars on the syncer process. See scripts/run_mem_sync.py.
+enabled = false                         # Set true + run scripts/run_mem_sync.py
+helix_url = "http://127.0.0.1:11437"
+sync_interval_s = 60                    # Poll cadence; human-speed writes, cheap stat+hash
+agent_kind = "claude-code"              # Stamp on every ingest; identifies writer tool
+watch_dirs = [                          # Expand ~ automatically; add more as needed
+  "~/.claude/projects/f--Projects-Education/memory",
+]
+
+[synonyms]
+# Fix 1: lightweight synonym expansion for promoter queries
+slow = ["performance", "latency", "bottleneck", "timeout", "lag"]
+fast = ["performance", "speed", "optimization", "cache"]
+cache = ["redis", "ttl", "invalidation", "cdn", "caching", "eviction"]
+auth = ["jwt", "login", "security", "token", "session", "oauth"]
+protein = ["folding", "amino", "alpha_helix", "beta_sheet", "alphafold", "biochemistry"]
+tree = ["btree", "b-tree", "data_structures", "index", "binary_tree"]
+helix = ["genome", "ribosome", "codons", "splice", "chromatin", "promoter", "context compression"]
+pipeline = ["steps", "expression", "workflow", "process", "stages"]
+scoring = ["scorerift", "divergence", "audit", "grades", "ratchet", "dimensions"]
+compress = ["compression", "ratio", "target", "context_compression"]
+ratio = ["compression", "ratio", "target", "factor"]
+biged = ["biged-rs", "rust", "axum", "egui", "pyo3", "supervisor", "fleet"]
+bookkeeper = ["bookkeeping", "financial", "transactions", "xero", "invoices", "tenant"]
+cosmictasha = ["cosmic", "tasha", "novabridge", "biged-rs"]
+error = ["exception", "crash", "failure", "bug", "traceback"]
+port = ["proxy", "server", "configuration", "system_settings", "api"]
+threshold = ["divergence", "scoring", "reconciliation", "configuration"]
+model = ["ollama", "llm", "configuration", "deployment", "agent_frameworks"]
+skills = ["fleet", "agent", "worker", "llm_systems", "systems_architecture"]
+monetary = ["decimal", "financial", "data_processing", "bookkeeping"]
+budget = ["tokens", "configuration", "ribosome", "expression"]
+dimensions = ["audit", "scoring", "preset", "ci_cd"]
+binary = ["rust", "deployment", "packaging", "compatibility"]
+default = ["configuration", "system_settings", "deployment"]
+db = ["database", "sqlite", "postgres", "sql", "query", "schema"]
+api = ["endpoint", "route", "rest", "http", "request", "response"]
+ui = ["frontend", "component", "render", "layout", "css", "style"]
+test = ["pytest", "unittest", "mock", "assert", "coverage"]
+deploy = ["docker", "kubernetes", "ci", "cd", "pipeline", "helm"]
+config = ["settings", "toml", "env", "environment", "dotenv"]
+conductor = ["llm", "agent", "orchestration", "model", "fleet"]
+
+# Session terms (2026-04-09 SIKE / MoE decoder work)
+vacuum = ["reclaim", "sqlite", "pages", "compact", "shrink", "admin"]
+sike = ["scale_invariant", "benchmark", "retrieval", "sike_score"]
+moe = ["mixture_of_experts", "sliding_window", "swa", "gemma4", "tissue", "answer_slate"]
+slate = ["answer_slate", "kv_facts", "front_loaded", "extraction", "moe"]
+decoder = ["decoder_mode", "condensed", "moe", "ribosome_prompt", "instructions"]
+maintenance = ["admin", "vacuum", "refresh", "checkpoint", "compact"]
+
+# ── Vault export (Obsidian) — opt-in, off by default ────────────────────
+# Renders the genome as a browsable markdown vault for operators.
+# v1: read-only export + diagnostic /context traces. Curation/inbox in v1.1.
+# [vault]
+# enabled = false
+# path = "~/.helix/vault"
+# party_id = ""                     # empty = server's primary party
+# fan_out_threshold = 5000          # split domain folders above this count
+# redact_body = false               # true → replace body with sha+excerpt
+#                                   # recommended for cloud-synced setups
+# stale_threshold = 0.5             # genes with live_truth_score < this go to _stale/
+#
+# [vault.traces]
+# enabled = true                    # auto-export every /context call
+# retention_hours = 48              # default; ≥720 for 30-day audit
+# max_retention_hours_hard = 720    # force-deletes pinned past this; 0 disables
+# max_count = 10000                 # safety cap on burst floods (v1.1: not yet enforced)
+# rollup_enabled = true
+# rollup_shard = "hour"             # hour | daily
+# prune_interval_minutes = 60
+# trigger_only = false              # emit only on threshold (v1.1: not yet enforced)
+
+# ── Stage 4 (2026-05-08): per-classifier confidence floors ──────────────
+# Spec: docs/specs/2026-05-08-stage-4-threshold-calibration.md §6.
+# When mode='global' (default), context_manager uses the legacy hard-coded
+# TIGHT_SCORE_FLOOR=5.0 / FOCUSED_SCORE_FLOOR=2.5 / abstain=2.5 — pre-Stage-4
+# behavior byte-for-byte. Flip to 'per_classifier' after running
+# scripts/calibrate_thresholds.py to consume the emitted [abstain.<cls>] blocks.
+#
+# 'per_classifier' REQUIRES an [abstain.default] block (loader raises
+# ConfigError otherwise). Other classes may be omitted — runtime falls back
+# to [abstain.default].
+[abstain]
+mode = "global"  # "global" | "per_classifier"
+
+# Example calibrated blocks (commented out — populated by calibrate_thresholds.py):
+# [abstain.factual]
+# abstain_top = 0.42
+# focused_top = 0.71
+# tight_top = 1.18
+# foveated_alpha = 1.4
+#
+# [abstain.multi_hop]
+# abstain_top = 0.38
+# focused_top = 0.55
+# tight_top = 0.92
+# foveated_alpha = 0.6
+#
+# [abstain.arithmetic]
+# abstain_top = 0.30
+# focused_top = 0.60
+# tight_top = 1.00
+# foveated_alpha = 1.6
+#
+# [abstain.procedural]
+# abstain_top = 0.40
+# focused_top = 0.65
+# tight_top = 1.10
+# foveated_alpha = 0.9
+#
+# [abstain.default]
+# abstain_top = 0.40
+# focused_top = 0.65
+# tight_top = 1.10
+# foveated_alpha = 1.0
+```

--- a/docs/operator-runbooks.md
+++ b/docs/operator-runbooks.md
@@ -1,0 +1,899 @@
+# Operator Runbooks
+
+This document is the operator reference for `helix-context` post-deployment
+maintenance and the three calibration scripts the 2026-05-08 7-stage
+retrieval-fix landed in `master` on 2026-05-10. After upgrading to a
+release with the Stage 2 / Stage 4 / Stage 6 / Stage 7 changes, the new
+code paths take effect on a production genome only after these scripts
+run against it.
+
+Assumptions: `helix.toml` at repo root (or `HELIX_CONFIG`); active genome
+at `genomes/main/genome.db`; server at `127.0.0.1:11437`;
+`HELIX_AUTH_TOKEN` set for admin endpoints.
+
+## Overview
+
+Apply the three calibration runbooks in this order, exactly once, the
+first time you bring a genome up against a release containing PR #46
+(Stage 2) through the Stage 7 freshness gate:
+
+1. **Pull and stop traffic** — block writers (`/v1/chat/completions`,
+   `/ingest`, `/consolidate`) by stopping the helix process.
+2. **Runbook 1 — BGE-M3 1024-dim backfill** (Stage 2). Re-encode every
+   gene into the new `embedding_dense_v2 BLOB` column.
+3. **Runbook 2 — Threshold calibration** (Stage 4). Derive a
+   margin-over-random ANN cutoff and per-classifier floors from
+   `located_n1000`.
+4. **Runbook 3 — Know-confidence calibration** (Stage 6 + Stage 7). Fit
+   the 5-feature logistic for `KnowBlock.confidence`. Stage 7 added
+   `freshness_min` as β5.
+5. **Resume traffic** — restart helix or POST `/admin/refresh`. The
+   runbooks for `/admin/refresh`, `/admin/vacuum`, `/consolidate`, and
+   `/context/refresh-plan` follow as day-2 operations.
+
+The three calibration scripts (`scripts/backfill_bgem3_v2.py`,
+`scripts/calibrate_thresholds.py`, `scripts/calibrate_know_confidence.py`)
+have their CLI surfaces documented inline below; every flag has been
+verified against the script's `argparse` definitions in this worktree.
+
+---
+
+## Runbook 1: BGE-M3 1024-dim backfill (Stage 2)
+
+`scripts/backfill_bgem3_v2.py` re-encodes each gene's content at the full
+1024-dim BGE-M3 embedding and writes raw little-endian fp32 bytes into a
+new `embedding_dense_v2 BLOB` column on the `genes` table. After Stage 2,
+this column is what the dense recall path reads; the legacy
+`embedding_dense TEXT` (256-dim JSON) column stays in the schema for one
+release as a rollback safety net.
+
+### When to run
+
+After upgrading to a release containing PR #46 (Stage 2 dense recall).
+First-time only on a given genome; idempotent on rerun. The Stage 2 spec
+ships an init-time warning at `Genome.__init__`: if
+`dense_embedding_enabled=True` AND v2 coverage is non-zero, helix warns
+once that `ann_similarity_threshold` is calibrated for dim=256 and
+invalid against dim=1024 — Runbook 2 is the fix.
+
+### Wall time
+
+- CPU sentence-transformers BGE-M3: ~30-90 minutes for an 18.9k-gene genome.
+- FlagEmbedding + GPU: ~5-15 minutes for the same corpus.
+
+Source: docstring at `scripts/backfill_bgem3_v2.py:22-23`. The dominant
+cost is the embedding forward pass, not the SQLite write. Disk space:
+18.9k × 1024 × 4 = 77.6 MiB raw fp32 BLOB vs ~600 MiB for the legacy
+JSON column (spec `docs/specs/2026-05-08-stage-2-dense-recall.md` §3) —
+allow ~5 MiB per 1,000 genes.
+
+### Pre-flight checklist
+
+1. Stop the helix process. Background `replicate()` and `/admin/compact`
+   both UPSERT the `genes` table; concurrent writes interleave partial
+   rows that the idempotent skip-clause then has to retry.
+2. Snapshot-copy `genomes/main/genome.db` to a side path. The script is
+   non-destructive (adds a column, writes to NULL rows), but the snapshot
+   guards an interrupted encode that leaves a half-written row.
+3. Verify free disk space: ~5 MiB per 1,000 genes on top of the existing
+   DB size, plus headroom for the WAL during the encode.
+
+### Backfill command
+
+The CLI is the script's `main()` argparse block at
+`scripts/backfill_bgem3_v2.py:66-84`:
+
+```bash
+python scripts/backfill_bgem3_v2.py [DB_PATH]
+       [--batch INT]
+       [--limit INT]
+       [--dim INT]
+```
+
+Flags:
+
+- Positional `db_path` (optional). When omitted the script reads
+  `[genome] path` from `helix.toml`
+  (`scripts/backfill_bgem3_v2.py:87-88`).
+- `--batch INT` — encode batch + SQLite commit cadence. Default `64`
+  (`scripts/backfill_bgem3_v2.py:73`). Spec §3 describes "every 100
+  rows"; the actual default is 64. Pass `--batch 100` for bit-for-bit
+  spec alignment.
+- `--limit INT` — cap rows processed (smoke tests only;
+  `scripts/backfill_bgem3_v2.py:77-78`).
+- `--dim INT` — override encode dim. Defaults to
+  `cfg.retrieval.dense_embedding_dim` (1024 post-Stage-2,
+  `scripts/backfill_bgem3_v2.py:81-83`). Set only for non-default
+  Matryoshka 768/512 re-runs.
+
+Typical invocation against a snapshot:
+
+```bash
+python scripts/backfill_bgem3_v2.py genomes/main/genome.db --batch 64
+```
+
+### What it does
+
+The main loop (`scripts/backfill_bgem3_v2.py:126-156`):
+
+1. `_ensure_v2_schema(conn)` (`scripts/backfill_bgem3_v2.py:43-55`) —
+   adds the `embedding_dense_v2 BLOB` column when missing, then
+   unconditionally `CREATE INDEX IF NOT EXISTS idx_genes_dense_v2_hot ON
+   genes(gene_id) WHERE embedding_dense_v2 IS NOT NULL AND chromatin <
+   2`. The partial index covers hot-tier rows; heterochromatin
+   (chromatin=2) is reachable via `query_cold_tier()`.
+2. Pre-flight coverage report: `genes total=N v2_populated_before=K`.
+3. Selects rows where `embedding_dense_v2 IS NULL OR
+   length(embedding_dense_v2) != dim*4` — the length check guards
+   half-written rows from a crashed previous run.
+4. For each row: `BGEM3Codec(dim=dim).encode(content[:2000],
+   task="passage")` packed via `np.asarray(vec,
+   dtype="<f4").tobytes(order="C")` into a `dim*4`-byte little-endian
+   fp32 BLOB (`scripts/backfill_bgem3_v2.py:58-63, 136-145`), then
+   UPDATEd into the row.
+5. Commit + progress log every `--batch` rows. Empty content rows are
+   skipped.
+6. Post-flight: re-counts and prints `coverage=NN.NN% elapsed=S.s`
+   (`scripts/backfill_bgem3_v2.py:161-172`).
+
+### Progress signals
+
+Stdout prints (in order):
+
+- `[backfill] DB: ...`, `[backfill] dim=1024 expected_bytes_per_row=4096`
+- `[backfill] rows to process: K`
+- Every `--batch` rows: `[backfill] i/K processed=P skipped=S rate=R
+  genes/s`
+- Final: `[backfill] DONE. processed=P skipped=S
+  v2_populated_after=N coverage=NN.NN% elapsed=S.s`
+
+Sub-100% coverage on a complete run usually means empty `content`
+(skipped at line 131-133) or a dim-mismatch `ValueError` (line 139-142).
+Both print to stdout — grep the run log for `WARN:`.
+
+### Backfill verification
+
+After the script reports DONE, run the verification SQL against the
+backfilled database:
+
+```bash
+sqlite3 genomes/main/genome.db "
+  SELECT
+    (SELECT COUNT(*) FROM genes) AS total,
+    (SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL) AS v2_done,
+    1.0 * (SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL)
+        / (SELECT COUNT(*) FROM genes) AS coverage;
+"
+```
+
+Expect `coverage = 1.0` (or very close — a handful of empty-content rows
+are tolerated). If `coverage < 0.95`, the dense recall path's coverage
+gate (Stage 2 spec §4) refuses to run and `query_genes_dense_recall`
+returns `[]` with a one-time warn; lexical-only retrieval continues to
+work but `bench_needle_1000` recall numbers will not improve.
+
+### Backfill rollback
+
+The backfill is non-destructive. To revert:
+
+1. Set `[retrieval] dense_embedding_enabled = false` in `helix.toml` —
+   this skips the dense recall path; lexical-only retrieval resumes.
+2. Restart helix or POST `/admin/refresh`.
+
+The legacy `embedding_dense TEXT` (256-dim JSON) column stays intact for
+one release after Stage 2, so retrieval falls back to pre-Stage-2
+behavior. The `embedding_dense_v2 BLOB` column stays in the schema and
+is harmless when unused. To re-encode at a different Matryoshka dim
+(768/512), drop the column and re-run with `--dim` — the length-equality
+skip-clause selects all rows for re-encode automatically when the dim
+changes.
+
+### Resumption after interruption
+
+The WHERE clause `embedding_dense_v2 IS NULL OR
+length(embedding_dense_v2) != ?` is the resumption mechanism. After a
+Ctrl-C, OOM, or reboot, restart with the same arguments and it picks up
+at the first un-encoded row. The pre-flight `v2_populated_before` print
+tells you how far the previous run got; if it is unexpectedly low after
+a long run, run `PRAGMA integrity_check` before assuming the script is
+the problem.
+
+---
+
+## Runbook 2: Threshold calibration (Stage 4)
+
+`scripts/calibrate_thresholds.py` derives two artifacts from a backfilled
+genome plus a `located_n1000` bench JSON:
+
+1. The margin-over-random ANN cosine cutoff,
+   `threshold = mu + sigma_mult * sigma`, computed from N=10,000 random
+   gene-pair cosines drawn from `embedding_dense_v2`.
+2. Per-classifier `abstain_top` / `focused_top` / `tight_top` floors,
+   derived from the bench's `agent.score_top` distributions split by
+   query class (`factual`, `multi_hop`, `arithmetic`, `procedural`,
+   `default`).
+
+Both replace hand-picked constants. The output is a TOML snippet that the
+operator pastes into `helix.toml`, plus a JSON provenance report.
+
+### When to calibrate thresholds
+
+After Runbook 1 is complete (the calibration reads
+`embedding_dense_v2` BLOBs directly), AND after a fresh
+`scripts/bench_needle_1000.py --axis located` run produces a current
+`located_n1000.json`. The bench must reflect the genome you are
+calibrating; calibrating against a stale bench is the most common failure
+mode.
+
+### Threshold-calibration pre-flight
+
+1. Confirm `located_n1000.json` exists at the path you intend to pass to
+   `--bench`. The script's existence check at
+   `scripts/calibrate_thresholds.py:551-553` exits 2 if not.
+2. Spot-check that the bench has at least 30 rows per classifier class.
+   The threshold is `MIN_ROWS_PER_CLASS = 30`
+   (`scripts/calibrate_thresholds.py:57`); below this, the per-class
+   floors are flagged degenerate and copied from the `default` floors.
+   The TOML snippet emits an inline `# WARNING:` comment for any
+   degenerate class
+   (`scripts/calibrate_thresholds.py:385-389`).
+3. The genome must have at least 2 dense-encoded genes
+   (`scripts/calibrate_thresholds.py:136-140`). On a freshly-backfilled
+   18.9k-gene genome this is trivially true.
+
+### Threshold-calibration wall time
+
+Minutes for an 18.9k-gene genome. Random-pair sampling at N=10,000 is
+~50 ms; `_load_dense_vectors` is bounded by SQLite read throughput at a
+few hundred ms; per-classifier floor compute is `classify_query` once
+per bench row (~1000 × ~ms). Total runtime is dominated by imports,
+not work — the script is essentially instant.
+
+### Threshold-calibration command
+
+The CLI is the script's `_build_parser` at
+`scripts/calibrate_thresholds.py:453-494`:
+
+```bash
+python scripts/calibrate_thresholds.py
+       --genome PATH           (required)
+       --bench PATH            (required)
+       [--output-toml PATH]
+       [--output-report PATH]
+       [--sigma-mult FLOAT]
+       [--random-pairs INT]
+       [--seed INT]
+       [--abstain-pct FLOAT]
+       [--focused-pct FLOAT]
+       [--tight-pct FLOAT]
+       [--dim INT]
+       [--write-db | --no-write-db]
+       [--dry-run]
+       [-v | --verbose]
+```
+
+Flags (verified at lines 458-493):
+
+- `--genome PATH` (required) — sqlite path.
+- `--bench PATH` (required) — `located_n1000.json` (a JSON list, not
+  JSONL).
+- `--output-toml PATH` — default `None` (prints to stdout).
+- `--output-report PATH` — default `Path("calibration_report.json")`.
+- `--sigma-mult FLOAT` — default `3.0` (cosine cutoff is
+  `mu + sigma_mult * sigma`).
+- `--random-pairs INT` — default `10000`.
+- `--seed INT` — default `42` (seeds `random.Random`, not numpy).
+- `--abstain-pct FLOAT` — default `85.0` — p85 of MISS scores per class.
+- `--focused-pct FLOAT` — default `25.0` — p25 of HIT scores per class.
+- `--tight-pct FLOAT` — default `60.0` — p60 of HIT scores per class.
+- `--dim INT` — default `1024` (BGE-M3 full).
+- `--write-db / --no-write-db` (default `--write-db`) — UPSERT
+  `ann_threshold` into `genome_calibration`. The script CREATEs the
+  table if missing (`scripts/calibrate_thresholds.py:509-515`).
+- `--dry-run` — TOML + report only, no DB write.
+- `-v` / `--verbose` — DEBUG log level.
+
+Typical invocation:
+
+```bash
+python scripts/calibrate_thresholds.py \
+    --genome genomes/main/genome.db \
+    --bench results/located_n1000.json \
+    --output-toml docs/calibrations/2026-05-10.toml \
+    --output-report docs/calibrations/2026-05-10.json
+```
+
+The TOML snippet also writes to stdout when `--output-toml` is omitted —
+useful for piping or CI.
+
+### Outputs
+
+Three outputs:
+
+1. **TOML snippet** at `--output-toml` (or stdout). Layout per
+   `scripts/calibrate_thresholds.py:357-394`: a `[retrieval]` block with
+   `ann_threshold_mode = "margin_over_random"` and
+   `ann_threshold_sigma_multiplier`, an `[abstain]` block with
+   `mode = "per_classifier"`, and per-class blocks
+   `[abstain.factual]`, `[abstain.multi_hop]`, `[abstain.arithmetic]`,
+   `[abstain.procedural]`, `[abstain.default]` carrying `abstain_top`,
+   `focused_top`, `tight_top`. Degenerate classes (n_total < 30) ship
+   with default floors (2.5, 2.5, 5.0) and a `# WARNING:` comment.
+
+2. **JSON provenance report** at `--output-report` — schema URI
+   `https://helix-context.dev/schemas/calibration_report.v1.json`. Layout
+   per `scripts/calibrate_thresholds.py:397-442`: `computed_at`,
+   `genome.{path,gene_count,dim}`, `ann_threshold.{mode,value,mu,sigma,
+   sigma_mult,n_pairs,seed}`, `floors.{abstain_pct,focused_pct,tight_pct,
+   bench_path,n_bench_rows,n_skipped,per_class}`. Commit these under
+   `docs/calibrations/<date>.json` for auditability.
+
+3. **`genome_calibration` row** UPSERTed into the database (when
+   `--write-db` and not `--dry-run`,
+   `scripts/calibrate_thresholds.py:603-609`). Key `ann_threshold`,
+   `value_json` carries `{value, mu, sigma, N, dim, sigma_mult, seed}`.
+   `genome.query_genes()` reads this row when `ann_threshold_mode =
+   "margin_over_random"`.
+
+### Apply the output
+
+1. In `helix.toml`, add `ann_threshold_mode = "margin_over_random"` and
+   `ann_threshold_sigma_multiplier = 3.0` to `[retrieval]` (leave the
+   legacy `ann_similarity_threshold` in place as fallback).
+2. Set `[abstain] mode = "per_classifier"`.
+3. Append every `[abstain.<cls>]` block from the snippet. The loader
+   raises `ConfigError` at startup if a per-class block is missing for
+   any emitted class (Stage 4 spec §6).
+4. Restart helix or POST `/admin/refresh`. The genome reads
+   `ann_threshold` from `genome_calibration` on the first
+   `query_genes()` after refresh; the cache invalidates on
+   `set_replication_manager` rotation per Stage 4 spec §3.
+
+### What it computes
+
+Algorithm per Stage 4 spec §3-§5:
+
+- `_load_dense_vectors` reads every `embedding_dense_v2` BLOB whose
+  length equals `dim*4` bytes — skips legacy or partial-coverage rows
+  (`scripts/calibrate_thresholds.py:75-114`).
+- `calibrate_ann_threshold` L2-normalises defensively, draws `n_pairs`
+  unique unordered random pairs, computes pairwise cosines, returns
+  `mu + sigma_mult * sigma` with `sigma` as sample std (ddof=1)
+  (`scripts/calibrate_thresholds.py:117-189`).
+- `calibrate_floors` re-runs `classify_query` on each bench row's
+  `query`, splits into hits (`agent.gene_id_top == row.gene_id`) vs
+  misses, and computes per class: `abstain_top=p85_miss`,
+  `focused_top=p25_hit`, `tight_top=p60_hit`
+  (`scripts/calibrate_thresholds.py:244-346`).
+- Classes with `n_total < MIN_ROWS_PER_CLASS=30` flag degenerate; the
+  `default_floors` fallback at `scripts/calibrate_thresholds.py:574-577`
+  carries `abstain_top=2.5, focused_top=2.5, tight_top=5.0` —
+  preserving the pre-Stage-4 hand-picked floors for under-sampled
+  classes.
+
+### Threshold-calibration verification
+
+After applying the snippet to `helix.toml` and refreshing:
+
+```bash
+curl -s http://127.0.0.1:11437/health | jq .calibration
+```
+
+Expected fields (server.py:2752-2768):
+
+- `ann_threshold_mode`: `"margin_over_random"`
+- `abstain_mode`: `"per_classifier"`
+- `abstain_classes`: sorted list of every per-class block found in
+  `helix.toml`. Should contain the five known classes.
+- `ann_threshold`: nested dict from `Genome.get_calibration_provenance()`
+  carrying `value`, `mu`, `sigma`, `N`, `dim`, `sigma_mult`, `seed`,
+  `computed_at`. Omitted when mode is `"absolute"` or no calibration row
+  exists (server.py:2767-2768).
+
+If the `ann_threshold` sub-key is absent under `calibration`, the
+genome_calibration row was not written or could not be read. Re-run the
+calibration without `--no-write-db` and without `--dry-run`, then
+`/admin/refresh`.
+
+### Threshold-calibration rollback
+
+To revert to pre-Stage-4 behavior:
+
+1. In `helix.toml`, set `[abstain] mode = "global"` and `[retrieval]
+   ann_threshold_mode = "absolute"` — the legacy `ann_similarity_threshold`
+   value is read.
+2. Restart helix or POST `/admin/refresh`.
+
+The legacy floors `TIGHT_SCORE_FLOOR = 5.0`, `FOCUSED_SCORE_FLOOR = 2.5`,
+`FOCUSED_SCORE_FLOOR_FOR_ABSTAIN = 2.5` resume. The `genome_calibration`
+table row stays intact and unused; flipping `ann_threshold_mode` back to
+`"margin_over_random"` re-engages it without re-running calibration.
+
+### Cadence
+
+Re-run when:
+
+- Bench composition changes materially (new query classes, different
+  needle taxonomy, corpus grew/shrank > 20%).
+- Retrieval signal weights are retuned (Stage 3 RRF) — the score scale
+  shifts and floors no longer match.
+- `/health` reports `calibration_age_days > 30` (loader emits a startup
+  WARNING in this case, Stage 4 spec §9).
+
+Tag and commit `docs/calibrations/<date>.{toml,json}` per run for
+auditability.
+
+---
+
+## Runbook 3: Know-confidence calibration (Stage 6 + Stage 7)
+
+`scripts/calibrate_know_confidence.py` fits the logistic that drives
+`KnowBlock.confidence`. Stage 6 was a 4-feature logistic; Stage 7
+extended it to 5 features by adding `freshness_min` (β5). The script
+reads the same `located_n1000` ground truth as Runbook 2, but in JSONL
+form (one row per query) — not JSON like Runbook 2 wants.
+
+### When to calibrate know-confidence
+
+After Runbook 2. Optional but recommended; the default coefficients
+(`DEFAULT_BETAS = (-2.0, 2.0, 1.5, 0.7, 1.8, 1.5)` in
+`helix_context/know_calibration.py:57`) are a reasonable cold-start, and
+the absent `[know]` block falls back to defaults with a `log.warning`.
+Calibration mainly improves precision at the boundary — it shifts the
+emit_floor toward the data's actual P95 operating point and re-fits the
+β intercept against a real positive/negative class balance.
+
+If you do not have a `located_n1000.jsonl` file (Stage 1 bench output),
+skip this runbook entirely and rely on the defaults.
+
+### Know-calibration wall time
+
+Seconds, not minutes:
+
+- With `scikit-learn` installed: a single `LogisticRegression(penalty="l2",
+  C=1.0, max_iter=1000, solver="lbfgs")` fit on ~800 train rows is
+  sub-second (script branch at `scripts/calibrate_know_confidence.py:351-363`).
+- Without scikit-learn: pure-Python gradient descent at lr=0.1, 500 epochs,
+  l2=1e-4 (`scripts/calibrate_know_confidence.py:364-372`). Single-digit
+  seconds for the 4 or 5 features × ~800 rows. The pure-Python path is
+  the default fallback when `import sklearn` fails.
+
+Optional: `pip install scikit-learn` for ~1% AUC bump on small calibration
+sets and faster convergence on larger ones.
+
+### Know-calibration command
+
+The CLI is at `scripts/calibrate_know_confidence.py:251-295`:
+
+```bash
+python scripts/calibrate_know_confidence.py
+       --input PATH             (required)
+       [--out PATH]
+       [--target-precision FLOAT]
+       [--seed INT]
+       [--smoke]
+       [--n-features INT]
+```
+
+Flags (verified at lines 252-294):
+
+- `--input PATH` (required) — `located_n1000.jsonl`. JSONL (one object
+  per line), not the JSON list Runbook 2 takes. Each row needs:
+  `top_score`, `score_gap`, `lexical_dense_agree`,
+  `coordinate_confidence`, `label`, and optionally `freshness_min`
+  (5th feature). Schema at `scripts/calibrate_know_confidence.py:85-115`.
+- `--out PATH` — default `Path("helix.toml")`. The writer at
+  `scripts/calibrate_know_confidence.py:187-248` reads the existing
+  file, replaces the `[know]` section (or appends if absent). Hand-rolled
+  because `tomllib` is parse-only.
+- `--target-precision FLOAT` — default `0.95`. Operating-point precision
+  for picking `emit_floor` from the held-out test set
+  (`scripts/calibrate_know_confidence.py:268-270`).
+- `--seed INT` — default `42`. Seeds the train/test split.
+- `--smoke` — synthetic separable fixture instead of `--input`. Does NOT
+  touch `helix.toml`.
+- `--n-features INT` — default `N_FEATURES = 5` (Stage 7,
+  `helix_context/know_calibration.py:69`). Stage 6 era was 4; the
+  pure-Python fitter still works against a Stage 6 era JSONL because
+  `_row_to_features` only emits 4 features when `freshness_min` is
+  absent.
+
+Typical invocation:
+
+```bash
+python scripts/calibrate_know_confidence.py \
+    --input results/located_n1000.jsonl \
+    --out helix.toml
+```
+
+### What it fits
+
+Per Stage 6 spec §11 and Stage 7 spec §10:
+
+- Reads JSONL rows (`scripts/calibrate_know_confidence.py:68-82`); picks
+  `s_ref = median(top_score)`, `g_ref = median(score_gap)` so `tanh(...)`
+  saturates at the typical retriever scale
+  (`scripts/calibrate_know_confidence.py:332-337`).
+- Feature vector: `[tanh(top/s_ref), tanh(gap/g_ref), agree,
+  clip(coord, 0, 1)]`, plus `freshness_min` as feature 5 when present
+  (`scripts/calibrate_know_confidence.py:109-115`).
+- 80/20 train/test split with the seed
+  (`scripts/calibrate_know_confidence.py:129-150`).
+- Fits sklearn `LogisticRegression(penalty="l2", C=1.0,
+  max_iter=1000, solver="lbfgs")` if available, else
+  `fit_betas_from_features(lr=0.1, epochs=500, l2=1e-4)`.
+- Sweeps held-out test probabilities; picks the lowest threshold where
+  precision ≥ `--target-precision` as `emit_floor`. Falls back to
+  `DEFAULT_EMIT_FLOOR = 0.55` on small/imbalanced sets
+  (`scripts/calibrate_know_confidence.py:166-184`).
+
+### Output
+
+The script writes (or replaces) the `[know]` block in `helix.toml`
+(`scripts/calibrate_know_confidence.py:198-214`):
+
+```toml
+[know]
+emit_floor      = 0.55
+s_ref           = 1.0
+g_ref           = 0.5
+betas           = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]
+calibrated_at   = "2026-05-10T..."
+calibrated_on_n = 1000
+```
+
+`betas` is the intercept followed by one coefficient per feature
+(length = 1 + N_FEATURES = 6 for Stage 7). β0 is the intercept; β1-β5
+multiply the five features in order: top_score-tanh, score_gap-tanh,
+lexical_dense_agree, coordinate_confidence, freshness_min. The default
+β5 is +1.5 — Stage 7 spec §10. When the JSONL does not carry
+freshness_min, β5 falls back to its default and the loader continues to
+work (Stage 7 spec §10 falls back to `decay_score` for legacy rows
+without `last_verified_at`).
+
+### Know-calibration apply + verify
+
+`helix.toml` is hot-reloaded per `/context` call (the
+`know_calibration` loader is pure functions, no per-call I/O beyond the
+file read). No restart required. If `--out` writes somewhere your server
+does not load (`HELIX_CONFIG` override), copy the `[know]` block over
+manually and POST `/admin/refresh`.
+
+```bash
+curl -s http://127.0.0.1:11437/health | jq .calibration.know
+```
+
+Expect `calibrated_at` recent and `calibrated_on_n` matching your input
+row count. If the file write was malformed, the loader warns and falls
+back to defaults — `/health` then reports defaults rather than your fit.
+
+Sanity-check the betas by issuing `/context` against a known-hit and a
+known-miss and confirming `agent.confidence` separates them cleanly. If
+both return `~0.5`, the fit collapsed — re-check the JSONL for missing
+labels or all-zero features.
+
+### Skip rationale
+
+Without `located_n1000` ground truth (early bring-up, novel genome, no
+Stage 1 bench), the default `(-2.0, 2.0, 1.5, 0.7, 1.8, 1.5)` is a
+reasonable cold-start. The loader at
+`helix_context/know_calibration.py:160` falls back to defaults on a
+missing or malformed `[know]` table with a `log.warning`. Calibration
+mainly improves precision at the boundary.
+
+Re-run this calibration after a bench refresh, after Stage 3 RRF signal
+weights are retuned (the score scale shifts and `s_ref`/`g_ref` need
+re-fitting), or after planted-stale needles are added to the bench
+(Stage 7 §10: β5 re-fits to drive stale-needle confidence below
+`emit_floor`).
+
+### Optional: smoke test
+
+```bash
+python scripts/calibrate_know_confidence.py --smoke
+```
+
+Runs an 80-row synthetic separable fixture through the full fit. Does
+NOT touch `helix.toml`. Confirms the script wires together.
+
+---
+
+## Runbook 4: `/admin/refresh` (admin-only)
+
+The `/admin/refresh` endpoint at `helix_context/server.py:2805-2810`
+forces the genome connection to reopen its WAL snapshot. Effective on
+external writers — useful when ingest happened via a sibling replica or
+direct sqlite3 write.
+
+### When to refresh
+
+- After manual edits to `helix.toml` that need to take effect without a
+  full process restart. The `helix.toml` loader is a pure function
+  invoked per relevant code path, so most config flips already hot-reload;
+  use `/admin/refresh` for the conservative case where you want the
+  genome connection itself reset.
+- After a `genome_calibration` UPSERT from `calibrate_thresholds.py`
+  outside the server process, if you want the cached `ann_threshold` to
+  re-read on the next `query_genes()` call.
+- After a manual `sqlite3 genome.db "..."` write that the server's
+  long-lived WAL snapshot otherwise wouldn't see until commit.
+
+### Refresh command
+
+```bash
+curl -X POST http://127.0.0.1:11437/admin/refresh \
+     -H "Authorization: Bearer $HELIX_AUTH_TOKEN"
+```
+
+The endpoint handler at `helix_context/server.py:2806-2810` calls
+`helix.genome.refresh()` and then `helix.genome.stats()["total_genes"]`
+to confirm the connection is healthy. The response is
+`{"refreshed": true, "genes": <count>}`.
+
+### What it triggers
+
+`helix.genome.refresh()` (`helix_context/genome.py:4089-4112`):
+
+- Primary path: `_refresh_snapshot()` commits the read transaction so
+  the next SELECT starts a new WAL snapshot, then `SELECT 1` verifies
+  the connection is alive.
+- Fallback path: if the verify raises, closes and reopens the
+  connection with standard PRAGMAs (`journal_mode=WAL`,
+  `busy_timeout=30000`, `journal_size_limit` 64 MB).
+
+Spec divergence: Stage 2 spec §4 wording described `/admin/refresh` as
+also calling `_invalidate_dense_matrix(force=True)`. The actual handler
+does not — the in-memory dense matrix
+(`helix_context/genome.py:3062-3074`) is invalidated only by the
+upsert/delete paths. After a manual UPDATE of `embedding_dense_v2`
+outside the server, restart the helix process to force a lazy-load
+rebuild.
+
+---
+
+## Runbook 5: `/admin/vacuum` (admin-only)
+
+The `/admin/vacuum` endpoint at `helix_context/server.py:2812-2828`
+calls `Genome.vacuum()` to reclaim free pages from the SQLite genome
+file after thinning, compaction, or large-scale deletions.
+
+### When to vacuum
+
+- After large bulk ingests that thinned a lot of duplicate genes — the
+  pages stay marked free until VACUUM releases them. Common after a
+  `scripts/compact_genome_sweep.py` run, or after a `/admin/compact`
+  POST with a non-trivial demotion count.
+- When the WAL grows excessively (more than ~64 MB sustained — that's
+  the `journal_size_limit`).
+- Quarterly on a low-traffic window, even if no thinning happened —
+  SQLite page fragmentation accumulates over long-lived databases.
+- When `genome.db` size is more than 1.5x the logical content size you
+  would expect from the gene count.
+
+### Vacuum command
+
+```bash
+curl -X POST http://127.0.0.1:11437/admin/vacuum \
+     -H "Authorization: Bearer $HELIX_AUTH_TOKEN"
+```
+
+Returns `{"ok": true, "before_bytes": ..., "after_bytes": ...,
+"reclaimed_bytes": ...}` from `Genome.vacuum()` at
+`helix_context/genome.py:4182-4236`.
+
+### Vacuum wall time
+
+Depends on DB size. SQLite `VACUUM` rewrites the entire file:
+
+- Small genome (< 100 MiB): seconds.
+- Medium genome (100 MiB - 1 GiB): tens of seconds to a few minutes.
+- Large genome (> 1 GiB): minutes.
+
+Disk usage temporarily doubles during the rewrite. Run during a
+maintenance window — the operation blocks all writers for its duration.
+
+### Vacuum effect
+
+`Genome.vacuum()` (`helix_context/genome.py:4202-4232`), in order:
+
+1. `PRAGMA wal_checkpoint(TRUNCATE)` flushes the WAL into the main DB.
+2. Closes the long-lived connection (VACUUM needs exclusive access).
+3. Opens a fresh autocommit connection and runs `VACUUM`.
+4. Closes the VACUUM connection; reopens the long-lived connection with
+   standard PRAGMAs.
+
+VACUUM rewrites all indexes, so the `idx_genes_dense_v2_hot` partial
+index shrinks to match the compacted table footprint. Subsequent queries
+hit the rebuilt index with no warm-up cost.
+
+On failure the handler returns `{"ok": false, "error": "..."}` with 500
+(server.py:2823-2828); the long-lived connection is already reopened by
+the time the exception surfaces, so subsequent reads still work.
+
+---
+
+## Runbook 6: `/consolidate` (rewrite stale gene bodies)
+
+The `/consolidate` endpoint at `helix_context/server.py:2672-2690`
+distills the session buffer into consolidated knowledge genes,
+extracting only new facts, decisions, and discoveries.
+
+### When to consolidate
+
+- A gene's source file mtime moved past its `last_verified_at` (Stage 7
+  freshness check) AND the gene body is structurally outdated (the file
+  changed shape, not just a tweak).
+- After a session-mode interaction has built up `pending_replication`
+  buffer and you want to commit those distilled exchanges as long-lived
+  genes rather than letting them age out.
+- As the bulk recovery option after a partial restore from WAL — see
+  Runbook 9.
+
+Stage 7's `MissBlock(reason="stale")` carries `refresh_targets: list[str]`
+that typically point at gene source paths the agent should refetch.
+`/consolidate` is the server-side counterpart for the case where the
+refresh target IS a gene the helix process owns and can rewrite from
+its source.
+
+### Consolidate command
+
+```bash
+curl -X POST http://127.0.0.1:11437/consolidate \
+     -H "Content-Type: application/json"
+```
+
+The endpoint takes no required body fields — it operates on the active
+session buffer. The handler invokes
+`helix.consolidate_session_async()` and returns
+`{"facts_extracted": <int>, "gene_ids": [...]}`.
+
+(Note: the endpoint signature in the worktree's `server.py:2673` does
+not parse a request body; the spec phrasing
+`{"gene_id": "..."}` does not match the implementation. To consolidate a
+specific gene-by-id, use `/admin/compact` with appropriate filters or
+work directly against the genome — `/consolidate` operates on the
+session buffer aggregate, not a single gene.)
+
+### Consolidate effect
+
+- Distills the session buffer (recent in-memory exchanges) into
+  long-lived consolidated genes via the ribosome's
+  `pack`/`re_rank`/`splice` paths.
+- Updates `last_verified_at` on rewritten genes.
+- Extends the genome's coverage of the session's distilled knowledge,
+  which means the next `/context` query against a related topic gets a
+  better hit.
+
+If consolidation fails, the handler returns
+`{"error": "...", "facts_extracted": 0, "gene_ids": []}` with a 500
+status (server.py:2685-2690). The session buffer is unaffected by
+failure; retry is safe.
+
+---
+
+## Runbook 7: `/context/refresh-plan` vs `/context`
+
+`/context/refresh-plan` at `helix_context/server.py:1546-1593` is a thin
+convenience over `/context/packet`: it returns only the `refresh_targets`
+list — the set of source paths or URLs the agent should refetch — without
+the full evidence items (no `KnowBlock`, no `expressed_context`, no
+genes). Use it when the caller already has the genome content cached
+(typical for an agent that just made a `/context` call seconds ago and
+wants to know whether to re-read its sources before acting), and only
+needs the cheap reread plan. The handler short-circuits past the
+ribosome and assembly paths and runs only the refresh-target extractor —
+much cheaper than `/context` itself, no LLM calls. For everything else,
+use `/context` (the full contract) or `/context/packet` (the full
+contract plus the agent-safe verified/stale_risk/refresh_targets
+breakout). See Stage 7 spec §11 for the round-trip mapping between
+`MissBlock(reason=...).refresh_targets` and the `/context/refresh-plan`
+`RefreshTarget` payload.
+
+---
+
+## Runbook 8: Disaster recovery — corrupt `genome.db`
+
+### Symptoms
+
+- `database disk image is malformed` from sqlite3 or any helix endpoint
+  that reads the genome.
+- `/health` returns `status: "degraded"` with `genome_ready: false` and
+  the message `Genome stats failed; inspect the local knowledge store.`
+- `Genome.vacuum()` raises in pre-checkpoint or in the VACUUM connection.
+- SQLite `PRAGMA integrity_check` returns anything other than `ok`.
+
+### Recovery: backup-from-WAL → reingest-from-source-paths
+
+1. Stop helix. Side-copy `genome.db`, `genome.db-wal`, `genome.db-shm`.
+2. Try `sqlite3 genome.db ".recover" | sqlite3 recovered.db` — pulls
+   every readable page out of the corrupt DB into a fresh file. If it
+   succeeds, swap `recovered.db` in for `genome.db` and skip to step 5.
+3. If `.recover` fails, drop back to the most recent WAL-checkpointed
+   replica snapshot under `[genome] replicas`.
+4. Re-ingest from source paths: each gene carries a `source_id`
+   pointing back at the file or URL it was extracted from. Bulk path:
+   `python scripts/ingest_all.py <source_root>` against the recovered
+   genome. Single-source: POST `/consolidate` (Runbook 6), which uses
+   each gene's `source_id` fingerprint to rewrite the body.
+5. Re-run all three calibration runbooks — the `genome_calibration`
+   table is gone if you started from a fresh DB.
+6. Bring helix up. Verify `/health` reports `status: "ok"` and the gene
+   count matches the pre-corruption snapshot.
+
+`/consolidate` is also the bulk-recovery option for per-gene corruption
+(rather than file-level): for any gene returning malformed content,
+POST `/consolidate` to have the ribosome rewrite the body from source.
+
+---
+
+## Runbook 9: Quarterly hygiene checklist
+
+Run this checklist on a low-traffic window every quarter, or after
+significant changes to the genome corpus.
+
+1. **Re-run the bench** to detect retrieval drift:
+
+   ```bash
+   python scripts/bench_needle_1000.py --axis located \
+       --output results/located_n1000.json
+   ```
+
+   Compare retrieval@1 against the baseline you committed in
+   `docs/calibrations/<previous>.json`.
+
+2. **Re-run the three calibration scripts** if bench retrieval rate
+   dropped more than 5 percentage points from the baseline:
+
+   ```bash
+   python scripts/backfill_bgem3_v2.py genomes/main/genome.db
+   python scripts/calibrate_thresholds.py \
+       --genome genomes/main/genome.db \
+       --bench results/located_n1000.json \
+       --output-toml docs/calibrations/$(date +%Y-%m-%d).toml \
+       --output-report docs/calibrations/$(date +%Y-%m-%d).json
+   python scripts/calibrate_know_confidence.py \
+       --input results/located_n1000.jsonl \
+       --out helix.toml
+   ```
+
+   Apply the new TOML snippet to `helix.toml`; POST `/admin/refresh`.
+
+3. **Run `/admin/vacuum`** if `genome.db` size is more than 1.5x the
+   logical content size (gene count × average content length × ~2 for
+   indexes and metadata):
+
+   ```bash
+   curl -X POST http://127.0.0.1:11437/admin/vacuum \
+        -H "Authorization: Bearer $HELIX_AUTH_TOKEN"
+   ```
+
+4. **Verify calibration freshness** in `/context` responses:
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:11437/context \
+        -H "Content-Type: application/json" \
+        -d '{"query": "calibration health probe"}' \
+        | jq '.agent.calibration_age_days'
+   ```
+
+   Expect `calibration_age_days < 30`. If above, run Runbook 2 + Runbook
+   3. The loader emits a startup WARNING when this exceeds 30 days
+   (Stage 4 spec §9).
+
+5. **Re-snapshot the genome** to a versioned backup directory before the
+   next quarter's work begins.
+
+6. **Audit `docs/calibrations/`**: confirm every `.toml` has a
+   side-by-side `.json` provenance report, and that the `computed_at`
+   timestamps match the calibration run logs.
+
+7. **Spot-check `/health`** — confirm `calibration.ann_threshold` is
+   present and `calibration.abstain_classes` has all five known
+   classifier classes:
+
+   ```bash
+   curl -s http://127.0.0.1:11437/health | jq '.calibration.abstain_classes'
+   ```
+
+   Expected: `["arithmetic", "default", "factual", "multi_hop",
+   "procedural"]`.


### PR DESCRIPTION
Closes #8 (filed 2026-04-19) and #59 (filed 2026-05-10 superseding #8). Lands the docs initiative for both the original gap inventory and the post-7-stage-merge surface area.

## Files

| File | Lines | Status |
|---|---|---|
| `docs/SETUP.md` | 704 | new — install paths, extras matrix, implicit reqs |
| `docs/TROUBLESHOOTING.md` | 834 | new — 12 failure modes |
| `.env.example` | 308 | new — 43 `HELIX_*` env vars verified by grep |
| `docs/api/context-endpoint.md` | 817 | new — `/context` API incl. `caller_model_class`, know/miss, refresh |
| `docs/operator-runbooks.md` | 899 | new — backfill + 2 calibration scripts + admin endpoints |
| `docs/config-reference.md` | 1559 | new — every `helix.toml` section |
| `README.md` | 298 → 272 | rewrite — clean restructure + agent-integration + cross-links |

Total: ~5400 new doc lines, all spec→write through 7 parallel agents working in a shared worktree.

## Spec-vs-code discrepancies surfaced (worth follow-up issues)

These were discovered during the agents' verification pass against `helix_context/` source. None block this PR — the docs reflect actual shipped behavior, not spec text. Listed for triage:

1. **`[know] betas` is 5 entries in `helix.toml` but `DEFAULT_BETAS` in code is 6** after Stage 7 added β5 (`freshness_min` coefficient = +1.5). Loader warns and falls back. **Stage 7's freshness_min coefficient is effectively dormant in shipped config — needs hotfix.**
2. Stage 4 spec §9 fields `agent.calibration_age_days`, `calibration_stale`, `warnings: [\"calibration_stale\"]` are spec'd but absent in `server.py:1346-1350` (only `ann_threshold_mode` + `abstain_mode` emitted).
3. `helix_context._asgi:app` vs `helix_context.server:app` entrypoint drift — `backend-with-otel.bat:10` uses `server:app`. Pick a canonical entrypoint.
4. `HELIX_DEVICE` is overloaded as both federation attribution (`start-helix-mcpo.bat:35`) and hardware picker (`helix.toml:47`). Worth disambiguation.
5. `HELIX_AUTH_TOKEN` referenced in older docs but does not exist in code. Admin endpoints are auth-free (local-only deployment model).
6. `/admin/refresh` per Stage 2 spec §4 should call `_invalidate_dense_matrix(force=True)`, but actual handler at `server.py:2806-2810` only calls `genome.refresh()`.
7. `/consolidate` does not parse a request body — operates on active session buffer aggregate, not a `{\"gene_id\": ...}` payload (despite spec text).
8. Stage 7 reasons (`stale | cold | superseded`) only surface via structured `miss.reason`, never inside `<helix:no_match/>` token. May be intentional.
9. `<helix:answer_slate>` tag does not exist in code — only `<helix:slate>` is used; decoder templates substitute into `{answer_slate}` placeholders.
10. `backfill_bgem3_v2.py` default `--batch=64`; Stage 2 spec §3 said 100. Default works; spec text is wrong.

## New failure modes discovered (beyond #59's original 10)

The TROUBLESHOOTING agent found these by reading `helix_context/launcher/`, `server.py`, and `genome.py`. Worth a follow-up scoped issue if any operator hits them:

11. **Headroom upstream auto-routing silently rewrites `HELIX_SERVER_UPSTREAM`** at `helix_context/launcher/app.py:287-338`.
12. **Hardware fallback balloon** at `tray.py:107-120` fires once on probe-fail (cuda/rocm/mps → CPU); headless deployments miss it. The `/health \"low_vram\"` hint is the only audit trail.
13. **Ribosome `cost_class=\"api+paid\"` activation** only emits a startup WARN at `server.py:618-643` — easy to miss in supervised deployments.
14. **WAL bloat from non-canonical readers** that don't use `isolation_level=None` (helix's own dedicated reader does).

## Cross-doc linkage verified

- `docs/SETUP.md` → SETUP / TROUBLESHOOTING / context-endpoint / runbooks / config-reference / .env.example / agent-sdk-fragment ✓
- `README.md` → all of the above + existing `docs/architecture/*` ✓
- All cross-links resolve in this branch ✓

## How this was built

Mirrors the 7-stage retrieval-fix pattern: 7 parallel agents (spec → write), each writing one non-overlapping file in a shared worktree at `f:/Projects/_worktrees/helix-docs`. Orchestrator (this PR) consolidates into a single commit. Each agent reported file:line citations, structural completeness, and any source-text discrepancies — full reports preserved in the parent conversation transcript.

Closes #8.
Closes #59.