### PR TITLE
fix(tests): revive 2 stale test markers post Stage-4 refactor + R2 sweep

### DIFF
--- a/tests/test_abstain_tier.py
+++ b/tests/test_abstain_tier.py
@@ -157,28 +157,26 @@ def test_weak_retrieval_triggers_abstain(abstain_manager):
 
 
 def test_focused_score_floor_constants_in_sync():
-    """The ABSTAIN gate mirrors the FOCUSED_SCORE_FLOOR = 2.5 constant
-    defined just below it in context_manager.py. If one is bumped
-    without the other, the gate's strict-less-than semantic and the
-    FOCUSED tier's threshold will drift. This test pins them together
-    by extracting both literals and asserting numeric equality — robust
-    to formatting changes (extra whitespace, comments, scientific
-    notation) that string-matching would miss.
-    """
-    import inspect
-    import re
+    """The ABSTAIN gate threshold mirrors the FOCUSED tier threshold.
+    If one is bumped without the other, the gate's strict-less-than
+    semantic and the FOCUSED tier's at-or-above threshold drift apart.
 
-    src = inspect.getsource(cm.HelixContextManager.build_context)
-    matches = re.findall(
-        r"FOCUSED_SCORE_FLOOR(?:_FOR_ABSTAIN)?\s*=\s*([\d.]+(?:[eE][-+]?\d+)?)",
-        src,
-    )
-    assert len(matches) == 2, (
-        f"expected exactly 2 FOCUSED_SCORE_FLOOR literals, got {matches}"
-    )
-    assert float(matches[0]) == float(matches[1]), (
-        f"FOCUSED_SCORE_FLOOR_FOR_ABSTAIN ({matches[0]}) and "
-        f"FOCUSED_SCORE_FLOOR ({matches[1]}) drifted apart"
+    Stage 4 (2026-05-08) moved the literal floors out of build_context
+    into _floors_for / AbstainClassFloors. Both modes need pinning:
+    - global mode reads _GLOBAL_FOCUSED_FLOOR / _GLOBAL_ABSTAIN_FLOOR
+      from HelixContextManager;
+    - per_classifier mode falls back to AbstainClassFloors defaults
+      when a class lacks an explicit block.
+    """
+    from helix_context.config import AbstainClassFloors
+
+    assert (
+        cm.HelixContextManager._GLOBAL_FOCUSED_FLOOR
+        == cm.HelixContextManager._GLOBAL_ABSTAIN_FLOOR
+    ), "global-mode floors drifted apart"
+    defaults = AbstainClassFloors()
+    assert defaults.focused_top == defaults.abstain_top, (
+        "AbstainClassFloors default focused_top / abstain_top drifted apart"
     )
 
 

--- a/tests/test_observability_docs.py
+++ b/tests/test_observability_docs.py
@@ -69,9 +69,16 @@ def test_root_readme_demotes_docker_to_advanced_footnote():
 
 
 def test_root_readme_preserves_canonical_launch_section():
-    """Regression: don't rip out existing Quick Start ▸ Launch content."""
+    """Regression: don't rip out existing Quick Start ▸ Launch content.
+
+    The original 'Canonical path' marker was reworded by the R2 rename
+    sweep (commit 5c00a21); pin on the section header + the tray entry
+    point, both of which the launch flow can't function without.
+    """
     body = _read("README.md")
-    assert "Canonical path" in body
+    assert "## Quick Start" in body, (
+        "Root README must keep the '## Quick Start' section"
+    )
     assert "start-helix-tray.bat" in body.lower()
 
 


### PR DESCRIPTION
## Summary

Fixes the two pre-existing failures on `master` that PR #71's test plan explicitly flagged as out-of-scope:

- `tests/test_abstain_tier.py::test_focused_score_floor_constants_in_sync`
- `tests/test_observability_docs.py::test_root_readme_preserves_canonical_launch_section`

Both broke because legitimate refactors moved the markers each test pinned. No production code changes — the tests had drifted, not the code.

## Diagnosis

### 1. `test_focused_score_floor_constants_in_sync`

The original test used `inspect.getsource(HelixContextManager.build_context)` + a regex (`r"FOCUSED_SCORE_FLOOR(?:_FOR_ABSTAIN)?\s*=\s*([\d.]+...)"`) to extract two numeric literals and assert they're equal — pinning the invariant that the ABSTAIN gate's strict-less-than threshold mirrors the FOCUSED tier's at-or-above threshold.

The Stage-4 per-classifier-floor refactor (`docs/specs/2026-05-08-stage-4-threshold-calibration.md`) moved both literals out of `build_context` into:

- Class constants on `HelixContextManager`: `_GLOBAL_FOCUSED_FLOOR = 2.5`, `_GLOBAL_ABSTAIN_FLOOR = 2.5` (commented "mirrors FOCUSED_SCORE_FLOOR_FOR_ABSTAIN")
- An `AbstainClassFloors` dataclass with defaults `focused_top: float = 2.5`, `abstain_top: float = 2.5`

Inside `build_context`, the values now arrive as expressions (`_cls_floors.focused_top`, not `= 2.5`), so the regex matches 0/2 and the assertion fires.

**Fix:** Drop the `inspect.getsource()` + regex approach. Assert the runtime invariant under both Stage-4 modes:

- **Global mode:** `HelixContextManager._GLOBAL_FOCUSED_FLOOR == HelixContextManager._GLOBAL_ABSTAIN_FLOOR`
- **Per-classifier mode (default fallback):** `AbstainClassFloors().focused_top == AbstainClassFloors().abstain_top`

Robust to source-text refactors; still trips if someone bumps one floor without the other.

### 2. `test_root_readme_preserves_canonical_launch_section`

Asserted on the marker phrase `"Canonical path"` in `README.md`. The R2 rename sweep (commit `5c00a21`) reworded the section during the canonical-vocab pass for PR #70. The launch flow itself is intact — `## Quick Start` header, `start-helix-tray.bat`, three install paths are all still documented — but the specific phrase the test pinned no longer exists.

**Fix:** Repin on durable markers: the `## Quick Start` section header + the `start-helix-tray.bat` entry point. These are exactly what the test's docstring claims it's protecting (the Quick Start ▸ Launch flow). A future docs rewrite that preserves the launch flow won't trip the test, but ripping out the section still will.

## Broader scan (no other findings)

While here, I scanned the test suite for the two anti-patterns these failures exemplified:

- **`inspect.getsource()` + regex on a function/class.** Only one occurrence in `tests/` (the failure above). No others at risk.
- **String-marker assertions on `.md` files.** ~12 occurrences across `test_observability_docs.py` + scattered. All currently pass. Three are AT RISK because they pin short generic words (`"tray"`, `"Advanced"`, `"Docker"`, `"alternate"`) — vulnerable to the same kind of docs rewrite, but not broken today.
- **Hardcoded file paths in tests.** All resolve. No dead-path bugs.

A previously-flagged concern that `helix_context/config.py:528-533` silently swallows `tomllib.TOMLDecodeError` was investigated and **refuted**: the code does `log.error("helix.toml is malformed ... — using defaults")` then falls back. That's loud graceful degradation, not silent fallback. The error message reaches stderr / log aggregators.

## Test plan

- [x] `python -m pytest tests/test_abstain_tier.py::test_focused_score_floor_constants_in_sync tests/test_observability_docs.py::test_root_readme_preserves_canonical_launch_section -v` — both pass.
- [x] `python -m pytest tests/test_abstain_tier.py tests/test_observability_docs.py -q` — 32/32 pass (no sibling regressions).
- [x] `python -m pytest tests/ -m "not live" -q` on this branch — **1836 passed / 0 failed** (vs. 1834 / 2 failed on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)