### PR TITLE
feat(stage-4): surface calibration staleness on /context agent block (#63)

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -354,6 +354,16 @@ s_ref           = 1.0
 g_ref           = 0.5
 betas           = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]
 
+# Stage 4 (spec §9, issue #63) — calibration staleness window in days.
+# When ``calibrated_at`` (set by scripts/calibrate_know_confidence.py)
+# is older than this threshold the /context response surfaces:
+#   agent.calibration_age_days : int    — days since calibration
+#   agent.calibration_stale    : bool   — true iff age > threshold
+#   agent.warnings             : [..., "calibration_stale"]
+# The check is strict (age > N) so the boundary day still reads fresh.
+# Operator action when this fires: re-run the calibration script.
+stale_after_days = 30
+
 [mem_sync]
 # Auto-memory → helix sync. Every .md file in a watched dir becomes a
 # gene; persona/agent attribution comes from HELIX_AGENT / HELIX_USER

--- a/helix_context/know_calibration.py
+++ b/helix_context/know_calibration.py
@@ -64,6 +64,14 @@ DEFAULT_G_REF: float = 0.5
 # decision falls through to MissBlock(reason="sparse").
 DEFAULT_EMIT_FLOOR: float = 0.55
 
+# Stage 4 (spec §9, issue #63): age in days after which a calibration
+# row is considered stale and ``calibration_stale`` flips to True on
+# the /context response. The check is strict ``age > threshold`` so a
+# row exactly at the boundary still reads as fresh — gives operators
+# a one-day window to re-run the calibration script before the warning
+# fires.
+DEFAULT_STALE_AFTER_DAYS: int = 30
+
 # Number of feature inputs (excluding intercept) the logistic accepts.
 # Stage 7: bumped to 5 — added freshness_min as feature index 4.
 N_FEATURES: int = 5
@@ -86,6 +94,12 @@ class KnowCalibration:
     emit_floor: float = DEFAULT_EMIT_FLOOR
     calibrated_at: Optional[str] = None
     calibrated_on_n: Optional[int] = None
+    # Stage 4 (spec §9, issue #63) — staleness threshold in days. When
+    # ``calibrated_at`` is older than this the /context response sets
+    # ``agent.calibration_stale = True`` and appends "calibration_stale"
+    # to ``agent.warnings``. Operator action: re-run
+    # ``scripts/calibrate_know_confidence.py``.
+    stale_after_days: int = DEFAULT_STALE_AFTER_DAYS
 
     def expected_betas_len(self) -> int:
         """Required length of the betas tuple: intercept + N_FEATURES.
@@ -93,6 +107,84 @@ class KnowCalibration:
         Used by validators and the calibration script.
         """
         return 1 + N_FEATURES
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Staleness helpers (Stage 4 spec §9, issue #63)
+# ─────────────────────────────────────────────────────────────────────
+
+def calibration_age_days(
+    calibrated_at: Optional[str],
+    *,
+    now: Optional[float] = None,
+) -> Optional[int]:
+    """Days since ``calibrated_at`` (an ISO-8601 timestamp), or None.
+
+    Returns ``None`` when ``calibrated_at`` is None or unparseable —
+    callers should treat None as "age unknown, do not warn".
+
+    ``now`` is the current wall-clock time in seconds since epoch
+    (UTC). Defaults to ``time.time()``; tests pass a fixed value to
+    pin the result.
+
+    Soft-fails on unparseable timestamps with a debug log so a bad
+    helix.toml entry does not break /context.
+    """
+    if not calibrated_at:
+        return None
+
+    import time as _time
+    from datetime import datetime, timezone
+
+    if now is None:
+        now = _time.time()
+
+    raw = str(calibrated_at).strip()
+    # tomllib hands us either a string or a datetime; normalize.
+    try:
+        # Accept trailing 'Z' as UTC, matching ISO-8601 shorthand.
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        dt = datetime.fromisoformat(raw)
+        # Bare timestamps (no offset) are assumed UTC — same convention
+        # used elsewhere for ``last_verified_at``.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        age_seconds = float(now) - dt.timestamp()
+        # Clamp negatives (future-dated timestamps) to 0 — they
+        # shouldn't fire a staleness warning, but they're also not a
+        # crash-worthy state. A debug log makes the anomaly traceable.
+        if age_seconds < 0:
+            log.debug(
+                "know_calibration: calibrated_at %r is in the future; "
+                "treating age as 0",
+                calibrated_at,
+            )
+            return 0
+        return int(age_seconds // 86400)
+    except (ValueError, TypeError):
+        log.debug(
+            "know_calibration: could not parse calibrated_at %r",
+            calibrated_at,
+            exc_info=True,
+        )
+        return None
+
+
+def is_calibration_stale(
+    age_days: Optional[int],
+    stale_after_days: int,
+) -> bool:
+    """True iff ``age_days`` exceeds ``stale_after_days`` (strict >).
+
+    Strict greater-than (not ``>=``) is deliberate: a row exactly at
+    the boundary day reads as fresh so operators get one day of
+    notice before the warning surfaces. ``age_days is None`` returns
+    False — unknown age is the safe default.
+    """
+    if age_days is None:
+        return False
+    return int(age_days) > int(stale_after_days)
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -248,6 +340,23 @@ def load_calibration_from_toml(
             )
             betas = DEFAULT_BETAS
 
+        # Stage 4 (spec §9, issue #63) — parse stale_after_days with the
+        # same soft-fail discipline as the other numeric fields.
+        try:
+            stale_after_days = int(
+                table.get("stale_after_days", DEFAULT_STALE_AFTER_DAYS)
+            )
+            if stale_after_days < 0:
+                raise ValueError("negative")
+        except (TypeError, ValueError):
+            log.warning(
+                "know_calibration: malformed stale_after_days in %s; "
+                "using default %d",
+                toml_path,
+                DEFAULT_STALE_AFTER_DAYS,
+            )
+            stale_after_days = DEFAULT_STALE_AFTER_DAYS
+
         return KnowCalibration(
             betas=betas,
             s_ref=float(table.get("s_ref", DEFAULT_S_REF)),
@@ -263,6 +372,7 @@ def load_calibration_from_toml(
                 if table.get("calibrated_on_n") is not None
                 else None
             ),
+            stale_after_days=stale_after_days,
         )
     except Exception:
         log.warning(

--- a/helix_context/server.py
+++ b/helix_context/server.py
@@ -1330,6 +1330,36 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
                 recommendation = "reread_raw"
                 hint = "Context is unreliable. Read raw files instead of trusting the genome."
 
+            # Stage 4 (spec §9, issue #63) — calibration staleness surface.
+            # Load cal once for both the age computation and to read the
+            # configured threshold. Soft-fails to defaults so a missing or
+            # malformed helix.toml never poisons /context.
+            try:
+                from .know_calibration import (
+                    calibration_age_days as _cal_age_days,
+                    is_calibration_stale as _is_cal_stale,
+                )
+                _cal_for_warn = load_calibration_from_toml()
+                _cal_age = _cal_age_days(_cal_for_warn.calibrated_at)
+                _cal_stale = _is_cal_stale(
+                    _cal_age, _cal_for_warn.stale_after_days,
+                )
+            except Exception:
+                log.debug(
+                    "Stage 4 §9 calibration staleness compute failed",
+                    exc_info=True,
+                )
+                _cal_age = None
+                _cal_stale = False
+
+            # ``warnings`` is always present (even when empty) so callers
+            # do not have to branch on key existence. Append the
+            # ``calibration_stale`` token when the threshold trips; other
+            # warning sources may be added here in future stages.
+            _warnings: list[str] = []
+            if _cal_stale:
+                _warnings.append("calibration_stale")
+
             response["agent"] = {
                 "recommendation": recommendation,
                 "hint": hint,
@@ -1348,6 +1378,15 @@ def create_app(config: Optional[HelixConfig] = None) -> FastAPI:
                 # produced under without an extra /health roundtrip.
                 "ann_threshold_mode": config.retrieval.ann_threshold_mode,
                 "abstain_mode": config.abstain.mode,
+                # Stage 4 §9 (issue #63) — calibration staleness fields.
+                # ``calibration_age_days`` is None when calibrated_at is
+                # absent or unparseable; ``calibration_stale`` is False in
+                # the same "unknown" case (safe default).
+                "calibration_age_days": _cal_age,
+                "calibration_stale": _cal_stale,
+                # Always-present warning list — callers iterate without
+                # checking for key existence.
+                "warnings": _warnings,
             }
 
             # Activation profile: per-tier score breakdown for the

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -596,3 +596,134 @@ def test_calibration_script_smoke(fixture_genome, tmp_path):
     assert row is not None
     payload = json.loads(row[0])
     assert abs(payload["value"] - report["ann_threshold"]["value"]) < 1e-9
+
+
+# ─── Stage 4 §9 (issue #63): calibration staleness surface ───────────────
+#
+# Three caller-facing fields on the /context ``agent`` block:
+#   - calibration_age_days : int|None
+#   - calibration_stale    : bool
+#   - warnings             : list[str] (always present; appends
+#                            "calibration_stale" when threshold trips)
+#
+# These tests exercise the underlying helpers in
+# ``helix_context.know_calibration`` so the contract is enforced without
+# spinning up FastAPI for every assertion.
+
+
+from datetime import datetime, timedelta, timezone
+
+from helix_context.know_calibration import (
+    DEFAULT_STALE_AFTER_DAYS,
+    KnowCalibration,
+    calibration_age_days,
+    is_calibration_stale,
+    load_calibration_from_toml,
+)
+
+
+def _iso_days_ago(days: int, now: float) -> str:
+    """ISO-8601 timestamp ``days`` days before ``now`` (UTC, with Z)."""
+    dt = datetime.fromtimestamp(now, tz=timezone.utc) - timedelta(days=days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_calibration_age_fresh_returns_zero():
+    """Fresh calibration (just now) reports age 0, not stale, no warning."""
+    now = 1_750_000_000.0  # fixed epoch second so the test is deterministic
+    cal_at = _iso_days_ago(0, now)
+    age = calibration_age_days(cal_at, now=now)
+    assert age == 0
+    assert is_calibration_stale(age, DEFAULT_STALE_AFTER_DAYS) is False
+
+
+def test_calibration_age_stale_trips_warning():
+    """A 2025-01-01 calibration vs 2026-05-11 evaluation is stale."""
+    # 2026-05-11 evaluation point — well past the 30-day threshold from
+    # a 2025-01-01 calibration (~495 days old).
+    now = datetime(2026, 5, 11, tzinfo=timezone.utc).timestamp()
+    age = calibration_age_days("2025-01-01T00:00:00Z", now=now)
+    assert age is not None and age > DEFAULT_STALE_AFTER_DAYS
+    assert is_calibration_stale(age, DEFAULT_STALE_AFTER_DAYS) is True
+
+
+def test_calibration_age_none_when_calibrated_at_missing():
+    """Missing calibrated_at → age=None, stale=False (safe default)."""
+    assert calibration_age_days(None) is None
+    assert calibration_age_days("") is None
+    assert is_calibration_stale(None, DEFAULT_STALE_AFTER_DAYS) is False
+
+
+def test_calibration_stale_strict_greater_than_at_boundary():
+    """Age exactly at threshold is NOT stale — strict ``>`` per spec §9.
+
+    The boundary day reads as fresh so operators get one day of
+    notice before the warning fires.
+    """
+    threshold = DEFAULT_STALE_AFTER_DAYS
+    # exactly threshold days old → not stale
+    assert is_calibration_stale(threshold, threshold) is False
+    # one day past threshold → stale
+    assert is_calibration_stale(threshold + 1, threshold) is True
+
+
+def test_calibration_age_unparseable_returns_none():
+    """Garbage in calibrated_at degrades silently to age=None."""
+    assert calibration_age_days("not-a-timestamp") is None
+    assert calibration_age_days("2026-13-99") is None
+
+
+def test_calibration_age_future_dated_clamps_to_zero():
+    """A calibrated_at in the future clamps to age=0, not negative."""
+    now = 1_750_000_000.0
+    future_iso = (
+        datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=5)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert calibration_age_days(future_iso, now=now) == 0
+
+
+def test_load_calibration_from_toml_reads_stale_after_days(tmp_path):
+    """Loader picks up stale_after_days from [know] table."""
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[know]\n"
+        "emit_floor = 0.55\n"
+        "s_ref = 1.0\n"
+        "g_ref = 0.5\n"
+        "betas = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]\n"
+        "stale_after_days = 7\n",
+        encoding="utf-8",
+    )
+    cal = load_calibration_from_toml(toml)
+    assert cal.stale_after_days == 7
+
+
+def test_load_calibration_from_toml_defaults_stale_after_days(tmp_path):
+    """Missing stale_after_days → DEFAULT_STALE_AFTER_DAYS (30)."""
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[know]\n"
+        "emit_floor = 0.55\n"
+        "betas = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]\n",
+        encoding="utf-8",
+    )
+    cal = load_calibration_from_toml(toml)
+    assert cal.stale_after_days == DEFAULT_STALE_AFTER_DAYS
+
+
+def test_load_calibration_from_toml_rejects_negative_stale_days(tmp_path):
+    """Negative stale_after_days falls back to default with a warning."""
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[know]\n"
+        "betas = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]\n"
+        "stale_after_days = -3\n",
+        encoding="utf-8",
+    )
+    cal = load_calibration_from_toml(toml)
+    assert cal.stale_after_days == DEFAULT_STALE_AFTER_DAYS
+
+
+def test_know_calibration_default_stale_after_days_is_thirty():
+    """The bare KnowCalibration() ships with the documented default."""
+    assert KnowCalibration().stale_after_days == DEFAULT_STALE_AFTER_DAYS


### PR DESCRIPTION
## Summary

Stage 4 spec §9 declared three caller-facing fields on the `/context` `agent` block that were never implemented. The `calibrated_at` ISO timestamp was already loaded into `KnowCalibration.calibrated_at` (`helix_context/know_calibration.py:251`) but never propagated to callers.

**Closes #63.**

## Three new caller-facing fields

- `agent.calibration_age_days: int | None` — days since the last calibration run
- `agent.calibration_stale: bool` — `true` iff `age > stale_after_days`
- `agent.warnings: list[str]` — always present (may be empty); contains `"calibration_stale"` when the threshold trips

## Config

New `stale_after_days = 30` on `[know]` in `helix.toml` (commented with intent). Default = 30 days. Strict greater-than at the boundary so the threshold day still reads fresh — one day of warning before the alert fires. Loader soft-fails to the default on malformed/negative values.

## What the agent block now looks like

```json
{
  "agent": {
    "recommendation": "trust",
    "hint": "Context is well-grounded. Use directly.",
    "citations": [...],
    "latency_ms": 12.4,
    "total_tokens_est": 1820,
    "compression_ratio": 6.4,
    "moe_mode": false,
    "budget_tier": "broad",
    "budget_tokens_est": 15000,
    "cold_tier_used": false,
    "cold_tier_count": 0,
    "ann_threshold_mode": "per_classifier",
    "abstain_mode": "global",
    "calibration_age_days": 12,
    "calibration_stale": false,
    "warnings": []
  }
}
```

When the calibration is stale:

```json
{
  "calibration_age_days": 47,
  "calibration_stale": true,
  "warnings": ["calibration_stale"]
}
```

When `calibrated_at` is missing or unparseable (safe default):

```json
{
  "calibration_age_days": null,
  "calibration_stale": false,
  "warnings": []
}
```

## Tests added (`tests/test_calibration.py`)

- `test_calibration_age_fresh_returns_zero` — fresh (age 0) → not stale, no warning
- `test_calibration_age_stale_trips_warning` — 2025-01-01 vs 2026-05-11 (~495d) → stale=True, warning surfaces
- `test_calibration_age_none_when_calibrated_at_missing` — None/empty → age=None, stale=False (safe default)
- `test_calibration_stale_strict_greater_than_at_boundary` — age == threshold is NOT stale (strict `>` per spec §9)
- `test_calibration_age_unparseable_returns_none` — garbage timestamp → age=None
- `test_calibration_age_future_dated_clamps_to_zero` — future-dated → age=0, not negative
- `test_load_calibration_from_toml_reads_stale_after_days` — TOML loader picks up the field
- `test_load_calibration_from_toml_defaults_stale_after_days` — missing field → default 30
- `test_load_calibration_from_toml_rejects_negative_stale_days` — negative → falls back with warning
- `test_know_calibration_default_stale_after_days_is_thirty` — dataclass default

## Design notes

- The agent block remains a plain dict (no `AgentBlock` schema class was actually present despite the issue body mention) — smallest change wins.
- Loader and helpers live in `helix_context/know_calibration.py` so the timestamp-parsing concern stays scoped to the calibration module.
- Server-side computation is the lowest-invasive path: `decide_know_or_miss` keeps its current return shape.
- All paths soft-fail to safe defaults (`age=None`, `stale=False`, empty warnings) — a missing or malformed `helix.toml` cannot poison `/context`.

## Test plan

- [x] `python -m pytest tests/test_calibration.py tests/test_know_miss_block.py -q` — 42 passed, 1 skipped
- [x] Broader sweep `python -m pytest tests/ -q -m "not live"` — 1779 passed (1 unrelated README docs test failure pre-existing on master, unrelated to this PR)
- [ ] Smoke `/context` against a local server with both fresh and aged `calibrated_at` values to spot-check the agent block shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)