### PR TITLE
cleanup: post-Stage-7 discrepancies (betas + OTel entrypoint + admin auth docs)

### DIFF
--- a/backend-with-otel.bat
+++ b/backend-with-otel.bat
@@ -7,4 +7,4 @@ set "HELIX_OTEL_INSECURE=1"
 set "HELIX_OTEL_SAMPLER_RATIO=1.0"
 set "HELIX_USER=max"
 set "HELIX_AGENT=raude"
-python -m uvicorn helix_context.server:app --host 127.0.0.1 --port 11437
+python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11437

--- a/docs/architecture/OBSERVABILITY.md
+++ b/docs/architecture/OBSERVABILITY.md
@@ -32,7 +32,7 @@ pip install "helix-context[otel]"
 ```bash
 export HELIX_OTEL_ENABLED=1
 export HELIX_OTEL_ENDPOINT=localhost:4317   # default
-python -m uvicorn helix_context.server:app --port 11437
+python -m uvicorn helix_context._asgi:app --port 11437
 ```
 
 Open <http://localhost:3000/d/helix-overview>. Retrieval latency, tier contributions, CWoLa f_gap, chromatin distribution, harmonic-edges-by-source — all live.
@@ -92,7 +92,7 @@ cd deploy/otel && docker compose up -d
 
 # In another shell, start helix with OTel on
 export HELIX_OTEL_ENABLED=1
-python -m uvicorn helix_context.server:app --port 11437
+python -m uvicorn helix_context._asgi:app --port 11437
 
 # Hit /context to emit spans + tier metrics
 curl -s -X POST http://localhost:11437/context \

--- a/docs/operator-runbooks.md
+++ b/docs/operator-runbooks.md
@@ -8,8 +8,9 @@ code paths take effect on a production genome only after these scripts
 run against it.
 
 Assumptions: `helix.toml` at repo root (or `HELIX_CONFIG`); active genome
-at `genomes/main/genome.db`; server at `127.0.0.1:11437`;
-`HELIX_AUTH_TOKEN` set for admin endpoints.
+at `genomes/main/genome.db`; server bound to loopback at `127.0.0.1:11437`.
+Admin endpoints are auth-free by design — bind to loopback or a reverse
+proxy that enforces auth in front; do not expose to a public interface.
 
 ## Overview
 
@@ -621,8 +622,7 @@ direct sqlite3 write.
 ### Refresh command
 
 ```bash
-curl -X POST http://127.0.0.1:11437/admin/refresh \
-     -H "Authorization: Bearer $HELIX_AUTH_TOKEN"
+curl -X POST http://127.0.0.1:11437/admin/refresh
 ```
 
 The endpoint handler at `helix_context/server.py:2806-2810` calls
@@ -673,8 +673,7 @@ file after thinning, compaction, or large-scale deletions.
 ### Vacuum command
 
 ```bash
-curl -X POST http://127.0.0.1:11437/admin/vacuum \
-     -H "Authorization: Bearer $HELIX_AUTH_TOKEN"
+curl -X POST http://127.0.0.1:11437/admin/vacuum
 ```
 
 Returns `{"ok": true, "before_bytes": ..., "after_bytes": ...,
@@ -863,8 +862,7 @@ significant changes to the genome corpus.
    indexes and metadata):
 
    ```bash
-   curl -X POST http://127.0.0.1:11437/admin/vacuum \
-        -H "Authorization: Bearer $HELIX_AUTH_TOKEN"
+   curl -X POST http://127.0.0.1:11437/admin/vacuum
    ```
 
 4. **Verify calibration freshness** in `/context` responses:

--- a/helix.toml
+++ b/helix.toml
@@ -334,13 +334,13 @@ high_risk_threshold = 0.5               # `prob_B > this` surfaces a coarse "lik
 # Calibration requires Stage 1 to land first (it produces the bench
 # JSONL).
 #
-# # STAGE-7-EXT: Stage 7 will append b5 (default +1.5) for
-# # freshness_min as the fifth feature; the betas list grows to 6
-# # entries. The calibration script auto-detects the feature count.
+# Stage 7 added b5 (default +1.5) for freshness_min as the fifth
+# feature, so the betas list is now 6 entries. The calibration script
+# auto-detects the feature count.
 emit_floor      = 0.55
 s_ref           = 1.0
 g_ref           = 0.5
-betas           = [-2.0, 2.0, 1.5, 0.7, 1.8]
+betas           = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]
 
 [mem_sync]
 # Auto-memory → helix sync. Every .md file in a watched dir becomes a

--- a/helix_context/know_calibration.py
+++ b/helix_context/know_calibration.py
@@ -196,7 +196,7 @@ def load_calibration_from_toml(
         emit_floor      = 0.55
         s_ref           = 1.0
         g_ref           = 0.5
-        betas           = [-2.0, 2.0, 1.5, 0.7, 1.8]
+        betas           = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]
         calibrated_at   = "2026-05-08T..."
         calibrated_on_n = 800
 


### PR DESCRIPTION
Closes 4 of the 14 spec-vs-code discrepancies captured in PR #60's body (the four that are concrete bugs, not design questions). The other 10 are bucketed into separate tracking issues — see "Remaining discrepancies" below.

## Changes

### `helix.toml` betas (disc-1)

- **Before:** `betas = [-2.0, 2.0, 1.5, 0.7, 1.8]` (5 entries) with comment saying Stage 7 "will append b5".
- **After:** `betas = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]` (6 entries) matching code `DEFAULT_BETAS`. Past-tense comment.
- **Behavior at startup:** `load_calibration_from_toml` no longer emits `"betas length 5 != expected 6"` WARN + fallback. The freshness coefficient β5 was already active via the fallback path; this just lets operators tune all six coefficients through `helix.toml` without breaking the loader.
- `know_calibration.py` docstring example also updated to 6 entries.

### OTel entrypoint (disc-3, partial)

- **`backend-with-otel.bat:10`**: `server:app` → `_asgi:app`. The file is named "with-otel" but `server:app` bypasses the OTel ASGI wrapper, so OTel was silently not instrumented when the .bat was used.
- **`docs/architecture/OBSERVABILITY.md:35, 95`**: two `server:app` → `_asgi:app` fixes. Same root cause — the OTel docs were demoing the entrypoint that bypasses the wrapper.
- `_asgi.py` docstring is the authoritative source: *"Use this module as the uvicorn target — NOT helix_context.server"*.
- Other docs (LAUNCHER.md, TROUBLESHOOTING.md, SETUP.md, claude-code.md) intentionally show both entrypoints with context for development workflows; not touched.

### `HELIX_AUTH_TOKEN` docs (disc-5)

- The env var was referenced in 4 places in `operator-runbooks.md` but doesn't exist in code. Admin endpoints (`/admin/refresh`, `/admin/vacuum`) are auth-free by design (bind to loopback).
- Removed the Bearer header from the curl examples and replaced the preamble assumption with explicit guidance:
  > "Admin endpoints are auth-free by design — bind to loopback or a reverse proxy that enforces auth in front."

## Discrepancies re-examined and re-classified as false positives

- **disc-9 (`<helix:answer_slate>`):** the doc at `context-endpoint.md:428` already says *"there is no distinct `<helix:answer_slate>` tag"* — it's correctly clarifying the absence. PR #60 misread.
- **disc-10 (backfill `--batch 100` vs spec):** Stage 2 spec §3 line 51 says *"Batched commit every 100 rows"* — that's the SQLite commit batch, not the BGE-M3 inference batch (default 64 in the script's argparse). Two different things; PR #60 conflated them.

## Test impact

- `tests/test_know_miss_block.py`: 21/21 pass
- Config parses cleanly: `betas: [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5] len: 6`, loader emits no WARN.

## Remaining discrepancies (filed as separate tracking issues)

- **#62** — disc-6: `/admin/refresh` doesn't call `_invalidate_dense_matrix(force=True)` (Stage 2 §4 drift)
- **#63** — disc-2: Stage 4 §9 calibration staleness warnings not implemented
- **#64** — disc-4, disc-7, disc-8: three design questions (`HELIX_DEVICE` overloaded, `/consolidate` body parsing, freshness reasons in `<helix:no_match/>`)
- **#65** — disc-11–14: four operational silent-failure modes (Headroom upstream rewrite, hardware fallback balloon, ribosome paid WARN, WAL bloat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)