### PR TITLE
[codex] add shard file workers

### DIFF
--- a/helix_context/parallel.py
+++ b/helix_context/parallel.py
@@ -9,15 +9,20 @@ Two helpers:
   pool used by ``build_fixture_matrix.py --mode sharded --shard-workers``.
   VRAM-bound because each shard-worker holds its own SPLADE model on
   the GPU (~4 GB per worker).
+- :func:`auto_shard_file_workers` picks the CPU-only file worker count
+  inside each shard worker.
 
-Both honour an explicit override at call time; these helpers are only
-consulted when the user does not pass ``--workers`` / ``--shard-workers``.
+These helpers are only consulted when the user does not pass the matching
+``--workers`` / ``--shard-workers`` / ``--shard-file-workers`` override.
 """
 
 from __future__ import annotations
 
 import math
 import os
+
+_SPLADE_VRAM_GB = 4.0
+_VRAM_ROUNDING_SLACK = 0.05
 
 
 def auto_workers(buffer_pct: float = 0.125) -> int:
@@ -33,21 +38,56 @@ def auto_workers(buffer_pct: float = 0.125) -> int:
     return max(1, physical - reserved)
 
 
+def _vram_worker_cap(vram_gb: float | None) -> int:
+    """Return SPLADE worker cap for a VRAM amount in GB."""
+    if vram_gb is None:
+        return 1
+    return max(
+        1,
+        int((max(0.0, vram_gb) / _SPLADE_VRAM_GB) + _VRAM_ROUNDING_SLACK),
+    )
+
+
 def auto_shard_workers(buffer_pct: float = 0.125) -> int:
     """Shard-worker count for ``--mode sharded --shard-workers``.
 
     Each shard-worker holds an independent SPLADE model on the GPU
-    (~4 GB). The cap is ``min(vram_gb // 4, auto_workers())`` so we never
-    exceed CPU headroom or VRAM. Falls back to 1 when no GPU is reported.
+    (~4 GB). The cap is the lower of total-VRAM capacity, live free-VRAM
+    capacity when reported, and CPU headroom. Falls back to 1 when no GPU
+    is reported.
 
     On a 3080 Ti (12 GB) + 5800X this returns 3.
     """
     try:
         from helix_context.hardware import get_hardware
-        vram = get_hardware().vram_total_gb
+        hw = get_hardware()
+        vram_total = hw.vram_total_gb
+        vram_free = getattr(hw, "vram_free_gb", None)
     except Exception:
-        vram = None
+        vram_total = None
+        vram_free = None
 
-    vram_cap = max(1, int((vram or 4) // 4))  # 4 GB per SPLADE worker
+    if vram_total is None:
+        vram_cap = 1
+    else:
+        total_cap = _vram_worker_cap(vram_total)
+        free_cap = _vram_worker_cap(vram_free) if vram_free is not None else total_cap
+        vram_cap = max(1, min(total_cap, free_cap))
     cpu_cap = max(1, auto_workers(buffer_pct))
     return max(1, min(vram_cap, cpu_cap))
+
+
+def auto_shard_file_workers(
+    shard_workers: int,
+    buffer_pct: float = 0.125,
+) -> int:
+    """CPU-only file workers to run inside each shard worker.
+
+    The total file-worker budget follows :func:`auto_workers`; this helper
+    splits that CPU budget across the SPLADE-owning shard workers. On the
+    reference 8-core box that means 2 shard workers get 3 file workers each,
+    while 3 shard workers get 2 each.
+    """
+    shards = max(1, int(shard_workers or 1))
+    cpu_budget = max(1, auto_workers(buffer_pct))
+    return max(1, cpu_budget // shards)

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -41,12 +41,14 @@ Parallel modes (issue #92)
                             (0 = auto via helix_context.parallel.auto_workers).
     --shard-workers N       Run sharded builds with N concurrent shard
                             processes. 0 = auto from VRAM + CPU.
+    --shard-file-workers N  CPU-only chunk/tag workers inside each shard
+                            process. 0 = auto from CPU budget.
     --batch-size N          SPLADE batch size in the writer (default 64).
 
 Examples:
     python scripts/build_fixture_matrix.py --profile medium --parallel
     python scripts/build_fixture_matrix.py --profile xl --parallel --workers 6
-    python scripts/build_fixture_matrix.py --profile xl --mode sharded --shard-workers 3
+    python scripts/build_fixture_matrix.py --profile xl --mode sharded --shard-workers 2 --shard-file-workers 3
 
 The script does not talk to the running Helix server -- it builds fresh
 SQLite files directly. Use ``POST /admin/swap-db`` with ``mode="blob"``
@@ -57,8 +59,10 @@ of the resulting files into a running server without restarting.
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import json
 import logging
+import multiprocessing as mp
 import os
 import re
 import sys
@@ -125,6 +129,11 @@ SQLITE_SIDECAR_SUFFIXES = (".db", ".sqlite", ".sqlite3", ".db-wal", ".db-shm",
 
 MAX_FILE_SIZE = 200_000
 MIN_FILE_SIZE = 50
+
+
+def _is_sqlite_sidecar(path: str) -> bool:
+    """Picklable filter for SQLite sidecars in process-pool shard tasks."""
+    return any(path.lower().endswith(s) for s in SQLITE_SIDECAR_SUFFIXES)
 
 
 # ── File -> gene-dict helper (shared by sequential + parallel paths) ──────
@@ -292,8 +301,6 @@ def _parallel_ingest_to_genome(
 
     Caller is responsible for opening / closing ``genome``.
     """
-    import multiprocessing as mp
-
     log.info(
         "parallel ingest: %d files, %d workers, batch_size=%d",
         len(files), n_workers, batch_size,
@@ -305,6 +312,29 @@ def _parallel_ingest_to_genome(
         )
         _drain_with_batched_splade(
             gene_dict_iter, genome, stats, batch_size=batch_size,
+        )
+
+
+def _iter_chunked_file_gene_dicts(
+    files: list[tuple[str, str]],
+    file_workers: int,
+    chunksize: int = 4,
+) -> Iterable[list[dict]]:
+    """Yield per-file gene dict lists, optionally using shard-local CPU workers."""
+    file_workers = max(1, int(file_workers or 1))
+    if file_workers <= 1:
+        _init_worker()
+        for f in files:
+            yield _chunk_and_tag_file(f)
+        return
+
+    log.info(
+        "shard file ingest: %d files, %d file_workers, chunksize=%d",
+        len(files), file_workers, chunksize,
+    )
+    with mp.Pool(file_workers, initializer=_init_worker) as pool:
+        yield from pool.imap_unordered(
+            _chunk_and_tag_file, files, chunksize=chunksize,
         )
 
 
@@ -342,22 +372,14 @@ PROFILES: dict[str, dict] = {
         "extra_skip_dirs": set(),
         # Skip any .db / .sqlite sidecars under helix-context. The walker
         # already filters by extension; this is just an extra safety belt.
-        "extra_filename_filters": [
-            lambda path: any(
-                path.lower().endswith(s) for s in SQLITE_SIDECAR_SUFFIXES
-            ),
-        ],
+        "extra_filename_filters": [_is_sqlite_sidecar],
     },
     "large": {
         "label": "Full projects corpus",
         "active_roots": 1,
         "roots": [r"F:\Projects"],
         "extra_skip_dirs": set(),
-        "extra_filename_filters": [
-            lambda path: any(
-                path.lower().endswith(s) for s in SQLITE_SIDECAR_SUFFIXES
-            ),
-        ],
+        "extra_filename_filters": [_is_sqlite_sidecar],
     },
     "xl": {
         "label": "Projects plus external Steam/game code corpus",
@@ -383,11 +405,7 @@ PROFILES: dict[str, dict] = {
             "crashdump", "CrashDump", "Crashes",
             "PlayerData", "Recordings",
         },
-        "extra_filename_filters": [
-            lambda path: any(
-                path.lower().endswith(s) for s in SQLITE_SIDECAR_SUFFIXES
-            ),
-        ],
+        "extra_filename_filters": [_is_sqlite_sidecar],
     },
 }
 
@@ -618,14 +636,17 @@ def _build_one_shard(
     extra_filename_filters: list,
     use_batched_splade: bool = True,
     batch_size: int = 64,
+    file_workers: int = 1,
+    file_chunksize: int = 4,
 ) -> dict:
     """Build a single shard ``.db`` for ``root``. Returns the shard's
     fingerprint payload + stats -- caller writes rows into main.db.
 
-    Runs end-to-end in one process: discover files, chunk+tag, batched
-    SPLADE upsert. Used by both the serial sharded build (called from
-    the parent process) and the parallel pool (called inside subprocesses
-    via :func:`_shard_worker_entry`).
+    Runs one SPLADE-owning shard process; chunk+tag may fan out to a
+    shard-local CPU-only file pool before batched SPLADE upsert. Used by
+    both the serial sharded build (called from the parent process) and the
+    parallel shard executor (called inside subprocesses via
+    :func:`_shard_worker_entry`).
     """
     p = Path(shard_db_path)
     if p.exists():
@@ -649,8 +670,9 @@ def _build_one_shard(
             files = _iter_ingestable_files(
                 [root], skip_dirs, extra_filename_filters, s_stats,
             )
-            _init_worker()  # fill module-level chunker/tagger
-            gen = (_chunk_and_tag_file(f) for f in files)
+            gen = _iter_chunked_file_gene_dicts(
+                files, file_workers=file_workers, chunksize=file_chunksize,
+            )
             _drain_with_batched_splade(
                 gen, shard, s_stats, batch_size=batch_size,
             )
@@ -727,6 +749,8 @@ def _shard_worker_entry(task: dict) -> dict:
         extra_filename_filters=task["extra_filename_filters"],
         use_batched_splade=True,
         batch_size=task.get("batch_size", 64),
+        file_workers=task.get("shard_file_workers", 1),
+        file_chunksize=task.get("shard_file_chunksize", 4),
     )
 
 
@@ -735,18 +759,23 @@ def build_profile_sharded(
     profile_out_dir: str,
     shard_category: str = "reference",
     shard_workers: int = 1,
+    shard_file_workers: int = 0,
     batch_size: int = 64,
 ) -> dict:
     """Build the profile as a sharded layout under ``profile_out_dir``.
 
-    When ``shard_workers > 1`` the per-shard builds run in an ``mp.Pool``;
-    main.db writes happen in the parent process after each shard returns,
-    serialized through SQLite's ``busy_timeout``. ``shard_workers == 1``
-    (default) is the serial path.
+    When ``shard_workers > 1`` the per-shard builds run in a process
+    executor; main.db writes happen in the parent process after each shard
+    returns, serialized through SQLite's ``busy_timeout``. Each shard may
+    also run ``shard_file_workers`` CPU-only workers for chunk+tag prep;
+    ``0`` auto-sizes from the CPU budget.
     """
-    import multiprocessing as mp
-
     profile = PROFILES[name]
+    if shard_file_workers <= 0:
+        from helix_context.parallel import auto_shard_file_workers
+        shard_file_workers = auto_shard_file_workers(shard_workers)
+    else:
+        shard_file_workers = max(1, int(shard_file_workers))
     os.makedirs(profile_out_dir, exist_ok=True)
 
     main_path = main_db_path(profile_out_dir)
@@ -763,8 +792,8 @@ def build_profile_sharded(
     except Exception:
         log.debug("busy_timeout pragma failed", exc_info=True)
     log.info(
-        "sharded main.db at %s (shard_workers=%d)",
-        main_path, shard_workers,
+        "sharded main.db at %s (shard_workers=%d, shard_file_workers=%d)",
+        main_path, shard_workers, shard_file_workers,
     )
 
     skip_dirs = SKIP_DIRS_COMMON | profile["extra_skip_dirs"]
@@ -785,6 +814,7 @@ def build_profile_sharded(
         "missing_roots": [],
         "shards": [],
         "shard_workers": shard_workers,
+        "shard_file_workers": shard_file_workers,
         "t0": time.perf_counter(),
     }
 
@@ -804,6 +834,8 @@ def build_profile_sharded(
             "skip_dirs": skip_dirs,
             "extra_filename_filters": extra_filename_filters,
             "batch_size": batch_size,
+            "shard_file_workers": shard_file_workers,
+            "shard_file_chunksize": 4,
         })
 
     # Per-shard execution -- serial or pool.
@@ -853,12 +885,13 @@ def build_profile_sharded(
             _commit_shard_result(_shard_worker_entry(task))
     else:
         log.info(
-            "dispatching %d shards across %d workers",
-            len(tasks), shard_workers,
+            "dispatching %d shards across %d workers (%d file_workers each)",
+            len(tasks), shard_workers, shard_file_workers,
         )
-        with mp.Pool(shard_workers) as pool:
-            for res in pool.imap_unordered(_shard_worker_entry, tasks):
-                _commit_shard_result(res)
+        with ProcessPoolExecutor(max_workers=shard_workers) as pool:
+            futures = [pool.submit(_shard_worker_entry, task) for task in tasks]
+            for fut in as_completed(futures):
+                _commit_shard_result(fut.result())
 
     elapsed = time.perf_counter() - totals["t0"]
     totals["elapsed_s"] = round(elapsed, 1)
@@ -982,6 +1015,12 @@ def main() -> int:
              "0 = auto via helix_context.parallel.auto_shard_workers; "
              "1 = serial.",
     )
+    parser.add_argument(
+        "--shard-file-workers", type=int, default=0,
+        help="CPU-only file workers inside each shard-builder "
+             "(sharded mode only). 0 = auto via "
+             "helix_context.parallel.auto_shard_file_workers; 1 = serial.",
+    )
     args = parser.parse_args()
 
     profiles = parse_profile_arg(args.profile)
@@ -1024,24 +1063,30 @@ def main() -> int:
     os.makedirs(out_dir, exist_ok=True)
     log.info("BUILD START mode=sharded profiles=%s out_dir=%s", profiles, out_dir)
 
+    from helix_context.parallel import auto_shard_file_workers
     if args.shard_workers <= 0:
         from helix_context.parallel import auto_shard_workers
         shard_workers = auto_shard_workers()
     else:
         shard_workers = args.shard_workers
+    if args.shard_file_workers <= 0:
+        shard_file_workers = auto_shard_file_workers(shard_workers)
+    else:
+        shard_file_workers = max(1, args.shard_file_workers)
 
     results = {}
     for name in profiles:
         profile_dir = os.path.join(out_dir, name)
         log.info(
-            "### Profile: %s (sharded, %d workers) ###",
-            name, shard_workers,
+            "### Profile: %s (sharded, %d shard workers x %d file workers) ###",
+            name, shard_workers, shard_file_workers,
         )
         stats = build_profile_sharded(
             name=name,
             profile_out_dir=profile_dir,
             shard_category=args.shard_category,
             shard_workers=shard_workers,
+            shard_file_workers=shard_file_workers,
             batch_size=args.batch_size,
         )
         update_manifest(out_dir, stats, mode="sharded")

--- a/tests/test_build_fixture_matrix_parallel.py
+++ b/tests/test_build_fixture_matrix_parallel.py
@@ -7,6 +7,8 @@ the resulting gene_ids and content hashes are identical.
 
 from __future__ import annotations
 
+from concurrent.futures import ProcessPoolExecutor
+import pickle
 import sys
 import sqlite3
 from pathlib import Path
@@ -102,6 +104,115 @@ def _collect_main_db_summary(main_db_path: Path) -> dict[str, set[tuple]]:
     }
     conn.close()
     return {"shards": shards, "fingerprint_rows": fps}
+
+
+def _nested_pool_probe(_value: int) -> int:
+    import multiprocessing as mp
+
+    with mp.Pool(1) as pool:
+        return pool.map(abs, [-1])[0]
+
+
+def test_process_executor_allows_nested_file_pool():
+    """Outer shard executor workers must be able to spawn inner file pools."""
+    with ProcessPoolExecutor(max_workers=1) as pool:
+        assert pool.submit(_nested_pool_probe, 0).result(timeout=10) == 1
+
+
+def test_inner_file_worker_iter_uses_pool(monkeypatch):
+    """Shard-local file workers run chunk+tag in a CPU-only pool."""
+    import build_fixture_matrix as bfm
+
+    calls = {"workers": None, "chunksize": None, "initialized": 0}
+
+    class FakePool:
+        def __init__(self, workers, initializer=None):
+            calls["workers"] = workers
+            self.initializer = initializer
+
+        def __enter__(self):
+            if self.initializer is not None:
+                self.initializer()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def imap_unordered(self, func, files, chunksize=1):
+            calls["chunksize"] = chunksize
+            return [func(f) for f in files]
+
+    monkeypatch.setattr(bfm.mp, "Pool", FakePool)
+    monkeypatch.setattr(
+        bfm, "_init_worker",
+        lambda: calls.__setitem__("initialized", calls["initialized"] + 1),
+    )
+    monkeypatch.setattr(
+        bfm, "_chunk_and_tag_file",
+        lambda f: [{"source_id": f[0]}],
+    )
+
+    files = [("a.py", ".py"), ("b.py", ".py")]
+    rows = list(bfm._iter_chunked_file_gene_dicts(
+        files, file_workers=3, chunksize=2,
+    ))
+
+    assert calls == {"workers": 3, "chunksize": 2, "initialized": 1}
+    assert rows == [[{"source_id": "a.py"}], [{"source_id": "b.py"}]]
+
+
+def test_build_profile_sharded_passes_shard_file_workers(tmp_path, monkeypatch):
+    """Programmatic sharded builds include shard-local CPU worker count."""
+    import build_fixture_matrix as bfm
+
+    root = tmp_path / "root"
+    root.mkdir()
+    captured_tasks = []
+
+    monkeypatch.setattr(bfm, "PROFILES", {
+        "tiny95": {
+            "label": "issue #95 shard file workers",
+            "active_roots": 1,
+            "roots": [str(root)],
+            "extra_skip_dirs": set(),
+            "extra_filename_filters": [],
+        }
+    })
+
+    def fake_shard_worker_entry(task):
+        captured_tasks.append(task)
+        return {
+            "label": task["label"],
+            "root": task["root"],
+            "shard_db_path": task["shard_db_path"],
+            "gene_count": 0,
+            "byte_size": 0,
+            "elapsed_s": 0.0,
+            "files": 0,
+            "genes": 0,
+            "skipped": 0,
+            "errors": 0,
+            "missing_roots": [],
+            "fingerprint_payload": [],
+        }
+
+    monkeypatch.setattr(bfm, "_shard_worker_entry", fake_shard_worker_entry)
+
+    stats = bfm.build_profile_sharded(
+        "tiny95", str(tmp_path / "out"),
+        shard_workers=1, shard_file_workers=3, batch_size=8,
+    )
+
+    assert captured_tasks[0]["shard_file_workers"] == 3
+    assert stats["shard_file_workers"] == 3
+
+
+def test_sharded_profile_filters_are_process_picklable():
+    """Shard tasks cross Windows spawn process boundaries."""
+    import build_fixture_matrix as bfm
+
+    for profile in bfm.PROFILES.values():
+        pickle.dumps(profile["extra_filename_filters"])
 
 
 @pytest.mark.slow

--- a/tests/test_parallel_sizers.py
+++ b/tests/test_parallel_sizers.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from helix_context.parallel import auto_workers, auto_shard_workers
+from helix_context.parallel import (
+    auto_shard_file_workers,
+    auto_shard_workers,
+    auto_workers,
+)
 
 
 @patch("helix_context.parallel.os.cpu_count", return_value=8)
@@ -38,16 +42,33 @@ def test_auto_workers_handles_unknown_cpu(_):
 
 
 class _FakeHardware:
-    def __init__(self, vram: float | None):
+    def __init__(self, vram: float | None, free: float | None = None):
         self.vram_total_gb = vram
+        self.vram_free_gb = free
 
 
 @patch("helix_context.parallel.os.cpu_count", return_value=8)
 def test_auto_shard_workers_3080ti(_):
-    """12 GB VRAM + 8-core CPU: min(12//4, auto_workers) = min(3, 6) = 3."""
+    """12 GB VRAM + 8-core CPU: min(3 VRAM workers, 6 CPU workers) = 3."""
     with patch("helix_context.hardware.get_hardware",
                return_value=_FakeHardware(vram=12.0)):
         assert auto_shard_workers() == 3
+
+
+@patch("helix_context.parallel.os.cpu_count", return_value=8)
+def test_auto_shard_workers_3080ti_fractional_total(_):
+    """CUDA can report 11.9995 GB for a 12 GB card; that still allows 3."""
+    with patch("helix_context.hardware.get_hardware",
+               return_value=_FakeHardware(vram=11.99951171875)):
+        assert auto_shard_workers() == 3
+
+
+@patch("helix_context.parallel.os.cpu_count", return_value=8)
+def test_auto_shard_workers_respects_live_free_vram(_):
+    """When the server is already using VRAM, auto keeps startup below OOM."""
+    with patch("helix_context.hardware.get_hardware",
+               return_value=_FakeHardware(vram=12.0, free=10.8)):
+        assert auto_shard_workers() == 2
 
 
 @patch("helix_context.parallel.os.cpu_count", return_value=16)
@@ -80,3 +101,15 @@ def test_auto_shard_workers_hardware_import_error(_):
     with patch("helix_context.hardware.get_hardware",
                side_effect=RuntimeError("no torch")):
         assert auto_shard_workers() >= 1
+
+
+@patch("helix_context.parallel.os.cpu_count", return_value=8)
+def test_auto_shard_file_workers_feeds_two_splade_workers(_):
+    """5800X-class box: 2 shard workers get 3 CPU file workers each."""
+    assert auto_shard_file_workers(2) == 3
+
+
+@patch("helix_context.parallel.os.cpu_count", return_value=8)
+def test_auto_shard_file_workers_feeds_three_splade_workers(_):
+    """5800X-class box: 3 shard workers get 2 CPU file workers each."""
+    assert auto_shard_file_workers(3) == 2


### PR DESCRIPTION
## Summary
- Add shard-local CPU file workers so each SPLADE-owning shard process can receive chunked/tagged genes from an inner CPU pool.
- Add `--shard-file-workers` with auto-sizing based on the CPU budget per shard worker.
- Make `auto_shard_workers()` tolerate fractional 12 GB VRAM reports while respecting live free VRAM to avoid overcommitting a running server.
- Keep Windows process-spawn safe by using `ProcessPoolExecutor` for outer shard workers and replacing profile filter lambdas with a picklable top-level filter.

## Why
Issue #95 found two follow-ups from the sharded ingest run: 3080 Ti VRAM was rounded down too aggressively, and each shard worker was sequential inside the shard. On a live system where free VRAM keeps the safe SPLADE count at 2, the higher-value path is feeding those 2 SPLADE workers with more CPU chunk/tag work.

## Impact
A typical live run can now use:

```bash
python scripts/build_fixture_matrix.py --profile medium --mode sharded --shard-workers 2 --shard-file-workers 3
```

That keeps SPLADE VRAM bounded while using more CPU cores for file prep.

## Validation
- `python -m pytest -m "not slow" tests/test_build_fixture_matrix_parallel.py tests/test_parallel_sizers.py` -> 18 passed, 2 slow tests deselected
- `python -m py_compile helix_context/parallel.py scripts/build_fixture_matrix.py tests/test_parallel_sizers.py tests/test_build_fixture_matrix_parallel.py`
- `git diff --check`

Draft because the live medium/xl SPLADE benchmark has not been run in this PR branch yet.