### PR TITLE
feat(cli+api+mcp): agent walk-aware CLI + council doc fixes + 5 AI-user friction fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+- **feat(cli): agent walk-aware surface — `packet` / `gene` / `neighbors` /
+  `refresh-targets`.** Four new subcommands that complete the v1 CLI as a
+  full agent surface — agents drive genome lookups via subprocess CLI
+  calls instead of MCP-injected context. JSON shapes match the
+  corresponding HTTP endpoints (`/context/packet`, `/genes/<id>`,
+  `/debug/neighbors`, `/context/refresh-plan`) and MCP tools
+  (`helix_context_packet`, `helix_gene_get`, `helix_neighbors`,
+  `helix_refresh_targets`) so callers can swap surfaces without changing
+  call logic. Read-only by default (no genome mutation from inspection).
+- **feat(api): walk-aware methods on `HelixSession`.** `gene_get`,
+  `packet`, `refresh_targets`, `neighbors` — previously deferred to v1.1
+  per `helix_context/api.py:352-360`, now in v1 to back the CLI surface
+  above. Pure in-process wrappers over `Genome.get_gene`,
+  `build_context_packet`, and the existing SEMA codec; no HTTP server
+  required.
+- **docs: README — agent-CLI callout + benchmark sourcing.** New "Agent
+  CLI surface (no server required)" section advertises the CLI as a
+  first-class agent surface alongside MCP, with the full subcommand
+  surface inline. The "28.7× headline / 5.4× median" claim now cites the
+  reproducer at `benchmarks/bench_rag_vs_sike_tokens.py` and the
+  methodology doc at `docs/benchmarks/BENCHMARKS.md`; the overnight
+  result file referenced in the README-v2 spec is documented as internal.
+- **docs: ROSETTA — response-types section, dead-entry fix, ChromatinState
+  note.** Adds a "Response & routing types (STAYS — no biology twin)"
+  section covering `ContextWindow`, `ContextPacket`, `KnowBlock`,
+  `MissBlock`, `RefreshTarget`, `ContextHealth`, `ContextItem`,
+  `QueryResult`, `IngestResult`, `StatsResult`. The `HGT →
+  cross_store_import` row is annotated as a forward-pointer (no code under
+  either name today). The `OPEN/EUCHROMATIN/HETEROCHROMATIN →
+  OPEN/WARM/COLD` row notes the rename is deferred to R3 because
+  `ChromatinState` in `schemas.py` still emits the bio names.
+
 - **feat(cli): v1 cold-start CLI shipped.** `helix query`, `helix ingest`,
   `helix status`, `helix diag corpus`, `helix config show`. Mocked unit
   tests for every subcommand plus a live `@pytest.mark.live` integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+- **fix(api): `open_session()` now honors `HELIX_CONFIG` / `HELIX_GENOME_PATH`.**
+  Pre-fix, every cold-start CLI subcommand (query, diag corpus, packet,
+  gene, neighbors, refresh-targets) called `HelixConfig()` (defaults) and
+  silently created/read `./genome.db` regardless of what the operator had
+  configured — so `helix status` looked at the configured genome but
+  `helix query` looked at an empty one. Now routes through `load_config()`
+  the same way `helix status` does. Surfaced by AI-user testing on
+  `93deaf2`.
+- **fix(status): bump `/health` probe timeout default 1.5s → 10s, override
+  via `HELIX_STATUS_TIMEOUT_S`.** Cold-start `/health` can take 5-10s
+  under model warmup + manager init + WAL replay; the old 1.5s timeout
+  silently reported a healthy-but-slow server as `unreachable` in
+  `helix status --json`.
+- **fix(mcp): unwrap the Continue list shape in `helix_context` /
+  `helix_document_query` tools.** `POST /context` returns the
+  Continue-IDE HTTP context-provider list (`[{name, description, content,
+  ...}]`) so the FastAPI endpoint stays drop-in compatible with Continue.
+  MCP hosts validate tool returns against the declared `Dict[str, Any]`
+  schema and rejected the list. New `_unwrap_context_list` helper flattens
+  the single-entry list, passes error envelopes through, and wraps
+  unexpected shapes with a diagnostic note.
+- **fix(config): auto-fallback `ingestion.backend` → `"cpu"` when
+  `ribosome.enabled = false`.** The two settings contradict each other —
+  ingest with the ribosome disabled raised
+  `TranscriptionError: Pack failed: Ribosome is disabled` on the first
+  chunk. `load_config()` now flips ingestion to the spaCy/heuristic
+  CpuTagger path and logs a WARNING. Honors explicit `cpu` / `hybrid`
+  settings without override.
+- **feat(cli): `python -m helix_context.cli` works as a console-script
+  fallback.** Adds `helix_context/cli/__main__.py` so an agent or
+  operator with a broken pip-installed `helix.exe` (deleted editable
+  source path, Scripts dir off PATH) always has a module-direct
+  invocation. Documented in `docs/clients/cli.md`.
+
 - **feat(cli): agent walk-aware surface — `packet` / `gene` / `neighbors` /
   `refresh-targets`.** Four new subcommands that complete the v1 CLI as a
   full agent surface — agents drive genome lookups via subprocess CLI

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Coordinate-index engine for LLM agents. Helix retrieves, weighs, and compresses 
 
 ## At a glance
 
-- **Compression**: collapses ~9k tokens of raw working set into a ~600 effective-token assembled context (28.7× headline on production workloads, 5.4× median across 15 query shapes).
+- **Compression**: collapses ~9k tokens of raw working set into a ~600 effective-token assembled context. Best-case single-query result **28.7×** (WAL-checkpoint point-fact), **5.4× median across N=15 query shapes** on the May 2026 internal overnight bench. Reproducer: [`benchmarks/bench_rag_vs_sike_tokens.py`](benchmarks/bench_rag_vs_sike_tokens.py); methodology + per-shape breakdown in [`docs/benchmarks/BENCHMARKS.md`](docs/benchmarks/BENCHMARKS.md). The overnight result file is internal; running the script against your own genome reproduces the per-query numbers.
 - **Agent contract**: every `/context` response carries a top-level `know{}` (grounded, you may answer) or `miss{}` (`do_not_answer_from_genome:true`, plus `escalate_to` tools or `refresh_targets` paths). Stale `know` blocks downgrade to `miss(reason="stale"|"cold"|"superseded")` via the Stage 7 freshness gate.
 - **LLM-free retrieval**: `/context` runs spaCy NER, SQLite FTS5 BM25, BGE-M3 dense recall, RRF fusion, Howard-2005 TCM, and Hebbian co-activation — zero compressor calls. The only LLM call is downstream at `/v1/chat/completions`.
+- **Two agent surfaces, one operator surface**: agents drive helix via **MCP** (`python -m helix_context.mcp_server`) or **the CLI** (`helix query`, `helix packet`, `helix gene get`, `helix neighbors`, `helix refresh-targets`) — both expose the same retrieval primitives. The HTTP proxy and tray launcher are the operator surface; agents don't need them. See [`docs/clients/cli.md`](docs/clients/cli.md) and [`docs/clients/claude-code.md`](docs/clients/claude-code.md).
 - **Three install paths**: compact tray flow (`start-helix-tray.bat`) for the daily driver, proxy-only for `OPENAI_BASE_URL` redirection, agent-SDK fragment for frontier-model integration.
 
 ### Quick navigation
@@ -51,6 +52,23 @@ python scripts/backfill_bgem3_v2.py genomes/main/genome.db
 ```
 
 For full options including the extras matrix, see [docs/SETUP.md](docs/SETUP.md).
+
+## Agent CLI surface (no server required)
+
+The `helix` CLI is a cold-start agent surface: each invocation opens the SQLite genome read-only, runs one operation, and exits. Agents can drive a full retrieval-and-walk loop entirely through subprocess calls — no HTTP server, no MCP host, no long-lived daemon.
+
+```bash
+helix query    "what does the splice step do?" --json
+helix packet   "edit the splice step" --task-type edit --json
+helix gene get gene-abc123 --json
+helix gene preview gene-abc123 --chars 240 --json
+helix neighbors "splice step" --k 10 --json
+helix refresh-targets "edit the splice step" --json
+```
+
+Each subcommand emits the same JSON shape as the corresponding [MCP tool](docs/api/mcp-tools.md) and HTTP endpoint, so an agent can swap surfaces without changing call logic. Full reference: [`docs/clients/cli.md`](docs/clients/cli.md).
+
+If you want the FastAPI proxy as well (for `OPENAI_BASE_URL` redirection or Continue IDE), it ships as a separate entry point: `helix-server`.
 
 ## Pipeline
 

--- a/docs/ROSETTA.md
+++ b/docs/ROSETTA.md
@@ -62,7 +62,7 @@ work.
 | `epigenetics` (field) | `signals` | |
 | `ChromatinState` | `LifecycleTier` | The hot/warm/cold storage tier enum. |
 | `chromatin` (field) | `tier` | |
-| `OPEN` / `EUCHROMATIN` / `HETEROCHROMATIN` | `OPEN` / `WARM` / `COLD` | Tier values. The numeric IntEnum values stay the same. |
+| `OPEN` / `EUCHROMATIN` / `HETEROCHROMATIN` | `OPEN` / `WARM` / `COLD` | Tier values. Names are **not yet renamed in code** — `ChromatinState` in `schemas.py` still emits the bio names. The canonical name pair is the right-hand column; the rename is deferred to R3 (it would change pydantic field-string values, so it ships behind the same gate as the symbol rename). Numeric IntEnum values stay the same throughout. |
 | `codon` / `Codon` | `Fragment` / `Chunk` | The within-document compressed unit. |
 | `codons` (field) | `fragments` | |
 | `Ribosome` | `Compressor` | The small-model pipeline that encodes raw text into compressed documents. |
@@ -78,7 +78,33 @@ work.
 | `harmonic_bin_boost` | `random_walk_boost` | The Monte Carlo neighbour-expansion tier. |
 | `gene_attribution` | `document_attribution` | The party/participant authorship metadata on each document. |
 | `GeneAttribution` | `DocumentAttribution` | |
-| `HGT` (horizontal gene transfer) | `cross_store_import` | Importing documents from another helix instance. |
+| `HGT` (horizontal gene transfer) | `cross_store_import` | Importing documents from another helix instance. **Forward-pointer:** no code under either name today; `cross_store_import` is the name the feature will ship under when it lands. The legacy `HGT` acronym remains the term-of-art in design docs until then. |
+
+---
+
+## Response & routing types (STAYS — no biology twin)
+
+These types travel on the wire between helix and its callers (HTTP
+clients, MCP hosts, the CLI). They are the *response envelope*
+vocabulary, not the storage vocabulary. No biology metaphor applies;
+they keep their engineering names everywhere.
+
+| Type | Purpose | Where it surfaces |
+|---|---|---|
+| `ContextWindow` | Full pipeline output — the bytes the agent reads. Carries `expressed_context`, `expressed_gene_ids`, `total_estimated_tokens`, plus the `metadata` dict that pipes `know`/`miss` upward. | `helix_context.schemas.ContextWindow`; returned from `HelixContextManager.build_context()`. |
+| `QueryResult` | Agent-facing projection of `ContextWindow`. Adds `verdict` / `next_action` / `decision_reason`. The shape `helix query --json` emits via `to_agent_json()`. | `helix_context.api.QueryResult`. |
+| `ContextPacket` | Freshness-labeled agent-safe bundle for high-risk actions. Holds `verified[]`, `stale_risk[]`, `refresh_targets[]`, plus `coordinate_confidence` and `file_coverage`. | `helix_context.schemas.ContextPacket`; built by `build_context_packet()`; emitted by `/context/packet`, `helix packet`, and the `helix_context_packet` MCP tool. |
+| `ContextItem` | One evidence row inside a packet — `gene_id` / `title` / `content` / `relevance_score` / `live_truth_score` / `status` (`"verified"` / `"stale"` / `"missing"`). | `helix_context.schemas.ContextItem`. |
+| `RefreshTarget` | One reread directive in a packet — `target_kind` / `source_id` / `reason` / `priority`. | `helix_context.schemas.RefreshTarget`; emitted by `helix refresh-targets`. |
+| `KnowBlock` | Top-level "you may answer from this evidence" verdict. Fields: `found`, `confidence`, `gene_id_match`, `soft_stale`, etc. Mutually exclusive with `MissBlock` on a single response. | `helix_context.schemas.KnowBlock`; populated by `know_decision.decide_know_or_miss()`. |
+| `MissBlock` | Top-level "do **not** answer from the knowledge store" verdict. Carries `reason` (`"miss"` / `"stale"` / `"cold"` / `"superseded"`), `escalate_to[]`, `refresh_targets[]`, `do_not_answer_from_genome:true`. | `helix_context.schemas.MissBlock`; populated by `know_decision.decide_know_or_miss()`. |
+| `ContextHealth` | "Check-engine light" for a single retrieval — `ellipticity`, `coverage`, `density`, freshness signals, `coordinate_crispness`, `status` ∈ {`aligned`, `sparse`, `stale`, `denatured`}. | `helix_context.schemas.ContextHealth`; logged to the `health_log` table; not on the wire. |
+| `IngestResult` | One-shot ingest projection — `gene_ids[]`, `chunks`, `bytes_written`. | `helix_context.api.IngestResult`. |
+| `StatsResult` | One-shot stats projection used by `helix diag corpus`. | `helix_context.api.StatsResult`. |
+
+Note: `ellipticity` and `denatured` are CD-spectroscopy / physics terms,
+not biology. They remain on the [Terms that STAY](#terms-that-stay-not-biology-not-tax)
+list and are unrenamed.
 
 ---
 

--- a/docs/clients/cli.md
+++ b/docs/clients/cli.md
@@ -17,7 +17,31 @@ helix --help
 The legacy FastAPI launcher is still available as `helix-server` (or
 `python -m uvicorn helix_context._asgi:app`).
 
-## Subcommands
+## Title page — what the CLI does for an agent vs. an operator
+
+| Use case | Reach for |
+|---|---|
+| Agent: "what does X mean in this codebase?" | `helix query` |
+| Agent about to edit a file: "is what I know fresh?" | `helix packet --task-type edit` |
+| Agent before a destructive op: "what should I reread first?" | `helix refresh-targets` |
+| Agent: "show me document gene-abc123" | `helix gene get` / `helix gene preview` |
+| Agent: "what else is semantically near my query?" | `helix neighbors` |
+| Operator: "is the genome healthy?" | `helix status`, `helix diag corpus` |
+| Operator: "what config is actually loaded?" | `helix config show` |
+| Operator: "add a file to the genome" | `helix ingest` |
+| Operator (legacy): "run the FastAPI proxy" | `helix-server` (separate entry point) |
+
+## Agent-driven walk surface (v1.x)
+
+The four commands below are the **agent-facing** retrieval surface —
+the same operations the MCP tools `helix_context`, `helix_context_packet`,
+`helix_refresh_targets`, `helix_gene_get`, and `helix_neighbors` expose,
+but reachable from the CLI without an MCP host or a running HTTP server.
+An agent can drive a full retrieval-and-walk loop (query → packet → drill
+into specific genes → fetch neighbors → refresh-targets before acting)
+entirely through subprocess calls. All four default to JSON when `--json`
+is passed; the shape is identical to the matching MCP / HTTP surfaces so
+callers can swap freely.
 
 ### `helix query "<text>" [--k N] [--json] [--tier focused] [--learn]`
 
@@ -38,6 +62,79 @@ Run the retrieval pipeline once and print the result.
   so repeated CLI calls never silently mutate state).
 
 Exit codes: `0` success, `1` pipeline error.
+
+### `helix packet "<text>" [--task-type T] [--max-genes N] [--include-raw] [--json]`
+
+Build a freshness-labeled agent-safe evidence bundle. Use this instead
+of `helix query` when an agent is about to take a high-risk action (edit,
+ops, debug) — the packet returns evidence labeled `verified` / `stale_risk`
+plus an explicit `refresh_targets` reread plan, rather than raw bytes that
+may be stale.
+
+- `--task-type` ∈ `{plan, explain, review, edit, debug, ops, quote}`.
+  Default `explain`. Higher-risk types apply stricter freshness +
+  coordinate-confidence gates.
+- `--max-genes N` — retrieval top-K (default 8).
+- `--include-raw` — emit full `gene.content` per item (48k cap) instead
+  of the compressor-compressed summary. Use when the packet is the only
+  context source and the downstream model needs real bytes.
+- `--json` — emit the full `ContextPacket` shape: `task_type`, `query`,
+  `verified[]`, `stale_risk[]`, `refresh_targets[]`, `coordinate_confidence`,
+  `file_coverage`, `know` / `miss`, `notes`. Identical to the
+  `POST /context/packet` endpoint response.
+
+Exit codes: `0` success, `1` builder error.
+
+### `helix refresh-targets "<text>" [--task-type T] [--max-genes N] [--json]`
+
+Return only the reread plan (no evidence items). Cheaper than a full
+packet when the caller already has content cached and just wants to know
+which sources are stale enough to require a reread before acting.
+
+- `--task-type` — defaults to `edit` (the usual caller).
+- `--max-genes N` — retrieval top-K (default 8).
+- `--json` — `{ refresh_targets: [...], count: int }`. Identical shape
+  to the `POST /context/refresh-plan` endpoint.
+
+Exit codes: `0` success, `1` builder error.
+
+### `helix gene get <id> [--json]` / `helix gene preview <id> [--chars N] [--json]`
+
+Inspect a single document by ID. `get` returns the full `Gene` model
+(content, tags, signals, fragments, lifecycle tier, embedding). `preview`
+returns a content-only char-capped snippet (default 240 chars) for cheap
+relevance checks.
+
+- `get --json` — full `Gene.model_dump()`.
+- `preview --chars N` — preview character budget.
+- `preview --json` — `{ gene_id, preview, truncated, total_chars, path }`.
+
+Exit codes: `0` success, `1` unknown gene_id or read failure.
+
+The subcommand name `gene` matches the legacy MCP tool (`helix_gene_get`).
+The canonical engineering alias is `helix_document_get` per
+[`docs/ROSETTA.md`](../ROSETTA.md); both names will continue to resolve
+to the same document model.
+
+### `helix neighbors "<text>" [--k N] [--json]`
+
+Top-k SEMA neighbors for a query — a semantic-space graph walk. Read-only
+and cheap. Used by agents that want to "look around" a result before
+acting.
+
+- `--k N` — neighbor count (default 10).
+- `--json` — `{ query, k, neighbors: [{ gene_id, sema_cos_sim, preview, path }], count }`.
+  Identical shape to the `/debug/neighbors` HTTP endpoint and the
+  `helix_neighbors` MCP tool.
+
+Returns `count: 0` with no error when the SEMA codec is unavailable
+(e.g. the `embeddings` extra is not installed or no embeddings populated
+yet). Use `helix status` or `helix diag corpus` to distinguish those
+cases.
+
+Exit codes: `0` success, `1` codec / read error.
+
+## Operational subcommands
 
 ### `helix ingest <path> [--recursive] [--ext .EXT] [--json]`
 

--- a/docs/clients/cli.md
+++ b/docs/clients/cli.md
@@ -17,6 +17,35 @@ helix --help
 The legacy FastAPI launcher is still available as `helix-server` (or
 `python -m uvicorn helix_context._asgi:app`).
 
+### If `helix` says "no such command" or points at a deleted path
+
+The pip console script (`helix`, `helix-server`, `helix-status`,
+`helix-vault`, `helix-launcher`) is generated at install time and
+hardcodes the absolute path of the Python interpreter and the
+`helix_context` package. Two recovery cases:
+
+1. **`helix` is on PATH but resolves to a deleted editable-install
+   path** (you moved or removed the source tree). Re-install:
+   ```bash
+   pip install --force-reinstall --no-deps helix-context
+   ```
+   `--no-deps` keeps the long dependency chain from re-resolving;
+   `--force-reinstall` rewrites the console scripts against the
+   currently-active Python.
+
+2. **`helix` is not on PATH at all.** The console scripts land in
+   `<python-prefix>/Scripts` on Windows or `<python-prefix>/bin` on
+   POSIX. Either add that directory to PATH or invoke the entry point
+   directly:
+   ```bash
+   python -m helix_context.cli --help              # always works
+   python -c "from helix_context.cli import main; main()" status
+   ```
+
+The module-direct form (`python -m helix_context.cli`) bypasses the
+console script entirely and is the most reliable fallback when an
+agent or operator is debugging a broken install.
+
 ## Title page — what the CLI does for an agent vs. an operator
 
 | Use case | Reach for |

--- a/helix_context/api.py
+++ b/helix_context/api.py
@@ -570,8 +570,21 @@ def open_session(
     """
     global _DEFAULT_MANAGER
     if _DEFAULT_MANAGER is None:
+        from .config import load_config  # late import — cheap, but keeps the
+        # top-level import surface narrow
         from .context_manager import HelixContextManager  # late import
-        cfg = config or HelixConfig()
+
+        # If the caller hands us a config explicitly, honor it. Otherwise
+        # go through ``load_config`` so HELIX_CONFIG (path to helix.toml)
+        # and HELIX_GENOME_PATH (override of [genome] path) are respected
+        # the same way ``helix status`` already honors them. Before this
+        # call site used ``HelixConfig()`` directly, every cold-start CLI
+        # subcommand (query, packet, gene, neighbors, refresh-targets,
+        # diag corpus) silently fell back to defaults and read/created
+        # ./genome.db regardless of what the operator configured — which
+        # made ``helix status`` look healthy but ``helix query`` look at
+        # an entirely different (often empty) genome.
+        cfg = config or load_config()
         _DEFAULT_MANAGER = HelixContextManager(config=cfg)
     return HelixSession(
         manager=_DEFAULT_MANAGER,

--- a/helix_context/api.py
+++ b/helix_context/api.py
@@ -63,7 +63,9 @@ from typing import Any, Dict, List, Optional
 from .config import HelixConfig
 from .schemas import (
     ContextItem,
+    ContextPacket,
     ContextWindow,
+    Gene,
     KnowBlock,
     MissBlock,
     RefreshTarget,
@@ -349,15 +351,133 @@ class HelixSession:
             },
         )
 
-    # ── Walk-aware surface (deferred past v1) ────────────────────────
+    # ── Walk-aware surface (v1.x — added 2026-05-12) ──────────────────
     #
-    # The agent-walks-the-corpus workflow (drill into a document,
-    # fetch related ones, re-query with refined understanding) is
-    # NOT part of the v1 surface. Once the read-path API is wired
-    # through the manager (Genome.get_gene + list_neighbors) and the
-    # /context/packet builder is finalized, those methods will be
-    # added here. Until then callers should drive walks via repeated
-    # ``query()`` calls.
+    # The agent-walks-the-corpus workflow (drill into a document, fetch
+    # related ones, decide whether to act or reread). Each method is a
+    # thin in-process wrapper over the existing primitives — no HTTP,
+    # no separate server, so cold-start CLI keeps its single-process
+    # promise. Identical semantics to the matching MCP tools
+    # (helix_gene_get / helix_neighbors / helix_context_packet /
+    # helix_refresh_targets) so agents can switch surfaces without
+    # changing call logic.
+
+    def gene_get(self, gene_id: str) -> Optional[Gene]:
+        """Fetch a single document by ID.
+
+        Returns the full ``Gene`` model (content, tags, signals,
+        fragments, lifecycle tier, embedding) or ``None`` when the
+        gene_id is unknown. Read-only; never mutates the store.
+        """
+        return self._manager.genome.get_gene(gene_id)
+
+    def packet(
+        self,
+        query: str,
+        *,
+        task_type: str = "explain",
+        max_genes: int = 8,
+        include_raw: bool = False,
+    ) -> ContextPacket:
+        """Build a freshness-labeled agent-safe evidence packet.
+
+        Same builder the ``/context/packet`` HTTP endpoint uses.
+        ``task_type`` ∈ {"plan", "explain", "review", "edit", "debug",
+        "ops", "quote"} — higher-risk types apply stricter freshness
+        and coordinate-confidence gates. ``include_raw=True`` swaps
+        each item's compressed body for the full ``gene.content`` (the
+        2026-04-22 "real bytes" path).
+
+        Read-only: ``build_context_packet`` is called with
+        ``read_only=True`` so a CLI agent loop never mutates the store
+        by inspecting it.
+        """
+        from .context_packet import build_context_packet  # late import — heavy
+        return build_context_packet(
+            query,
+            task_type=task_type,
+            genome=self._manager.genome,
+            max_genes=max_genes,
+            read_only=True,
+            include_raw=include_raw,
+        )
+
+    def refresh_targets(
+        self,
+        query: str,
+        *,
+        task_type: str = "edit",
+        max_genes: int = 8,
+    ) -> List[RefreshTarget]:
+        """Return just the reread plan for a high-risk action.
+
+        Builds a full ``ContextPacket`` and returns the
+        ``refresh_targets`` list. Defaults to ``task_type="edit"`` —
+        that's the usual caller (an agent about to mutate a file).
+        See ``packet`` for the full bundle.
+        """
+        return list(self.packet(
+            query, task_type=task_type, max_genes=max_genes,
+        ).refresh_targets)
+
+    def neighbors(self, query: str, *, k: int = 10) -> List[Dict[str, Any]]:
+        """Top-k SEMA neighbors for ``query``.
+
+        Returns a list of ``{gene_id, sema_cos_sim, preview, path}``
+        dicts — the same shape the ``/debug/neighbors`` HTTP endpoint
+        and the ``helix_neighbors`` MCP tool emit. Read-only.
+
+        Returns an empty list when the SEMA codec is unavailable
+        (e.g. the ``embeddings`` extra is not installed, or no genes
+        have embeddings yet). Callers can distinguish "no neighbors"
+        from "codec missing" by checking ``stats().total_genes``.
+        """
+        import json as _json
+
+        codec = getattr(self._manager, "_sema_codec", None)
+        if codec is None:
+            return []
+
+        rows = self._manager.genome.read_conn.execute(
+            "SELECT gene_id, embedding FROM genes "
+            "WHERE embedding IS NOT NULL AND chromatin < 2 "
+            "LIMIT 20000"
+        ).fetchall()
+        if not rows:
+            return []
+
+        q_vec = codec.encode(query)
+        scored: List[tuple] = []
+        for r in rows:
+            try:
+                vec = _json.loads(r["embedding"])
+            except (TypeError, ValueError, _json.JSONDecodeError):
+                # Skip rows whose embedding column is malformed; never
+                # silent — log once at warning so the operator can
+                # spot a corrupted ingest.
+                log.warning(
+                    "neighbors: skipping gene %s with malformed embedding",
+                    r["gene_id"],
+                )
+                continue
+            scored.append((codec.similarity(q_vec, vec), r["gene_id"]))
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        out: List[Dict[str, Any]] = []
+        for sim, gid in scored[:k]:
+            g = self._manager.genome.get_gene(gid)
+            if g is None:
+                continue
+            path = None
+            if g.promoter and g.promoter.metadata:
+                path = g.promoter.metadata.get("path")
+            out.append({
+                "gene_id": gid,
+                "sema_cos_sim": round(float(sim), 4),
+                "preview": (g.content or "")[:160],
+                "path": path,
+            })
+        return out
 
     # ── Replication surface (v1.1) ──────────────────────────────────
 
@@ -499,6 +619,44 @@ def stats() -> StatsResult:
     return sess.stats()
 
 
+def gene_get(gene_id: str) -> Optional[Gene]:
+    """One-shot module-level gene_get. See ``query`` for lifecycle notes."""
+    return open_session().gene_get(gene_id)
+
+
+def packet(
+    query_text: str,
+    *,
+    task_type: str = "explain",
+    max_genes: int = 8,
+    include_raw: bool = False,
+) -> ContextPacket:
+    """One-shot module-level context-packet builder."""
+    return open_session().packet(
+        query_text,
+        task_type=task_type,
+        max_genes=max_genes,
+        include_raw=include_raw,
+    )
+
+
+def refresh_targets(
+    query_text: str,
+    *,
+    task_type: str = "edit",
+    max_genes: int = 8,
+) -> List[RefreshTarget]:
+    """One-shot module-level refresh-targets builder."""
+    return open_session().refresh_targets(
+        query_text, task_type=task_type, max_genes=max_genes,
+    )
+
+
+def neighbors(query_text: str, *, k: int = 10) -> List[Dict[str, Any]]:
+    """One-shot module-level SEMA neighbors lookup."""
+    return open_session().neighbors(query_text, k=k)
+
+
 # ── What this module deliberately does NOT expose ─────────────────────
 #
 # Belongs on the FastAPI surface (cross-device telemetry / ops):
@@ -526,4 +684,8 @@ __all__ = [
     "query",
     "ingest",
     "stats",
+    "gene_get",
+    "packet",
+    "refresh_targets",
+    "neighbors",
 ]

--- a/helix_context/cli/__main__.py
+++ b/helix_context/cli/__main__.py
@@ -1,0 +1,14 @@
+"""Enable ``python -m helix_context.cli`` as a fallback when the
+pip-installed ``helix`` console script is broken or off PATH.
+
+Documented in ``docs/clients/cli.md`` as the always-works recovery path
+when the editable-install entry point points at a deleted source tree.
+"""
+from __future__ import annotations
+
+import sys
+
+from .dispatcher import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helix_context/cli/cmd_gene.py
+++ b/helix_context/cli/cmd_gene.py
@@ -1,0 +1,137 @@
+"""`helix gene <action>` — inspect a single document.
+
+Two actions:
+  * ``get <id>``     — full document (content + tags + signals + tier
+                       + embedding). Use when you need everything.
+  * ``preview <id>`` — content-only snippet, capped at ``--chars`` (default
+                       240). Cheaper than ``get`` when you just want to
+                       eyeball whether the document is relevant.
+
+Both wrap :meth:`helix_context.api.HelixSession.gene_get`, which uses
+``Genome.get_gene`` under the hood. Read-only.
+
+Vocabulary note: the subcommand is ``gene`` to match the legacy MCP
+tool name (``helix_gene_get``) — the canonical engineering alias is
+``helix_document_get`` per ROSETTA.md. A future ``helix document``
+top-level subcommand alias can co-exist once the R4 soft-deprecation
+wave lands.
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict, Optional
+
+from . import output
+from helix_context.api import open_session
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="helix gene",
+        description="Inspect a single document by ID.",
+    )
+    sub = parser.add_subparsers(dest="action", metavar="<action>", required=True)
+
+    get_p = sub.add_parser("get", help="Full document (content + tags + signals + tier).")
+    get_p.add_argument("gene_id", help="The document ID (e.g. gene-abc123…).")
+    get_p.add_argument("--json", action="store_true", help="Machine-readable JSON.")
+
+    prev_p = sub.add_parser("preview", help="Content-only snippet, char-capped.")
+    prev_p.add_argument("gene_id", help="The document ID.")
+    prev_p.add_argument(
+        "--chars", type=int, default=240,
+        help="Max characters to include in the preview (default: 240).",
+    )
+    prev_p.add_argument("--json", action="store_true", help="Machine-readable JSON.")
+
+    return parser
+
+
+def _get_payload(gene) -> Dict[str, Any]:
+    return gene.model_dump()
+
+
+def _preview_payload(gene, chars: int) -> Dict[str, Any]:
+    content = gene.content or ""
+    snippet = content[:chars]
+    truncated = len(content) > chars
+    path: Optional[str] = None
+    if gene.promoter and gene.promoter.metadata:
+        path = gene.promoter.metadata.get("path")
+    return {
+        "gene_id": gene.gene_id,
+        "preview": snippet,
+        "truncated": truncated,
+        "total_chars": len(content),
+        "path": path,
+    }
+
+
+def _render_get_text(payload: Dict[str, Any]) -> list[str]:
+    promoter = payload.get("promoter") or {}
+    tags_domains = promoter.get("domains") or []
+    tags_entities = promoter.get("entities") or []
+    lines = [
+        f"gene_id: {payload.get('gene_id', '?')}",
+        f"chromatin: {payload.get('chromatin', '?')}",
+        f"domains: {', '.join(tags_domains) or '(none)'}",
+        f"entities: {', '.join(tags_entities) or '(none)'}",
+        f"content_chars: {len(payload.get('content') or '')}",
+        "",
+        "--- content ---",
+        payload.get("content") or "",
+    ]
+    return lines
+
+
+def _render_preview_text(payload: Dict[str, Any]) -> list[str]:
+    lines = [
+        f"gene_id: {payload['gene_id']}",
+        f"total_chars: {payload['total_chars']} "
+        f"({'truncated' if payload['truncated'] else 'complete'})",
+        f"path: {payload.get('path') or '(none)'}",
+        "",
+        "--- preview ---",
+        payload["preview"],
+    ]
+    return lines
+
+
+def run(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        sess = open_session()
+        gene = sess.gene_get(args.gene_id)
+    except Exception as exc:
+        err = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        if args.json:
+            output.print_json(err)
+        else:
+            output.eprint(err["error"])
+        return output.EXIT_ERROR
+
+    if gene is None:
+        err = {"ok": False, "error": f"unknown gene_id: {args.gene_id}"}
+        if args.json:
+            output.print_json(err)
+        else:
+            output.eprint(err["error"])
+        return output.EXIT_ERROR
+
+    if args.action == "get":
+        payload = _get_payload(gene)
+        if args.json:
+            output.print_json(payload)
+        else:
+            output.print_lines(_render_get_text(payload))
+        return output.EXIT_OK
+
+    # preview
+    payload = _preview_payload(gene, args.chars)
+    if args.json:
+        output.print_json(payload)
+    else:
+        output.print_lines(_render_preview_text(payload))
+    return output.EXIT_OK

--- a/helix_context/cli/cmd_neighbors.py
+++ b/helix_context/cli/cmd_neighbors.py
@@ -1,0 +1,85 @@
+"""`helix neighbors` — top-k SEMA neighbors for a query.
+
+Read-only, cheap. Mirrors the ``/debug/neighbors`` HTTP endpoint and
+the ``helix_neighbors`` MCP tool. Returns an empty list (exit 0) when
+the SEMA codec is unavailable or no embeddings are populated — the
+``--json`` shape includes a ``count: 0`` so consumers don't have to
+distinguish "no codec" from "no matches" structurally; check
+``helix status`` or ``helix diag corpus`` for that.
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict, List
+
+from . import output
+from helix_context.api import open_session
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="helix neighbors",
+        description="Top-k SEMA neighbors for a query (semantic graph walk).",
+    )
+    parser.add_argument("text", help="The query string.")
+    parser.add_argument(
+        "--k", type=int, default=10,
+        help="Number of neighbors to return (default: 10).",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Machine-readable JSON.",
+    )
+    return parser
+
+
+def _payload(query: str, k: int, neighbors: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "query": query,
+        "k": k,
+        "neighbors": neighbors,
+        "count": len(neighbors),
+    }
+
+
+def _render_text(payload: Dict[str, Any]) -> list[str]:
+    neighbors = payload.get("neighbors", []) or []
+    if not neighbors:
+        return [
+            f"query: {payload['query']}",
+            "neighbors: (none — SEMA codec missing or no embeddings yet)",
+        ]
+    lines = [f"query: {payload['query']}", f"k: {payload['k']}", "neighbors:"]
+    for n in neighbors:
+        path = n.get("path") or "(no path)"
+        preview = (n.get("preview") or "").replace("\n", " ")
+        lines.append(
+            f"  [{n.get('sema_cos_sim', 0.0):.4f}] "
+            f"{n.get('gene_id', '?')} — {path}"
+        )
+        if preview:
+            lines.append(f"    {preview}")
+    return lines
+
+
+def run(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        sess = open_session()
+        neighbors = sess.neighbors(args.text, k=args.k)
+    except Exception as exc:
+        err = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        if args.json:
+            output.print_json(err)
+        else:
+            output.eprint(err["error"])
+        return output.EXIT_ERROR
+
+    payload = _payload(args.text, args.k, neighbors)
+    if args.json:
+        output.print_json(payload)
+    else:
+        output.print_lines(_render_text(payload))
+    return output.EXIT_OK

--- a/helix_context/cli/cmd_packet.py
+++ b/helix_context/cli/cmd_packet.py
@@ -1,0 +1,134 @@
+"""`helix packet` — agent-safe evidence bundle with freshness labels.
+
+Wraps :meth:`helix_context.api.HelixSession.packet`, which itself
+delegates to ``helix_context.context_packet.build_context_packet`` —
+the same builder the FastAPI ``/context/packet`` endpoint and the
+``helix_context_packet`` MCP tool use. Output shape is identical so
+agents can swap surfaces (CLI ↔ MCP ↔ HTTP) without changing call
+logic.
+
+The packet is the right surface for high-risk actions (edit, ops):
+it returns freshness-labeled evidence (verified / stale_risk) plus
+an explicit ``refresh_targets`` reread plan, instead of raw bytes
+that may be stale.
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict
+
+from . import output
+from helix_context.api import open_session
+
+
+# Task-type vocabulary matches the MCP tool + /context/packet endpoint.
+# Listed explicitly so `--task-type foo` fails fast at argparse rather
+# than silently coercing inside the builder.
+_TASK_TYPES = ("plan", "explain", "review", "edit", "debug", "ops", "quote")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="helix packet",
+        description=(
+            "Build a freshness-labeled evidence packet for an agent action. "
+            "Returns verified / stale_risk items plus refresh_targets."
+        ),
+    )
+    parser.add_argument("text", help="The query string.")
+    parser.add_argument(
+        "--task-type",
+        choices=_TASK_TYPES,
+        default="explain",
+        help=(
+            "Risk profile (default: explain). Higher-risk types (edit, ops) "
+            "apply stricter freshness + coordinate-confidence gates."
+        ),
+    )
+    parser.add_argument(
+        "--max-genes", type=int, default=8,
+        help="Retrieval top-K cap (default: 8).",
+    )
+    parser.add_argument(
+        "--include-raw", action="store_true",
+        help=(
+            "Return the full gene content per item instead of the "
+            "compressor-compressed summary. Use when the packet is the only "
+            "context source and the downstream LLM needs real bytes."
+        ),
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Machine-readable JSON (use for agent / bench consumption).",
+    )
+    return parser
+
+
+def _packet_to_payload(packet) -> Dict[str, Any]:
+    """Project a ``ContextPacket`` pydantic model into the agent-facing
+    JSON shape. Identical structure to the ``/context/packet`` endpoint
+    response so callers can swap CLI ↔ HTTP without code changes."""
+    return packet.model_dump()
+
+
+def _render_text(payload: Dict[str, Any]) -> list[str]:
+    verified = payload.get("verified", []) or []
+    stale = payload.get("stale_risk", []) or []
+    refresh = payload.get("refresh_targets", []) or []
+    lines = [
+        f"task_type: {payload.get('task_type', '?')}",
+        f"query: {payload.get('query', '')}",
+        f"coordinate_confidence: {payload.get('coordinate_confidence', 0.0):.2f}",
+        f"file_coverage: {payload.get('file_coverage', 0.0):.2f}",
+        f"verified: {len(verified)}",
+        f"stale_risk: {len(stale)}",
+        f"refresh_targets: {len(refresh)}",
+    ]
+    know = payload.get("know")
+    miss = payload.get("miss")
+    if know is not None:
+        lines.append(f"verdict: know (soft_stale={know.get('soft_stale', False)})")
+    elif miss is not None:
+        lines.append(f"verdict: miss (escalate_to={miss.get('escalate_to', [])})")
+    notes = payload.get("notes") or []
+    if notes:
+        lines.append("notes:")
+        for n in notes:
+            lines.append(f"  - {n}")
+    if refresh:
+        lines.append("refresh_targets:")
+        for t in refresh:
+            lines.append(
+                f"  - [{t.get('priority', 0.0):.2f}] "
+                f"{t.get('target_kind', '?')}:{t.get('source_id', '?')} "
+                f"— {t.get('reason', '')}"
+            )
+    return lines
+
+
+def run(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        sess = open_session()
+        packet = sess.packet(
+            args.text,
+            task_type=args.task_type,
+            max_genes=args.max_genes,
+            include_raw=args.include_raw,
+        )
+    except Exception as exc:
+        err = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        if args.json:
+            output.print_json(err)
+        else:
+            output.eprint(err["error"])
+        return output.EXIT_ERROR
+
+    payload = _packet_to_payload(packet)
+    if args.json:
+        output.print_json(payload)
+    else:
+        output.print_lines(_render_text(payload))
+    return output.EXIT_OK

--- a/helix_context/cli/cmd_refresh_targets.py
+++ b/helix_context/cli/cmd_refresh_targets.py
@@ -1,0 +1,96 @@
+"""`helix refresh-targets` — just the reread plan, no evidence items.
+
+Useful when the caller already has content cached and only needs to
+know which sources are stale enough that rereading is required before
+a high-risk action completes. Same call as ``helix packet`` then
+projected down to the ``refresh_targets`` list — cheap to build, no
+extra retrieval pass.
+
+Mirrors the ``/context/refresh-plan`` HTTP endpoint and the
+``helix_refresh_targets`` MCP tool.
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict, List
+
+from . import output
+from helix_context.api import open_session
+
+
+_TASK_TYPES = ("plan", "explain", "review", "edit", "debug", "ops", "quote")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="helix refresh-targets",
+        description=(
+            "Return the reread plan for a query — refresh_targets only, "
+            "no evidence items. Default task_type is 'edit'."
+        ),
+    )
+    parser.add_argument("text", help="The query string.")
+    parser.add_argument(
+        "--task-type",
+        choices=_TASK_TYPES,
+        default="edit",
+        help="Risk profile (default: edit — the usual caller).",
+    )
+    parser.add_argument(
+        "--max-genes", type=int, default=8,
+        help="Retrieval top-K cap (default: 8).",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Machine-readable JSON.",
+    )
+    return parser
+
+
+def _payload(targets) -> Dict[str, List[Dict[str, Any]]]:
+    """Flatten the RefreshTarget pydantic models to dicts."""
+    return {
+        "refresh_targets": [t.model_dump() for t in targets],
+        "count": len(targets),
+    }
+
+
+def _render_text(payload: Dict[str, Any]) -> list[str]:
+    targets = payload.get("refresh_targets", []) or []
+    if not targets:
+        return ["refresh_targets: (none — packet would be clean)"]
+    lines = [f"refresh_targets: {len(targets)}"]
+    for t in targets:
+        lines.append(
+            f"  - [{t.get('priority', 0.0):.2f}] "
+            f"{t.get('target_kind', '?')}:{t.get('source_id', '?')} "
+            f"— {t.get('reason', '')}"
+        )
+    return lines
+
+
+def run(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        sess = open_session()
+        targets = sess.refresh_targets(
+            args.text,
+            task_type=args.task_type,
+            max_genes=args.max_genes,
+        )
+    except Exception as exc:
+        err = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        if args.json:
+            output.print_json(err)
+        else:
+            output.eprint(err["error"])
+        return output.EXIT_ERROR
+
+    payload = _payload(targets)
+    if args.json:
+        output.print_json(payload)
+    else:
+        output.print_lines(_render_text(payload))
+    return output.EXIT_OK

--- a/helix_context/cli/dispatcher.py
+++ b/helix_context/cli/dispatcher.py
@@ -33,6 +33,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Run one retrieval pipeline pass over the genome and print the result.",
     )
     sub.add_parser(
+        "packet",
+        help="Build a freshness-labeled agent-safe evidence bundle.",
+    )
+    sub.add_parser(
+        "refresh-targets",
+        help="Reread plan only — refresh_targets without evidence items.",
+    )
+    sub.add_parser(
+        "gene",
+        help="Inspect a single document (`helix gene get|preview <id>`).",
+    )
+    sub.add_parser(
+        "neighbors",
+        help="Top-k SEMA neighbors for a query (semantic graph walk).",
+    )
+    sub.add_parser(
         "ingest",
         help="Add a file (or directory of files) to the genome.",
     )
@@ -61,6 +77,18 @@ def _resolve(name: str) -> Optional[Callable[[list[str]], int]]:
     if name == "query":
         from . import cmd_query
         return cmd_query.run
+    if name == "packet":
+        from . import cmd_packet
+        return cmd_packet.run
+    if name == "refresh-targets":
+        from . import cmd_refresh_targets
+        return cmd_refresh_targets.run
+    if name == "gene":
+        from . import cmd_gene
+        return cmd_gene.run
+    if name == "neighbors":
+        from . import cmd_neighbors
+        return cmd_neighbors.run
     if name == "ingest":
         from . import cmd_ingest
         return cmd_ingest.run

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -869,5 +869,31 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             k: list(v) for k, v in raw["synonyms"].items()
         }
 
+    # Coherence guard: if the ribosome is disabled (the LLM-free design
+    # default — see docs/MISSION.md) but ingestion.backend still asks for
+    # an LLM-backed path (``ollama`` / ``deberta`` / ``litellm``), the
+    # CLI ``helix ingest`` call will raise ``TranscriptionError: Pack
+    # failed: Ribosome is disabled`` on the first chunk. The two settings
+    # contradict each other; flip ``ingestion.backend`` to ``"cpu"`` so
+    # the spaCy/heuristic CpuTagger handles the ingest. Emit at WARNING
+    # so the operator can see the auto-fallback in logs and disable it
+    # by either (a) enabling ``[ribosome]`` explicitly or (b) setting
+    # ``[ingestion] backend = "cpu"`` themselves. Requires the ``[cpu]``
+    # extra (spaCy) to be installed — CpuTagger logs its own warning if
+    # spaCy is missing.
+    if (
+        not cfg.ribosome.enabled
+        and cfg.ingestion.backend in ("ollama", "deberta", "litellm")
+    ):
+        log.warning(
+            "[ribosome] enabled=false but [ingestion] backend=%r requires the "
+            "ribosome — auto-falling-back to backend='cpu' (spaCy CpuTagger). "
+            "Install the [cpu] extra if you have not. Override by either "
+            "enabling [ribosome] or setting [ingestion] backend='cpu' / 'hybrid' "
+            "explicitly in helix.toml.",
+            cfg.ingestion.backend,
+        )
+        cfg.ingestion.backend = "cpu"
+
     log.info("Config loaded from %s", config_path)
     return cfg

--- a/helix_context/mcp_server.py
+++ b/helix_context/mcp_server.py
@@ -202,6 +202,29 @@ def _http(method: str, path: str, body: Optional[Dict] = None) -> Dict[str, Any]
         raise
 
 
+def _unwrap_context_list(result: Any) -> Dict[str, Any]:
+    """Unwrap the Continue HTTP context-provider list shape into the flat
+    dict that MCP tool consumers (and the ``Dict[str, Any]`` return-type
+    annotation) expect.
+
+    ``POST /context`` returns ``[response]`` — a single-entry list — to
+    stay drop-in compatible with the Continue IDE HTTP context provider
+    protocol. MCP hosts validate tool returns against their declared
+    schema and reject a list when a dict was declared. This helper:
+
+      * unwraps a single-entry dict list ``[{...}]`` → ``{...}``
+      * passes through error envelopes already produced by ``_http``
+        (``{_error: ...}``, ``{_raw: ...}``)
+      * defensively wraps any unexpected list shape so MCP callers see
+        a validatable dict plus a diagnostic note
+    """
+    if isinstance(result, list):
+        if len(result) == 1 and isinstance(result[0], dict):
+            return result[0]
+        return {"items": result, "_note": "unexpected list shape from /context"}
+    return result
+
+
 def _normalize_health_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Project raw /health or transport errors into a stable status shape."""
     normalized: Dict[str, Any] = {"server": payload}
@@ -345,7 +368,7 @@ def helix_context(
         # labels (request rate / latency by agent) reflect THIS shim,
         # not the bare HELIX_AGENT env on the helix server process.
         body["agent"] = MCP_AGENT_HANDLE
-    return _http("POST", "/context", body)
+    return _unwrap_context_list(_http("POST", "/context", body))
 
 
 # ── Tool: helix_context_packet ───────────────────────────────────────
@@ -888,7 +911,7 @@ def helix_document_query(
         # labels (request rate / latency by agent) reflect THIS shim,
         # not the bare HELIX_AGENT env on the helix server process.
         body["agent"] = MCP_AGENT_HANDLE
-    return _http("POST", "/context", body)
+    return _unwrap_context_list(_http("POST", "/context", body))
 
 
 @mcp.tool()

--- a/helix_status.py
+++ b/helix_status.py
@@ -18,8 +18,30 @@ from typing import Any, Dict, Optional
 DEFAULT_SERVER_URL = os.environ.get("HELIX_STATUS_URL", "http://127.0.0.1:11437").rstrip("/")
 DEFAULT_LAUNCHER_URL = os.environ.get("HELIX_LAUNCHER_URL", "http://127.0.0.1:11438").rstrip("/")
 
+# Status probe timeout (seconds). The pre-fix default was 1.5s, which
+# silently reported a healthy but slow server as ``unreachable`` —
+# cold-start ``/health`` can take 5-10s under model warmup / manager
+# init / SQLite WAL replay. 10s is generous for a status check and
+# matches the operator's expectation that "alive but slow" is still
+# alive. Override via ``HELIX_STATUS_TIMEOUT_S`` for tight CI loops
+# (e.g. ``0.5``) or for very large genomes (e.g. ``30``).
+_DEFAULT_STATUS_TIMEOUT_S = 10.0
+try:
+    DEFAULT_STATUS_TIMEOUT_S = float(
+        os.environ.get("HELIX_STATUS_TIMEOUT_S", _DEFAULT_STATUS_TIMEOUT_S)
+    )
+except ValueError:
+    # Never let a malformed env var crash status — fall back, warn the
+    # operator on stderr so the override gets noticed and fixed.
+    import sys
+    sys.stderr.write(
+        f"HELIX_STATUS_TIMEOUT_S={os.environ.get('HELIX_STATUS_TIMEOUT_S')!r} "
+        f"is not a float; falling back to {_DEFAULT_STATUS_TIMEOUT_S}s\n"
+    )
+    DEFAULT_STATUS_TIMEOUT_S = _DEFAULT_STATUS_TIMEOUT_S
 
-def _get_json(url: str, timeout_s: float = 1.5) -> Dict[str, Any]:
+
+def _get_json(url: str, timeout_s: float = DEFAULT_STATUS_TIMEOUT_S) -> Dict[str, Any]:
     try:
         with urllib.request.urlopen(url, timeout=timeout_s) as resp:
             return json.loads(resp.read().decode("utf-8"))

--- a/tests/test_api_walk.py
+++ b/tests/test_api_walk.py
@@ -199,6 +199,50 @@ def test_neighbors_sorts_by_similarity_desc():
     assert out[0]["path"] == "helix_context/splice.py"
 
 
+def test_open_session_honors_helix_config_env(monkeypatch, tmp_path):
+    """`open_session()` must route through ``load_config()`` so that
+    ``HELIX_CONFIG`` and ``HELIX_GENOME_PATH`` are honored exactly like
+    ``helix status`` already honors them. Pre-fix this used the
+    ``HelixConfig()`` default and silently fell back to ``./genome.db``
+    regardless of operator config — making ``helix status`` and
+    ``helix query`` look at different genomes."""
+    import helix_context.api as api
+
+    # Reset the cached manager so the test exercises the cold-start path.
+    api._DEFAULT_MANAGER = None
+
+    cfg_path = tmp_path / "helix.toml"
+    cfg_path.write_text(
+        "[genome]\npath = \"" + str(tmp_path / "configured.db").replace("\\", "/") + "\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HELIX_CONFIG", str(cfg_path))
+    # The test environment sets HELIX_GENOME_PATH=:memory: to keep tests
+    # off-disk; that env var wins over helix.toml at load_config time
+    # (see config.py:611). Delete it for this test so we exercise the
+    # TOML-discovery path. Real operators usually don't set both.
+    monkeypatch.delenv("HELIX_GENOME_PATH", raising=False)
+
+    seen: dict = {}
+
+    class _FakeMgr:
+        def __init__(self, config):
+            seen["config"] = config
+
+    monkeypatch.setattr(
+        "helix_context.context_manager.HelixContextManager", _FakeMgr,
+    )
+
+    api.open_session()
+    assert seen["config"].genome.path.endswith("configured.db"), (
+        "open_session() did not propagate HELIX_CONFIG → load_config(); got: "
+        f"{seen['config'].genome.path!r}"
+    )
+
+    # Cleanup so subsequent tests start cold.
+    api._DEFAULT_MANAGER = None
+
+
 def test_neighbors_skips_malformed_embedding_row():
     """A row whose embedding column is non-JSON gets logged + skipped;
     the rest of the result still comes back."""

--- a/tests/test_api_walk.py
+++ b/tests/test_api_walk.py
@@ -1,0 +1,224 @@
+"""Tests for the walk-aware methods on ``helix_context.api.HelixSession``.
+
+These methods (``gene_get``, ``packet``, ``refresh_targets``,
+``neighbors``) were added 2026-05-12 to back the CLI agent surface. The
+council review of the v1 CLI flagged that the in-process API
+deliberately deferred them to v1.1; making them v1 unblocks `helix
+packet`, `helix gene get`, etc. without standing up an HTTP server.
+
+The tests stub the underlying ``HelixContextManager`` (and the
+``build_context_packet`` helper that the packet methods delegate to) so
+they verify the API boundary in isolation from the retrieval stack.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helix_context.api import HelixSession
+from helix_context.schemas import (
+    ChromatinState,
+    ContextItem,
+    ContextPacket,
+    Gene,
+    PromoterTags,
+    RefreshTarget,
+)
+
+
+def _make_session(manager=None):
+    """Build a HelixSession bound to a MagicMock manager — bypasses
+    open_session() so we don't accidentally spin up a real
+    HelixContextManager (and a real SQLite genome)."""
+    manager = manager or MagicMock()
+    return HelixSession(manager=manager, session_id="sess-test-walk")
+
+
+def _make_gene(gene_id="gene-001", content="splice trims fragments"):
+    return Gene(
+        gene_id=gene_id,
+        content=content,
+        complement=content[:40],
+        codons=["splice"],
+        promoter=PromoterTags(metadata={"path": "helix_context/splice.py"}),
+        chromatin=ChromatinState.OPEN,
+    )
+
+
+# ── gene_get ─────────────────────────────────────────────────────────
+
+
+def test_gene_get_delegates_to_genome():
+    mgr = MagicMock()
+    mgr.genome.get_gene.return_value = _make_gene()
+    sess = _make_session(mgr)
+    gene = sess.gene_get("gene-001")
+    assert gene.gene_id == "gene-001"
+    mgr.genome.get_gene.assert_called_once_with("gene-001")
+
+
+def test_gene_get_returns_none_on_unknown_id():
+    mgr = MagicMock()
+    mgr.genome.get_gene.return_value = None
+    sess = _make_session(mgr)
+    assert sess.gene_get("nope") is None
+
+
+# ── packet ───────────────────────────────────────────────────────────
+
+
+def test_packet_calls_builder_with_genome_and_read_only_true():
+    mgr = MagicMock()
+    expected = ContextPacket(
+        task_type="explain",
+        query="splice",
+        verified=[],
+        stale_risk=[],
+        refresh_targets=[],
+    )
+    with patch(
+        "helix_context.context_packet.build_context_packet",
+        return_value=expected,
+    ) as builder:
+        sess = _make_session(mgr)
+        out = sess.packet("splice", task_type="explain", max_genes=4)
+    assert out is expected
+    _, kwargs = builder.call_args
+    assert kwargs["genome"] is mgr.genome
+    assert kwargs["task_type"] == "explain"
+    assert kwargs["max_genes"] == 4
+    assert kwargs["read_only"] is True
+    assert kwargs["include_raw"] is False
+
+
+def test_packet_include_raw_passes_through():
+    mgr = MagicMock()
+    with patch(
+        "helix_context.context_packet.build_context_packet",
+        return_value=ContextPacket(task_type="edit", query="x"),
+    ) as builder:
+        sess = _make_session(mgr)
+        sess.packet("x", task_type="edit", include_raw=True)
+    _, kwargs = builder.call_args
+    assert kwargs["include_raw"] is True
+
+
+# ── refresh_targets ──────────────────────────────────────────────────
+
+
+def test_refresh_targets_returns_only_the_reread_plan():
+    mgr = MagicMock()
+    packet = ContextPacket(
+        task_type="edit",
+        query="splice",
+        verified=[ContextItem(title="t", content="c")],  # would be in packet, not in refresh
+        stale_risk=[],
+        refresh_targets=[
+            RefreshTarget(
+                target_kind="file", source_id="a.py", reason="stale", priority=0.5,
+            ),
+            RefreshTarget(
+                target_kind="file", source_id="b.py", reason="cold", priority=0.2,
+            ),
+        ],
+    )
+    with patch(
+        "helix_context.context_packet.build_context_packet",
+        return_value=packet,
+    ):
+        sess = _make_session(mgr)
+        targets = sess.refresh_targets("splice", task_type="edit")
+    assert [t.source_id for t in targets] == ["a.py", "b.py"]
+
+
+def test_refresh_targets_default_task_type_is_edit():
+    """High-risk default — the CLI subcommand mirrors this."""
+    mgr = MagicMock()
+    with patch(
+        "helix_context.context_packet.build_context_packet",
+        return_value=ContextPacket(task_type="edit", query="x"),
+    ) as builder:
+        sess = _make_session(mgr)
+        sess.refresh_targets("x")
+    _, kwargs = builder.call_args
+    assert kwargs["task_type"] == "edit"
+
+
+# ── neighbors ────────────────────────────────────────────────────────
+
+
+def test_neighbors_empty_when_codec_missing():
+    """If the SEMA codec didn't initialize (e.g. `embeddings` extra not
+    installed), we return [] rather than raise — the CLI surface relies
+    on this so a fresh install doesn't crash on `helix neighbors`."""
+    mgr = MagicMock()
+    mgr._sema_codec = None
+    sess = _make_session(mgr)
+    assert sess.neighbors("test") == []
+
+
+def test_neighbors_empty_when_no_embeddings_in_genome():
+    mgr = MagicMock()
+    mgr._sema_codec = MagicMock()
+    mgr.genome.read_conn.execute.return_value.fetchall.return_value = []
+    sess = _make_session(mgr)
+    assert sess.neighbors("test", k=5) == []
+
+
+def test_neighbors_sorts_by_similarity_desc():
+    """The cosine-similarity tuple is sorted descending; top-k truncates."""
+    mgr = MagicMock()
+    codec = MagicMock()
+    codec.encode.return_value = [1.0, 0.0]
+    # Three genes — manager's similarity returns a different score per call.
+    codec.similarity.side_effect = [0.3, 0.9, 0.6]
+    mgr._sema_codec = codec
+
+    # sqlite rows are dict-indexable; emulate with a list of dicts.
+    class Row(dict):
+        def __getitem__(self, k):
+            return super().__getitem__(k)
+
+    rows = [
+        Row(gene_id="gene-A", embedding="[1.0, 0.1]"),
+        Row(gene_id="gene-B", embedding="[1.0, 0.2]"),
+        Row(gene_id="gene-C", embedding="[1.0, 0.3]"),
+    ]
+    mgr.genome.read_conn.execute.return_value.fetchall.return_value = rows
+
+    def _get_gene(gid):
+        return _make_gene(gene_id=gid, content=f"content of {gid}")
+
+    mgr.genome.get_gene.side_effect = _get_gene
+
+    sess = _make_session(mgr)
+    out = sess.neighbors("query", k=2)
+    assert [n["gene_id"] for n in out] == ["gene-B", "gene-C"]
+    assert out[0]["sema_cos_sim"] == pytest.approx(0.9)
+    assert out[0]["path"] == "helix_context/splice.py"
+
+
+def test_neighbors_skips_malformed_embedding_row():
+    """A row whose embedding column is non-JSON gets logged + skipped;
+    the rest of the result still comes back."""
+    mgr = MagicMock()
+    codec = MagicMock()
+    codec.encode.return_value = [1.0]
+    codec.similarity.return_value = 0.5
+    mgr._sema_codec = codec
+
+    class Row(dict):
+        def __getitem__(self, k):
+            return super().__getitem__(k)
+
+    rows = [
+        Row(gene_id="gene-A", embedding="this is not json"),
+        Row(gene_id="gene-B", embedding="[1.0, 0.0]"),
+    ]
+    mgr.genome.read_conn.execute.return_value.fetchall.return_value = rows
+    mgr.genome.get_gene.side_effect = lambda gid: _make_gene(gene_id=gid)
+
+    sess = _make_session(mgr)
+    out = sess.neighbors("q", k=10)
+    assert [n["gene_id"] for n in out] == ["gene-B"]

--- a/tests/test_cli_gene.py
+++ b/tests/test_cli_gene.py
@@ -1,0 +1,93 @@
+"""Tests for `helix gene get` and `helix gene preview`."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helix_context.cli import main
+from helix_context.schemas import (
+    ChromatinState,
+    Gene,
+    PromoterTags,
+)
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _make_gene(gene_id="gene-001", content="The splice step trims low-value fragments. " * 20):
+    return Gene(
+        gene_id=gene_id,
+        content=content,
+        complement=content[:80],
+        codons=["splice", "fragment"],
+        promoter=PromoterTags(
+            domains=["retrieval"],
+            entities=["splice"],
+            intent="explain",
+            summary="splice step",
+            metadata={"path": "helix_context/splice.py"},
+        ),
+        chromatin=ChromatinState.OPEN,
+    )
+
+
+@pytest.fixture
+def fake_session():
+    sess = MagicMock()
+    sess.gene_get.return_value = _make_gene()
+    return sess
+
+
+def test_gene_get_json_dumps_full_model(fake_session):
+    with patch("helix_context.cli.cmd_gene.open_session", return_value=fake_session):
+        rc, out, err = _run(["gene", "get", "gene-001", "--json"])
+    assert rc == 0, err
+    payload = json.loads(out)
+    assert payload["gene_id"] == "gene-001"
+    assert "content" in payload
+    assert payload["promoter"]["domains"] == ["retrieval"]
+
+
+def test_gene_preview_truncates_to_chars(fake_session):
+    with patch("helix_context.cli.cmd_gene.open_session", return_value=fake_session):
+        rc, out, err = _run(["gene", "preview", "gene-001", "--chars", "40", "--json"])
+    assert rc == 0, err
+    payload = json.loads(out)
+    assert len(payload["preview"]) == 40
+    assert payload["truncated"] is True
+    assert payload["path"] == "helix_context/splice.py"
+
+
+def test_gene_get_unknown_id_returns_one():
+    sess = MagicMock()
+    sess.gene_get.return_value = None
+    with patch("helix_context.cli.cmd_gene.open_session", return_value=sess):
+        rc, out, err = _run(["gene", "get", "gene-nope", "--json"])
+    assert rc == 1
+    payload = json.loads(out)
+    assert payload["ok"] is False
+    assert "gene-nope" in payload["error"]
+
+
+def test_gene_requires_action():
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        with pytest.raises(SystemExit) as exc:
+            main(["gene"])
+    assert exc.value.code == 2
+
+
+def test_gene_preview_text_mode_shows_truncation_marker(fake_session):
+    with patch("helix_context.cli.cmd_gene.open_session", return_value=fake_session):
+        rc, out, err = _run(["gene", "preview", "gene-001", "--chars", "20"])
+    assert rc == 0, err
+    assert "truncated" in out

--- a/tests/test_cli_neighbors.py
+++ b/tests/test_cli_neighbors.py
@@ -1,0 +1,69 @@
+"""Tests for `helix neighbors`."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helix_context.cli import main
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def fake_session():
+    sess = MagicMock()
+    sess.neighbors.return_value = [
+        {
+            "gene_id": "gene-001",
+            "sema_cos_sim": 0.91,
+            "preview": "splice trims fragments",
+            "path": "helix_context/splice.py",
+        },
+        {
+            "gene_id": "gene-002",
+            "sema_cos_sim": 0.84,
+            "preview": "codon chunker splits text",
+            "path": "helix_context/codons.py",
+        },
+    ]
+    return sess
+
+
+def test_neighbors_json_shape(fake_session):
+    with patch(
+        "helix_context.cli.cmd_neighbors.open_session", return_value=fake_session
+    ):
+        rc, out, err = _run(["neighbors", "splice step", "--json"])
+    assert rc == 0, err
+    payload = json.loads(out)
+    assert payload["query"] == "splice step"
+    assert payload["count"] == 2
+    assert payload["neighbors"][0]["gene_id"] == "gene-001"
+
+
+def test_neighbors_passes_k(fake_session):
+    with patch(
+        "helix_context.cli.cmd_neighbors.open_session", return_value=fake_session
+    ):
+        rc, _, _ = _run(["neighbors", "test", "--k", "5"])
+    assert rc == 0
+    _, kwargs = fake_session.neighbors.call_args
+    assert kwargs["k"] == 5
+
+
+def test_neighbors_empty_text_mode_explains_why():
+    sess = MagicMock()
+    sess.neighbors.return_value = []
+    with patch("helix_context.cli.cmd_neighbors.open_session", return_value=sess):
+        rc, out, _ = _run(["neighbors", "test"])
+    assert rc == 0
+    assert "SEMA codec missing" in out or "no embeddings" in out

--- a/tests/test_cli_packet.py
+++ b/tests/test_cli_packet.py
@@ -1,0 +1,118 @@
+"""Tests for `helix packet`. Mocks ``helix_context.api.open_session`` so
+the CLI surface is tested without standing up the retrieval stack."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helix_context.cli import main
+from helix_context.schemas import (
+    ContextItem,
+    ContextPacket,
+    RefreshTarget,
+)
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def fake_session():
+    sess = MagicMock()
+    sess.session_id = "sess-test-0000000000000000"
+    sess.packet.return_value = ContextPacket(
+        task_type="explain",
+        query="what does the splice step do?",
+        verified=[
+            ContextItem(
+                kind="gene",
+                gene_id="gene-001",
+                title="splice.py docstring",
+                content="The splice step trims low-value fragments.",
+                relevance_score=0.82,
+                live_truth_score=0.91,
+                status="verified",
+            ),
+        ],
+        stale_risk=[],
+        refresh_targets=[
+            RefreshTarget(
+                target_kind="file",
+                source_id="helix_context/splice.py",
+                reason="last_seen_outside_freshness_window",
+                priority=0.5,
+            ),
+        ],
+        notes=["coordinate_confidence=0.71 below 0.80 floor"],
+        coordinate_confidence=0.71,
+        file_coverage=0.80,
+    )
+    return sess
+
+
+def test_packet_json_emits_full_packet(fake_session):
+    with patch("helix_context.cli.cmd_packet.open_session", return_value=fake_session):
+        rc, out, err = _run(["packet", "what does the splice step do?", "--json"])
+    assert rc == 0, err
+    payload = json.loads(out)
+    assert payload["task_type"] == "explain"
+    assert payload["query"] == "what does the splice step do?"
+    assert len(payload["verified"]) == 1
+    assert payload["verified"][0]["gene_id"] == "gene-001"
+    assert len(payload["refresh_targets"]) == 1
+    assert payload["refresh_targets"][0]["source_id"] == "helix_context/splice.py"
+
+
+def test_packet_text_mode_surfaces_counts(fake_session):
+    with patch("helix_context.cli.cmd_packet.open_session", return_value=fake_session):
+        rc, out, err = _run(["packet", "test"])
+    assert rc == 0, err
+    assert "verified: 1" in out
+    assert "stale_risk: 0" in out
+    assert "refresh_targets: 1" in out
+
+
+def test_packet_passes_task_type_through(fake_session):
+    with patch("helix_context.cli.cmd_packet.open_session", return_value=fake_session):
+        rc, _, _ = _run(["packet", "test", "--task-type", "edit"])
+    assert rc == 0
+    _, kwargs = fake_session.packet.call_args
+    assert kwargs["task_type"] == "edit"
+
+
+def test_packet_rejects_unknown_task_type(fake_session):
+    out, err = io.StringIO(), io.StringIO()
+    with patch("helix_context.cli.cmd_packet.open_session", return_value=fake_session):
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            with pytest.raises(SystemExit) as exc:
+                main(["packet", "test", "--task-type", "bogus"])
+    assert exc.value.code == 2
+    assert "bogus" in err.getvalue()
+    assert fake_session.packet.call_count == 0
+
+
+def test_packet_include_raw_passes_through(fake_session):
+    with patch("helix_context.cli.cmd_packet.open_session", return_value=fake_session):
+        rc, _, _ = _run(["packet", "test", "--include-raw"])
+    assert rc == 0
+    _, kwargs = fake_session.packet.call_args
+    assert kwargs["include_raw"] is True
+
+
+def test_packet_error_path_returns_one():
+    sess = MagicMock()
+    sess.packet.side_effect = RuntimeError("genome unreachable")
+    with patch("helix_context.cli.cmd_packet.open_session", return_value=sess):
+        rc, out, err = _run(["packet", "test", "--json"])
+    assert rc == 1
+    payload = json.loads(out)
+    assert payload["ok"] is False
+    assert "genome unreachable" in payload["error"]

--- a/tests/test_cli_refresh_targets.py
+++ b/tests/test_cli_refresh_targets.py
@@ -1,0 +1,85 @@
+"""Tests for `helix refresh-targets`."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helix_context.cli import main
+from helix_context.schemas import RefreshTarget
+
+
+def _run(argv):
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = main(argv)
+    return rc, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def fake_session():
+    sess = MagicMock()
+    sess.refresh_targets.return_value = [
+        RefreshTarget(
+            target_kind="file",
+            source_id="helix_context/splice.py",
+            reason="stale",
+            priority=0.7,
+        ),
+        RefreshTarget(
+            target_kind="file",
+            source_id="helix_context/codons.py",
+            reason="weakly_grounded",
+            priority=0.3,
+        ),
+    ]
+    return sess
+
+
+def test_refresh_targets_json_emits_list(fake_session):
+    with patch(
+        "helix_context.cli.cmd_refresh_targets.open_session",
+        return_value=fake_session,
+    ):
+        rc, out, err = _run(["refresh-targets", "edit splice", "--json"])
+    assert rc == 0, err
+    payload = json.loads(out)
+    assert payload["count"] == 2
+    assert payload["refresh_targets"][0]["source_id"] == "helix_context/splice.py"
+
+
+def test_refresh_targets_default_task_type_is_edit(fake_session):
+    with patch(
+        "helix_context.cli.cmd_refresh_targets.open_session",
+        return_value=fake_session,
+    ):
+        rc, _, _ = _run(["refresh-targets", "test"])
+    assert rc == 0
+    _, kwargs = fake_session.refresh_targets.call_args
+    assert kwargs["task_type"] == "edit"
+
+
+def test_refresh_targets_empty_list_text_mode():
+    sess = MagicMock()
+    sess.refresh_targets.return_value = []
+    with patch(
+        "helix_context.cli.cmd_refresh_targets.open_session",
+        return_value=sess,
+    ):
+        rc, out, _ = _run(["refresh-targets", "test"])
+    assert rc == 0
+    assert "(none" in out
+
+
+def test_refresh_targets_passes_max_genes(fake_session):
+    with patch(
+        "helix_context.cli.cmd_refresh_targets.open_session",
+        return_value=fake_session,
+    ):
+        rc, _, _ = _run(["refresh-targets", "test", "--max-genes", "16"])
+    assert rc == 0
+    _, kwargs = fake_session.refresh_targets.call_args
+    assert kwargs["max_genes"] == 16

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,57 @@ def test_budget_abstain_enabled_toml_override(tmp_path):
     assert cfg.budget.abstain_enabled is False
 
 
+# ── Ingestion / ribosome coherence guard ──────────────────────────────
+# Tests pin the auto-fallback added 2026-05-12: when [ribosome] is
+# disabled (LLM-free pillar) but [ingestion] still points at an LLM
+# backend, ``load_config`` flips ingestion to "cpu" so `helix ingest`
+# doesn't crash with "Ribosome is disabled". See AI-user feedback on
+# cli+mcp ingest path.
+
+
+def test_ingestion_falls_back_to_cpu_when_ribosome_disabled(tmp_path, caplog):
+    """Default-disabled ribosome + ollama ingest → auto-flip to cpu."""
+    import logging
+    from helix_context.config import load_config
+
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[ribosome]\nenabled = false\n[ingestion]\nbackend = \"ollama\"\n",
+        encoding="utf-8",
+    )
+    with caplog.at_level(logging.WARNING, logger="helix_context.config"):
+        cfg = load_config(str(toml))
+    assert cfg.ingestion.backend == "cpu"
+    assert any("auto-falling-back" in r.message for r in caplog.records), (
+        "expected an auto-fallback WARNING; got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+
+def test_ingestion_left_alone_when_ribosome_enabled(tmp_path):
+    """Operators who enable ribosome + ollama get exactly what they asked for."""
+    from helix_context.config import load_config
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[ribosome]\nenabled = true\n[ingestion]\nbackend = \"ollama\"\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(str(toml))
+    assert cfg.ingestion.backend == "ollama"
+
+
+def test_ingestion_left_alone_when_explicitly_cpu(tmp_path):
+    """Explicit cpu / hybrid backends stay put even with ribosome off."""
+    from helix_context.config import load_config
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[ribosome]\nenabled = false\n[ingestion]\nbackend = \"hybrid\"\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(str(toml))
+    assert cfg.ingestion.backend == "hybrid"
+
+
 # ── Hardware section + ribosome.device deprecation shim (Task 9) ─────
 # Tests pin parsing of the [hardware] TOML section and the deprecation
 # warning emitted for legacy [ribosome] device usage. See

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from helix_context.mcp_server import _default_ingest_identity, _normalize_health_payload
+from helix_context.mcp_server import (
+    _default_ingest_identity,
+    _normalize_health_payload,
+    _unwrap_context_list,
+)
 
 
 @pytest.fixture
@@ -184,6 +188,68 @@ def test_register_with_registry_no_match_sends_none(monkeypatch, mock_bridge):
     call = mock_bridge.register_participant_calls[-1]
     assert call["ide_detected"] is None
     assert call["ide_detection_via"] == "no_match"
+
+
+class TestUnwrapContextList:
+    """The MCP ``helix_context`` tool declares ``Dict[str, Any]`` but
+    ``POST /context`` returns the Continue HTTP context-provider list
+    shape. _unwrap_context_list bridges the two without breaking the
+    HTTP layer for Continue IDE."""
+
+    def test_single_entry_list_unwraps_to_dict(self):
+        out = _unwrap_context_list(
+            [{"name": "helix", "description": "...", "content": "x"}]
+        )
+        assert isinstance(out, dict)
+        assert out["name"] == "helix"
+
+    def test_error_envelope_dict_passes_through(self):
+        envelope = {"_error": "helix unreachable", "_detail": "connection refused"}
+        assert _unwrap_context_list(envelope) is envelope
+
+    def test_raw_envelope_dict_passes_through(self):
+        envelope = {"_raw": "not-json bytes"}
+        assert _unwrap_context_list(envelope) is envelope
+
+    def test_unexpected_multi_entry_list_wrapped_with_diagnostic(self):
+        out = _unwrap_context_list([{"a": 1}, {"b": 2}])
+        assert isinstance(out, dict)
+        assert out["items"] == [{"a": 1}, {"b": 2}]
+        assert "_note" in out
+
+    def test_empty_list_wrapped_with_diagnostic(self):
+        out = _unwrap_context_list([])
+        assert isinstance(out, dict)
+        assert out["items"] == []
+
+
+def test_helix_context_unwraps_continue_list_shape(monkeypatch):
+    """End-to-end: helix_context tool returns a flat dict even though
+    /context responds with the Continue list shape. This is the failure
+    the AI-user feedback hit on origin/master@93deaf2."""
+    from helix_context import mcp_server
+
+    captured: dict = {}
+
+    def _fake_http(method, path, body=None):
+        captured["call"] = (method, path, body)
+        # Mirror what the real /context endpoint returns — a single-entry
+        # list whose entry is the Continue context-provider dict.
+        return [{
+            "name": "helix",
+            "description": "helix context",
+            "content": "<helix>example</helix>",
+        }]
+
+    monkeypatch.setattr(mcp_server, "_http", _fake_http)
+    out = mcp_server.helix_context("what does the splice step do?")
+    assert isinstance(out, dict), f"expected dict, got {type(out).__name__}: {out!r}"
+    assert out["content"] == "<helix>example</helix>"
+    # Verify the call was made with the expected shape so we don't
+    # accidentally regress the body payload.
+    method, path, body = captured["call"]
+    assert (method, path) == ("POST", "/context")
+    assert body["query"] == "what does the splice step do?"
 
 
 def test_helix_announce_tool_calls_bridge_announce(monkeypatch, mock_bridge):


### PR DESCRIPTION
## Summary

Two commits, two slices of work, both surfaced by AI-user testing of the CLI+MCP surface:

1. **`9dbd960`** — _Council prioritized doc fixes + agent walk-aware CLI._ Closes the gap the first council flagged on the v1 CLI (PR #71): agents now drive genome lookups via subprocess CLI calls instead of MCP-injected context. Plus the README / ROSETTA / docs fixes the council prioritized.
2. **`0a68896`** — _Five friction points reported by a second AI-user pass on origin/master@93deaf2._ Each is a one-shot fix with a focused unit test.

Branch is two commits ahead of `origin/master`. Full mock suite green (**1924 passed, 0 failures, ~8min**).

## Commit 1 — Agent walk-aware CLI + council doc fixes

**CLI agent surface** (4 new subcommands; identical JSON shape to the matching MCP tools + HTTP endpoints):

- `helix packet <text> --task-type edit|ops|...` — agent-safe bundle with `verified` / `stale_risk` / `refresh_targets`
- `helix gene get <id>` / `helix gene preview <id> --chars N` — single-document inspection
- `helix neighbors <text> --k N` — SEMA graph walk
- `helix refresh-targets <text>` — reread plan only

**`api.HelixSession`**: promote `gene_get`, `packet`, `refresh_targets`, `neighbors` from v1.1-deferred to v1 — they back the four new CLI subcommands without requiring an HTTP server or MCP host. Pure in-process wrappers over `Genome.get_gene`, `build_context_packet`, and the existing SEMA codec. Read-only.

**Docs**: README adds an "Agent CLI surface (no server required)" section and sources the `28.7× / 5.4×` headline against the reproducer at `benchmarks/bench_rag_vs_sike_tokens.py`. ROSETTA adds a "Response & routing types (STAYS — no biology twin)" section covering `ContextWindow` / `ContextPacket` / `KnowBlock` / `MissBlock` / `RefreshTarget` / `ContextHealth` / `ContextItem` / `QueryResult` / `IngestResult` / `StatsResult`. The `HGT → cross_store_import` row is annotated as a forward-pointer; the `OPEN/EUCHROMATIN/HETEROCHROMATIN → OPEN/WARM/COLD` row notes the rename is deferred to R3.

## Commit 2 — Five AI-user friction fixes

| # | Friction reported | Fix |
|---|---|---|
| 1 | `helix query` and `helix diag corpus` silently ignored `HELIX_CONFIG` / `HELIX_GENOME_PATH` — read/created `./genome.db` while `helix status` looked at the configured genome | `api.py: open_session()` now routes through `load_config()` (single-source with `helix status`) |
| 2 | `helix status --json` falsely reported a healthy-but-slow server as `unreachable` (1.5s timeout, cold-start `/health` takes 5-10s) | `helix_status.py`: default 1.5s → 10s, override via `HELIX_STATUS_TIMEOUT_S`, malformed-value fallback warns instead of crashes |
| 3 | MCP `helix_context` failed schema validation — `/context` returns the Continue HTTP list shape, MCP host expected `Dict[str, Any]` | New `_unwrap_context_list()` helper unwraps the single-entry list; applied to `helix_context` and `helix_document_query`. Continue IDE compatibility untouched. |
| 4 | `helix ingest README.md` raised `TranscriptionError: Pack failed: Ribosome is disabled` on cold-start install | `config.py: load_config()` auto-flips `ingestion.backend` → `"cpu"` when ribosome is disabled. Routes to the spaCy/heuristic CpuTagger that's already in tree. Explicit cpu/hybrid configs untouched. LLM-free pillar intact. Logs WARNING. |
| 5 | `helix.exe` broken (pip console script pointed at deleted editable path; Scripts dir off PATH) | Added `helix_context/cli/__main__.py` so `python -m helix_context.cli` works as a fallback. Recovery recipe + `pip install --force-reinstall --no-deps` documented in `docs/clients/cli.md`. |

## Test plan

- [x] 38 new unit tests (10 cli_packet/refresh/neighbors/gene + 10 api_walk + 3 config + 6 mcp_server + 9 dispatcher/integration). All pass.
- [x] Full mock suite: `python -m pytest -m "not live and not requires_rocm and not requires_real_cuda and not requires_mps"` → **1924 passed, 0 failures, 10 skipped, 26 deselected, 2 xfailed in 470s**.
- [ ] Manual smoke against a real genome: `helix packet "foo" --json`, `helix gene get <id> --json`, `helix refresh-targets "edit X"` — not done here; reviewer should sanity-check on their workstation before merge.
- [ ] Manual MCP smoke: confirm Claude Code / Cursor see `helix_context` returning a dict (not a list) after the unwrap fix.

## Related issues

This PR does **not** close any open issue outright. Two issues partially overlap and should be reconciled at merge time:

- **#80 (MCP slimdown — Move 2: CLI parity for 13 deprecation candidates)** — this PR ships 4 of the 13 candidates as CLI peers (`packet`, `gene get/preview`, `neighbors`, `refresh-targets`), but under different command names than #80 specifies (top-level `helix packet` etc. vs. spec's `helix diag packet` / `helix diag refresh-plan`). The remaining 9 candidates are not addressed here. See "Note on the MCP slimdown plan" below.
- **#65 (Operational silent-failure modes)** — different specific items than the four in this PR (SF1-SF4 are Headroom upstream rewrite, hardware balloon, ribosome paid WARN, WAL bloat). Spiritually adjacent — all four fixes in commit 2 are silent-failure-mode cleanups in the same vein.

## Note on the MCP slimdown plan (#78 / #79 / #80 / #81)

Building the four CLI peers in this PR was originally framed under the council's recommendation to "complete the CLI as an agent tool." The earlier round of analysis on **PR #78 (MCP slimdown spec)** found that:

- The 13-tool demotion-to-CLI premise rests on CLI peers existing — 9 of 13 still don't, and would degrade agent UX on day-one.
- The latency-defense argument the spec uses for keeping 6 MCP tools (in-stdio beats subprocess.run) applies equally to most of the demoted tools agents walk during a multi-step loop.
- The "1038 → 450 adapter LOC" headline is engineering convenience, not user value.
- Agent UX is the product; shrinking the easiest agent surface to save adapter code works against the product thesis.

Recommendation kept from that analysis: **don't merge #78 as written.** What stays valuable from the slimdown work:

- **#79 (HELIX_IDENTITY_TOML)** — legitimate ergonomics win regardless of tool count. Worth landing as a separate small PR.
- **Drop the 4 software-vocab aliases (`helix_document_*`)** — they're redundant after R2 and shipping is no-cost.
- **Keep building CLI peers (#80 scope)** as _additions_, not replacements. The 4 in this PR are a start; the remaining 9 are valuable as a scripting surface. Reconcile naming with the spec at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)