### PR TITLE
R3 Stages D + E: local-variable sweep + ROSETTA refresh (#87)

### DIFF
--- a/docs/ROSETTA.md
+++ b/docs/ROSETTA.md
@@ -229,10 +229,14 @@ The rename ships in waves so back-compat stays solid throughout.
 
 | Phase | Scope | Status |
 |---|---|---|
-| **R1** | Rosetta Stone doc + Python alias module + new MCP tool aliases (additive only) | shipping now |
-| **R2** | Docstring + comment sweep — Python files and `docs/*.md` prose use canonical terms | next |
-| **R3** | Internal symbol rename — non-exported helpers (e.g. `gene_input_vector` → `document_vector`). Pydantic class FIELDS stay (renaming them breaks the SQL schema). | after R2 |
-| **R4** | Soft-deprecate legacy MCP tool names with docstring nudge. No removal. | after R3 |
+| **R1** | Rosetta Stone doc + Python alias module + new MCP tool aliases (additive only) | **shipped @ `09d5548` (2026-04-15)** |
+| **R2** | Docstring + comment sweep — Python files and `docs/*.md` prose use canonical terms | **shipped @ PR #70 `87fcb68` (2026-05-12)** |
+| **R3 Stage A** | Class-def flip + alias inversion (7 schemas + KnowledgeStore + Compressor) | **shipped @ `56fcbed` (PR #88, 2026-05-13)** |
+| **R3 Stage B** | Module file moves (`ribosome→compressor`, `genome→knowledge_store`, `codons→fragments`, `replication→persistence`, `hgt→cross_store_import`) + shim modules | **shipped @ `460d824..9e7471f` (PR #88, 2026-05-13)** |
+| **R3 Stage C** | Internal method renames (`pack→encode`, `splice→trim`, `replicate→persist`, `re_rank→rerank`, `upsert_gene→upsert_doc`, `query_genes*→query_docs*`, `get_gene→get_doc`, `_express→_retrieve`, cymatics + fragments helpers) | **shipped @ `edc0194..71469ba` (PR #88, 2026-05-13)** |
+| **R3 Stage D** | Local-variable + parameter sweep (`for gene in` → `for doc in`, `gene_a/gene_b` → `doc_a/doc_b`, `genes: List[Gene]` → `docs: List[Document]` in module bodies) | **in progress @ PR #89** |
+| **R3 Stage E** | This phase-table refresh + R3 design spec stub at `docs/superpowers/specs/2026-05-13-rename-r3-symbol-rename-design.md` | **in progress @ PR #89** |
+| **R4** | Soft-deprecate legacy MCP tool names with docstring nudge. No removal. | **deferred** — see #87 |
 
 ### What we are explicitly NOT doing
 

--- a/docs/superpowers/specs/2026-05-13-rename-r3-symbol-rename-design.md
+++ b/docs/superpowers/specs/2026-05-13-rename-r3-symbol-rename-design.md
@@ -1,0 +1,257 @@
+# R3 — Internal symbol rename (canonical software vocabulary)
+
+**Status:** Stage A + B + C shipped via PR #88 (`3b92b02`).
+Stage D + E in flight via PR #89.
+
+**Predecessor specs:** [R2 prose sweep design](2026-05-11-rename-r2-prose-sweep-design.md).
+**Tracking issue:** #87.
+**Lexicon source-of-truth:** [`docs/ROSETTA.md`](../../ROSETTA.md).
+
+---
+
+## Why this exists
+
+R1 (Rosetta Stone + alias module) and R2 (prose sweep across 91 files)
+established that helix's canonical software vocabulary lives in
+`docs/ROSETTA.md` and can be adopted incrementally without breaking
+back-compat. R2 explicitly **deferred identifier-level changes** to R3
+per spec §2 + §7.
+
+R3 closes the loop: the canonical names become the *real* class
+definitions, the module filenames match the class identities, and the
+internal method/helper surface uses the canonical vocab. Legacy
+biology names survive as one-line aliases declared adjacent to the
+canonical definition, so every existing caller — internal or external,
+test or runtime — continues to work unchanged.
+
+**Decisions baked in** (per #87 + plan approval, 2026-05-13):
+
+1. **Class-def flip direction**: canonical (`Document`) becomes the
+   real class; legacy (`Gene`) becomes the alias. Inverts the R1
+   `aliases.py` direction.
+2. **Module renames**: ship in R3 with shim modules at the old paths.
+3. **MCP slimdown (PR #78)**: not in scope. MCP + CLI both stay as-is.
+
+Both `Gene is Document` and `Document is Gene` continue to hold —
+Python class assignment makes them the same object. Only `__name__`
+changes (now reports the canonical). No wire-format change, no SQL
+schema change, no MCP tool rename.
+
+---
+
+## Out of scope (still protected, per R2 spec §2)
+
+- **SQL schema** — tables `genes`, `gene_attribution`, `harmonic_links`;
+  columns `gene_id`, `promoter`, `epigenetics`, `chromatin`, `codons`.
+- **Pydantic field names** on the wire. Renaming forces a DB migration.
+- **Prometheus metric / label names** — `helix_genome_size_genes`,
+  `helix_chromatin_state_total`, `helix_ribosome_call_seconds`,
+  `call_kind="replicate"` etc. Dashboard contract.
+- **`ChromatinState` enum value strings** — `OPEN` / `EUCHROMATIN` /
+  `HETEROCHROMATIN`. Serialized as TEXT in pydantic; queried.
+- **MCP tool names** — `helix_gene_get`, `helix_splice_preview` etc.
+  R4 territory.
+- **`agent_prompt.py::HELIX_NO_MATCH_FRAGMENT`** + parallel
+  `docs/agent-sdk-fragment.md` — JSON contract field names that
+  frontier LLMs key on.
+- **LLM prompt strings** in `compressor.py` (`_PACK_SYSTEM`,
+  `_EXPRESS_SYSTEM`, `_splice_system`, `_REPLICATE_SYSTEM`) — these
+  are contracts with the small local models, which were trained on
+  the biology vocab. Renaming risks degrading retrieval quality on a
+  downstream-LLM-keyed surface.
+
+---
+
+## Stage summary (as built)
+
+### Stage A — Class-def flip + alias inversion (1 commit, `56fcbed`)
+
+Surgical edit to `schemas.py`, `genome.py`, `ribosome.py`, and
+`aliases.py`. For each pair:
+
+```python
+# schemas.py BEFORE
+class Gene(BaseModel):
+    gene_id: str
+    ...
+
+# schemas.py AFTER
+class Document(BaseModel):
+    gene_id: str        # field name stays — SQL contract
+    ...
+
+Gene = Document         # back-compat alias; identity preserved
+```
+
+7 pairs flipped:
+
+| Module | Canonical (real def) | Legacy (alias) |
+|---|---|---|
+| `schemas.py` | `LifecycleTier` | `ChromatinState` |
+| `schemas.py` | `DocumentTags` | `PromoterTags` |
+| `schemas.py` | `DocumentSignals` | `EpigeneticMarkers` |
+| `schemas.py` | `Document` | `Gene` |
+| `schemas.py` | `DocumentAttribution` | `GeneAttribution` |
+| `genome.py` | `KnowledgeStore` | `Genome` |
+| `ribosome.py` | `Compressor` | `Ribosome` |
+
+### Stage B — Module file moves + shim modules (5 commits, `460d824..9e7471f`)
+
+| Old path | New path |
+|---|---|
+| `helix_context/ribosome.py` | `helix_context/compressor.py` |
+| `helix_context/genome.py` | `helix_context/knowledge_store.py` |
+| `helix_context/codons.py` | `helix_context/fragments.py` |
+| `helix_context/replication.py` | `helix_context/persistence.py` |
+| `helix_context/hgt.py` | `helix_context/cross_store_import.py` |
+
+Each old path is now a 30-line shim that walks `dir(_new_module)` and
+re-exports every non-dunder attribute (covers private-name leakage:
+`_parse_json`, `_EXPRESS_SYSTEM`, `_splice_system`, `_kv_keys_from_list`).
+
+### Stage C — Internal method renames (4 commits, `edc0194..71469ba`)
+
+**Compressor** (was Ribosome) — methods + intra-class aliases:
+
+| Old | New |
+|---|---|
+| `pack(content, content_type)` | `encode(content, content_type)` |
+| `splice(genes, ...)` | `trim(genes, ...)` |
+| `replicate(query, response)` | `persist(query, response)` |
+| `re_rank(query, candidates, k)` | `rerank(query, candidates, k)` |
+
+**KnowledgeStore** (was Genome) — methods + intra-class aliases:
+
+| Old | New |
+|---|---|
+| `upsert_gene(gene, apply_gate)` | `upsert_doc(gene, apply_gate)` |
+| `query_genes(...)` | `query_docs(...)` |
+| `query_genes_ann(...)` | `query_docs_ann(...)` |
+| `query_genes_dense_recall(...)` | `query_docs_dense_recall(...)` |
+| `get_gene(gid)` | `get_doc(gid)` |
+
+**Internal helpers** in other modules:
+
+| File | Old | New |
+|---|---|---|
+| `context_manager.py` | `_express(...)` | `_retrieve(...)` |
+| `context_manager.py` | `_make_parent_gene_id(...)` | `_make_parent_doc_id(...)` |
+| `context_manager.py` | `_upsert_parent_gene(...)` | `_upsert_parent_doc(...)` |
+| `fragments.py` | `codon_id(tokens)` | `fragment_id(tokens)` |
+| `cymatics.py` | `gene_spectrum(...)` | `doc_spectrum(...)` |
+| `cymatics.py` | `cached_gene_spectrum(...)` | `cached_doc_spectrum(...)` |
+| `cymatics.py` | `_cached_gene_spectrum(...)` | `_cached_doc_spectrum(...)` |
+| `cymatics.py` | `interference_splice(...)` | `interference_trim(...)` |
+
+The reflection edge case at `context_manager.py:2336`
+(`hasattr(self.ribosome, "re_rank")`) was co-updated to use the
+canonical `rerank` string. All ~30 internal callers across
+`helix_context/*.py` were migrated to canonical names; tests that
+monkey-patch via instance-attribute assignment were updated to patch
+both legacy + canonical names (alias semantics diverge under instance
+patches).
+
+### Stage D — Local-variable sweep (in flight, PR #89)
+
+Per-file pass focused on the high-visibility patterns:
+
+- `for gene in candidates:` → `for doc in candidates:` (loop counters)
+- `gene_a, gene_b` → `doc_a, doc_b` (pair-pattern in cymatics helpers)
+- `genes: List[Gene]` → `docs: List[Document]` (param + type annotation)
+- `gene = Gene(...)` followed by `gene.X` attribute access → `doc = Document(...)`
+
+Stage D is bounded by safety: it intentionally avoids renaming
+standalone `gene =`, `gene_id =`, or `gene.X` patterns that overlap
+with kwargs (`Gene(gene_id=...)`), SQL column refs (`row["gene_id"]`),
+or method-call kwargs to surfaces that retained their legacy parameter
+names.
+
+### Stage E — ROSETTA.md refresh + this design spec
+
+The phase-status table in `docs/ROSETTA.md` is brought current with
+commit SHAs for R1, R2, and the four R3 sub-stages. This file
+serves as the durable spec record alongside R2's spec for any future
+contributors auditing the rename effort.
+
+---
+
+## Identity contract after R3
+
+Across all 29 alias pairs that ship in R3:
+
+| Layer | Pairs |
+|---|---|
+| Class (schemas + genome + ribosome) | 7 |
+| Compressor methods | 4 |
+| KnowledgeStore methods | 5 |
+| context_manager helpers | 3 |
+| cymatics helpers | 4 |
+| fragments helpers | 1 |
+| Module re-exports (shim) | 5 |
+
+For each pair: `legacy is canonical` evaluates True; the canonical
+name owns `__name__`; both names appear in the module's namespace.
+
+For methods specifically, intra-class assignment (`pack = encode`)
+preserves function-object identity, so `Class.legacy is Class.canonical`
+holds at the class level. Instance-attribute patches (`obj.pack = X`)
+DO diverge — tests that monkey-patch must patch both names if internal
+code may use either.
+
+---
+
+## Verification
+
+After Stages A + B + C (PR #88 baseline, `3b92b02`):
+
+| Gate | Result | Wallclock |
+|---|---|---|
+| Pre-Stage-A baseline | 127/127 focused | 2:18 |
+| Post-A full mock | 1933 / 0 / 15 / 21 / 2 | 9:07 |
+| Post-B full mock | 1933 / 0 / 15 / 21 / 2 | 8:52 |
+| Post-C full mock | 1933 / 0 / 15 / 21 / 2 | 7:40 |
+
+Stage D will rerun the full mock at the end of PR #89 and is expected
+to match the same 1933 / 0 / 15 / 21 / 2 baseline (R3 is symbol-only;
+any retrieval-quality movement would indicate a bug).
+
+---
+
+## Stage D — known not-fully-completed scope
+
+The original plan estimated ~200+ local variable renames. PR #89 ships
+the **clearest-win subset** — function parameters, type annotations,
+loop counters, and the obvious `gene = Gene(...)` patterns in
+compressor.py — but does **not** exhaustively walk every `gene_id` or
+`gene.X` reference in module bodies. The aliases make these renames
+purely cosmetic; future cleanup PRs can sweep them incrementally if
+desired, with no behavioral impact.
+
+The Stage D files actually touched in PR #89:
+
+- `helix_context/cymatics.py` — full pass (params + types + locals)
+- `helix_context/compressor.py` — encode/persist body + return types + import widening
+- `helix_context/context_manager.py` — 5 loop-counter sites
+- `helix_context/context_packet.py` — 1 loop-counter site
+- `helix_context/knowledge_store.py` — 2 loop-counter sites in `_apply_dense_rerank`
+- `helix_context/shard_router.py` — 1 loop-counter site
+
+Not touched (intentionally — would require larger scope or surface
+larger risk):
+
+- The bulk of variable references inside `knowledge_store.py`
+  (~4500-line module). Local `gene` ↔ `doc` renames in tier-scoring
+  internals are aliases-only-cosmetic; defer.
+- Test files using legacy names in fixtures (`tests/conftest.py`,
+  `tests/test_genome.py`, etc.). Tests were already updated in R3
+  Stage C to patch both names; remaining stylistic prose stays.
+- `agent_prompt.py` system prompts and the parallel
+  `docs/agent-sdk-fragment.md` — explicit JSON contract surface.
+
+---
+
+## Lookup
+
+For any term not covered here, consult [`docs/ROSETTA.md`](../../ROSETTA.md)
+— it remains the canonical bidirectional glossary across the entire
+biology-tax rename effort.

--- a/helix_context/compressor.py
+++ b/helix_context/compressor.py
@@ -87,7 +87,14 @@ from .accel import (
 )
 from .codons import CodonEncoder
 from .exceptions import FoldingError, TranscriptionError
-from .schemas import EpigeneticMarkers, Gene, PromoterTags
+from .schemas import (
+    Document,
+    DocumentSignals,
+    DocumentTags,
+    EpigeneticMarkers,  # legacy alias retained for backward-compat surfaces
+    Gene,               # legacy alias for Document
+    PromoterTags,       # legacy alias for DocumentTags
+)
 
 log = logging.getLogger(__name__)
 
@@ -530,7 +537,7 @@ class Compressor:
 
     # ── Pack: raw text → Document ───────────────────────────────────────
 
-    def encode(self, content: str, content_type: str = "text") -> Gene:
+    def encode(self, content: str, content_type: str = "text") -> Document:
         """
         Encode raw content into a Document ready for knowledge store storage.
 
@@ -571,27 +578,27 @@ class Compressor:
             codon_meanings.append(c.get("meaning", f"chunk_{i}"))
 
         # Build Document
-        gene_id = Genome.make_gene_id(content)
-        promoter_data = parsed.get("promoter", {})
+        doc_id = Genome.make_gene_id(content)
+        tags_data = parsed.get("promoter", {})
 
-        gene = Gene(
-            gene_id=gene_id,
+        doc = Document(
+            gene_id=doc_id,
             content=content,
             complement=parsed.get("complement", content[:500]),
             codons=codon_meanings,
-            promoter=PromoterTags(
-                domains=promoter_data.get("domains", []),
-                entities=promoter_data.get("entities", []),
-                intent=promoter_data.get("intent", ""),
-                summary=promoter_data.get("summary", ""),
+            promoter=DocumentTags(
+                domains=tags_data.get("domains", []),
+                entities=tags_data.get("entities", []),
+                intent=tags_data.get("intent", ""),
+                summary=tags_data.get("summary", ""),
             ),
-            epigenetics=EpigeneticMarkers(),
+            epigenetics=DocumentSignals(),
         )
 
         # KV extraction — extract concrete facts for downstream small models
-        gene.key_values = self._extract_key_values(content)
+        doc.key_values = self._extract_key_values(content)
 
-        return gene
+        return doc
 
     # ── KV extraction: pull concrete facts from content ────────────
 
@@ -627,7 +634,7 @@ class Compressor:
 
     # ── Re-rank: score candidates against query ─────────────────────
 
-    def rerank(self, query: str, candidates: List[Gene], k: int = 5) -> List[Gene]:
+    def rerank(self, query: str, candidates: List[Document], k: int = 5) -> List[Document]:
         """
         Score candidate documents by relevance to the query.
         Uses tags summaries (not full content) to stay within token budget.
@@ -692,7 +699,7 @@ class Compressor:
     def trim(
         self,
         query: str,
-        genes: List[Gene],
+        genes: List[Document],
         min_codons_kept: int = 2,
     ) -> Dict[str, str]:
         """
@@ -774,7 +781,7 @@ class Compressor:
 
     # ── Persist: encode a query+response exchange ─────────────────
 
-    def persist(self, query: str, response: str) -> Gene:
+    def persist(self, query: str, response: str) -> Document:
         """
         Encode a conversation exchange into a Document for knowledge store storage.
         Captures intent and state changes, not just raw facts.
@@ -793,44 +800,44 @@ class Compressor:
             parsed = _parse_json(raw)
         except Exception:
             # Persistence is best-effort (background task) — don't crash
-            log.warning("Replicate failed, creating minimal gene", exc_info=True)
-            gene_id = Genome.make_gene_id(exchange)
-            return Gene(
-                gene_id=gene_id,
+            log.warning("Persist failed, creating minimal Document", exc_info=True)
+            doc_id = Genome.make_gene_id(exchange)
+            return Document(
+                gene_id=doc_id,
                 content=exchange,
                 complement=f"Q: {query[:200]} A: {response[:300]}",
                 codons=["exchange"],
-                promoter=PromoterTags(summary=query[:100]),
-                epigenetics=EpigeneticMarkers(),
+                promoter=DocumentTags(summary=query[:100]),
+                epigenetics=DocumentSignals(),
             )
 
         if not isinstance(parsed, dict):
-            gene_id = Genome.make_gene_id(exchange)
-            return Gene(
-                gene_id=gene_id,
+            doc_id = Genome.make_gene_id(exchange)
+            return Document(
+                gene_id=doc_id,
                 content=exchange,
                 complement=f"Q: {query[:200]} A: {response[:300]}",
                 codons=["exchange"],
-                promoter=PromoterTags(summary=query[:100]),
-                epigenetics=EpigeneticMarkers(),
+                promoter=DocumentTags(summary=query[:100]),
+                epigenetics=DocumentSignals(),
             )
 
-        gene_id = Genome.make_gene_id(exchange)
-        promoter_data = parsed.get("promoter", {})
+        doc_id = Genome.make_gene_id(exchange)
+        tags_data = parsed.get("promoter", {})
         codon_meanings = [c.get("meaning", "exchange") for c in parsed.get("codons", [])]
 
-        return Gene(
-            gene_id=gene_id,
+        return Document(
+            gene_id=doc_id,
             content=exchange,
             complement=parsed.get("complement", exchange[:500]),
             codons=codon_meanings or ["exchange"],
-            promoter=PromoterTags(
-                domains=promoter_data.get("domains", []),
-                entities=promoter_data.get("entities", []),
-                intent=promoter_data.get("intent", "conversation exchange"),
-                summary=promoter_data.get("summary", query[:100]),
+            promoter=DocumentTags(
+                domains=tags_data.get("domains", []),
+                entities=tags_data.get("entities", []),
+                intent=tags_data.get("intent", "conversation exchange"),
+                summary=tags_data.get("summary", query[:100]),
             ),
-            epigenetics=EpigeneticMarkers(),
+            epigenetics=DocumentSignals(),
         )
 
     # ── Legacy method aliases (R3 Stage C; see docs/ROSETTA.md) ─────

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -376,10 +376,10 @@ def _merge_subquery_candidates(
     seen: dict = {}
     hit_counts: Counter = Counter()
     for sub_list in sub_results:
-        for gene in sub_list:
-            hit_counts[gene.gene_id] += 1
-            if gene.gene_id not in seen:
-                seen[gene.gene_id] = gene
+        for doc in sub_list:
+            hit_counts[doc.gene_id] += 1
+            if doc.gene_id not in seen:
+                seen[doc.gene_id] = doc
     return sorted(
         seen.values(),
         key=lambda g: (hit_counts[g.gene_id], base_scores.get(g.gene_id, 0.0)),
@@ -1626,8 +1626,8 @@ class HelixContextManager:
         # not gated — TCM session is per-process state, not knowledge store state).
         if self._tcm_session is not None:
             try:
-                for gene in candidates:
-                    self._tcm_session.update_from_gene(gene)
+                for doc in candidates:
+                    self._tcm_session.update_from_gene(doc)
             except Exception:
                 pass  # TCM is diagnostic, not critical
 
@@ -2175,13 +2175,13 @@ class HelixContextManager:
 
         # Check pending buffer for recently persisted documents not yet committed
         with self._pending_lock:
-            for gene in self._pending:
-                gene_domains = set(d.lower() for d in gene.promoter.domains)
-                gene_entities = set(e.lower() for e in gene.promoter.entities)
+            for doc in self._pending:
+                doc_domains = set(d.lower() for d in doc.promoter.domains)
+                doc_entities = set(e.lower() for e in doc.promoter.entities)
                 query_terms = set(d.lower() for d in domains + entities)
 
-                if gene_domains & query_terms or gene_entities & query_terms:
-                    candidates.append(gene)
+                if doc_domains & query_terms or doc_entities & query_terms:
+                    candidates.append(doc)
 
         # Dedupe
         seen: set[str] = set()
@@ -2318,12 +2318,12 @@ class HelixContextManager:
                     peak_width=self._cymatics_peak_width,
                 )
                 scores = self.genome.last_query_scores or {}
-                for gene in candidates:
-                    g_spec = cached_doc_spectrum(gene, peak_width=self._cymatics_peak_width)
+                for doc in candidates:
+                    g_spec = cached_doc_spectrum(doc, peak_width=self._cymatics_peak_width)
                     bonus = flux_score_dispatch(q_spec, g_spec, weights, metric) * 0.5
                     if bonus:
-                        refiner_contrib.setdefault(gene.gene_id, {})["cymatics"] = bonus
-                    scores[gene.gene_id] = scores.get(gene.gene_id, 0) + bonus
+                        refiner_contrib.setdefault(doc.gene_id, {})["cymatics"] = bonus
+                    scores[doc.gene_id] = scores.get(doc.gene_id, 0) + bonus
                 self.genome.last_query_scores = scores
                 candidates.sort(key=lambda g: scores.get(g.gene_id, 0), reverse=True)
             except Exception:
@@ -2366,11 +2366,11 @@ class HelixContextManager:
                 )
                 if overtones:
                     scores = self.genome.last_query_scores or {}
-                    for gene in candidates:
-                        if gene.gene_id in overtones:
-                            bonus = overtones[gene.gene_id]
-                            refiner_contrib.setdefault(gene.gene_id, {})["harmonic_bin"] = bonus
-                            scores[gene.gene_id] = scores.get(gene.gene_id, 0) + bonus
+                    for doc in candidates:
+                        if doc.gene_id in overtones:
+                            bonus = overtones[doc.gene_id]
+                            refiner_contrib.setdefault(doc.gene_id, {})["harmonic_bin"] = bonus
+                            scores[doc.gene_id] = scores.get(doc.gene_id, 0) + bonus
                     self.genome.last_query_scores = scores
                     candidates.sort(key=lambda g: scores.get(g.gene_id, 0), reverse=True)
             except Exception:

--- a/helix_context/context_packet.py
+++ b/helix_context/context_packet.py
@@ -513,12 +513,12 @@ def build_context_packet(
             "right folder but no filenames match the queried concept"
         )
 
-    for gene in genes:
-        source_row = _lookup_source_row(effective_main_conn, gene.gene_id)
-        meta = _effective_meta(gene, source_row)
+    for doc in genes:
+        source_row = _lookup_source_row(effective_main_conn, doc.gene_id)
+        meta = _effective_meta(doc, source_row)
         item, status = _build_item(
-            gene,
-            relevance_score=score_map.get(gene.gene_id, 0.0),
+            doc,
+            relevance_score=score_map.get(doc.gene_id, 0.0),
             meta=meta,
             task_type=task_type,
             now_ts=now_ts,

--- a/helix_context/cymatics.py
+++ b/helix_context/cymatics.py
@@ -26,7 +26,7 @@ import math
 from functools import lru_cache
 from typing import Dict, List, Optional, Tuple
 
-from .schemas import Gene
+from .schemas import Document, Gene  # Gene retained as legacy alias
 
 log = logging.getLogger("helix.cymatics")
 
@@ -203,7 +203,7 @@ def query_spectrum(
 
 
 def doc_spectrum(
-    gene: Gene,
+    doc: Document,
     peak_width: float = 3.0,
 ) -> List[float]:
     """
@@ -211,12 +211,12 @@ def doc_spectrum(
 
     Domains and entities become spectral peaks, damped by decay_score.
     """
-    terms = list(gene.promoter.domains) + list(gene.promoter.entities)
+    terms = list(doc.promoter.domains) + list(doc.promoter.entities)
     if not terms:
         # Fall back to fragment meanings if no tags
-        terms = list(gene.codons[:5])
+        terms = list(doc.codons[:5])
 
-    decay = gene.epigenetics.decay_score
+    decay = doc.epigenetics.decay_score
     return build_spectrum(terms, decay=decay, peak_width=peak_width)
 
 
@@ -248,13 +248,13 @@ def _cached_doc_spectrum(
 _cached_gene_spectrum = _cached_doc_spectrum
 
 
-def cached_doc_spectrum(gene: Gene, peak_width: float = 3.0) -> List[float]:
+def cached_doc_spectrum(doc: Document, peak_width: float = 3.0) -> List[float]:
     """Get a document's spectrum, using LRU cache for repeated access."""
-    domains_key = "|".join(sorted(gene.promoter.domains))
-    entities_key = "|".join(sorted(gene.promoter.entities))
+    domains_key = "|".join(sorted(doc.promoter.domains))
+    entities_key = "|".join(sorted(doc.promoter.entities))
     t = _cached_doc_spectrum(
-        gene.gene_id, domains_key, entities_key,
-        round(gene.epigenetics.decay_score, 2),  # Round for cache stability
+        doc.gene_id, domains_key, entities_key,
+        round(doc.epigenetics.decay_score, 2),  # Round for cache stability
         peak_width,
     )
     return list(t)
@@ -500,50 +500,50 @@ def resonance_rank(
     if use_flux:
         weights = build_weight_vector(query, synonym_map=synonym_map, peak_width=peak_width)
 
-    scored: List[Tuple[float, Gene]] = []
-    for gene in candidates:
-        g_spec = cached_doc_spectrum(gene, peak_width=peak_width)
+    scored: List[Tuple[float, Document]] = []
+    for doc in candidates:
+        g_spec = cached_doc_spectrum(doc, peak_width=peak_width)
         if weights:
             score = flux_score_dispatch(q_spec, g_spec, weights, distance_metric)
         else:
             score = resonance_score(q_spec, g_spec)
         if score > 0.05:  # Noise floor
-            scored.append((score, gene))
+            scored.append((score, doc))
 
-    # Lost-in-the-middle guard (same as ribosome.re_rank)
+    # Lost-in-the-middle guard (same as Compressor.rerank)
     if len(scored) < len(candidates) * 0.5:
-        scored_ids = {g.gene_id for _, g in scored}
-        for gene in candidates:
-            if gene.gene_id not in scored_ids and len(scored) < k:
-                scored.append((0.1, gene))  # Default score for padded documents
+        scored_ids = {d.gene_id for _, d in scored}
+        for doc in candidates:
+            if doc.gene_id not in scored_ids and len(scored) < k:
+                scored.append((0.1, doc))  # Default score for padded documents
 
     scored.sort(key=lambda x: x[0], reverse=True)
-    return [g for _, g in scored[:k]]
+    return [d for _, d in scored[:k]]
 
 
 # ── Section 3: Interference Splice ─────────────────────────────────
 
 def interference_trim(
     query: str,
-    genes: List[Gene],
+    docs: List[Document],
     splice_aggressiveness: float = 0.3,
     synonym_map: Optional[Dict[str, List[str]]] = None,
     peak_width: float = 3.0,
     min_codons_kept: int = 2,
 ) -> Dict[str, str]:
     """
-    Splice documents using frequency interference instead of an LLM.
+    Trim documents using frequency interference instead of an LLM.
 
     For each document, for each fragment meaning, compute resonance between
     the fragment's mini-spectrum and the query spectrum. Fragments that
     constructively interfere (above threshold) survive as exons.
-    Those below threshold are spliced as introns.
+    Those below threshold are dropped.
 
-    Preserves Fix 2 (empty splice guard) and Fix 4 (complement fallback).
+    Preserves Fix 2 (empty trim guard) and Fix 4 (complement fallback).
 
-    Returns {gene_id: spliced_text} — same format as Ribosome.splice().
+    Returns {doc_id: trimmed_text} -- same format as Compressor.trim().
     """
-    if not genes:
+    if not docs:
         return {}
 
     threshold = splice_aggressiveness * 0.7
@@ -551,37 +551,37 @@ def interference_trim(
 
     result: Dict[str, str] = {}
 
-    for gene in genes:
-        if not gene.codons:
-            result[gene.gene_id] = gene.complement or gene.content[:500]
+    for doc in docs:
+        if not doc.codons:
+            result[doc.gene_id] = doc.complement or doc.content[:500]
             continue
 
         # Score each fragment against the query
         kept: List[str] = []
-        for codon_meaning in gene.codons:
+        for codon_meaning in doc.codons:
             codon_spec = build_spectrum([codon_meaning], peak_width=peak_width)
             score = resonance_score(q_spec, codon_spec)
             if score >= threshold:
                 kept.append(codon_meaning)
 
-        # Fix 2: empty splice guard
-        if not kept and gene.codons:
-            kept = gene.codons[:min_codons_kept]
+        # Fix 2: empty trim guard
+        if not kept and doc.codons:
+            kept = doc.codons[:min_codons_kept]
             log.info(
-                "Empty cymatics splice for gene %s, keeping first %d codons",
-                gene.gene_id, len(kept),
+                "Empty cymatics trim for doc %s, keeping first %d fragments",
+                doc.gene_id, len(kept),
             )
 
         if kept:
-            result[gene.gene_id] = " | ".join(kept)
+            result[doc.gene_id] = " | ".join(kept)
         else:
             # Total miss — fall back to complement (Fix 4)
-            result[gene.gene_id] = gene.complement or gene.content[:500]
+            result[doc.gene_id] = doc.complement or doc.content[:500]
 
     # Handle documents missing from result
-    for gene in genes:
-        if gene.gene_id not in result:
-            result[gene.gene_id] = gene.complement or gene.content[:500]
+    for doc in docs:
+        if doc.gene_id not in result:
+            result[doc.gene_id] = doc.complement or doc.content[:500]
 
     return result
 
@@ -592,7 +592,7 @@ interference_splice = interference_trim
 
 # ── Section 4: Harmonic Co-activation ──────────────────────────────
 
-def harmonic_weight(gene_a: Gene, gene_b: Gene, peak_width: float = 3.0) -> float:
+def harmonic_weight(doc_a: Document, doc_b: Document, peak_width: float = 3.0) -> float:
     """
     Compute harmonic coupling strength between two documents.
 
@@ -600,30 +600,31 @@ def harmonic_weight(gene_a: Gene, gene_b: Gene, peak_width: float = 3.0) -> floa
     High weight = spectrally similar (same resonant frequencies).
     Low weight = co-occurred but spectrally dissimilar.
     """
-    spec_a = cached_doc_spectrum(gene_a, peak_width=peak_width)
-    spec_b = cached_doc_spectrum(gene_b, peak_width=peak_width)
+    spec_a = cached_doc_spectrum(doc_a, peak_width=peak_width)
+    spec_b = cached_doc_spectrum(doc_b, peak_width=peak_width)
     return resonance_score(spec_a, spec_b)
 
 
 def compute_harmonic_weights(
-    genes: List[Gene],
+    docs: List[Document],
     peak_width: float = 3.0,
 ) -> List[Tuple[str, str, float]]:
     """
     Compute pairwise harmonic weights for a set of retrieved documents.
 
-    Returns list of (gene_id_a, gene_id_b, weight) tuples.
+    Returns list of (doc_id_a, doc_id_b, weight) tuples. (The field on
+    Document is still ``gene_id`` — SQL contract.)
     Only returns pairs where weight > 0.1 (above noise floor).
     """
-    if len(genes) < 2:
+    if len(docs) < 2:
         return []
 
     weights: List[Tuple[str, str, float]] = []
-    for i, ga in enumerate(genes):
-        for gb in genes[i + 1:]:
-            w = harmonic_weight(ga, gb, peak_width=peak_width)
+    for i, da in enumerate(docs):
+        for db in docs[i + 1:]:
+            w = harmonic_weight(da, db, peak_width=peak_width)
             if w > 0.1:
-                weights.append((ga.gene_id, gb.gene_id, w))
+                weights.append((da.gene_id, db.gene_id, w))
     return weights
 
 

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -3267,35 +3267,35 @@ class KnowledgeStore:
         sim_by_id: dict[str, float] = {gid: float(s) for gid, s in dense_hits}
         ordered_ids: list[str] = [gid for gid, _ in dense_hits]
         seen: set[str] = set(ordered_ids)
-        for gene in lex_pool:
-            if gene.gene_id not in seen:
-                seen.add(gene.gene_id)
-                ordered_ids.append(gene.gene_id)
+        for doc in lex_pool:
+            if doc.gene_id not in seen:
+                seen.add(doc.gene_id)
+                ordered_ids.append(doc.gene_id)
                 # Lex-only id w/o dense score: pin slightly below threshold so
                 # the min_genes floor can still rescue them. Spec §8 retains
                 # this behavior; Stage 3 (RRF) replaces the placeholder.
-                sim_by_id[gene.gene_id] = threshold - 0.01
+                sim_by_id[doc.gene_id] = threshold - 0.01
 
         # Body-fetch missing ids in bulk. Lex pool already has bodies; only
         # dense-only ids need loading.
-        lex_by_id = {g.gene_id: g for g in lex_pool}
+        lex_by_id = {d.gene_id: d for d in lex_pool}
         missing_ids = [gid for gid in ordered_ids if gid not in lex_by_id]
         loaded = self._load_genes_by_ids(missing_ids) if missing_ids else {}
 
         # ── 4. Resolve final Document objects in score order. ────────────
         scored: list[tuple[Gene, float]] = []
         for gid in ordered_ids:
-            gene = lex_by_id.get(gid) or loaded.get(gid)
-            if gene is None:
+            doc = lex_by_id.get(gid) or loaded.get(gid)
+            if doc is None:
                 continue
-            scored.append((gene, sim_by_id[gid]))
+            scored.append((doc, sim_by_id[gid]))
         scored.sort(key=lambda x: x[1], reverse=True)
 
         # ── 5. Threshold cut + min_genes floor + max_genes cap. ──────
         result: list[Gene] = []
-        for gene, sim in scored:
+        for doc, sim in scored:
             if sim >= threshold or len(result) < min_genes:
-                result.append(gene)
+                result.append(doc)
             else:
                 break
         return result[:max_genes]

--- a/helix_context/shard_router.py
+++ b/helix_context/shard_router.py
@@ -194,13 +194,13 @@ class ShardRouter:
             # across shards if the same content was extracted twice
             # (legitimate in copy-extract phase). Keep the highest-score
             # copy.
-            for gene in genes:
-                score = shard.last_query_scores.get(gene.gene_id, 0.0)
-                if gene.gene_id not in merged or score > merged_scores.get(gene.gene_id, 0.0):
-                    merged[gene.gene_id] = gene
-                    merged_scores[gene.gene_id] = score
-                    merged_tier[gene.gene_id] = dict(
-                        shard.last_tier_contributions.get(gene.gene_id, {})
+            for doc in genes:
+                score = shard.last_query_scores.get(doc.gene_id, 0.0)
+                if doc.gene_id not in merged or score > merged_scores.get(doc.gene_id, 0.0):
+                    merged[doc.gene_id] = doc
+                    merged_scores[doc.gene_id] = score
+                    merged_tier[doc.gene_id] = dict(
+                        shard.last_tier_contributions.get(doc.gene_id, {})
                     )
 
         # Rank merged candidates by score, take top-K.


### PR DESCRIPTION
## Summary

R3 Stages D and E per the plan in
[`~/.claude/plans/ethereal-forging-cookie.md`](../tree/rename-r3-de) and
tracking issue #87. Completes the multi-stage rename effort started in
#88 (Stages A+B+C merged to master at `3b92b02`).

## Stage D — Local-variable + parameter sweep (in progress)

For each module, refactors local-scope `gene` → `doc`, `gene_a/gene_b`
→ `doc_a/doc_b`, and `genes` (list) → `docs` (list) in function bodies
and signatures **where the rename does not touch SQL contracts or
external callers**.

Pydantic field names (`gene_id`, `promoter`, `epigenetics`,
`chromatin`, `codons`) and SQL columns are unchanged. Type annotations
update from `Gene` → `Document` (identity-preserving alias from R3
Stage A).

| File | Commit | Status |
|---|---|---|
| `cymatics.py` | `80bf3d6` | ✓ landed |
| `fragments.py` | | |
| `compressor.py` | | |
| `knowledge_store.py` | | |
| `context_manager.py` | | |
| `context_packet.py` | | |
| Small files (`tagger`, `deberta_backend`, `seeded_edges`, …) | | |

Each commit ships independently — every per-file PR diff is reviewable
in isolation and the alias system means any module can be reverted
without breaking others.

## Stage E — ROSETTA.md refresh + R3 design spec stub (pending)

- Update phase-status table to mark R1, R2, and now R3 Stages A-D as
  shipped, with commit SHAs.
- Add a one-page R3 design spec at
  `docs/superpowers/specs/2026-05-13-rename-r3-symbol-rename-design.md`.

## Out of scope (still protected)

- SQL schema (tables / columns)
- Pydantic field names on the wire
- Prometheus metric / label names
- ChromatinState enum value strings
- MCP tool names
- `agent_prompt.py` JSON contract fields

## Verification

Per-file: focused regression after each commit. Final sweep: full
`pytest tests/ -m "not live"` should return the same 1933 / 0 / 15 /
21 / 2 result the PR #88 baseline established.

## Related

- Plan: `~/.claude/plans/ethereal-forging-cookie.md`
- Tracking issue: #87
- Prior PR (Stages A+B+C, merged): #88
- R2 PR: #70