### PR TITLE
feat(bench): matrix orchestrator + claude -p Haiku harness + citation scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,10 @@ benchmarks/docs_tidy_*.json
 benchmarks/*error*.json
 benchmarks/snow/results/*error*.json
 # Benchmark run outputs — regenerable, large, per-run timestamps. If a JSON
-# *should* be tracked (curated fixture, etc.) commit it with `git add -f`.
+# *should* be tracked (curated fixture, etc.) commit it with `git add -f`
+# or add an explicit exception below.
 benchmarks/*.json
+!benchmarks/fixtures.json
 benchmarks/results/
 benchmarks/*_report.txt
 benchmarks/*_report_utf8.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ A transparent OpenAI-compatible proxy that intercepts LLM requests and injects c
 
 0. **Classify** — rule-based query classifier picks decoder mode + assembly cap (no model call)
 1. **Extract** — heuristic keyword extraction from query (no model call)
-2. **Retrieve** — tag lookup + BGE-M3 dense recall + synonym expansion + co-activation; ranks via Reciprocal Rank Fusion when `[retrieval] fusion_mode = "rrf"` (default: `"additive"`)
+2. **Retrieve** — FTS5 lexical + tag lookup + synonym expansion + co-activation + cymatics 256-bin spectrum scoring (all default-on, no neural inference at query time); optional BGE-M3 dense recall (`[retrieval] dense_embedding_enabled`, default off) and SPLADE sparse expansion (`[ingestion] splade_enabled`, default off) add transformer query-encoding when enabled; ranks via Reciprocal Rank Fusion when `[retrieval] fusion_mode = "rrf"` (default: `"additive"`)
 3. **Re-rank** — CPU model scores candidates by relevance (optional, off by default)
 4. **Splice** — CPU model compresses each candidate, keeping high-value fragments (batched)
 5. **Assemble** — join spliced parts, enforce token budget, attach per-document legibility headers (fired tiers, confidence marker, compression ratio), elide already-delivered documents via session working-set register

--- a/benchmarks/bench_claude_matrix.py
+++ b/benchmarks/bench_claude_matrix.py
@@ -1,0 +1,615 @@
+r"""Run the 10-needle bench against all 6 frozen fixtures via ``claude -p``.
+
+Per fixture:
+  1. POST /admin/swap-db pointing at the fixture's primary .db
+     (or restart uvicorn with HELIX_USE_SHARDS=1 when crossing
+     blob<->sharded mode boundaries — handled by BenchServer)
+  2. For each needle, invoke ``claude -p --output-format json`` so the
+     model answers via helix-context MCP (which now hits the swapped db)
+  3. Also call /context directly per needle for retrieval-only metrics
+     (citation-grounded gold-source check, with legacy <GENE src> regex
+     fallback for older response shapes / archived JSONL)
+  4. Score answer ∈ {-1, 0, +1} via word-boundary accept-match
+  5. Write per-fixture JSONL into a timestamped results dir
+
+Pre-conditions:
+  * Claude Code CLI available on PATH and the helix-context MCP wired up
+    in the user's settings/.mcp.json. New ``claude -p`` subprocesses
+    discover the MCP automatically.
+  * By default the harness manages the helix server itself via
+    ``bench_orchestrator.BenchServer``, including the
+    HELIX_USE_SHARDS=1 env required for sharded fixtures. Pass
+    ``--external-server`` to use a server you've started manually
+    (legacy behavior).
+
+Output (no overwrite — per-run subdir):
+  benchmarks/results/claude_matrix_<UTC-timestamp>/
+    summary.json
+    small.jsonl
+    medium.jsonl
+    large.jsonl
+    xl.jsonl
+    medium-sharded.jsonl
+    xl-sharded.jsonl
+    run.log
+    uvicorn.log         (when managing the server)
+
+Usage:
+  python benchmarks/bench_claude_matrix.py
+  python benchmarks/bench_claude_matrix.py --only small,medium
+  python benchmarks/bench_claude_matrix.py --skip xl-sharded
+  python benchmarks/bench_claude_matrix.py --model sonnet --max-usd 0.20
+  python benchmarks/bench_claude_matrix.py --external-server
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+# Sibling imports — bench_orchestrator + _citations live alongside this
+# script in benchmarks/. Insert our own dir on sys.path so the imports
+# work whether the script is invoked by absolute path, from the project
+# root, or via python -m.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bench_orchestrator import BenchServer, Fixture  # noqa: E402
+import _citations  # noqa: E402
+
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+HELIX_URL = os.environ.get("HELIX_URL", "http://127.0.0.1:11437")
+MANIFEST = Path(r"F:\Projects\helix-context\genomes\bench\matrix\frozen.json")
+RESULTS_ROOT = Path(r"F:\Projects\helix-context\benchmarks\results")
+
+CLAUDE_TIMEOUT_S = 300        # 5 min per question — generous for MCP + reasoning
+SWAP_TIMEOUT_S = 60           # SPLADE rebuild on swap can take a moment
+CONTEXT_TIMEOUT_S = 30        # /context retrieval-only call
+
+
+# ── Needles (copied from benchmarks/bench_needle.py so this script is
+#     standalone and the runner doesn't depend on the bench dir on PYTHONPATH).
+
+NEEDLES = [
+    {"name": "helix_port",
+     "query": "What port does the Helix proxy server listen on?",
+     "expected": "11437", "accept": ["11437"],
+     "gold_source": ["helix-context/helix.toml"]},
+    {"name": "scorerift_threshold",
+     "query": "What is the divergence threshold that triggers alerts in ScoreRift?",
+     "expected": "0.15", "accept": ["0.15", ".15"],
+     "gold_source": ["two-brain-audit/README.md"]},
+    {"name": "biged_skills_count",
+     "query": "How many skills does the BigEd fleet have?",
+     "expected": "125", "accept": ["125", "129"],
+     "gold_source": ["Education/CLAUDE.md"]},
+    {"name": "bookkeeper_monetary",
+     "query": "What type should be used for monetary values in BookKeeper instead of float?",
+     "expected": "Decimal", "accept": ["decimal", "Decimal"],
+     "gold_source": ["BookKeeper/CLAUDE.md"]},
+    {"name": "helix_pipeline_steps",
+     "query": "How many steps are in the Helix expression pipeline?",
+     "expected": "6", "accept": ["6", "six"],
+     "gold_source": ["helix-context/CLAUDE.md", "helix-context/README.md"]},
+    {"name": "biged_rust_binary_size",
+     "query": "What is the binary size of the Rust BigEd build in MB?",
+     "expected": "11", "accept": ["11", "11mb", "11 mb"],
+     "gold_source": ["Education/biged-rs/README.md"]},
+    {"name": "genome_compression_target",
+     "query": "What is the target compression ratio for Helix Context?",
+     "expected": "5x", "accept": ["5x", "5:1", "5 to 1"],
+     "gold_source": ["helix-context/README.md", "helix-context/docs"]},
+    {"name": "scorerift_preset_dimensions",
+     "query": "How many dimensions does the Python preset in ScoreRift check?",
+     "expected": "8", "accept": ["8", "eight"],
+     "gold_source": ["two-brain-audit/README.md"]},
+    {"name": "helix_ribosome_budget",
+     "query": "How many tokens are allocated for the ribosome decoder prompt?",
+     "expected": "3000", "accept": ["3000", "3k", "3,000"],
+     "gold_source": ["helix-context/helix.toml", "helix-context/README.md"]},
+    {"name": "biged_default_model",
+     "query": "What is the default local model used by BigEd for conductor tasks?",
+     "expected": "qwen3", "accept": ["qwen3", "qwen3:4b", "qwen"],
+     "gold_source": ["Education/CLAUDE.md"]},
+]
+
+
+# Markers that indicate the model abstained rather than guessed.
+ABSTAIN_MARKERS = [
+    r"\bi (?:don't|cannot|can't|am unable to|do not) (?:find|know|determine)\b",
+    r"\bno (?:relevant )?information\b",
+    r"\bnot (?:available|found|present)\b",
+    r"\binsufficient (?:context|information|data)\b",
+    r"\bunable to (?:find|determine|answer)\b",
+    r"\bcouldn't find\b",
+]
+ABSTAIN_RE = re.compile("|".join(ABSTAIN_MARKERS), re.IGNORECASE)
+
+# Legacy renderer fallback for /context content. Modern path uses the
+# structured ``agent.citations`` list (preferred); ``_citations`` (PR #109)
+# is the canonical shared parser — we reuse its regex for the fallback
+# instead of redefining one here.
+LEGACY_GENE_SRC_RE = _citations.LEGACY_GENE_SRC_RE
+
+
+# ── Setup logging ────────────────────────────────────────────────────────
+
+def make_run_dir() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = RESULTS_ROOT / f"claude_matrix_{stamp}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def setup_logger(run_dir: Path) -> logging.Logger:
+    log_path = run_dir / "run.log"
+    logger = logging.getLogger("bench.claude_matrix")
+    logger.setLevel(logging.INFO)
+    fmt = logging.Formatter("%(asctime)s %(levelname)-7s %(message)s",
+                            datefmt="%H:%M:%S")
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setFormatter(fmt)
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(fh)
+    logger.addHandler(sh)
+    return logger
+
+
+# ── Swap helper (external-server path) ────────────────────────────────────
+
+def swap_db_external(target_path: str, log: logging.Logger) -> dict:
+    """POST /admin/swap-db when running against an externally-managed server.
+
+    Used only with ``--external-server``. When the harness manages uvicorn
+    itself (default), it uses BenchServer.switch which also handles
+    cross-mode (blob<->sharded) restarts that this endpoint alone cannot.
+    """
+    log.info("swap-db (external) -> %s", target_path)
+    try:
+        resp = httpx.post(
+            f"{HELIX_URL}/admin/swap-db",
+            json={"path": target_path},
+            timeout=SWAP_TIMEOUT_S,
+        )
+    except Exception as exc:
+        return {"error": f"swap-db request failed: {exc}"}
+    if resp.status_code != 200:
+        return {"error": f"swap-db HTTP {resp.status_code}: {resp.text[:200]}"}
+    body = resp.json()
+    log.info("  swapped: %d genes in %s ms", body.get("genes", -1), body.get("elapsed_ms"))
+    return body
+
+
+# ── Retrieval-only probe via /context ────────────────────────────────────
+
+def retrieval_probe(query: str, gold_sources: list[str],
+                    helix_url: str = HELIX_URL) -> dict:
+    """Direct /context call to get retrieval signal independent of the model.
+
+    Prefers structured ``agent.citations[].source`` (issue #101 fix),
+    falls back to ``<GENE src="...">`` regex on the rendered content
+    (still emitted by context_manager.py:1367 in the splice path).
+    """
+    t0 = time.perf_counter()
+    try:
+        resp = httpx.post(
+            f"{helix_url}/context",
+            json={"query": query, "decoder_mode": "none"},
+            timeout=CONTEXT_TIMEOUT_S,
+        )
+    except Exception as exc:
+        return {"status": "error", "error": str(exc),
+                "latency_s": time.perf_counter() - t0}
+    latency = time.perf_counter() - t0
+    if resp.status_code != 200:
+        return {"status": "error", "http": resp.status_code,
+                "latency_s": latency}
+    data = resp.json()
+    entry = data[0] if isinstance(data, list) and data else {}
+    content = entry.get("content", "") or ""
+    citations = entry.get("agent", {}).get("citations", []) or []
+
+    # Primary: structured citations.
+    delivered_sources: list[str] = [
+        str(c.get("source", "") or "") for c in citations
+        if c.get("source")
+    ]
+    sources_via = "citations" if delivered_sources else None
+
+    # Fallback: legacy regex on rendered content (still works today, kept
+    # in case the renderer changes or for cases where citations are empty
+    # but content has <GENE src=> wrappers).
+    if not delivered_sources:
+        delivered_sources = LEGACY_GENE_SRC_RE.findall(content)
+        if delivered_sources:
+            sources_via = "regex_fallback"
+
+    gold_hit = False
+    for src in delivered_sources:
+        norm = src.replace("\\", "/").lower()
+        if any(gs.replace("\\", "/").lower() in norm for gs in gold_sources):
+            gold_hit = True
+            break
+
+    return {
+        "status": "ok",
+        "latency_s": latency,
+        "delivered_count": len(delivered_sources),
+        "delivered_sources": delivered_sources[:20],
+        "sources_via": sources_via,
+        "gold_delivered": gold_hit,
+        "ellipticity": entry.get("context_health", {}).get("ellipticity"),
+        "n_citations": len(citations),
+    }
+
+
+# ── Claude -p invocation ─────────────────────────────────────────────────
+
+def run_claude(query: str, model: str, max_usd: float,
+               cwd: str, log: logging.Logger) -> dict:
+    """Run a single ``claude -p`` subprocess and capture structured output."""
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--no-session-persistence",
+        "--permission-mode", "bypassPermissions",
+        "--model", model,
+        "--max-budget-usd", str(max_usd),
+        query,
+    ]
+    log.info("  claude -p (model=%s, budget=$%.2f): %s", model, max_usd, query[:60])
+    t0 = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CLAUDE_TIMEOUT_S,
+            cwd=cwd,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "elapsed_s": CLAUDE_TIMEOUT_S}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc),
+                "elapsed_s": time.perf_counter() - t0}
+    elapsed = time.perf_counter() - t0
+    if proc.returncode != 0:
+        return {
+            "status": "exit_nonzero",
+            "returncode": proc.returncode,
+            "stderr_tail": (proc.stderr or "")[-400:],
+            "stdout_tail": (proc.stdout or "")[-400:],
+            "elapsed_s": elapsed,
+        }
+    raw = proc.stdout.strip()
+    try:
+        result = json.loads(raw)
+    except Exception:
+        return {
+            "status": "parse_error",
+            "stdout_tail": raw[-400:],
+            "elapsed_s": elapsed,
+        }
+    return {"status": "ok", "result": result, "elapsed_s": elapsed,
+            "stderr_tail": (proc.stderr or "")[-200:] if proc.stderr else ""}
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────
+
+def score_answer(answer_text: str, accept_substrings: list[str]) -> dict:
+    """Return {-1, 0, +1} score plus diagnostics.
+
+    +1: word-boundary match of any accept substring (correct)
+     0: model abstained (says "I don't know" or similar)
+    -1: confident answer but no accept-substring match (likely wrong)
+    """
+    text = (answer_text or "").strip()
+    if not text:
+        return {"score": 0, "reason": "empty"}
+
+    for a in accept_substrings:
+        if re.search(rf"\b{re.escape(a)}\b", text, re.IGNORECASE):
+            return {"score": 1, "reason": f"accept-match:{a}",
+                    "matched_token": a}
+
+    if ABSTAIN_RE.search(text):
+        return {"score": 0, "reason": "abstain"}
+
+    return {"score": -1, "reason": "no-match-and-confident"}
+
+
+# ── Per-needle execution (factored out so the inner loop is identical
+#     whether the harness is managing uvicorn or running against an
+#     external server) ─────────────────────────────────────────────────────
+
+def run_one_needle(needle: dict, profile_key: str, model: str,
+                   max_usd: float, claude_cwd: str, helix_url: str,
+                   log: logging.Logger) -> dict:
+    log.info("[%s] %s", profile_key, needle["name"])
+    retr = retrieval_probe(needle["query"], needle["gold_source"], helix_url=helix_url)
+    claude_r = run_claude(needle["query"], model, max_usd, claude_cwd, log)
+
+    answer_text = ""
+    tokens: dict = {}
+    cost_usd = None
+    if claude_r["status"] == "ok":
+        res = claude_r["result"]
+        answer_text = (
+            res.get("result")
+            or res.get("answer")
+            or res.get("content")
+            or ""
+        )
+        for k in ("total_tokens", "input_tokens", "output_tokens",
+                  "cache_creation_input_tokens",
+                  "cache_read_input_tokens"):
+            if k in res:
+                tokens[k] = res[k]
+        if "usage" in res and isinstance(res["usage"], dict):
+            for k, v in res["usage"].items():
+                tokens.setdefault(k, v)
+        cost_usd = (
+            res.get("total_cost_usd")
+            or res.get("total_cost")
+            or res.get("cost_usd")
+        )
+
+    score = score_answer(answer_text, needle["accept"])
+
+    record = {
+        "profile": profile_key,
+        "needle": needle["name"],
+        "query": needle["query"],
+        "expected": needle["expected"],
+        "accept": needle["accept"],
+        "gold_source": needle["gold_source"],
+        "retrieval": retr,
+        "claude_status": claude_r["status"],
+        "claude_elapsed_s": claude_r.get("elapsed_s"),
+        "answer_text": answer_text[:2000],
+        "tokens": tokens,
+        "cost_usd": cost_usd,
+        "score": score["score"],
+        "score_reason": score["reason"],
+        "score_matched_token": score.get("matched_token"),
+    }
+    if claude_r["status"] != "ok":
+        record["claude_debug"] = {
+            k: v for k, v in claude_r.items() if k != "result"
+        }
+
+    in_tok = tokens.get("input_tokens", 0)
+    out_tok = tokens.get("output_tokens", 0)
+    cache_r = tokens.get("cache_read_input_tokens", 0)
+    cache_w = tokens.get("cache_creation_input_tokens", 0)
+    cost_s = f"${cost_usd:.4f}" if isinstance(cost_usd, (int, float)) else "?"
+    log.info(
+        "  retr=%s score=%+d cost=%s in=%s out=%s cache_r=%s cache_w=%s",
+        retr.get("gold_delivered"), score["score"],
+        cost_s, in_tok, out_tok, cache_r, cache_w,
+    )
+    return record
+
+
+# ── Main loop ────────────────────────────────────────────────────────────
+
+def parse_filter(spec: str | None, all_keys: list[str]) -> set[str]:
+    if not spec:
+        return set()
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    bad = [p for p in parts if p not in all_keys]
+    if bad:
+        raise SystemExit(f"unknown profile(s): {bad}; available: {all_keys}")
+    return set(parts)
+
+
+def summarize_profile(per_needle: list[dict], n_needles: int) -> dict:
+    n_correct = sum(1 for r in per_needle if r["score"] == 1)
+    n_abstain = sum(1 for r in per_needle if r["score"] == 0)
+    n_wrong = sum(1 for r in per_needle if r["score"] == -1)
+    n_retr_hit = sum(1 for r in per_needle if r["retrieval"].get("gold_delivered"))
+    total_score = sum(r["score"] for r in per_needle)
+    total_cost = sum((r["cost_usd"] or 0.0) for r in per_needle)
+    return {
+        "needles_run": len(per_needle),
+        "answers": {
+            "correct": n_correct,
+            "abstain": n_abstain,
+            "wrong": n_wrong,
+            "score_sum": total_score,
+            "score_normalized": (total_score / n_needles) if n_needles else 0,
+        },
+        "retrieval": {
+            "gold_delivered_count": n_retr_hit,
+            "gold_delivered_rate": n_retr_hit / n_needles if n_needles else 0,
+        },
+        "total_cost_usd": round(total_cost, 4),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", help="Comma-separated profiles to run")
+    parser.add_argument("--skip", help="Comma-separated profiles to skip")
+    parser.add_argument("--model", default="haiku",
+                        help="claude -p --model arg (haiku/sonnet/opus/full id). "
+                             "Default: haiku — cloud speed prioritized over model "
+                             "quality for retrieval-quality bench. See "
+                             "memory/bench_default_haiku.md.")
+    parser.add_argument("--max-usd", type=float, default=0.30,
+                        help="Per-question budget cap (sonnet smoke run averaged $0.11)")
+    parser.add_argument("--cwd", default=r"F:\Projects\helix-context",
+                        help="cwd for claude -p subprocess")
+    parser.add_argument("--external-server", action="store_true",
+                        help="Don't manage uvicorn; use a server you've started yourself. "
+                             "Required for sharded fixtures to set HELIX_USE_SHARDS=1 "
+                             "manually. Default: harness manages uvicorn via BenchServer.")
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="Host for the managed server (ignored with --external-server)")
+    parser.add_argument("--port", default=11437, type=int,
+                        help="Port for the managed server (ignored with --external-server)")
+    parser.add_argument("--health-timeout", default=180.0, type=float,
+                        help="Seconds to wait for /health after uvicorn boot")
+    args = parser.parse_args()
+
+    if not MANIFEST.exists():
+        print(f"!! manifest not found at {MANIFEST}; run freeze_matrix_manifest.py first",
+              file=sys.stderr)
+        return 2
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    all_keys = list(manifest["targets"].keys())
+    only = parse_filter(args.only, all_keys)
+    skip = parse_filter(args.skip, all_keys)
+    keys = [k for k in all_keys
+            if (not only or k in only) and k not in skip]
+
+    run_dir = make_run_dir()
+    log = setup_logger(run_dir)
+    log.info("RUN START run_dir=%s", run_dir)
+    log.info("model=%s max_usd_per_question=%.2f external_server=%s",
+             args.model, args.max_usd, args.external_server)
+    log.info("profiles in run: %s", keys)
+
+    overall: dict = {
+        "run_dir": str(run_dir),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "model": args.model,
+        "max_usd_per_question": args.max_usd,
+        "external_server": args.external_server,
+        "profiles": {},
+    }
+
+    helix_url = f"http://{args.host}:{args.port}"
+
+    if args.external_server:
+        # Legacy path: server is already running. We can only hot-swap (no
+        # cross-mode handling). For sharded fixtures the operator must
+        # have started the server with HELIX_USE_SHARDS=1.
+        try:
+            r = httpx.get(f"{helix_url}/stats", timeout=10)
+            log.info("server /stats ok: %d genes", r.json().get("total_genes", -1))
+        except Exception as exc:
+            log.error("server not reachable at %s: %s", helix_url, exc)
+            return 3
+        rc = _run_loop_external(keys, manifest, run_dir, args, helix_url, log, overall)
+    else:
+        # Managed path: BenchServer handles boot + hot-swap + cross-mode
+        # restarts automatically.
+        rc = _run_loop_managed(keys, manifest, run_dir, args, helix_url, log, overall)
+
+    overall["finished_at"] = datetime.now(timezone.utc).isoformat()
+    summary_path = run_dir / "summary.json"
+    summary_path.write_text(json.dumps(overall, indent=2), encoding="utf-8")
+    log.info("=" * 60)
+    log.info("RUN DONE. Summary at %s", summary_path)
+    return rc
+
+
+def _run_loop_external(keys, manifest, run_dir, args, helix_url, log, overall) -> int:
+    for key in keys:
+        target = manifest["targets"][key]
+        log.info("=" * 60)
+        log.info("PROFILE: %s (mode=%s)", key, target.get("mode"))
+
+        if target.get("status") == "missing":
+            log.warning("  target missing on disk, skipping")
+            continue
+        if target.get("mode") == "sharded":
+            log.warning(
+                "  sharded profile %s requires the external server to "
+                "have been started with HELIX_USE_SHARDS=1; harness "
+                "cannot enforce this in --external-server mode",
+                key,
+            )
+
+        swap_result = swap_db_external(target["path"], log)
+        if "error" in swap_result:
+            log.error("  swap failed: %s", swap_result["error"])
+            overall["profiles"][key] = {"swap_error": swap_result["error"]}
+            continue
+
+        per_needle = _run_profile(key, run_dir, args, helix_url, log)
+        overall["profiles"][key] = summarize_profile(per_needle, len(NEEDLES))
+    return 0
+
+
+def _run_loop_managed(keys, manifest, run_dir, args, helix_url, log, overall) -> int:
+    uvicorn_log = run_dir / "uvicorn.log"
+    with BenchServer(
+        host=args.host,
+        port=args.port,
+        health_timeout_s=args.health_timeout,
+        log_to=uvicorn_log,
+    ) as srv:
+        for key in keys:
+            target = manifest["targets"][key]
+            log.info("=" * 60)
+            log.info("PROFILE: %s (mode=%s)", key, target.get("mode"))
+
+            if target.get("status") == "missing":
+                log.warning("  target missing on disk, skipping")
+                continue
+
+            fixture = Fixture(
+                name=key,
+                db=str(target["path"]).replace("\\", "/"),
+                sharded=(target.get("mode") == "sharded"),
+                read_only=True,
+            )
+            try:
+                swap = srv.switch(fixture)
+            except Exception as exc:
+                log.error("  switch failed: %s", exc)
+                overall["profiles"][key] = {"swap_error": str(exc)}
+                continue
+            log.info("  %s in %.2fs (genes=%d, pid=%s)",
+                     swap.mechanism, swap.elapsed_s, swap.genes, swap.server_pid)
+
+            per_needle = _run_profile(key, run_dir, args, helix_url, log)
+            overall["profiles"][key] = summarize_profile(per_needle, len(NEEDLES))
+    return 0
+
+
+def _run_profile(profile_key: str, run_dir: Path, args, helix_url: str,
+                 log: logging.Logger) -> list[dict]:
+    profile_path = run_dir / f"{profile_key}.jsonl"
+    per_needle: list[dict] = []
+    with open(profile_path, "w", encoding="utf-8") as f:
+        for i, n in enumerate(NEEDLES):
+            log.info("[%s %d/%d] %s", profile_key, i + 1, len(NEEDLES), n["name"])
+            record = run_one_needle(
+                n, profile_key, args.model, args.max_usd, args.cwd,
+                helix_url, log,
+            )
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            f.flush()
+            per_needle.append(record)
+    total_correct = sum(1 for r in per_needle if r["score"] == 1)
+    total_abstain = sum(1 for r in per_needle if r["score"] == 0)
+    total_wrong = sum(1 for r in per_needle if r["score"] == -1)
+    total_retr = sum(1 for r in per_needle if r["retrieval"].get("gold_delivered"))
+    total_cost = sum((r["cost_usd"] or 0.0) for r in per_needle)
+    log.info(
+        "  PROFILE %s: correct=%d abstain=%d wrong=%d retr_hit=%d/%d cost=$%.4f",
+        profile_key, total_correct, total_abstain, total_wrong,
+        total_retr, len(NEEDLES), total_cost,
+    )
+    return per_needle
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_needle_1000.py
+++ b/benchmarks/bench_needle_1000.py
@@ -162,6 +162,33 @@ def _looks_like_literal_value(v: str) -> bool:
     return False
 
 
+def _gold_source_in_citations(citations, gold_source: str) -> bool:
+    """Issue #101 (2026-05): citation-grounded gold delivery check.
+
+    The existing ``retrieved`` metric is a payload-wide word-boundary match
+    on ``content`` — useful as a permissive retrieval-rate proxy but blind
+    to whether the actual gold source document was delivered (vs. a stray
+    value mention in a header, an unrelated document, or metadata).
+
+    This function answers the stricter question: did /context return a
+    citation whose ``source`` path matches the needle's gold source?
+    Reported alongside ``retrieved`` as ``gold_source_delivered`` so
+    cross-run comparability with pre-2026-05 result files is preserved.
+
+    Matching is forward-slash normalized and case-insensitive, and uses
+    substring containment (so ``helix-context/helix.toml`` matches
+    ``F:/Projects/helix-context/helix.toml`` from the citation).
+    """
+    if not citations or not gold_source:
+        return False
+    gold_norm = gold_source.replace("\\", "/").lower()
+    for c in citations:
+        src = str(c.get("source", "") or "").replace("\\", "/").lower()
+        if src and (gold_norm in src or src in gold_norm):
+            return True
+    return False
+
+
 def _word_boundary_match(text: str, value: str) -> bool:
     """Match `value` inside `text` with word boundaries when safe.
 
@@ -467,6 +494,12 @@ def run_needle(client: httpx.Client, needle: dict) -> dict:
     else:
         retrieved = _word_boundary_match(content, needle["value"])
 
+    # Issue #101 (2026-05): citation-grounded gold-source delivery check.
+    # Additive — does not change ``retrieved`` semantics so cross-run
+    # comparability with pre-2026-05 result files is preserved.
+    citations = agent_meta.get("citations", []) or []
+    gold_source_delivered = _gold_source_in_citations(citations, needle.get("source", ""))
+
     # Step 2: downstream model extraction (skipped when ASK_PROXY=0;
     # /chat dispatches the downstream model AND triggers the proxy's
     # background helix.learn replication that MUTATES the genome —
@@ -516,6 +549,8 @@ def run_needle(client: httpx.Client, needle: dict) -> dict:
 
     result.update({
         "retrieved": retrieved,
+        "gold_source_delivered": gold_source_delivered,
+        "n_citations": len(citations),
         "answered": answered,
         "context_latency_s": round(ctx_latency, 3),
         "proxy_latency_s": round(proxy_latency, 3),
@@ -539,14 +574,22 @@ def summarize(results: list[dict]) -> dict:
     retrieved = sum(1 for r in results if r.get("retrieved"))
     answered = sum(1 for r in results if r.get("answered"))
     errors = sum(1 for r in results if r.get("error"))
+    # Issue #101: citation-grounded gold-source delivery. Additive — field
+    # is missing on pre-2026-05 result files (sum collapses to 0 there, which
+    # is the honest representation: that metric wasn't computed).
+    gold_delivered = sum(1 for r in results if r.get("gold_source_delivered"))
 
     # Per-category breakdown
-    by_cat: dict[str, dict] = defaultdict(lambda: {"n": 0, "retrieved": 0, "answered": 0})
+    by_cat: dict[str, dict] = defaultdict(
+        lambda: {"n": 0, "retrieved": 0, "gold_delivered": 0, "answered": 0}
+    )
     for r in results:
         c = r.get("category", "other")
         by_cat[c]["n"] += 1
         if r.get("retrieved"):
             by_cat[c]["retrieved"] += 1
+        if r.get("gold_source_delivered"):
+            by_cat[c]["gold_delivered"] += 1
         if r.get("answered"):
             by_cat[c]["answered"] += 1
 
@@ -555,6 +598,15 @@ def summarize(results: list[dict]) -> dict:
         "retrieval_miss": sum(1 for r in results if not r.get("retrieved")),
         "extraction_miss": sum(1 for r in results if r.get("retrieved") and not r.get("answered")),
         "error": errors,
+        # Issue #101: phantom hit — value substring matched somewhere in the
+        # payload but the gold source document was NOT among the citations.
+        # Signals that ``retrieved=True`` overcounted (header/metadata/unrelated
+        # doc carried the value). Only populated when results have citations.
+        "phantom_hit": sum(
+            1 for r in results
+            if r.get("retrieved") and not r.get("gold_source_delivered")
+            and r.get("n_citations", 0) > 0
+        ),
     }
 
     # Latency percentiles
@@ -595,13 +647,16 @@ def summarize(results: list[dict]) -> dict:
     return {
         "n": n,
         "retrieval_rate": round(retrieved / max(n, 1), 4),
+        "gold_source_delivery_rate": round(gold_delivered / max(n, 1), 4),
         "answer_accuracy_rate": round(answered / max(n, 1), 4),
         "retrieved": retrieved,
+        "gold_source_delivered": gold_delivered,
         "answered": answered,
         "errors": errors,
         "failure_modes": failures,
         "by_category": {k: {**v,
                             "retrieval_rate": round(v["retrieved"] / max(v["n"], 1), 4),
+                            "gold_delivery_rate": round(v["gold_delivered"] / max(v["n"], 1), 4),
                             "answer_rate": round(v["answered"] / max(v["n"], 1), 4)}
                         for k, v in by_cat.items()},
         "latency": {

--- a/benchmarks/bench_orchestrator.py
+++ b/benchmarks/bench_orchestrator.py
@@ -1,0 +1,551 @@
+"""Bench orchestrator — manage uvicorn lifecycle + hot-swap across the
+6-fixture matrix (4 monolithic blobs + 2 sharded) without manual server
+restarts between runs.
+
+Two transition shapes:
+
+- **Same-mode (blob→blob, sharded→sharded)**: POST /admin/swap-db.
+  Atomic, ~milliseconds, no process restart. Available since PR #91.
+- **Cross-mode (blob↔sharded)**: full uvicorn restart with the
+  ``HELIX_USE_SHARDS`` env var set/unset. ``open_read_source()`` in
+  ``helix_context/sharding.py`` reads that env at store-construction time;
+  it can't be flipped mid-process.
+
+The orchestrator hides this distinction from the bench code: callers just
+say "switch to fixture X" and the orchestrator picks the right mechanism.
+
+Usage as a library::
+
+    from bench_orchestrator import BenchServer, Fixture
+
+    with BenchServer() as srv:
+        for fx in fixtures:
+            srv.switch(fx)
+            run_my_bench(srv.url)
+
+Usage as a CLI (loops the matrix, invokes existing bench scripts per
+fixture)::
+
+    python benchmarks/bench_orchestrator.py \\
+        --manifest benchmarks/fixtures.json \\
+        --bench bench_needle_1000 \\
+        --out results/
+
+The manifest is a JSON list of fixtures::
+
+    [
+      {"name": "small",  "db": "F:/.../small.db",            "sharded": false},
+      {"name": "medium", "db": "F:/.../medium.db",           "sharded": false},
+      {"name": "large",  "db": "F:/.../large.db",            "sharded": false},
+      {"name": "xl",     "db": "F:/.../xl.db",               "sharded": false},
+      {"name": "medium-sharded", "db": "F:/.../medium-sharded/main.genome.db", "sharded": true},
+      {"name": "xl-sharded",     "db": "F:/.../xl-sharded/main.genome.db",     "sharded": true}
+    ]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+log = logging.getLogger("bench.orchestrator")
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 11437
+DEFAULT_HEALTH_TIMEOUT_S = 60.0
+DEFAULT_HEALTH_POLL_S = 0.5
+DEFAULT_SHUTDOWN_TIMEOUT_S = 10.0
+DEFAULT_SWAP_TIMEOUT_S = 60.0
+DEFAULT_REQUEST_TIMEOUT_S = 15.0
+
+# Windows: prevent console-window flash on subprocess spawn (per CLAUDE.md
+# global "Subprocess Safety (Windows)" rule).
+_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+@dataclass
+class Fixture:
+    """One row of the bench fixture matrix.
+
+    ``db`` is the SQLite path to swap in. For sharded fixtures, this is the
+    routing DB path (``.../main.genome.db``); ``open_read_source`` in
+    ``helix_context/sharding.py`` detects the basename and dispatches to
+    ``ShardedGenomeAdapter`` when ``HELIX_USE_SHARDS=1``.
+
+    ``read_only`` defaults True so a bench run can't accidentally mutate
+    the fixture (PR #91 ``read_only`` guard).
+    """
+    name: str
+    db: str
+    sharded: bool = False
+    read_only: bool = True
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class SwapResult:
+    """Outcome of switching to a new fixture."""
+    fixture: Fixture
+    mechanism: str        # "hot_swap" | "restart" | "start"
+    elapsed_s: float
+    genes: int
+    server_pid: Optional[int]
+
+
+class BenchServerError(RuntimeError):
+    pass
+
+
+class BenchServer(AbstractContextManager["BenchServer"]):
+    """Manage a uvicorn process + transparent hot-swap across fixtures.
+
+    Lifecycle::
+
+        srv = BenchServer()
+        srv.start(initial_fixture)   # boots uvicorn
+        for fx in remaining_fixtures:
+            srv.switch(fx)           # picks hot-swap or restart automatically
+        srv.stop()
+
+    Or as a context manager::
+
+        with BenchServer() as srv:
+            srv.switch(first_fixture)
+            ...
+        # stop() runs on __exit__ regardless of exceptions
+
+    The server is started under the current Python interpreter so the
+    venv/conda env in use carries over without explicit configuration.
+    """
+
+    def __init__(
+        self,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+        *,
+        python: Optional[str] = None,
+        app: str = "helix_context._asgi:app",
+        health_timeout_s: float = DEFAULT_HEALTH_TIMEOUT_S,
+        shutdown_timeout_s: float = DEFAULT_SHUTDOWN_TIMEOUT_S,
+        log_to: Optional[Path] = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.python = python or sys.executable
+        self.app = app
+        self.health_timeout_s = health_timeout_s
+        self.shutdown_timeout_s = shutdown_timeout_s
+        self.log_to = Path(log_to) if log_to else None
+
+        self._proc: Optional[subprocess.Popen] = None
+        self._current: Optional[Fixture] = None
+        self._log_fh = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def current(self) -> Optional[Fixture]:
+        return self._current
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._proc.pid if self._proc else None
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    def start(self, fixture: Fixture) -> SwapResult:
+        """Boot uvicorn pointed at ``fixture``.
+
+        Idempotent: if already running and the requested fixture matches
+        the current mode, this delegates to ``switch`` (hot-swap path).
+        """
+        if self._proc is not None and self._proc.poll() is None:
+            return self.switch(fixture)
+
+        t0 = time.time()
+        self._spawn(fixture)
+        self._wait_healthy()
+
+        # After spawn, set the active fixture via hot-swap so we always
+        # know the active path (the initial app boot may pick whatever
+        # the config file points at).
+        swap = self._post_swap(fixture)
+        elapsed = time.time() - t0
+        self._current = fixture
+        return SwapResult(
+            fixture=fixture, mechanism="start",
+            elapsed_s=round(elapsed, 3),
+            genes=int(swap.get("genes", 0)),
+            server_pid=self.pid,
+        )
+
+    def switch(self, fixture: Fixture) -> SwapResult:
+        """Transition to ``fixture``. Picks hot-swap or restart.
+
+        Cross-mode transitions (sharded ↔ blob) require restarting uvicorn
+        because ``HELIX_USE_SHARDS`` is read at process startup by
+        ``open_read_source``. Same-mode transitions use the atomic
+        ``/admin/swap-db`` endpoint.
+        """
+        if self._proc is None or self._proc.poll() is not None:
+            return self.start(fixture)
+
+        prev = self._current
+        if prev is not None and prev.sharded != fixture.sharded:
+            return self._restart_for_fixture(fixture, prev)
+        return self._hot_swap(fixture)
+
+    def stop(self) -> None:
+        """Terminate uvicorn. Best-effort; kills if graceful exit fails."""
+        if self._proc is None:
+            return
+        proc, self._proc = self._proc, None
+        if proc.poll() is not None:
+            self._close_log()
+            return
+        try:
+            if os.name == "nt":
+                # CTRL_BREAK won't reach the child without
+                # CREATE_NEW_PROCESS_GROUP at spawn time; terminate() maps
+                # to TerminateProcess which is the right hammer on Windows.
+                proc.terminate()
+            else:
+                proc.send_signal(signal.SIGINT)
+            proc.wait(timeout=self.shutdown_timeout_s)
+        except subprocess.TimeoutExpired:
+            log.warning("uvicorn did not exit cleanly; killing pid=%s", proc.pid)
+            proc.kill()
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                log.warning("uvicorn kill timed out; abandoning pid=%s", proc.pid)
+        except Exception:
+            log.warning("uvicorn shutdown raised", exc_info=True)
+        finally:
+            self._close_log()
+            self._current = None
+
+    def health(self) -> dict[str, Any]:
+        """Fetch ``/health``. Raises if unreachable."""
+        return self._http("GET", "/health")
+
+    # ── Context manager ───────────────────────────────────────────────
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+    # ── Internals ─────────────────────────────────────────────────────
+
+    def _spawn(self, fixture: Fixture) -> None:
+        cmd = [
+            self.python, "-m", "uvicorn", self.app,
+            "--host", self.host, "--port", str(self.port),
+        ]
+        env = os.environ.copy()
+        if fixture.sharded:
+            env["HELIX_USE_SHARDS"] = "1"
+        else:
+            env.pop("HELIX_USE_SHARDS", None)
+        env.update(fixture.extra_env)
+
+        if self.log_to:
+            self.log_to.parent.mkdir(parents=True, exist_ok=True)
+            self._log_fh = self.log_to.open("ab")
+            stdout = stderr = self._log_fh
+        else:
+            stdout = stderr = subprocess.DEVNULL
+
+        self._proc = subprocess.Popen(
+            cmd, env=env, stdout=stdout, stderr=stderr,
+            stdin=subprocess.DEVNULL,
+            creationflags=_NO_WINDOW,
+            close_fds=(os.name != "nt"),
+        )
+
+    def _wait_healthy(self) -> None:
+        deadline = time.time() + self.health_timeout_s
+        last_err: Optional[Exception] = None
+        while time.time() < deadline:
+            if self._proc is not None and self._proc.poll() is not None:
+                rc = self._proc.returncode
+                raise BenchServerError(f"uvicorn exited during startup (rc={rc})")
+            try:
+                self.health()
+                return
+            except Exception as exc:
+                last_err = exc
+                time.sleep(DEFAULT_HEALTH_POLL_S)
+        raise BenchServerError(
+            f"uvicorn did not become healthy within {self.health_timeout_s}s "
+            f"(last error: {last_err})"
+        )
+
+    def _hot_swap(self, fixture: Fixture) -> SwapResult:
+        t0 = time.time()
+        result = self._post_swap(fixture)
+        self._current = fixture
+        return SwapResult(
+            fixture=fixture, mechanism="hot_swap",
+            elapsed_s=round(time.time() - t0, 3),
+            genes=int(result.get("genes", 0)),
+            server_pid=self.pid,
+        )
+
+    def _restart_for_fixture(self, fixture: Fixture, prev: Fixture) -> SwapResult:
+        log.info(
+            "cross-mode transition (%s sharded=%s → %s sharded=%s); restarting uvicorn",
+            prev.name, prev.sharded, fixture.name, fixture.sharded,
+        )
+        t0 = time.time()
+        self.stop()
+        self._spawn(fixture)
+        self._wait_healthy()
+        swap = self._post_swap(fixture)
+        self._current = fixture
+        return SwapResult(
+            fixture=fixture, mechanism="restart",
+            elapsed_s=round(time.time() - t0, 3),
+            genes=int(swap.get("genes", 0)),
+            server_pid=self.pid,
+        )
+
+    def _post_swap(self, fixture: Fixture) -> dict[str, Any]:
+        payload = {"path": fixture.db, "read_only": fixture.read_only}
+        try:
+            return self._http(
+                "POST", "/admin/swap-db", payload,
+                timeout=DEFAULT_SWAP_TIMEOUT_S,
+            )
+        except Exception as exc:
+            raise BenchServerError(
+                f"hot-swap to {fixture.name} ({fixture.db}) failed: {exc}"
+            ) from exc
+
+    def _http(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict] = None,
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+    ) -> dict[str, Any]:
+        url = f"{self.url}{path}"
+        data: Optional[bytes] = None
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            try:
+                detail = exc.read().decode("utf-8", errors="replace")
+            except Exception:
+                detail = str(exc)
+            raise BenchServerError(f"{method} {path} → HTTP {exc.code}: {detail}") from exc
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise BenchServerError(f"{method} {path} → non-JSON response: {exc}") from exc
+
+    def _close_log(self) -> None:
+        if self._log_fh is not None:
+            try:
+                self._log_fh.close()
+            except Exception:
+                pass
+            self._log_fh = None
+
+
+# ── Manifest loading ─────────────────────────────────────────────────
+
+
+def load_manifest(path: Path) -> list[Fixture]:
+    """Parse a fixture manifest JSON file into ``Fixture`` instances.
+
+    Each entry must have ``name`` and ``db``. Optional: ``sharded`` (bool,
+    default False), ``read_only`` (bool, default True), ``env`` (dict of
+    extra env vars to inject when this fixture is active).
+    """
+    with path.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    if not isinstance(raw, list):
+        raise ValueError(f"manifest at {path} must be a JSON list of fixtures")
+    fixtures = []
+    for i, entry in enumerate(raw):
+        if "name" not in entry or "db" not in entry:
+            raise ValueError(f"fixture #{i} missing 'name' or 'db'")
+        fixtures.append(Fixture(
+            name=str(entry["name"]),
+            db=str(entry["db"]),
+            sharded=bool(entry.get("sharded", False)),
+            read_only=bool(entry.get("read_only", True)),
+            extra_env={str(k): str(v) for k, v in (entry.get("env") or {}).items()},
+        ))
+    return fixtures
+
+
+# ── CLI: loop the matrix, invoke per-fixture bench ───────────────────
+
+
+# Map "--bench" arg to the script under benchmarks/ that gets invoked
+# per fixture. Add new entries here when wiring in another bench harness.
+BENCH_SCRIPTS = {
+    "bench_needle": "bench_needle.py",
+    "bench_needle_1000": "bench_needle_1000.py",
+}
+
+
+def _run_one_bench(
+    bench_script: Path,
+    *,
+    helix_url: str,
+    fixture: Fixture,
+    out_dir: Path,
+    extra_args: Iterable[str] = (),
+    python: str = sys.executable,
+    timeout_s: Optional[float] = None,
+) -> int:
+    """Invoke a bench script as a subprocess, env-configured for the fixture.
+
+    Returns the script's exit code. Output is written to
+    ``out_dir/<fixture.name>.log``; bench-specific JSON output is the
+    script's responsibility (set via env or args by the caller).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_path = out_dir / f"{fixture.name}.log"
+    env = os.environ.copy()
+    env["HELIX_URL"] = helix_url
+    # bench_needle_1000.py honors GENOME_DB for needle harvesting; the
+    # orchestrator points it at the same path the server is serving so
+    # harvested needles and retrieval target match.
+    env["GENOME_DB"] = fixture.db
+    env.setdefault("OUTPUT", str(out_dir / f"{fixture.name}_results.json"))
+
+    cmd = [python, str(bench_script), *list(extra_args)]
+    with log_path.open("ab") as fh:
+        try:
+            return subprocess.call(
+                cmd, env=env, stdout=fh, stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                creationflags=_NO_WINDOW,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning("bench %s on fixture %s timed out", bench_script.name, fixture.name)
+            return -1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path,
+                        help="Path to a fixture manifest JSON file.")
+    parser.add_argument("--bench", choices=sorted(BENCH_SCRIPTS),
+                        default="bench_needle_1000",
+                        help="Which bench to run per fixture.")
+    parser.add_argument("--out", default="benchmarks/results/matrix",
+                        type=Path, help="Output directory for logs + JSON results.")
+    parser.add_argument("--only", default="",
+                        help="Comma-separated fixture names to run (default: all).")
+    parser.add_argument("--port", default=DEFAULT_PORT, type=int)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--health-timeout", default=DEFAULT_HEALTH_TIMEOUT_S, type=float)
+    parser.add_argument("--bench-timeout", default=None, type=float,
+                        help="Per-fixture bench timeout in seconds (default: no limit).")
+    parser.add_argument("--read-write", action="store_true",
+                        help="Disable read-only guard. Default is read-only "
+                             "so benches cannot mutate the fixture DB.")
+    parser.add_argument("--server-log", type=Path, default=None,
+                        help="Optional path for uvicorn stdout/stderr.")
+    args, extra = parser.parse_known_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    fixtures = load_manifest(args.manifest)
+    only = {n.strip() for n in args.only.split(",") if n.strip()}
+    if only:
+        fixtures = [f for f in fixtures if f.name in only]
+        if not fixtures:
+            log.error("no fixtures match --only=%s", args.only)
+            return 2
+
+    if args.read_write:
+        for f in fixtures:
+            f.read_only = False
+
+    bench_script = Path(__file__).parent / BENCH_SCRIPTS[args.bench]
+    if not bench_script.is_file():
+        log.error("bench script not found: %s", bench_script)
+        return 2
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    summary: list[dict[str, Any]] = []
+
+    with BenchServer(
+        host=args.host,
+        port=args.port,
+        health_timeout_s=args.health_timeout,
+        log_to=args.server_log,
+    ) as srv:
+        for fx in fixtures:
+            log.info("→ fixture %s (db=%s sharded=%s)", fx.name, fx.db, fx.sharded)
+            try:
+                swap = srv.switch(fx)
+            except BenchServerError as exc:
+                log.error("fixture %s: switch failed: %s", fx.name, exc)
+                summary.append({
+                    "fixture": fx.name, "status": "switch_failed",
+                    "error": str(exc),
+                })
+                continue
+            log.info(
+                "  %s in %.2fs (genes=%d, pid=%s)",
+                swap.mechanism, swap.elapsed_s, swap.genes, swap.server_pid,
+            )
+
+            rc = _run_one_bench(
+                bench_script,
+                helix_url=srv.url,
+                fixture=fx,
+                out_dir=args.out,
+                extra_args=extra,
+                timeout_s=args.bench_timeout,
+            )
+            summary.append({
+                "fixture": fx.name, "status": "ok" if rc == 0 else "failed",
+                "rc": rc, "mechanism": swap.mechanism,
+                "switch_elapsed_s": swap.elapsed_s, "genes": swap.genes,
+                "results_path": str(args.out / f"{fx.name}_results.json"),
+                "log_path": str(args.out / f"{fx.name}.log"),
+            })
+
+    summary_path = args.out / "matrix_summary.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump({"summary": summary, "bench": args.bench}, f, indent=2)
+    log.info("matrix summary: %s", summary_path)
+    return 0 if all(s.get("status") == "ok" for s in summary) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/fixtures.json
+++ b/benchmarks/fixtures.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "small",
+    "db": "F:/Projects/helix-context/genomes/bench/matrix/small.db",
+    "sharded": false,
+    "read_only": true,
+    "_genes": 1237,
+    "_sha256": "39364a7c4e28de65973019ae68068a98d7b7ac37e7a81d985adcc046ed1e0ad7"
+  },
+  {
+    "name": "medium",
+    "db": "F:/Projects/helix-context/genomes/bench/matrix/medium.db",
+    "sharded": false,
+    "read_only": true,
+    "_genes": 17324,
+    "_sha256": "d004dd66ee7aec3a9380c425696b56f4a645fd142ac467205a096d1b4b5743f2"
+  },
+  {
+    "name": "large",
+    "db": "F:/Projects/helix-context/genomes/bench/matrix/large.db",
+    "sharded": false,
+    "read_only": true,
+    "_genes": 27627,
+    "_sha256": "cc640a5d53c8a8d24135f0a3bdf476ebb6d8a64179254976f142d5e56b4fd692"
+  },
+  {
+    "name": "xl",
+    "db": "F:/Projects/helix-context/genomes/bench/matrix/xl.db",
+    "sharded": false,
+    "read_only": true,
+    "_genes": 46029,
+    "_sha256": "a7a6f8428f0cdae41d628f0c52252ff3c407cc121ced65fd0e392e5ec22d991f"
+  },
+  {
+    "name": "medium-sharded",
+    "db": "F:/Projects/helix-context/genomes/bench/matrix-sharded/medium/main.genome.db",
+    "sharded": true,
+    "read_only": true,
+    "_genes": 17351,
+    "_shard_count": 6,
+    "_sha256": "6170c7ff836fd8500782a00602a7d11d2c696c257105f79dd74bfaaa55be2b8a"
+  },
+  {
+    "name": "xl-sharded",
+    "db": "F:/Projects/helix-context/genomes/bench/matrix-sharded/xl/main.genome.db",
+    "sharded": true,
+    "read_only": true,
+    "_genes": 46060,
+    "_shard_count": 12,
+    "_sha256": "2d0f5ab1688862cc9f6eeebc092bb1ec19d75195c904b157d7d4d8c0e9f40004"
+  }
+]


### PR DESCRIPTION
## Summary

Bench infrastructure for the 6-fixture matrix (4 monolithic blobs + 2 sharded). One invocation now walks every fixture, switches modes transparently, and scores retrieval-only + agent-correctness side-by-side. Builds on the `/admin/swap-db` hot-swap from PR #91 and the preflight fix from PR #102.

### New files

- **`benchmarks/bench_orchestrator.py`** — `BenchServer` class manages uvicorn lifecycle.
  Same-mode transitions (blob↔blob, sharded↔sharded) use `/admin/swap-db`. Cross-mode (blob↔sharded) does a full uvicorn restart with `HELIX_USE_SHARDS=1` flipped, because `open_read_source` in `helix_context/sharding.py` reads that env at store-construction time. Bench code calls `srv.switch(fixture)` and doesn't have to care which mechanism runs. Includes a CLI that loops a manifest and invokes per-fixture bench scripts as subprocesses (`bench_needle`, `bench_needle_1000`). Read-only by default.

- **`benchmarks/fixtures.json`** — canonical 6-fixture manifest derived from `genomes/bench/matrix/frozen.json`. Tracked via an explicit `.gitignore` exception under the broad `benchmarks/*.json` exclude.

- **`benchmarks/bench_claude_matrix.py`** — ported from the untracked `scripts/bench_claude_matrix.py` with three patches:
  1. Default `--model haiku` (was sonnet). Memory-driven rationale: cloud speed prioritized over model quality for the retrieval-quality bench. See `memory/bench_default_haiku.md`. Override with `--model sonnet` when intelligence is the variable.
  2. Issue #101: retrieval probe prefers structured `agent.citations[].source` over the legacy `<GENE src=` regex. The regex stays as fallback because [context_manager.py:1367](helix_context/context_manager.py:1367) still emits the wrapper.
  3. `BenchServer` integration: harness manages its own uvicorn by default, including cross-mode restarts. `--external-server` preserves the legacy 'server-already-running' flow.

### Modified

- **`benchmarks/bench_needle.py`** — Issue #101 retrieval-source robustness: `parse_delivered_genes` now accepts `agent.citations`, splits content by `[gene=...]` legibility headers, cross-references short-id → source via the citation list. Falls back to legacy `<GENE src=` regex, then to citations-only blocks (empty bodies but gold_delivered still computable) for unusual response shapes.
- **`benchmarks/bench_needle_1000.py`** — adds `gold_source_delivered` (citation-grounded) as an additive metric alongside the existing permissive `retrieved` flag. The delta is the phantom-hit zone (value appears in payload but gold source isn't among citations). New aggregations: top-level `gold_source_delivery_rate`, failure mode `phantom_hit`, per-category `gold_delivery_rate`. All additive — pre-2026-05 result files aggregate cleanly with missing fields collapsing to zero.
- **`CLAUDE.md`** — Stage 2 description was inaccurate. Updated to reflect that FTS5 + tags + synonyms + co-activation + cymatics 256-bin spectrum are default-on (no neural inference at query time); BGE-M3 dense (`dense_embedding_enabled`) and SPLADE (`splade_enabled`) are default-off transformer-encoded options.
- **`.gitignore`** — explicit exception for `benchmarks/fixtures.json`.

## Test plan

- [x] Syntax-check all .py files; `fixtures.json` parses as JSON.
- [x] Unit tests on new helpers: `parse_delivered_genes` (modern + legacy + fallback paths), `_gold_source_in_citations` (forward-slash normalization, case-insensitive substring), `Fixture` defaults (read_only=True, sharded=False).
- [x] `pytest tests/test_benchmark_monitor_preflight.py` — 8/8 pass (preflight tests from PR #102 still green).
- [x] Live smoke: orchestrator on `small` fixture booted uvicorn (17s), hot-swapped to small.db, ran 10-needle bench, terminated cleanly. Total ~50s wall time.
- [x] Live cross-mode run: medium (blob) → medium-sharded transition via uvicorn restart took 17.6s. Results in `benchmarks/results/claude_matrix_20260514T193211Z/`.

## Findings during validation (filed separately)

The medium↔medium-sharded run surfaced [issue #104](https://github.com/mbachaud/helix-context/issues/104) — on sharded fixtures, `/context` returns empty `agent.citations` and the retriever surfaces different documents than the blob mode for the same query (0/10 gold-delivered on medium-sharded vs 4/10 on medium blob). Sub-task spawned. Not blocking this PR — the bench infrastructure correctly *measures* the divergence; the fix lives in `helix_context/sharding.py` and the citation enrichment SQL.

## How to use

```bash
# Full matrix (blob + sharded) via orchestrator's per-fixture bench CLI
python benchmarks/bench_orchestrator.py --manifest benchmarks/fixtures.json --bench bench_needle_1000 --only small,medium

# claude -p Haiku across the matrix with auto cross-mode lifecycle
python benchmarks/bench_claude_matrix.py --only medium,medium-sharded --model haiku --max-usd 0.20

# Single fixture, retrieval-only (no Ollama needed thanks to PR #102 preflight fix)
N=50 ASK_PROXY=0 python benchmarks/bench_orchestrator.py --manifest benchmarks/fixtures.json --bench bench_needle_1000 --only small
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)