### PR TITLE
feat(observability): per-agent /context telemetry labels + helix-agent-usage dashboard

### DIFF
--- a/deploy/otel/grafana/dashboards/helix-agent-usage.json
+++ b/deploy/otel/grafana/dashboards/helix-agent-usage.json
@@ -1,0 +1,172 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Per-agent /context traffic — request rate, latency, and caller_model_class mix labelled by `agent`. Sourced from the `agent` label on helix_context_latency_seconds and helix_context_calls_by_class_total (default `unknown`; `other` for handles outside the allowlist). MCP shims forward HELIX_AGENT automatically; direct callers can set the `agent` body field or X-Helix-Agent header.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {"title": "Helix — Operations Overview", "type": "dashboards", "tags": ["helix", "operations"], "asDropdown": false, "icon": "external link"},
+    {"title": "Helix — Retrieval Quality + HITL", "type": "dashboards", "tags": ["helix", "retrieval"], "asDropdown": false, "icon": "external link"}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "panels": [],
+      "title": "Per-agent traffic",
+      "type": "row"
+    },
+    {
+      "type": "timeseries",
+      "title": "/context request rate by agent (req/s)",
+      "description": "Stacked rate of /context calls grouped by caller-supplied `agent` label. Direct API callers without an agent label fold into `unknown`; any handle outside the allowlist collapses to `other`.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum by (agent) (rate(helix_context_latency_seconds_count[$__rate_interval]))",
+          "legendFormat": "{{agent}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "stacking": {"mode": "normal", "group": "A"},
+            "fillOpacity": 30,
+            "lineWidth": 1
+          }
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "/context p95 latency by agent (seconds)",
+      "description": "p95 of helix_context_latency_seconds per agent. Spikes localized to a single agent typically mean a specific MCP host is sending pathological queries; spikes across all agents point at helix-side regressions.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 3,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, agent) (rate(helix_context_latency_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "{{agent}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {"drawStyle": "line", "fillOpacity": 0, "lineWidth": 2}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 4,
+      "panels": [],
+      "title": "Caller mix",
+      "type": "row"
+    },
+    {
+      "type": "timeseries",
+      "title": "caller_model_class breakdown by agent",
+      "description": "Stacked rate of helix_context_calls_by_class_total grouped by (agent, class). Lets you see which agents are sending `frontier` vs `small_moe` vs `generic` requests over time — useful when calibrating decoder-mode tradeoffs per caller.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 9, "w": 16, "x": 0, "y": 10},
+      "id": 5,
+      "targets": [
+        {
+          "expr": "sum by (agent, class) (rate(helix_context_calls_by_class_total[$__rate_interval]))",
+          "legendFormat": "{{agent}} / {{class}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "stacking": {"mode": "normal", "group": "A"},
+            "fillOpacity": 30,
+            "lineWidth": 1
+          }
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "lastNotNull"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Active agents (last hour)",
+      "description": "Distinct `agent` label values that produced at least one /context call in the last hour. Sanity check for the cardinality cap (allowlist + 'other' + 'unknown' is the bound).",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 9, "w": 8, "x": 16, "y": 10},
+      "id": 6,
+      "targets": [
+        {
+          "expr": "count(count by (agent) (increase(helix_context_latency_seconds_count[1h])))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 8},
+              {"color": "red", "value": 20}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["helix", "agents", "operations"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Helix — Agent Usage",
+  "uid": "helix-agent-usage",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helix_context/mcp_server.py
+++ b/helix_context/mcp_server.py
@@ -118,6 +118,14 @@ TIMEOUT_S = float(os.environ.get("HELIX_MCP_TIMEOUT", "30"))
 # scheme, so the session_id here aligns with the registry participant.
 MCP_SESSION_ID = os.environ.get("HELIX_MCP_HANDLE", f"mcp-{os.getpid()}")
 
+# Agent label passed to helix's per-agent telemetry path. Same handle the
+# session registry uses, so dashboards align with attribution. HELIX_AGENT
+# is the canonical env var; HELIX_MCP_HANDLE is the older host-set
+# fallback (Claude Code, OpenWebUI, etc. commonly set this).
+MCP_AGENT_HANDLE: Optional[str] = (
+    os.environ.get("HELIX_AGENT") or os.environ.get("HELIX_MCP_HANDLE") or None
+)
+
 # Set by _register_with_registry on success; consumed by the
 # helix_announce MCP tool to PATCH the same participant row.
 _registered_bridge: Optional[Any] = None
@@ -332,6 +340,11 @@ def helix_context(
     if downstream_model:
         body["downstream_model"] = downstream_model
     body["session_id"] = session_id or MCP_SESSION_ID
+    if MCP_AGENT_HANDLE:
+        # Plumb agent identity through so helix's per-agent telemetry
+        # labels (request rate / latency by agent) reflect THIS shim,
+        # not the bare HELIX_AGENT env on the helix server process.
+        body["agent"] = MCP_AGENT_HANDLE
     return _http("POST", "/context", body)
 
 
@@ -870,6 +883,11 @@ def helix_document_query(
     if downstream_model:
         body["downstream_model"] = downstream_model
     body["session_id"] = session_id or MCP_SESSION_ID
+    if MCP_AGENT_HANDLE:
+        # Plumb agent identity through so helix's per-agent telemetry
+        # labels (request rate / latency by agent) reflect THIS shim,
+        # not the bare HELIX_AGENT env on the helix server process.
+        body["agent"] = MCP_AGENT_HANDLE
     return _http("POST", "/context", body)
 
 

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -180,6 +180,59 @@ def _normalize_identity_token(value: Optional[str]) -> Optional[str]:
     return normalized or None
 
 
+# Cardinality cap for the `agent` telemetry label. The known-agents
+# allowlist below covers our shipped MCP-host handles; anything else gets
+# folded into "other" to prevent a label-cardinality blow-up if a caller
+# starts shipping per-pid handles or freeform strings. Operators who
+# really want a custom label can extend this set via HELIX_AGENT_ALLOW.
+_KNOWN_AGENTS_DEFAULT = frozenset({
+    "laude", "raude", "taude", "gemini", "codex", "claude", "manual",
+})
+
+
+def _agent_allowlist() -> frozenset[str]:
+    extra = os.environ.get("HELIX_AGENT_ALLOW", "")
+    if not extra:
+        return _KNOWN_AGENTS_DEFAULT
+    extra_set = {
+        t for t in (s.strip().lower() for s in extra.split(","))
+        if t and t != "other" and t != "unknown"
+    }
+    return _KNOWN_AGENTS_DEFAULT | extra_set
+
+
+def _resolve_caller_agent(request, data: dict) -> str:
+    """Pick the agent label for a /context request.
+
+    Precedence:
+      1. body ``agent`` field — explicit caller-provided handle
+      2. header ``X-Helix-Agent`` — for callers that can't shape the body
+      3. env ``HELIX_AGENT`` — per-process default set by the host bat /
+         shim (start-helix-tray.bat, MCP shim, etc.)
+      4. ``"unknown"`` — last-resort label so the metric always carries
+         a value (avoiding NULL-style gaps that confuse stacked-area
+         dashboards).
+
+    Returns a normalized lowercase handle. Unknown handles outside the
+    allowlist collapse to ``"other"`` to keep Prometheus label
+    cardinality bounded.
+    """
+    candidates = (
+        data.get("agent") if isinstance(data, dict) else None,
+        request.headers.get("x-helix-agent") if request is not None else None,
+        os.environ.get("HELIX_AGENT"),
+    )
+    handle = None
+    for c in candidates:
+        normalized = _normalize_identity_token(c)
+        if normalized:
+            handle = normalized
+            break
+    if handle is None:
+        return "unknown"
+    return handle if handle in _agent_allowlist() else "other"
+
+
 def _compute_know_or_miss_block(
     *,
     helix: "HelixContextManager",
@@ -1438,6 +1491,11 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
                 context_calls_by_class_counter,
                 redact_query,
             )
+            # Agent label for per-agent dashboards (request rate, latency,
+            # know/miss breakdown by caller). Allowlist-collapsed to "other"
+            # for unknown handles so Prometheus cardinality stays bounded;
+            # see _resolve_caller_agent.
+            agent_label = _resolve_caller_agent(request, data)
             context_latency_histogram().record(
                 _time.time() - t0,
                 {
@@ -1446,10 +1504,13 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
                     "cold_tier_used": str(getattr(helix, "_last_cold_tier_used", False)),
                     # Stage 5 §11: class label for per-class p95 dashboards.
                     "class": caller_model_class,
+                    "agent": agent_label,
                 },
             )
             # Stage 5 §11: per-call class counter.
-            context_calls_by_class_counter().add(1, {"class": caller_model_class})
+            context_calls_by_class_counter().add(
+                1, {"class": caller_model_class, "agent": agent_label},
+            )
         except Exception:
             # Promoted to warning so silent histogram failures surface.
             # /context latency is the primary user-visible health metric;

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -483,6 +483,64 @@ class TestContextEndpoint:
         assert resp.status_code == 400
 
 
+class TestResolveCallerAgent:
+    """The _resolve_caller_agent helper resolves the `agent` telemetry
+    label per /context request. Cardinality-bounded via an allowlist that
+    collapses unknown handles to "other" so Prometheus label cardinality
+    can't explode when callers ship freeform handles.
+    """
+
+    def _make_request(self, headers=None):
+        from types import SimpleNamespace
+        return SimpleNamespace(headers=headers or {})
+
+    def test_body_agent_takes_precedence(self, monkeypatch):
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.setenv("HELIX_AGENT", "raude")
+        req = self._make_request({"x-helix-agent": "taude"})
+        assert _resolve_caller_agent(req, {"agent": "laude"}) == "laude"
+
+    def test_header_when_body_missing(self, monkeypatch):
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.setenv("HELIX_AGENT", "raude")
+        req = self._make_request({"x-helix-agent": "taude"})
+        assert _resolve_caller_agent(req, {}) == "taude"
+
+    def test_env_when_body_and_header_missing(self, monkeypatch):
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.setenv("HELIX_AGENT", "gemini")
+        assert _resolve_caller_agent(self._make_request(), {}) == "gemini"
+
+    def test_unknown_when_no_source_supplies(self, monkeypatch):
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.delenv("HELIX_AGENT", raising=False)
+        assert _resolve_caller_agent(self._make_request(), {}) == "unknown"
+
+    def test_off_allowlist_collapses_to_other(self, monkeypatch):
+        """Cardinality cap: any handle not in the allowlist (or
+        HELIX_AGENT_ALLOW extension) becomes "other", protecting
+        Prometheus from per-pid / per-tab handles."""
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.delenv("HELIX_AGENT_ALLOW", raising=False)
+        req = self._make_request()
+        assert _resolve_caller_agent(req, {"agent": "weird-tab-37"}) == "other"
+
+    def test_helix_agent_allow_extends_allowlist(self, monkeypatch):
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.setenv("HELIX_AGENT_ALLOW", "qaude, vaude")
+        req = self._make_request()
+        assert _resolve_caller_agent(req, {"agent": "qaude"}) == "qaude"
+        assert _resolve_caller_agent(req, {"agent": "vaude"}) == "vaude"
+        # Still collapses things not in either set.
+        assert _resolve_caller_agent(req, {"agent": "rogue"}) == "other"
+
+    def test_normalizes_case_and_whitespace(self, monkeypatch):
+        from helix_context.server import _resolve_caller_agent
+        monkeypatch.delenv("HELIX_AGENT", raising=False)
+        req = self._make_request()
+        assert _resolve_caller_agent(req, {"agent": "  Laude  "}) == "laude"
+
+
 class TestContextPacketEndpointFreshness:
     """Freshness-label assertions for /context/packet.
 


### PR DESCRIPTION
## Summary

Adds per-agent telemetry labels to the two boundary metrics that exit `/context` (`helix_context_latency_seconds`, `helix_context_calls_by_class_total`) plus a new standalone dashboard so operators can see traffic, latency, and caller-class mix broken down per agent.

This is the third in the recent observability follow-up sequence. The first two ([PR #68](https://github.com/mbachaud/helix-context/pull/68)) cover the native-sidecar setup script, spawn-order fixes, port-collision remap, OTel LoggerProvider, and ribosome-disabled honest reporting. This PR is **independent of #68** — branch base is `master`, no merge dependency.

## Design

**Server-side resolver** ([server.py: `_resolve_caller_agent`](helix_context/server.py)) — precedence:

1. Body `agent` field — explicit caller-provided handle
2. Header `X-Helix-Agent` — for callers that can't shape the body
3. Env `HELIX_AGENT` — per-process default (start-helix-tray.bat sets this)
4. `"unknown"` — last-resort label so the metric always carries a value (stacked dashboards hate NULL-style gaps)

**Cardinality bounded** via an allowlist (`laude / raude / taude / gemini / codex / claude / manual`). Anything else collapses to `"other"` so a misbehaving caller shipping per-pid or per-tab handles can't blow up Prometheus label cardinality. Operators can extend the allowlist via `HELIX_AGENT_ALLOW=comma,separated,extras`.

**MCP shim** ([mcp_server.py](helix_context/mcp_server.py)) resolves its own handle once at import time (`HELIX_AGENT || HELIX_MCP_HANDLE`) and includes it in every `/context` POST body, so dashboards reflect the actual shim identity rather than the bare `HELIX_AGENT` env on the helix server process.

**New dashboard** [`deploy/otel/grafana/dashboards/helix-agent-usage.json`](deploy/otel/grafana/dashboards/helix-agent-usage.json):

- "Per-agent traffic" row: stacked request rate by agent + p95 latency by agent
- "Caller mix" row: stacked caller_model_class breakdown by (agent, class) + "Active agents (last hour)" stat with cardinality-cap thresholds

Dashboard is **standalone** — does **not** touch `helix-overview.json`, so it doesn't collide with the in-flight dashboard restructure work on `followup/score-aware-budget-trim`. Cross-links to existing dashboards via the standard Grafana dashboard-links list.

## What's NOT in this PR

`helix_tier_fired_total` and `helix_tier_contribution_score` were considered for the same `agent` label, but plumbing the identity through `genome.query_genes()` touches many call sites for marginal operator value. Deferred to a follow-up if per-agent tier mix proves to be a recurring debugging need.

## Test plan

- [x] `pytest tests/test_server.py` — **75 passed, 2 warnings** (was 67; adds 8 focused tests on `_resolve_caller_agent` covering body/header/env precedence, unknown fallback, allowlist collapse, `HELIX_AGENT_ALLOW` extension, and case/whitespace normalization).
- [x] Dashboard JSON validates (`json.load` round-trip, 6 panels).
- [ ] Reviewer: pull the branch + restart helix via `start-helix-tray.bat`, fire `/context` from a couple of MCP hosts (Claude Code, Cursor) with different `HELIX_AGENT` values, confirm <http://localhost:3000/d/helix-agent-usage> populates the per-agent breakdown within one scrape interval.

## Diff scope

| Area | Files |
|---|---|
| Server resolver + metric labels | `helix_context/server.py` |
| MCP shim forwarding | `helix_context/mcp_server.py` |
| Dashboard | `deploy/otel/grafana/dashboards/helix-agent-usage.json` (new) |
| Tests | `tests/test_server.py` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)