### PR TITLE
fix(launcher): explicit [headroom] route_upstream toggle, default off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **fix(launcher): `[headroom] route_upstream` is now a separate, default-off
+  config knob; routing no longer happens implicitly from "upstream is remote".**
+  Pre-fix, `_should_route_helix_upstream_via_headroom` returned True for any
+  remote (non-loopback) upstream as long as `HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO`
+  wasn't explicitly set falsy. So an operator with `cfg.server.upstream =
+  "https://api.openai.com/v1"` and `cfg.headroom.enabled = false` (defaults!)
+  would have the launcher rewrite `HELIX_SERVER_UPSTREAM` to
+  `http://127.0.0.1:8787` and start helix pointing at a Headroom proxy that
+  was never started — every chat call then failed with ECONNREFUSED, with
+  no clear diagnostic. `route_upstream` is now an explicit `[headroom]` bool
+  (default `false`) gating the rewrite. `HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO`
+  remains as a per-launch override (truthy → on, falsy → off, unset →
+  defer to config). The existing test
+  `test_remote_upstream_routes_helix_via_headroom` (which pinned the buggy
+  behavior) is replaced with four tests covering the new precedence rules.
+
 - **fix(launcher): `POST /api/control/start` no longer reports success on a
   hung backend; returns `202 Accepted` with `started_pending=true`.** PR #68
   made `supervisor.start()` non-fatal on `/stats` timeout (proc left

--- a/helix.toml
+++ b/helix.toml
@@ -179,6 +179,14 @@ host = "127.0.0.1"
 port = 8787                             # Default headroom proxy port
 mode = "token"                          # "token" (compression-first) | "cache" (prefix-cache-stable)
 dashboard_path = "/dashboard"           # Appended to http://{host}:{port} for the tray menu link
+# route_upstream — controls whether the launcher rewrites helix's chat upstream
+# to dial this proxy. Off by default. Turn on ONLY when (a) Headroom is
+# actually installed/running AND (b) you want to pay its compression-pass
+# latency on every /v1/chat/completions call. Loopback upstreams (Ollama at
+# localhost:11434, etc.) are never rewritten regardless of this flag — the
+# proxy hop doesn't buy anything for a localhost model server. The env var
+# HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=0|1 overrides this per-launch.
+route_upstream = false
 
 [ingestion]
 backend = "cpu"                         # "ollama" (LLM, slow) | "cpu" (spaCy+regex, fast) | "hybrid"

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -420,6 +420,16 @@ class HeadroomConfig:
     surfaces it in the tray menu. When it's already running on
     ``port``, the launcher **adopts** the existing process rather than
     spawning a duplicate — the adopted process survives launcher Quit.
+
+    ``enabled`` controls the proxy lifecycle (start / adopt the process).
+    ``route_upstream`` controls whether helix's chat upstream is
+    rewritten to dial this proxy. Separate concerns: you may want the
+    proxy + dashboard running without the chat redirect, or vice versa.
+    Both default off so a fresh install never silently rewrites the
+    upstream to a proxy that isn't actually running. The
+    ``HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO`` env var (truthy → force on,
+    falsy → force off, unset → defer to config) continues to work as a
+    per-launch override.
     """
     enabled: bool = False               # Master switch; false = do nothing
     autostart: bool = True              # When enabled: adopt if running, spawn if not
@@ -427,6 +437,7 @@ class HeadroomConfig:
     port: int = 8787
     mode: str = "token"                 # "token" | "cache" (passed to --mode)
     dashboard_path: str = "/dashboard"  # Appended to http://{host}:{port}
+    route_upstream: bool = False        # When true: launcher points helix's chat upstream at this proxy
 
 
 @dataclass
@@ -790,6 +801,7 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             port=int(h.get("port", cfg.headroom.port)),
             mode=str(h.get("mode", cfg.headroom.mode)),
             dashboard_path=str(h.get("dashboard_path", cfg.headroom.dashboard_path)),
+            route_upstream=bool(h.get("route_upstream", cfg.headroom.route_upstream)),
         )
 
     # Classifier — upstream rule-based query classifier / injection router

--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -320,15 +320,29 @@ def _is_loopback_host(host: Optional[str]) -> bool:
 
 
 def _should_route_helix_upstream_via_headroom(cfg, auto_override: Optional[bool] = None) -> bool:
-    """Auto-route only remote/OpenAI-compatible upstreams through Headroom.
+    """Decide whether the launcher should rewrite helix's chat upstream
+    to dial the local Headroom proxy.
 
-    Local model servers stay direct by default — especially Ollama on
-    localhost:11434 — because the extra proxy hop doesn't buy much there.
-    Remote upstreams can benefit from Headroom's compression/cache layer.
+    Precedence (highest wins):
+
+      1. ``auto_override`` (from ``HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO``):
+         truthy forces ON, falsy forces OFF, ``None`` defers to config.
+      2. ``cfg.headroom.route_upstream``: must be ``True`` to route.
+         Defaults False so a fresh install never silently rewrites the
+         upstream to a proxy that isn't running. Separate from
+         ``cfg.headroom.enabled`` (which is the proxy *lifecycle* switch)
+         so an operator can run the proxy + dashboard without rerouting
+         chat, or vice versa.
+      3. Upstream must be a parseable non-loopback URL (local model
+         servers like Ollama on localhost:11434 stay direct).
+      4. Upstream must not already point at the configured Headroom
+         (avoid double-route).
     """
-    auto_route = True if auto_override is None else auto_override
-    if not auto_route:
+    if auto_override is False:
         return False
+    if auto_override is None and not getattr(cfg.headroom, "route_upstream", False):
+        return False
+    # auto_override is True OR config explicitly opted in.
 
     upstream = str(cfg.server.upstream or "").strip()
     if not upstream:

--- a/tests/test_launcher_app.py
+++ b/tests/test_launcher_app.py
@@ -371,29 +371,92 @@ class TestMaybeBuildHeadroom:
 
 
 class TestHeadroomAutoRoute:
-    def test_remote_upstream_routes_helix_via_headroom(self, monkeypatch):
+    def test_remote_upstream_does_not_route_when_route_upstream_disabled(self, monkeypatch):
+        """Default config (route_upstream=False) must NOT rewrite the
+        upstream even for a remote target. Pre-fix this routed silently
+        and pointed helix at a dead :8787 when Headroom wasn't installed."""
         from helix_context.launcher import app as app_mod
 
         cfg = HelixConfig(
             server=ServerConfig(upstream="https://api.openai.com/v1"),
             headroom=HeadroomConfig(host="127.0.0.1", port=8787),
         )
+        assert cfg.headroom.route_upstream is False  # contract guard
 
         monkeypatch.delenv("HELIX_SERVER_UPSTREAM", raising=False)
         monkeypatch.delenv("OPENAI_TARGET_API_URL", raising=False)
+        # auto_override=None means "defer to config" — the precedence path under
+        # test (HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO unset at the call site).
+        routed = app_mod._configure_helix_upstream_routing(cfg, auto_override=None)
 
-        routed = app_mod._configure_helix_upstream_routing(cfg, auto_override=True)
+        assert routed is False
+        assert "HELIX_SERVER_UPSTREAM" not in os.environ
+        assert "OPENAI_TARGET_API_URL" not in os.environ
+
+    def test_remote_upstream_routes_when_route_upstream_opted_in(self, monkeypatch):
+        """Explicit opt-in via [headroom] route_upstream = true keeps the
+        original auto-route behavior for operators who do want it."""
+        from helix_context.launcher import app as app_mod
+
+        cfg = HelixConfig(
+            server=ServerConfig(upstream="https://api.openai.com/v1"),
+            headroom=HeadroomConfig(host="127.0.0.1", port=8787, route_upstream=True),
+        )
+
+        monkeypatch.delenv("HELIX_SERVER_UPSTREAM", raising=False)
+        monkeypatch.delenv("OPENAI_TARGET_API_URL", raising=False)
+        routed = app_mod._configure_helix_upstream_routing(cfg, auto_override=None)
 
         assert routed is True
         assert os.environ["HELIX_SERVER_UPSTREAM"] == "http://127.0.0.1:8787"
         assert os.environ["OPENAI_TARGET_API_URL"] == "https://api.openai.com/v1"
 
+    def test_env_var_false_forces_off_even_when_config_opted_in(self, monkeypatch):
+        """HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=0 is the per-launch kill
+        switch: must override route_upstream=True. Useful when the proxy
+        is misbehaving and the operator wants helix direct for one session."""
+        from helix_context.launcher import app as app_mod
+
+        cfg = HelixConfig(
+            server=ServerConfig(upstream="https://api.openai.com/v1"),
+            headroom=HeadroomConfig(host="127.0.0.1", port=8787, route_upstream=True),
+        )
+
+        monkeypatch.delenv("HELIX_SERVER_UPSTREAM", raising=False)
+        monkeypatch.delenv("OPENAI_TARGET_API_URL", raising=False)
+        # auto_override=False simulates HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=0
+        routed = app_mod._configure_helix_upstream_routing(cfg, auto_override=False)
+
+        assert routed is False
+        assert "HELIX_SERVER_UPSTREAM" not in os.environ
+        assert "OPENAI_TARGET_API_URL" not in os.environ
+
+    def test_env_var_true_forces_on_even_when_config_disabled(self, monkeypatch):
+        """HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=1 is also a per-launch
+        override: must turn routing on even when route_upstream=False
+        in config. Symmetric to the kill-switch test."""
+        from helix_context.launcher import app as app_mod
+
+        cfg = HelixConfig(
+            server=ServerConfig(upstream="https://api.openai.com/v1"),
+            headroom=HeadroomConfig(host="127.0.0.1", port=8787),  # route_upstream defaults False
+        )
+
+        monkeypatch.delenv("HELIX_SERVER_UPSTREAM", raising=False)
+        monkeypatch.delenv("OPENAI_TARGET_API_URL", raising=False)
+        routed = app_mod._configure_helix_upstream_routing(cfg, auto_override=True)
+
+        assert routed is True
+        assert os.environ["HELIX_SERVER_UPSTREAM"] == "http://127.0.0.1:8787"
+
     def test_local_ollama_upstream_stays_direct(self, monkeypatch):
+        """Loopback upstream is never rewritten, even with route_upstream=True
+        (Headroom proxy hop doesn't buy anything for a localhost model server)."""
         from helix_context.launcher import app as app_mod
 
         cfg = HelixConfig(
             server=ServerConfig(upstream="http://localhost:11434"),
-            headroom=HeadroomConfig(host="127.0.0.1", port=8787),
+            headroom=HeadroomConfig(host="127.0.0.1", port=8787, route_upstream=True),
         )
 
         monkeypatch.setenv("HELIX_SERVER_UPSTREAM", "http://127.0.0.1:8787")


### PR DESCRIPTION
## Summary

Adds a config-level toggle to disable the launcher's chat-upstream rewriting through the Headroom proxy. Surfaced from operator pain — running with Headroom not installed locally was occasionally producing 30s+ stalls / ECONNREFUSED on chat calls because the launcher was preemptively redirecting helix's upstream to a proxy that hadn't started.

## The bug this fixes

`_should_route_helix_upstream_via_headroom` (`launcher/app.py:287`) was returning `True` whenever:
- `cfg.server.upstream` parsed cleanly,
- `cfg.server.upstream` was **not** a loopback host (so any remote API),
- `cfg.server.upstream` wasn't already pointing at the configured Headroom port.

It did **not** check `cfg.headroom.enabled`, nor any \"is Headroom actually going to be available?\" predicate. So a config like:

```toml
[server]
upstream = \"https://api.openai.com/v1\"
[headroom]
enabled = false   # default
```

with `headroom-ai` not installed (`pip show headroom-ai` → not found) would silently:

1. Set `HELIX_SERVER_UPSTREAM = http://127.0.0.1:8787` and `OPENAI_TARGET_API_URL = <real upstream>` in env (`launcher/app.py:327-333`).
2. Skip starting Headroom because `is_headroom_installed()` returned False at `launcher/app.py:363-365`.
3. Start helix as a child with the rewritten env. Helix's `load_config` then read `HELIX_SERVER_UPSTREAM` at `config.py:616-617` and set `cfg.server.upstream = http://127.0.0.1:8787`.
4. Every `/v1/chat/completions` call dialled a dead local port. ECONNREFUSED with no clear log line connecting the failure to the routing decision.

The existing test `test_remote_upstream_routes_helix_via_headroom` (`tests/test_launcher_app.py:339`) **pinned this exact buggy behavior** — constructed a config with default-disabled headroom + remote upstream and asserted routing was ON.

## What changed

1. **New `[headroom] route_upstream` bool**, default `False` (`config.py:HeadroomConfig`). Wired through the TOML parser at `config.py:783-804`. Documented inline in `helix.toml`.

2. **Routing decision rewritten** (`launcher/app.py:287`) with explicit precedence:
   - `auto_override=False` (from `HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=0`) → **off**, always.
   - `auto_override=True` (from `HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=1`) → **on**, even if config says off.
   - `auto_override=None` (env unset) → **defer to `cfg.headroom.route_upstream`** (default off).
   - Existing loopback / parse / double-route guards stay as final filters.

3. **`enabled` and `route_upstream` are now separate concerns**. `enabled` controls the proxy *lifecycle* (start / adopt the process); `route_upstream` controls whether helix's chat upstream is *rewritten* to dial the proxy. An operator can now:
   - Run Headroom + dashboard without rerouting chat through it (`enabled=true, route_upstream=false`).
   - Or vice versa (less common but legal): assume Headroom is externally managed, just rewrite helix's upstream (`enabled=false, route_upstream=true`).
   - Default install behaves as if neither is set (no proxy lifecycle, no upstream rewriting).

4. **Tests rewritten** (`tests/test_launcher_app.py:338`):
   - `test_remote_upstream_does_not_route_when_route_upstream_disabled` — the new default-off contract.
   - `test_remote_upstream_routes_when_route_upstream_opted_in` — explicit opt-in still works.
   - `test_env_var_false_forces_off_even_when_config_opted_in` — per-launch kill switch.
   - `test_env_var_true_forces_on_even_when_config_disabled` — per-launch opt-in symmetric.
   - `test_local_ollama_upstream_stays_direct` — loopback never gets rewritten, regardless.

## Per-launch override (immediate workaround, also works post-merge)

```powershell
$env:HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO = \"0\"
helix-launcher
```

This was already implemented (`_env_truthy` at `launcher/app.py:275-280`); the new code preserves it via the `auto_override` arg.

## What this does NOT change

- The `headroom-ai` **library** import path (`headroom_bridge.py` / `compress_text`) is untouched. That surface has correct graceful-degradation already — `is_headroom_available()` probes the import + the `HELIX_DISABLE_HEADROOM` env opt-out and falls back to `content[:target_chars]` truncation when the library isn't installed.
- The orphan-adopt path in `_maybe_build_headroom`. Operators with an externally-managed Headroom can still have the launcher adopt it. The decoupling above means orphan adoption no longer implicitly enables upstream rewriting — operators who want that should set `route_upstream = true` explicitly.

## Test plan

- [x] `pytest tests/test_launcher_app.py tests/test_config.py` — 54/54 pass.
- [x] `pytest tests/test_launcher_app.py tests/test_launcher_supervisor.py tests/test_headroom_supervisor.py tests/test_config.py tests/test_headroom_bridge.py` — 125/125 pass, 7 skipped.
- [ ] Smoke against `helix-launcher` in a fresh shell to confirm `HELIX_SERVER_UPSTREAM` is NOT set when `route_upstream` defaults to false.

## Related

- Builds on the analysis from the headroom-disabled audit; this is the toggle I described in chat. No issue # yet — open one if you want it tracked.