### PR TITLE
fix(sharded): adapter parity with KnowledgeStore + largest-first shard sort

### DIFF
--- a/helix_context/sharding.py
+++ b/helix_context/sharding.py
@@ -144,6 +144,7 @@ class IngestTargetRouter:
 
 
 import logging
+import threading
 from typing import Any, List
 
 log = logging.getLogger(__name__)
@@ -178,13 +179,41 @@ class ShardedGenomeAdapter:
         self.last_tier_contributions: dict = {}
         self._sharded_adapter = True  # sentinel for callers to detect
 
+        # Mirror the KnowledgeStore attributes that context_manager._retrieve
+        # and routes_admin read directly off self.genome. The adapter itself
+        # doesn't run dense or entity-graph retrieval — each per-shard
+        # Genome handles those internally during fan-out — so the
+        # adapter-level flags default to False.
+        self._dense_embedding_enabled: bool = False
+        self._entity_graph_retrieval_enabled: bool = False
+        # context_manager._build_signals uses this lock when fanning sub-queries
+        # across threads to read last_query_scores atomically.
+        self._last_query_scores_lock = threading.Lock()
+
+    @property
+    def path(self) -> str:
+        """Routing-DB path. Mirrors ``KnowledgeStore.path`` so
+        ``/admin/swap-db`` and other callers reading ``genome.path`` work
+        on a sharded knowledge store."""
+        return self._router.main_path
+
     # ── Reads ─────────────────────────────────────────────────────────
 
-    def query_genes(self, *args: Any, **kwargs: Any) -> List:
-        genes = self._router.query_docs(*args, **kwargs)
+    def query_docs(self, *args: Any, **kwargs: Any) -> List:
+        """Federated read across shards. R3 canonical name.
+
+        The router still exposes its read API under the legacy
+        ``query_genes`` name; bridge to it here so renaming the router
+        and renaming the adapter can ship independently.
+        """
+        genes = self._router.query_genes(*args, **kwargs)
         self.last_query_scores = dict(self._router.last_query_scores)
         self.last_tier_contributions = dict(self._router.last_tier_contributions)
         return genes
+
+    # Back-compat alias so older callers (and the existing shard-router
+    # tests) keep working after the canonical rename.
+    query_genes = query_docs
 
     def query_cold_tier(self, *args: Any, **kwargs: Any) -> list:
         """Cold-tier queries aren't fanned out in V1; return empty."""
@@ -237,8 +266,8 @@ class ShardedGenomeAdapter:
         """
         return self._router.main_conn
 
-    def get_gene(self, gene_id: str):
-        """Fetch a document by id across shards.
+    def get_doc(self, gene_id: str):
+        """Fetch a document by id across shards (R3 canonical name).
 
         Uses ``fingerprint_index`` to locate the owning shard, then opens
         that shard and delegates. Returns ``None`` if the gene_id is not
@@ -253,9 +282,33 @@ class ShardedGenomeAdapter:
         try:
             shard = self._router._open_shard(row["shard_name"])
         except Exception:
-            log.warning("get_gene: shard %s unavailable", row["shard_name"], exc_info=True)
+            log.warning("get_doc: shard %s unavailable", row["shard_name"], exc_info=True)
             return None
         return shard.get_doc(gene_id)
+
+    # Back-compat alias for callers still using the pre-R3 name.
+    get_gene = get_doc
+
+    def query_docs_ann(self, *args: Any, **kwargs: Any) -> List:
+        """ANN-dense retrieval is per-shard, not adapter-level.
+
+        ``context_manager._retrieve`` only calls this when
+        ``self.genome._dense_embedding_enabled`` is true; that flag is
+        False on the adapter, so the path is unreachable in V1. Provide
+        an empty list anyway so future callers don't ``AttributeError``.
+        """
+        return []
+
+    # Back-compat alias for callers still using the pre-R3 name.
+    query_genes_ann = query_docs_ann
+
+    def get_calibration_provenance(self):
+        """No cross-shard calibration record in V1 — return None.
+
+        Mirrors ``KnowledgeStore.get_calibration_provenance`` which can
+        also return None when no calibration has been recorded.
+        """
+        return None
 
     def health_history(self, limit: int = 10) -> list:
         """No cross-shard health log in V1 — return empty."""
@@ -263,9 +316,12 @@ class ShardedGenomeAdapter:
 
     # ── Write surface (no-ops in V1) ──────────────────────────────────
 
-    def upsert_gene(self, gene, **_kw) -> str:
-        log.debug("sharded-adapter: upsert_gene no-op for %s", getattr(gene, "gene_id", "?"))
+    def upsert_doc(self, gene, **_kw) -> str:
+        log.debug("sharded-adapter: upsert_doc no-op for %s", getattr(gene, "gene_id", "?"))
         return getattr(gene, "gene_id", "")
+
+    # Back-compat alias for callers still using the pre-R3 name.
+    upsert_gene = upsert_doc
 
     def touch_genes(self, *_a, **_kw) -> None: pass
     def link_coactivated(self, *_a, **_kw) -> None: pass
@@ -283,6 +339,7 @@ class ShardedGenomeAdapter:
     def compact_genome(self, *_a, **_kw) -> dict: return {"compacted": 0, "sharded": True}
     def invalidate_sema_cache(self, *_a, **_kw) -> None: pass
     def _build_sema_cache(self, *_a, **_kw) -> None: pass
+    def _invalidate_dense_matrix(self, *_a, **_kw) -> None: pass
 
     # SEMA cache is main-only (not per-shard in V1); expose an empty one.
     _sema_cache: dict = {}

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -43,6 +43,9 @@ Parallel modes (issue #92)
                             processes. 0 = auto from VRAM + CPU.
     --shard-file-workers N  CPU-only chunk/tag workers inside each shard
                             process. 0 = auto from CPU budget.
+    --no-shard-sort         Disable largest-first shard ordering. Default
+                            is enabled: pre-scan eligible bytes per shard
+                            so the long pole dispatches first (issue #97).
     --batch-size N          SPLADE batch size in the writer (default 64).
 
 Examples:
@@ -188,6 +191,48 @@ def _chunk_and_tag_file(args: tuple[str, str]) -> list[dict]:
 
 
 # ── File discovery iterator (drop-in for ingest_tree's walk) ─────────────
+
+
+def _estimate_eligible_bytes(
+    root: str,
+    skip_dirs: set[str],
+    extra_filename_filters: list,
+) -> tuple[int, int]:
+    """Walk ``root`` and return ``(eligible_files, eligible_bytes)``.
+
+    Counts only files that would pass the same ingestion filters as
+    :func:`_iter_ingestable_files`: extension in ``INGEST_EXTS``, not
+    filtered by ``extra_filename_filters``, and within
+    ``MIN_FILE_SIZE..MAX_FILE_SIZE``. Used by sharded builds to order
+    the shard queue largest-first so the long pole gets the longest
+    head start on the worker pool (issue #97, option A.1).
+
+    Filesystem errors on individual files are swallowed — the estimate
+    is a sizing hint, not a contract; the actual ingest walks the tree
+    again under the same filters and will report the truth.
+    """
+    if not os.path.exists(root):
+        return 0, 0
+    eligible_files = 0
+    eligible_bytes = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in skip_dirs]
+        for fname in filenames:
+            ext = os.path.splitext(fname)[1].lower()
+            if ext not in INGEST_EXTS:
+                continue
+            fpath = os.path.join(dirpath, fname)
+            if any(f(fpath) for f in extra_filename_filters):
+                continue
+            try:
+                size = os.path.getsize(fpath)
+            except OSError:
+                continue
+            if size < MIN_FILE_SIZE or size > MAX_FILE_SIZE:
+                continue
+            eligible_files += 1
+            eligible_bytes += size
+    return eligible_files, eligible_bytes
 
 
 def _iter_ingestable_files(
@@ -761,6 +806,7 @@ def build_profile_sharded(
     shard_workers: int = 1,
     shard_file_workers: int = 0,
     batch_size: int = 64,
+    sort_largest_first: bool = True,
 ) -> dict:
     """Build the profile as a sharded layout under ``profile_out_dir``.
 
@@ -769,6 +815,14 @@ def build_profile_sharded(
     returns, serialized through SQLite's ``busy_timeout``. Each shard may
     also run ``shard_file_workers`` CPU-only workers for chunk+tag prep;
     ``0`` auto-sizes from the CPU budget.
+
+    When ``sort_largest_first`` is True (default), shards are pre-scanned
+    for eligible-byte count and submitted to the worker pool from
+    largest to smallest. On uneven workloads (#97) this gives the long
+    pole the longest head start: e.g., XL's ``F:/Projects`` (~60% of
+    eligible bytes) dispatches first instead of waiting for 11 small
+    shards to drain. The pre-scan is a quick metadata walk, dwarfed by
+    the actual ingest cost.
     """
     profile = PROFILES[name]
     if shard_file_workers <= 0:
@@ -837,6 +891,34 @@ def build_profile_sharded(
             "shard_file_workers": shard_file_workers,
             "shard_file_chunksize": 4,
         })
+
+    # Pre-ingest sizing — order shards largest-first so the long pole
+    # gets the longest head start on the worker pool (issue #97 A.1).
+    # When ``shard_workers <= 1`` the order doesn't affect wall-clock,
+    # but we still record the estimate in the manifest for diagnostics.
+    if sort_largest_first and tasks:
+        sizing_t0 = time.perf_counter()
+        for task in tasks:
+            files, bytes_ = _estimate_eligible_bytes(
+                task["root"], skip_dirs, extra_filename_filters,
+            )
+            task["eligible_files"] = files
+            task["eligible_bytes"] = bytes_
+        tasks.sort(key=lambda t: t["eligible_bytes"], reverse=True)
+        sizing_elapsed = time.perf_counter() - sizing_t0
+        log.info(
+            "pre-ingest sizing complete in %.1fs — shard order:", sizing_elapsed,
+        )
+        for task in tasks:
+            log.info(
+                "  %s: %d eligible files, %.1f MB",
+                task["label"], task["eligible_files"],
+                task["eligible_bytes"] / 1_048_576,
+            )
+        totals["sizing_elapsed_s"] = round(sizing_elapsed, 1)
+        totals["sort_largest_first"] = True
+    else:
+        totals["sort_largest_first"] = False
 
     # Per-shard execution -- serial or pool.
     def _commit_shard_result(res: dict) -> None:
@@ -1021,6 +1103,15 @@ def main() -> int:
              "(sharded mode only). 0 = auto via "
              "helix_context.parallel.auto_shard_file_workers; 1 = serial.",
     )
+    parser.add_argument(
+        "--no-shard-sort", action="store_true",
+        help="Disable largest-first shard ordering (sharded mode only). "
+             "Default: shards are pre-scanned for eligible bytes and "
+             "submitted to the worker pool from largest to smallest so "
+             "the long pole gets the longest head start. Disable for "
+             "deterministic ordering (e.g., parity benches against "
+             "original declared order).",
+    )
     args = parser.parse_args()
 
     profiles = parse_profile_arg(args.profile)
@@ -1088,6 +1179,7 @@ def main() -> int:
             shard_workers=shard_workers,
             shard_file_workers=shard_file_workers,
             batch_size=args.batch_size,
+            sort_largest_first=not args.no_shard_sort,
         )
         update_manifest(out_dir, stats, mode="sharded")
         results[name] = stats

--- a/tests/test_build_fixture_matrix_parallel.py
+++ b/tests/test_build_fixture_matrix_parallel.py
@@ -253,3 +253,181 @@ def test_sharded_pool_matches_serial(tmp_path, monkeypatch):
 
     assert ser_summary["shards"] == pool_summary["shards"]
     assert ser_summary["fingerprint_rows"] == pool_summary["fingerprint_rows"]
+
+
+# ── Pre-ingest sizing + largest-first sort (issue #97 A.1) ────────────────
+
+
+def _make_files(root: Path, count: int, body_size: int, ext: str = ".py") -> None:
+    """Write ``count`` files of approximately ``body_size`` bytes each."""
+    root.mkdir(parents=True, exist_ok=True)
+    body = "x" * body_size
+    for i in range(count):
+        (root / f"f{i}{ext}").write_text(body, encoding="utf-8")
+
+
+def test_estimate_eligible_bytes_counts_only_passing_files(tmp_path):
+    """``_estimate_eligible_bytes`` returns ``(eligible_files, eligible_bytes)``
+    where eligibility matches the actual ingest filters: extension in
+    INGEST_EXTS, size within MIN/MAX bounds, and ``extra_filename_filters``
+    not rejecting the path."""
+    import build_fixture_matrix as bfm
+
+    root = tmp_path / "tree"
+    # 3 python files, each ~1000 bytes (well within MIN/MAX bounds).
+    _make_files(root, count=3, body_size=1000, ext=".py")
+    # A file with a non-ingestable extension — should NOT count.
+    (root / "ignored.bin").write_bytes(b"x" * 1000)
+    # A file smaller than MIN_FILE_SIZE — should NOT count.
+    (root / "tiny.py").write_text("x" * 10, encoding="utf-8")
+
+    files, bytes_ = bfm._estimate_eligible_bytes(
+        str(root), skip_dirs=set(), extra_filename_filters=[],
+    )
+    assert files == 3
+    # Each text-mode write is exactly 1000 bytes on disk for ASCII content.
+    assert bytes_ == 3 * 1000
+
+
+def test_estimate_eligible_bytes_respects_skip_dirs(tmp_path):
+    """``skip_dirs`` prunes directory descent, so files inside aren't counted."""
+    import build_fixture_matrix as bfm
+
+    root = tmp_path / "tree"
+    _make_files(root, count=2, body_size=500, ext=".py")
+    _make_files(root / "node_modules", count=5, body_size=500, ext=".py")
+
+    files, bytes_ = bfm._estimate_eligible_bytes(
+        str(root),
+        skip_dirs={"node_modules"},
+        extra_filename_filters=[],
+    )
+    assert files == 2
+    assert bytes_ == 2 * 500
+
+
+def test_estimate_eligible_bytes_respects_filename_filter(tmp_path):
+    """``extra_filename_filters`` (predicate funcs returning True to skip)
+    are applied per-file, same as the real ingest walker."""
+    import build_fixture_matrix as bfm
+
+    root = tmp_path / "tree"
+    _make_files(root, count=3, body_size=500, ext=".py")
+    (root / "skip_me.py").write_text("x" * 500, encoding="utf-8")
+
+    files, _bytes = bfm._estimate_eligible_bytes(
+        str(root),
+        skip_dirs=set(),
+        extra_filename_filters=[lambda p: "skip_me" in p],
+    )
+    assert files == 3
+
+
+def test_estimate_eligible_bytes_missing_root_returns_zero(tmp_path):
+    """A nonexistent root is treated as zero work, not an error."""
+    import build_fixture_matrix as bfm
+
+    files, bytes_ = bfm._estimate_eligible_bytes(
+        str(tmp_path / "does-not-exist"),
+        skip_dirs=set(),
+        extra_filename_filters=[],
+    )
+    assert (files, bytes_) == (0, 0)
+
+
+def test_build_profile_sharded_sorts_largest_first(tmp_path, monkeypatch):
+    """Default behavior: shard tasks are submitted to the worker pool
+    sorted by eligible_bytes descending so the long pole gets the
+    longest head start (issue #97 A.1)."""
+    import build_fixture_matrix as bfm
+
+    small_root = tmp_path / "small"
+    big_root = tmp_path / "big"
+    mid_root = tmp_path / "mid"
+    _make_files(small_root, count=1, body_size=200, ext=".py")
+    _make_files(mid_root, count=5, body_size=1000, ext=".py")
+    _make_files(big_root, count=20, body_size=1500, ext=".py")
+
+    captured_order: list[str] = []
+
+    def fake_entry(task):
+        captured_order.append(task["label"])
+        return {
+            "label": task["label"], "root": task["root"],
+            "shard_db_path": task["shard_db_path"],
+            "gene_count": 0, "byte_size": 0, "elapsed_s": 0.0,
+            "files": 0, "genes": 0, "skipped": 0, "errors": 0,
+            "missing_roots": [], "fingerprint_payload": [],
+        }
+
+    monkeypatch.setattr(bfm, "_shard_worker_entry", fake_entry)
+    monkeypatch.setattr(bfm, "PROFILES", {
+        "tiny97": {
+            "label": "issue #97 sort test",
+            "active_roots": 3,
+            # Declared smallest -> mid -> biggest; expect dispatch order reversed.
+            "roots": [str(small_root), str(mid_root), str(big_root)],
+            "extra_skip_dirs": set(),
+            "extra_filename_filters": [],
+        }
+    })
+
+    stats = bfm.build_profile_sharded(
+        "tiny97", str(tmp_path / "out"),
+        shard_workers=1, shard_file_workers=1, batch_size=8,
+        sort_largest_first=True,
+    )
+
+    big_slug = bfm._slug_for_root(str(big_root))
+    mid_slug = bfm._slug_for_root(str(mid_root))
+    small_slug = bfm._slug_for_root(str(small_root))
+    assert captured_order == [big_slug, mid_slug, small_slug]
+    assert stats["sort_largest_first"] is True
+    assert "sizing_elapsed_s" in stats
+
+
+def test_build_profile_sharded_preserves_order_when_disabled(tmp_path, monkeypatch):
+    """``sort_largest_first=False`` (the ``--no-shard-sort`` CLI flag)
+    preserves the declared ``profile["roots"]`` order."""
+    import build_fixture_matrix as bfm
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _make_files(a, count=1, body_size=200, ext=".py")
+    _make_files(b, count=20, body_size=1500, ext=".py")
+
+    captured_order: list[str] = []
+
+    def fake_entry(task):
+        captured_order.append(task["label"])
+        return {
+            "label": task["label"], "root": task["root"],
+            "shard_db_path": task["shard_db_path"],
+            "gene_count": 0, "byte_size": 0, "elapsed_s": 0.0,
+            "files": 0, "genes": 0, "skipped": 0, "errors": 0,
+            "missing_roots": [], "fingerprint_payload": [],
+        }
+
+    monkeypatch.setattr(bfm, "_shard_worker_entry", fake_entry)
+    monkeypatch.setattr(bfm, "PROFILES", {
+        "tiny97b": {
+            "label": "issue #97 no-sort test",
+            "active_roots": 2,
+            "roots": [str(a), str(b)],
+            "extra_skip_dirs": set(),
+            "extra_filename_filters": [],
+        }
+    })
+
+    stats = bfm.build_profile_sharded(
+        "tiny97b", str(tmp_path / "out"),
+        shard_workers=1, shard_file_workers=1, batch_size=8,
+        sort_largest_first=False,
+    )
+
+    a_slug = bfm._slug_for_root(str(a))
+    b_slug = bfm._slug_for_root(str(b))
+    # Declaration order preserved despite a being much smaller than b.
+    assert captured_order == [a_slug, b_slug]
+    assert stats["sort_largest_first"] is False
+

--- a/tests/test_sharded_adapter_parity.py
+++ b/tests/test_sharded_adapter_parity.py
@@ -1,0 +1,287 @@
+"""Parity tests for ``ShardedGenomeAdapter`` against the ``KnowledgeStore``
+surface that the rest of the codebase reads.
+
+The adapter is hand-maintained and historically lagged ``KnowledgeStore``
+additions, which surfaced as HTTP 500s during the bench when the
+``HELIX_USE_SHARDS=1`` read path was first driven end-to-end (issue #98).
+
+Two checks here:
+
+1. ``test_adapter_covers_known_caller_surface`` — a hard-coded list of every
+   attribute/method that ``context_manager`` and the FastAPI routes actually
+   read off ``self.genome`` / ``helix.genome`` today. This is the contract
+   the adapter MUST satisfy or callers crash at runtime.
+
+2. ``test_adapter_covers_full_knowledgestore_surface`` — a softer drift
+   catcher. Diffs the adapter's attributes against ``KnowledgeStore``'s
+   public + sentinel-private surface, with a whitelist for genuinely
+   adapter-only-irrelevant items (FTS reindex helpers, etc.).
+
+If you add a new attribute/method on ``KnowledgeStore`` that callers read
+via ``self.genome``, either (a) mirror it on the adapter, or (b) add it
+to the whitelist with a short note explaining why.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from helix_context.knowledge_store import KnowledgeStore
+from helix_context.shard_schema import init_main_db, open_main_db
+from helix_context.sharding import ShardedGenomeAdapter
+
+
+# ── Hard contract: every name read from genome in the current codebase ───
+#
+# Derived from:
+#   grep -oE "self\.genome\.[a-zA-Z_]+"  helix_context/context_manager.py
+#   grep -oE "helix\.genome\.[a-zA-Z_]+" helix_context/server/routes_*.py
+#
+# When a caller adds a new read, add it here. Failure means the adapter
+# will AttributeError at runtime for that caller's path.
+
+REQUIRED_CALLER_SURFACE = frozenset({
+    # Routing / lifecycle
+    "path",
+    "close",
+    "refresh",
+    "checkpoint",
+
+    # Storage / SQL handles
+    "conn",
+    "read_conn",
+
+    # Retrieval API
+    "query_docs",
+    "query_docs_ann",
+    "query_cold_tier",
+    "get_doc",
+
+    # Retrieval introspection
+    "last_query_scores",
+
+    # Internal flags read by context_manager._retrieve
+    "_dense_embedding_enabled",
+    "_entity_graph_retrieval_enabled",
+    "_last_query_scores_lock",
+
+    # SEMA cache (admin + invalidation paths)
+    "_sema_cache",
+    "_build_sema_cache",
+    "invalidate_sema_cache",
+    "_invalidate_dense_matrix",
+
+    # Document write surface (no-ops on adapter, but must exist)
+    "upsert_doc",
+    "touch_genes",
+    "link_coactivated",
+    "store_harmonic_weights",
+    "store_relations_batch",
+
+    # Lifecycle + maintenance
+    "log_health",
+    "compress_to_euchromatin",
+    "compress_to_heterochromatin",
+    "compact",
+    "compact_genome",
+    "vacuum",
+    "set_replication_manager",
+
+    # Stats / health
+    "stats",
+    "health_summary",
+    "health_history",
+    "get_calibration_provenance",
+})
+
+
+# ── Soft drift catcher: full KnowledgeStore surface vs adapter ───────────
+#
+# Items legitimately not on the adapter — write-path internals, FTS5
+# rebuild helpers, sema codec wiring, etc. Anything the adapter doesn't
+# need to mirror because (a) the sharded read path doesn't exercise it,
+# or (b) it's only ever called on the per-shard ``KnowledgeStore`` instance,
+# not the adapter.
+#
+# When a name shows up here unexpectedly, decide: mirror it, or whitelist
+# it with a comment.
+
+ADAPTER_ONLY_DIFFERENCES_WHITELIST = frozenset({
+    # Chromatin tier sentinels — adapter has no chromatin lifecycle,
+    # per-shard Genomes own theirs.
+    "TIER_EUCHROMATIN", "TIER_HETEROCHROMATIN", "TIER_OPEN",
+
+    # KnowledgeStore-internal constructor parameters / config snapshots —
+    # the adapter holds these on its per-shard Genomes instead.
+    "synonym_map", "sema_codec", "splade_enabled", "entity_graph",
+    "sr_enabled", "sr_gamma", "sr_k_steps", "sr_weight", "sr_cap",
+    "seeded_edges_enabled", "read_only", "_threshold_dim_warned",
+    "_dense_pool_size", "_dense_recall_enabled", "ann_similarity_threshold",
+    "_reader", "_fusion_mode", "_calibration_provenance",
+
+    # Internal builders / loaders that only make sense on a single .db.
+    "make_gene_id", "_load_genes_by_ids", "_score_query",
+    "_apply_promoter_tier", "_apply_dense_recall", "_apply_entity_graph",
+    "_apply_co_activation_lift", "_apply_seeded_edges_lift",
+    "_apply_tcm_bonus", "_apply_freshness_gate", "_pack_codons",
+    "_open_reader", "_close_reader", "_path_to_kv",
+    "_aggregate_parent_fingerprints", "_apply_authority_boosts",
+    "_auto_link_by_entity", "_bm25_candidate_set", "_compact_row_to_gene",
+    "_expand_by_entity_graph", "_expand_coactivated", "_expand_terms",
+    "_get_dense_codec", "_get_effective_ann_threshold",
+    "_init_db", "_refresh_snapshot", "_row_to_gene",
+
+    # FTS / KV / indexing helpers that operate on a single .db file's
+    # internal tables.
+    "rebuild_fts", "rebuild_path_kv_index", "rebuild_entity_graph",
+    "rebuild_dense_matrix", "_dense_matrix", "_ensure_dense_matrix",
+
+    # Dense recall — per-shard, no cross-shard fan-out in V1.
+    "query_docs_dense_recall", "query_genes_dense_recall",
+
+    # Cold-tier internals — adapter exposes query_cold_tier as a no-op
+    # but the underlying state is per-shard.
+    "_cold_tier_enabled", "_cold_tier_k", "_cold_tier_min_cosine",
+    "_build_cold_sema_cache", "invalidate_cold_sema_cache",
+
+    # Schema / DDL — handled at shard creation time, not at adapter time.
+    "_ensure_schema", "_apply_indexes", "ddl_version",
+    "_ensure_registry_schema",
+
+    # Density / calibration / relations — per-shard write-path helpers
+    # not consumed via the adapter today. If a route starts reading any
+    # of these off helix.genome, move them out of the whitelist and
+    # mirror them.
+    "apply_density_gate", "compute_density_score", "corpus_size",
+    "emit_wal_health_gauges", "get_relations", "store_relation",
+    "mark_verified", "upsert_calibration", "reassemble",
+})
+
+
+# ── Test setup ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def empty_main_db():
+    """Build a minimal main.genome.db so the adapter can open without shards."""
+    td = tempfile.TemporaryDirectory()
+    import os
+    main_path = os.path.join(td.name, "main.genome.db")
+    conn = open_main_db(main_path)
+    init_main_db(conn)
+    conn.close()
+    yield main_path
+    td.cleanup()
+
+
+@pytest.fixture
+def adapter(empty_main_db):
+    a = ShardedGenomeAdapter(main_path=empty_main_db)
+    yield a
+    a.close()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+def test_adapter_covers_known_caller_surface(adapter):
+    """Every name the codebase reads off ``self.genome`` exists on the adapter.
+
+    This is the regression net for issue #98 — any of these missing
+    causes ``AttributeError`` at runtime when a sharded knowledge store is active.
+    """
+    missing = sorted(name for name in REQUIRED_CALLER_SURFACE if not hasattr(adapter, name))
+    assert missing == [], (
+        f"ShardedGenomeAdapter is missing {len(missing)} attribute(s) that "
+        f"context_manager / routes_*.py read off self.genome: {missing}. "
+        f"Either add a (possibly no-op) shim on the adapter, or remove "
+        f"the read from the caller."
+    )
+
+
+def test_adapter_path_property_returns_main_path(adapter, empty_main_db):
+    """``/admin/swap-db`` reads ``helix.genome.path`` to log the previous DB."""
+    assert adapter.path == empty_main_db
+
+
+def test_adapter_dense_and_entity_graph_flags_default_off(adapter):
+    """``context_manager._retrieve`` gates ANN-dense + entity-graph paths
+    on these flags. Adapter defaults them off so the legacy non-ANN
+    branch runs (which is what the router actually supports in V1)."""
+    assert adapter._dense_embedding_enabled is False
+    assert adapter._entity_graph_retrieval_enabled is False
+
+
+def test_adapter_last_query_scores_lock_is_a_lock(adapter):
+    """``context_manager`` enters this lock to read scores across sub-query
+    threads. Must be a real lock (or compatible) so ``with`` works."""
+    # threading.Lock() objects expose acquire/release; use them via `with`.
+    with adapter._last_query_scores_lock:
+        adapter.last_query_scores = {"abc": 0.5}
+    assert adapter.last_query_scores == {"abc": 0.5}
+
+
+def test_adapter_query_docs_and_query_genes_are_same_callable(adapter):
+    """``query_genes`` is a back-compat alias for the R3-canonical
+    ``query_docs``. Both must accept the same call shape and route to
+    the same underlying router method.
+
+    The router still exposes its read API as ``query_genes``; the
+    adapter must bridge regardless of which name the caller uses.
+    """
+    # Empty-route case: no shards registered, route() returns []
+    docs_result = adapter.query_docs(domains=[], entities=[], max_genes=5)
+    genes_result = adapter.query_genes(domains=[], entities=[], max_genes=5)
+    assert docs_result == genes_result == []
+
+
+def test_adapter_upsert_doc_and_upsert_gene_are_same_callable(adapter):
+    """``upsert_gene`` is a back-compat alias for ``upsert_doc``."""
+    from helix_context.schemas import Gene, PromoterTags
+    g = Gene(
+        gene_id="abc123def456",
+        content="x", complement="x", codons=[],
+        promoter=PromoterTags(domains=[], entities=[], sequence_index=0),
+        source_id="/tmp/x",
+    )
+    # Both are no-ops returning the gene_id; same callable underneath.
+    assert adapter.upsert_doc(g) == "abc123def456"
+    assert adapter.upsert_gene(g) == "abc123def456"
+
+
+def test_adapter_get_doc_and_get_gene_are_same_callable(adapter):
+    """``get_gene`` is a back-compat alias for ``get_doc``."""
+    # No shards registered, so fingerprint_index is empty -> None.
+    assert adapter.get_doc("nonexistent") is None
+    assert adapter.get_gene("nonexistent") is None
+
+
+def test_adapter_covers_full_knowledgestore_surface(adapter):
+    """Soft drift catcher: warn when KnowledgeStore gains a name the adapter
+    doesn't expose, unless explicitly whitelisted.
+
+    This test passing today does not guarantee correctness — a method
+    on KnowledgeStore might be present on the adapter but with the wrong
+    signature. It catches missing-name drift, which is the most common
+    failure mode (and the one #98 was about).
+    """
+    ks_surface = {
+        name for name in dir(KnowledgeStore)
+        if not name.startswith("__")
+    }
+    adapter_surface = {
+        name for name in dir(adapter)
+        if not name.startswith("__")
+    }
+    missing = sorted(
+        (ks_surface - adapter_surface) - ADAPTER_ONLY_DIFFERENCES_WHITELIST
+    )
+    assert missing == [], (
+        f"ShardedGenomeAdapter is drifting behind KnowledgeStore. "
+        f"Names present on KnowledgeStore but missing on the adapter "
+        f"(and not whitelisted): {missing}\n"
+        f"Either mirror the name on the adapter, or add it to "
+        f"ADAPTER_ONLY_DIFFERENCES_WHITELIST with a one-line reason."
+    )

--- a/tests/test_swap_db.py
+++ b/tests/test_swap_db.py
@@ -23,8 +23,19 @@ from helix_context.config import (
     ServerConfig,
 )
 from helix_context.knowledge_store import KnowledgeStore
-from helix_context.schemas import Gene
+from helix_context.schemas import (
+    ChromatinState,
+    EpigeneticMarkers,
+    Gene,
+    PromoterTags,
+)
 from helix_context.server import create_app
+from helix_context.shard_schema import (
+    init_main_db,
+    open_main_db,
+    register_shard,
+    upsert_fingerprint,
+)
 
 
 # -- Helpers ---------------------------------------------------------------
@@ -260,3 +271,173 @@ class TestSwapDbEndpoint:
         assert resp.status_code == 200
         assert resp.json()["read_only"] is False
         assert app.state.helix.genome.read_only is False
+
+
+# -- Sharded round-trip via swap-db ----------------------------------------
+#
+# Issue #98: ``ShardedGenomeAdapter`` was missing several attributes
+# (``path``, ``_dense_embedding_enabled``, ``_entity_graph_retrieval_enabled``,
+# ``_last_query_scores_lock``, ``query_docs``) that callers read directly off
+# ``self.genome``. Most importantly, **every** ``/admin/swap-db`` call
+# against a live sharded store hit ``AttributeError: 'ShardedGenomeAdapter'
+# object has no attribute 'path'`` at line 858 in routes_admin.py.
+#
+# These tests cover the swap-A->B->A round trip with ``HELIX_USE_SHARDS=1``
+# active so each adapter call surface (path, stats, close) actually fires.
+
+
+def _build_sharded_layout(root_dir, gene_content: str, domains: list[str],
+                         entities: list[str]) -> tuple[str, str]:
+    """Create a one-shard sharded layout under ``root_dir``.
+
+    Returns ``(main_path, gene_id)``. ``main_path`` is the
+    ``main.genome.db`` that ``open_read_source`` will route through
+    ``ShardedGenomeAdapter`` when ``HELIX_USE_SHARDS=1`` is set.
+    """
+    main_path = str(root_dir / "main.genome.db")
+    shard_path = str(root_dir / "shard_a.genome.db")
+
+    # Seed the shard with one doc.
+    shard = KnowledgeStore(path=shard_path)
+    gene = Gene(
+        gene_id="",
+        content=gene_content,
+        complement=gene_content[:50],
+        codons=[],
+        promoter=PromoterTags(domains=domains, entities=entities, sequence_index=0),
+        epigenetics=EpigeneticMarkers(),
+        chromatin=ChromatinState.OPEN,
+        is_fragment=False,
+        source_id=f"/{domains[0] if domains else 'unknown'}.md",
+    )
+    gene_id = shard.upsert_doc(gene, apply_gate=False)
+    shard.conn.close()
+    if getattr(shard, "_reader", None):
+        shard._reader.close()
+
+    # Register the shard in main.db.
+    main = open_main_db(main_path)
+    init_main_db(main)
+    register_shard(main, "shard_a", "reference", shard_path, gene_count=1)
+    upsert_fingerprint(
+        main, gene_id=gene_id, shard_name="shard_a",
+        source_id=f"/{domains[0] if domains else 'unknown'}.md",
+        domains_json=json.dumps(domains),
+        entities_json=json.dumps(entities),
+        key_values_json="[]",
+    )
+    main.close()
+
+    return main_path, gene_id
+
+
+class TestSwapDbShardedRoundTrip:
+    """Round-trip swap-db with HELIX_USE_SHARDS=1 active (issue #98).
+
+    Each test enables sharding via monkeypatch so ``open_read_source``
+    returns a ``ShardedGenomeAdapter`` when handed a ``main.genome.db``
+    path.
+    """
+
+    def test_swap_blob_to_sharded(self, tmp_path, monkeypatch):
+        """A -> B where A is blob, B is sharded. After the swap,
+        ``helix.genome`` is a ``ShardedGenomeAdapter`` and ``/stats``
+        reports the shard's gene count."""
+        monkeypatch.setenv("HELIX_USE_SHARDS", "1")
+
+        db_a = str(tmp_path / "blob.db")
+        _make_db(db_a, genes=3).close()
+        sharded_dir = tmp_path / "sharded"
+        sharded_dir.mkdir()
+        main_b, _ = _build_sharded_layout(
+            sharded_dir, "Helix design doc.", domains=["docs"], entities=["helix"],
+        )
+
+        app, client = _make_app_and_client(db_a)
+
+        # Sanity: starts as a blob KnowledgeStore.
+        assert isinstance(app.state.helix.genome, KnowledgeStore)
+        assert app.state.helix.genome.path == db_a
+
+        resp = client.post("/admin/swap-db", json={"path": main_b})
+        assert resp.status_code == 200, resp.json()
+        data = resp.json()
+        assert data["swapped"] is True
+        assert data["new_path"] == main_b
+
+        # Now the active store is the sharded adapter.
+        from helix_context.sharding import ShardedGenomeAdapter
+        assert isinstance(app.state.helix.genome, ShardedGenomeAdapter)
+        # And critically: helix.genome.path is reachable (this was the
+        # AttributeError that blocked every swap-db once sharded was active).
+        assert app.state.helix.genome.path == main_b
+
+    def test_swap_sharded_back_to_blob(self, tmp_path, monkeypatch):
+        """The path that originally crashed in #98: an already-sharded
+        active store reads ``helix.genome.path`` during swap-db logging.
+        With the fix, the swap succeeds and the active store goes back
+        to a blob ``KnowledgeStore``."""
+        monkeypatch.setenv("HELIX_USE_SHARDS", "1")
+
+        sharded_dir = tmp_path / "sharded"
+        sharded_dir.mkdir()
+        main_a, _ = _build_sharded_layout(
+            sharded_dir, "Sharded source content.",
+            domains=["docs"], entities=["helix"],
+        )
+        db_b = str(tmp_path / "after_swap.db")
+        _make_db(db_b, genes=5).close()
+
+        app, client = _make_app_and_client(main_a)
+
+        from helix_context.sharding import ShardedGenomeAdapter
+        assert isinstance(app.state.helix.genome, ShardedGenomeAdapter), (
+            "App should start with a ShardedGenomeAdapter when "
+            "HELIX_USE_SHARDS=1 and genome path ends with main.genome.db"
+        )
+
+        # This call previously threw AttributeError: 'ShardedGenomeAdapter'
+        # object has no attribute 'path' at routes_admin.py:858 before the
+        # fix landed.
+        resp = client.post("/admin/swap-db", json={"path": db_b})
+        assert resp.status_code == 200, resp.json()
+        data = resp.json()
+        assert data["swapped"] is True
+        assert data["old_path"] == main_a
+        assert data["new_path"] == db_b
+        assert data["genes"] == 5
+        # Active store is now a blob KnowledgeStore again.
+        assert isinstance(app.state.helix.genome, KnowledgeStore)
+
+    def test_swap_blob_to_sharded_to_blob(self, tmp_path, monkeypatch):
+        """Full round-trip: A (blob) -> B (sharded) -> A (blob).
+
+        Exercises every adapter surface that fires during swap:
+        ``path``, ``stats``, ``invalidate_sema_cache``,
+        ``_build_sema_cache``, ``close``."""
+        monkeypatch.setenv("HELIX_USE_SHARDS", "1")
+
+        db_a = str(tmp_path / "blob_a.db")
+        _make_db(db_a, genes=2).close()
+
+        sharded_dir = tmp_path / "sharded"
+        sharded_dir.mkdir()
+        main_b, _ = _build_sharded_layout(
+            sharded_dir, "Sharded round-trip content.",
+            domains=["auth"], entities=["jwt"],
+        )
+
+        app, client = _make_app_and_client(db_a)
+
+        # A -> B
+        resp = client.post("/admin/swap-db", json={"path": main_b})
+        assert resp.status_code == 200, resp.json()
+        from helix_context.sharding import ShardedGenomeAdapter
+        assert isinstance(app.state.helix.genome, ShardedGenomeAdapter)
+
+        # B -> A
+        resp = client.post("/admin/swap-db", json={"path": db_a})
+        assert resp.status_code == 200, resp.json()
+        assert resp.json()["genes"] == 2
+        assert isinstance(app.state.helix.genome, KnowledgeStore)
+        assert app.state.helix.genome.path == db_a


### PR DESCRIPTION
Follow-up to merged #96. Closes #97, closes #98.

## #98 — ShardedGenomeAdapter API drift (bug)

The post-#96 bench (`HELIX_USE_SHARDS=1`, `mode=sharded`) caught every `/context` and `/admin/swap-db` call returning HTTP 500 because the adapter had drifted behind names that `context_manager._retrieve` and `routes_admin` read directly off `self.genome`.

Concrete fixes in [helix_context/sharding.py](helix_context/sharding.py):

| Gap | Caller | Fix |
|---|---|---|
| `path` attr missing | [routes_admin.py:858](helix_context/server/routes_admin.py:858) — blocked every swap-db against a sharded store | `@property path` → `self._router.main_path` |
| `_dense_embedding_enabled` | [context_manager.py:1988](helix_context/context_manager.py:1988) | `__init__` default `False` |
| `_entity_graph_retrieval_enabled` | [context_manager.py:1999](helix_context/context_manager.py:1999), [:2010](helix_context/context_manager.py:2010) | `__init__` default `False` |
| `_last_query_scores_lock` | [context_manager.py:1102](helix_context/context_manager.py:1102) | `__init__` `threading.Lock()` |
| `query_docs` method | [context_manager.py:2003](helix_context/context_manager.py:2003) | R3-canonical name; `query_genes` kept as alias |
| Router bridge bug | adapter called `self._router.query_docs` which never existed | Bridge to existing `self._router.query_genes` |

Also applied the same R3 rename pattern to `get_doc`/`get_gene` and `upsert_doc`/`upsert_gene`, and added `query_docs_ann`/`query_genes_ann`, `get_calibration_provenance`, `_invalidate_dense_matrix` shims so the grep-derived caller surface is fully covered.

## Drift catcher

[tests/test_sharded_adapter_parity.py](tests/test_sharded_adapter_parity.py) (new):

- **Hard contract**: every name found via `grep -oE 'self\.genome\.[a-zA-Z_]+'` and `helix\.genome\.[a-zA-Z_]+` in the codebase, asserted present on the adapter. Fails immediately when a new caller-read attribute lands.
- **Soft drift catcher**: diffs adapter against the full `KnowledgeStore` surface with a documented whitelist for legitimate adapter-only-irrelevant items (per-shard helpers, density gates, chromatin tier sentinels). When a new `KnowledgeStore` name appears, the test forces you to either mirror it or whitelist it with a one-line reason.

## Round-trip integration tests

[tests/test_swap_db.py](tests/test_swap_db.py) gains `TestSwapDbShardedRoundTrip`:

- `test_swap_blob_to_sharded` — mounts the sharded adapter, verifies `path` readable
- `test_swap_sharded_back_to_blob` — **this is the exact scenario that crashed in the bench**; verifies `helix.genome.path` doesn't `AttributeError`
- `test_swap_blob_to_sharded_to_blob` — full A→B→A round-trip across every adapter surface that fires during swap (`path`, `stats`, `invalidate_sema_cache`, `_build_sema_cache`, `close`)

## #97 A.1 — pre-ingest sizing + largest-first shard scheduling

Observation from the issue: in the post-#96 XL-sharded run, `F:/Projects` (~60% of eligible bytes) was declared last in the roots list and didn't dispatch until 11 small shards finished draining. The 4-worker pool then ran 3 idle for the tail of the run because the long pole only uses one outer SPLADE.

Changes in [scripts/build_fixture_matrix.py](scripts/build_fixture_matrix.py):

- `_estimate_eligible_bytes(root, skip_dirs, extra_filename_filters)` — quick metadata walk using the same filters as `_iter_ingestable_files`. Returns `(eligible_files, eligible_bytes)`.
- `build_profile_sharded(..., sort_largest_first=True)` — pre-scans every task, sorts by `eligible_bytes` descending, then dispatches.
- `--no-shard-sort` CLI flag for deterministic ordering (parity benches, etc.).
- Manifest gains `sort_largest_first` + `sizing_elapsed_s` for diagnostics.

A.2 (auto-split oversized shards) and B (mid-run worker redistribution) from issue #97 are intentionally left as follow-up — they're substantially larger refactors and the issue itself frames them as second-step work.

## Test plan

- [x] `python -m pytest tests/test_sharded_adapter_parity.py tests/test_swap_db.py tests/test_shard_router.py tests/test_shard_schema.py tests/test_build_fixture_matrix_parallel.py tests/test_parallel_sizers.py -m "not slow and not live"` → **73 passed**
- [x] Broader shard-adjacent sweep (`-k "shard or swap_db or sharding or fixture_matrix"`) → **71 passed**
- [x] Context-manager / routes smoke (`-k "context_manager or routes_admin or routes_context"`) → **5 passed**
- [ ] Live bench parity run on the dev box (medium-sharded + xl-sharded, `HELIX_USE_SHARDS=1`) — to be confirmed once this lands and a fresh ingest can be run with the new ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)