### PR TITLE
fix: score-aware budget-trim drops lowest-scored gene first (#58)

### DIFF
--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -2625,29 +2625,41 @@ class HelixContextManager:
         budget = self.config.budget.ribosome_tokens + self.config.budget.expression_tokens
 
         if est_tokens > budget and len(parts) > 1:
-            # Default path: parts[-1] is the LOWEST-rank gene (sorted_genes was
-            # ordered score-DESC or by sequence_index), so popping from the
-            # back drops the least-important entry first.
+            # Default path: drop the lowest-SCORED gene regardless of its
+            # position in the assembled prompt. Position-based pop() drops
+            # parts[-1], which is the lowest-rank gene only when sorted_genes
+            # is in score-DESC order. Under sequence_index ordering (the
+            # default for narrative coherence on factual/multi_hop queries),
+            # parts[-1] is whichever gene came last by source coordinate —
+            # often the highest-scored gene if it sits near the end of a
+            # file. Score-aware lookup via genome.last_query_scores ensures
+            # the actual lowest-ranked candidate is dropped first.
             #
             # Foveated reverse-rank path (respect_caller_order=True, spec §5):
             # the caller emits BROAD candidates in REVERSE-rank order so the
             # top-rank gene lands LAST in the prompt (closest to user query
-            # under decoder-only attention). Under that ordering parts[-1] is
-            # the TOP-rank gene — popping from the back here would silently
-            # drop the most important gene first, the exact opposite of what
-            # the spec wants. Pop from the FRONT instead to drop the
-            # bottom-rank gene and preserve the placement invariant.
+            # under decoder-only attention). Position-0 IS the lowest-rank
+            # gene by construction of that ordering, so positional pop(0)
+            # is correct here and preserves the placement invariant. A
+            # score-aware variant would be a strict improvement under
+            # invariant violations, but is out of scope for this PR (see
+            # the Stage 5 manager's note in the original #58 thread).
             #
             # sorted_genes is kept aligned with parts so the post-trim
             # delivered_ids / expressed_gene_ids slices stay correct under
             # both directions.
+            trim_scores = self.genome.last_query_scores or {}
             while est_tokens > budget and len(parts) > 1:
                 if respect_caller_order:
                     parts.pop(0)
                     sorted_genes.pop(0)
                 else:
-                    parts.pop()
-                    sorted_genes.pop()
+                    worst_idx = min(
+                        range(len(sorted_genes)),
+                        key=lambda i: trim_scores.get(sorted_genes[i].gene_id, 0.0),
+                    )
+                    parts.pop(worst_idx)
+                    sorted_genes.pop(worst_idx)
                 expressed = "\n---\n".join(parts)
                 expressed_wrapped = f"<expressed_context>\n{expressed}\n</expressed_context>"
                 est_tokens = estimate_tokens(decoder_prompt) + estimate_tokens(expressed_wrapped)

--- a/tests/test_score_aware_budget_trim.py
+++ b/tests/test_score_aware_budget_trim.py
@@ -1,0 +1,227 @@
+"""Tests for the score-aware budget-trimmer (#58).
+
+Under sequence_index ordering (the default for narrative coherence on
+factual/multi_hop queries without an answer_slate), the budget-overflow
+trim used to drop ``parts[-1]`` — whichever gene happened to land last
+in the assembled prompt. If the highest-scored gene was near the end
+of the file, that's exactly the gene that got dropped.
+
+This module pins the score-aware behavior with monotonicity assertions
+that don't depend on exact token-count tuning: regardless of how many
+genes the trim ends up dropping, the dropped set must be a prefix of
+the score-ascending order. A higher-scored gene can never be dropped
+while a lower-scored gene is still in the assembled context.
+
+Gemini 3.1 Pro flagged this during the 2026-05-08 council session;
+patch deferred to a follow-up because it conceptually sits outside
+the Stage 5 caller_model_class branch routing. Spec lives in the
+body of issue #58.
+"""
+from __future__ import annotations
+
+import pytest
+
+from helix_context.config import (
+    BudgetConfig,
+    ClassifierConfig,
+    GenomeConfig,
+    HelixConfig,
+    RibosomeConfig,
+)
+from helix_context.context_manager import HelixContextManager
+from helix_context.schemas import Gene, PromoterTags
+
+
+@pytest.fixture
+def manager_five_genes():
+    """Five genes ordered 0..4 by sequence_index with scores [10, 1, 8, 2, 9].
+
+    The score distribution is deliberately non-monotonic in
+    sequence_index so a position-based ``parts.pop()`` trim drops the
+    score=9 gene (highest score, last by sequence_index) while a
+    score-aware trim drops the score=1 gene (lowest score, second by
+    sequence_index).
+    """
+    cfg = HelixConfig(
+        ribosome=RibosomeConfig(model="mock", timeout=5),
+        budget=BudgetConfig(max_genes_per_turn=12),
+        genome=GenomeConfig(path=":memory:", cold_start_threshold=5),
+        classifier=ClassifierConfig(enabled=False),
+    )
+    mgr = HelixContextManager(cfg)
+
+    scores = [10.0, 1.0, 8.0, 2.0, 9.0]
+    gene_ids = [f"gene_{i:02d}" for i in range(5)]
+    genes = [
+        Gene(
+            gene_id=gid,
+            content=f"{gid} content payload " * 20,
+            complement=f"complement-{gid}",
+            codons=["c"],
+            promoter=PromoterTags(sequence_index=i),
+        )
+        for i, gid in enumerate(gene_ids)
+    ]
+
+    mgr.genome.last_query_scores = {gid: scores[i] for i, gid in enumerate(gene_ids)}
+
+    yield mgr, genes, gene_ids, scores
+    mgr.close()
+
+
+def _spliced_map(gene_ids):
+    """Each gene's spliced text is large enough that dropping one
+    materially reduces the assembled-prompt token count."""
+    return {
+        gid: f"content for {gid}: " + ("payload " * 60)
+        for gid in gene_ids
+    }
+
+
+def _survivors_by_score(window, gene_ids, scores):
+    """Return ``(survivors, dropped)`` partitions sorted by score-DESC.
+
+    Reads window.expressed_context (the actual emitted prompt) rather
+    than window.expressed_gene_ids so we're testing the user-visible
+    surface, not an internal bookkeeping field.
+    """
+    surviving = [
+        (gid, scores[i])
+        for i, gid in enumerate(gene_ids)
+        if gid in window.expressed_context
+    ]
+    dropped = [
+        (gid, scores[i])
+        for i, gid in enumerate(gene_ids)
+        if gid not in window.expressed_context
+    ]
+    return (
+        sorted(surviving, key=lambda x: x[1], reverse=True),
+        sorted(dropped, key=lambda x: x[1], reverse=True),
+    )
+
+
+class TestScoreAwareBudgetTrim:
+    """Default branch (no respect_caller_order, no caller_model_class)
+    sorts by sequence_index. Position-based trim would drop the wrong
+    gene; score-aware trim must drop the lowest-scored regardless of
+    its position."""
+
+    @pytest.mark.parametrize("budget_expression,budget_ribosome", [
+        (700, 100),    # very tight — most drops
+        (800, 100),    # tight — many drops
+        (900, 100),    # mid — a few drops
+        (1200, 100),   # looser — few drops
+        (1500, 100),   # comfortably above 5-gene baseline — possibly no drops
+    ])
+    def test_drops_monotone_in_score(
+        self, manager_five_genes, budget_expression, budget_ribosome,
+    ):
+        """For ANY trim count k, the surviving set is the top-(N-k) by score.
+
+        This is the load-bearing invariant of score-aware trimming. It
+        doesn't depend on exact token tuning — at every budget level
+        the property must hold.
+        """
+        mgr, genes, gene_ids, scores = manager_five_genes
+
+        mgr.config.budget.expression_tokens = budget_expression
+        mgr.config.budget.ribosome_tokens = budget_ribosome
+
+        window = mgr._assemble(
+            query="q",
+            candidates=genes,
+            spliced_map=_spliced_map(gene_ids),
+            relation_graph={},
+            answer_slate=None,
+        )
+
+        survivors, dropped = _survivors_by_score(window, gene_ids, scores)
+
+        if dropped and survivors:
+            lowest_survivor_score = survivors[-1][1]
+            highest_dropped_score = dropped[0][1]
+            assert lowest_survivor_score >= highest_dropped_score, (
+                f"Score-aware trim violated: a higher-score gene was "
+                f"dropped while a lower-score gene survives. "
+                f"Survivors (high→low): {survivors!r}. "
+                f"Dropped (high→low): {dropped!r}. "
+                f"Lowest survivor score ({lowest_survivor_score}) must "
+                f"be >= highest dropped score ({highest_dropped_score})."
+            )
+
+    def test_lowest_score_dropped_first_under_overflow(
+        self, manager_five_genes,
+    ):
+        """Spot check: at a budget tight enough to fire at least one
+        drop, gene_01 (score=1, the global minimum) must be among the
+        dropped, and gene_00 (score=10, the global maximum) must
+        survive. Position-based pop() would drop gene_04 (last by
+        sequence_index, score=9) — exactly backwards."""
+        mgr, genes, gene_ids, scores = manager_five_genes
+
+        mgr.config.budget.expression_tokens = 500
+        mgr.config.budget.ribosome_tokens = 100
+
+        window = mgr._assemble(
+            query="q",
+            candidates=genes,
+            spliced_map=_spliced_map(gene_ids),
+            relation_graph={},
+            answer_slate=None,
+        )
+
+        survivors, dropped = _survivors_by_score(window, gene_ids, scores)
+
+        if not dropped:
+            pytest.skip(
+                "Budget did not fire a drop — token estimator changed "
+                "or content shrunk. Lower budget_expression to force a "
+                "drop."
+            )
+
+        assert ("gene_01", 1.0) in dropped, (
+            f"gene_01 (score=1) must be the first dropped under "
+            f"score-aware trim. Got dropped={dropped!r}."
+        )
+        assert ("gene_00", 10.0) in survivors, (
+            f"gene_00 (score=10) must survive while any other gene is "
+            f"still in context. Got survivors={survivors!r}, "
+            f"dropped={dropped!r}."
+        )
+
+    def test_foveated_branch_unchanged_under_respect_caller_order(
+        self, manager_five_genes,
+    ):
+        """Foveated path uses position-based pop(0) by construction.
+
+        Under respect_caller_order=True the caller has arranged the
+        candidates in REVERSE-rank order so the top-rank gene lands
+        LAST in the prompt. Position-0 == lowest-rank by that
+        invariant, so positional pop(0) is correct and is the
+        invariant this PR preserves.
+        """
+        mgr, genes, gene_ids, scores = manager_five_genes
+
+        reverse_ranked = sorted(
+            genes,
+            key=lambda g: scores[gene_ids.index(g.gene_id)],
+        )
+
+        mgr.config.budget.expression_tokens = 800
+        mgr.config.budget.ribosome_tokens = 100
+
+        window = mgr._assemble(
+            query="q",
+            candidates=reverse_ranked,
+            spliced_map=_spliced_map(gene_ids),
+            relation_graph={},
+            answer_slate=None,
+            respect_caller_order=True,
+        )
+
+        assert "gene_00" in window.expressed_context, (
+            "Foveated trim dropped the top-rank gene. Position-0 under "
+            "reverse-rank IS the lowest-score gene by construction; "
+            "pop(0) should preserve gene_00 (top score)."
+        )


### PR DESCRIPTION
Closes #58. Gemini 3.1 Pro flagged this during the 2026-05-08 council session; the Stage 5 manager preserved a related slate-sort fix but flagged the budget-trimmer as conceptually separate and not carried into PR #47. After all 7 stages merged, the position-based trim was still live behavior at `helix_context/context_manager.py:2644-2653`. This PR finally lands the fix.

## The bug

Under the default (non-foveated) branch, [`_assemble()`](https://github.com/mbachaud/helix-context/blob/master/helix_context/context_manager.py#L2627-L2650) trimmed budget overflow with `parts.pop()` — dropping whichever gene came last in the assembled prompt. That's the lowest-rank gene **only** when `sorted_genes` is in score-DESC order.

For factual/multi_hop queries without an answer_slate, the default ordering is `sequence_index` (narrative coherence over file coordinates, set at [`context_manager.py:2462`](https://github.com/mbachaud/helix-context/blob/master/helix_context/context_manager.py#L2462)). Under `sequence_index` ordering, `parts[-1]` is whichever gene came last in the file — often the highest-scored gene if the relevant section lives near the end. Result: a quiet bug where top-ranked candidates got dropped first under budget pressure.

## The fix

Use `self.genome.last_query_scores` (already populated by the expression stage; used elsewhere in [`context_manager.py:1102`](https://github.com/mbachaud/helix-context/blob/master/helix_context/context_manager.py#L1102), [`:1192`](https://github.com/mbachaud/helix-context/blob/master/helix_context/context_manager.py#L1192), [`:1472`](https://github.com/mbachaud/helix-context/blob/master/helix_context/context_manager.py#L1472) for post-RRF score lookup) to find the lowest-scored gene by ID and pop it from both `parts` and `sorted_genes` in lockstep.

Genes not in `last_query_scores` get score `0.0`, which lands them at the front of the trim queue (matches existing semantics for un-scored candidates from cold-start / pending-replication paths).

## Foveated branch untouched

`respect_caller_order=True` keeps positional `pop(0)`. Under that flag the caller has arranged candidates in REVERSE-rank order so the top-rank gene lands LAST in the prompt; position 0 IS the lowest-rank gene by construction. A score-aware variant would be a strict improvement under invariant violations, but is out of scope here. A new test pins this invariant so a future refactor doesn't silently regress it.

## Tests

### New file: `tests/test_score_aware_budget_trim.py` (7 tests, all pass)

- **5 parameterized monotonicity tests** at budgets `[700, 800, 900, 1200, 1500]`: at every budget level, the surviving set must be the top-(N-k) by score. This is robust to token-estimator drift — no exact budget tuning required.
- **1 spot check**: budget tight enough to fire ≥1 drop, asserts `gene_01` (score=1, the global minimum) is among the dropped and `gene_00` (score=10, the global maximum) survives.
- **1 foveated regression check**: under `respect_caller_order=True` with REVERSE-rank input, the top-score gene (now at position -1) survives the trim.

Test fixture matches #58's recommended pattern: 5 candidates with scores `[10, 1, 8, 2, 9]` ordered by sequence_index so position-based `pop()` would drop the score=9 gene while score-aware drops score=1.

### Stage 5 generic golden — `PASS`

`tests/test_caller_model_class.py::test_generic_branch_byte_identical_to_pre_stage5_output` passes with `PYTHONHASHSEED=0`. The score-aware change does not perturb the 100-query Stage 5 baseline because none of those queries hit a budget overflow.

### Wider regression sweep

Full mock suite ran 1733 passed, 47 skipped, 1 failed. The single failure (`test_observability_docs.py::test_root_readme_preserves_canonical_launch_section`) is pre-existing on master — README rewrite in PR #60 dropped the asserted string. Plus a second pre-existing failure (`test_abstain_tier.py::test_focused_score_floor_constants_in_sync`) that fails on master because Stage 4 moved the `FOCUSED_SCORE_FLOOR` constants out of `build_context()`. Both surfaced by this run; will be filed as a separate small cleanup.

## Why not bundled into Stage 5

Stage 5 was scoped to render-branch routing (`caller_model_class`). The trim bug fires identically regardless of caller_model_class, so it sits outside that surface. Stage 5's spec also pinned a byte-identical golden against pre-Stage-5 output, which would have been the first regression signal had the trim changed behavior — and as it turns out, none of the golden's queries hit a budget overflow, so the golden still passes byte-for-byte. The trim bug only fires under tight `expression_tokens` budgets, which the golden doesn't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)