### PR TITLE
docs: refresh Obsidian vault paths + add operator status note (closes #100)

### DIFF
--- a/docs/clients/claude-code.md
+++ b/docs/clients/claude-code.md
@@ -222,6 +222,8 @@ retention_hours = 48
 ```
 
 CLI: `helix-vault {export, status, trace, pin, unpin}`. See
-`docs/superpowers/specs/2026-05-06-obsidian-vault-export-design.md` for the
-full v1 surface, and the `-full-design-v1.1plus.md` sibling for the deferred
-authored-delta-sync work.
+[`docs/ops/OBSIDIAN_VAULT_STATUS.md`](../ops/OBSIDIAN_VAULT_STATUS.md) for the
+current operator status (what works today, what's deferred to v1.1+, and the
+smoke-test path). The original design specs are archived under
+`docs/archive/superpowers/specs/2026-05-06-obsidian-vault-export-design.md`
+and `docs/archive/superpowers/specs/2026-05-06-obsidian-vault-export-full-design-v1.1plus.md`.

--- a/docs/ops/OBSIDIAN_VAULT_STATUS.md
+++ b/docs/ops/OBSIDIAN_VAULT_STATUS.md
@@ -1,0 +1,89 @@
+# Obsidian Vault Export — Operator Status
+
+Obsidian vault export is shipped as **v1** (read-only export + diagnostic traces).
+
+**Since:** helix-context v0.5.0 (PR #37, merged 2026-05-07)
+
+## v1 capabilities (current)
+
+What works today:
+
+- **Full and incremental export** of the knowledge store to an Obsidian-compatible
+  markdown vault (`genes/<domain>/<stem>-<id>.md`, one file per `gene_id`).
+- **Diagnostic traces** of `/context` calls auto-exported to `_traces/`, TTL-pruned
+  (default 48h, hard cap configurable).
+- **Pin / unpin** traces — pinned traces live in `_traces-pinned/` and are immune
+  to TTL prune (still subject to `vault.traces.max_retention_hours_hard`).
+- **`/vault/status`** HTTP endpoint and `helix-vault status` CLI — file counts per
+  folder, disk bytes, last export timestamps.
+- **`/export/obsidian`** HTTP endpoint and `helix-vault export {--full,--incremental}`
+  CLI for on-demand exports.
+- **`/vault/trace`** HTTP endpoint to capture a single-request diagnostic trace
+  on demand.
+- **`_stale/`** read-only view of genes below `vault.stale_threshold`.
+- **Fan-out migration** when a domain folder exceeds `vault.fan_out_threshold`.
+- **Vault file-count Prometheus gauge** per folder.
+
+Authored frontmatter fields (`operator_notes`, `operator_tags`, `pinned`,
+`supersedes`, ...) render as cosmetic placeholders for forward-compat with v1.1.
+**Edits in Obsidian are NOT synced back in v1.**
+
+## v1.1+ deferred
+
+Not yet implemented:
+
+- File **watcher** for authored-field changes in Obsidian.
+- **Delta-sync** of operator edits back into the knowledge store.
+- **Authored-field writeback** via watcher + validator pipeline.
+
+Tracking design lives in
+[`docs/archive/superpowers/specs/2026-05-06-obsidian-vault-export-full-design-v1.1plus.md`](../archive/superpowers/specs/2026-05-06-obsidian-vault-export-full-design-v1.1plus.md).
+
+## Smoke-test path
+
+1. Enable in `helix.toml`:
+
+   ```toml
+   [vault]
+   enabled = true
+   path = "~/.helix/vault"
+   # party_id = ""           # empty = server's primary party
+   # redact_body = false     # set true if Obsidian Sync / iCloud watches the path
+
+   [vault.traces]
+   retention_hours = 48
+   # max_retention_hours_hard = 720
+   ```
+
+2. Start the helix server (`helix-server` or `python -m uvicorn helix_context._asgi:app --port 11437`).
+
+3. Run a full export and check status:
+
+   ```bash
+   helix-vault export --full
+   helix-vault status
+   ```
+
+4. Run a `/context` query to generate a trace, then pin and unpin it:
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:11437/context \
+        -H "Content-Type: application/json" \
+        -d '{"query": "what does the splice step do?"}'
+
+   # Find the latest trace file in ~/.helix/vault/_traces/
+   helix-vault trace --list | head
+   helix-vault pin <trace-filename>
+   helix-vault status     # _traces-pinned count goes up by 1
+   helix-vault unpin <trace-filename>
+   ```
+
+If `helix-vault status` reports `enabled: true` and trace pin/unpin round-trip
+the file between `_traces/` and `_traces-pinned/`, v1 is healthy.
+
+## History
+
+The original design specs are preserved under `docs/archive/superpowers/specs/`:
+
+- [`2026-05-06-obsidian-vault-export-design.md`](../archive/superpowers/specs/2026-05-06-obsidian-vault-export-design.md) — v1 design.
+- [`2026-05-06-obsidian-vault-export-full-design-v1.1plus.md`](../archive/superpowers/specs/2026-05-06-obsidian-vault-export-full-design-v1.1plus.md) — v1.1+ deferred design.

--- a/helix_context/vault/__init__.py
+++ b/helix_context/vault/__init__.py
@@ -105,7 +105,8 @@ class VaultManager:
             "## v1.1 follow-up\n\n"
             "Authored fields (operator_notes, operator_tags, pinned, supersedes...) "
             "are placeholders in v1. v1.1 enables write-back via watcher + validator. "
-            "See `docs/superpowers/specs/2026-05-06-obsidian-vault-export-full-design-v1.1plus.md`.\n"
+            "See `docs/ops/OBSIDIAN_VAULT_STATUS.md` for current operator status and "
+            "the v1.1+ deferred work.\n"
         )
         readme.write_text(content, encoding="utf-8")
 

--- a/tests/test_vault_docs.py
+++ b/tests/test_vault_docs.py
@@ -1,0 +1,133 @@
+"""Regression tests for doc references embedded in vault output.
+
+If anyone moves operator-facing docs again (cf. PR #100), the generated
+vault README and the operator-facing docs must keep their pointers in sync.
+These tests fail loudly when a referenced local doc no longer exists.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from helix_context.config import HelixConfig, VaultConfig, VaultTracesConfig
+from helix_context.genome import Genome
+from helix_context.vault import VaultManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# Match backtick-quoted paths inside the README that look like local docs:
+#   `docs/foo/bar.md`
+#   `docs/foo/bar.py`
+# Stop at the closing backtick.
+_BACKTICK_LOCAL_PATH = re.compile(r"`((?:docs|helix_context|scripts|tests)/[^\s`]+\.(?:md|py|toml))`")
+
+# Match markdown link targets that point at local files (skip http/https/mailto).
+_MD_LINK_TARGET = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def _extract_local_paths(text: str) -> list[str]:
+    """Pull out every plausible local-doc path mentioned in `text`."""
+    paths: list[str] = []
+    paths.extend(_BACKTICK_LOCAL_PATH.findall(text))
+    for target in _MD_LINK_TARGET.findall(text):
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        # Strip anchor fragments + query strings.
+        clean = target.split("#", 1)[0].split("?", 1)[0]
+        if not clean:
+            continue
+        paths.append(clean)
+    return paths
+
+
+@pytest.fixture
+def vault_manager(tmp_path: Path):
+    cfg = HelixConfig()
+    cfg.vault = VaultConfig(
+        enabled=True,
+        path=str(tmp_path / "vault"),
+        party_id="",
+        fan_out_threshold=5000,
+        redact_body=False,
+        stale_threshold=0.5,
+        traces=VaultTracesConfig(
+            enabled=True,
+            retention_hours=48,
+            max_retention_hours_hard=720,
+            max_count=10000,
+            rollup_enabled=True,
+            rollup_shard="hour",
+            prune_interval_minutes=60,
+            trigger_only=False,
+        ),
+    )
+    genome = Genome(path=str(tmp_path / "genome.db"), synonym_map={})
+    manager = VaultManager(config=cfg, genome=genome)
+    manager.start()
+    yield manager, Path(cfg.vault.path)
+    manager.stop()
+    genome.close()
+
+
+def test_generated_readme_local_doc_paths_resolve(vault_manager):
+    """Every local-doc path referenced by the generated vault README must exist.
+
+    Regression for issue #100: PR #37 shipped a README pointing at
+    `docs/superpowers/specs/...` which later moved to `docs/archive/...`,
+    leaving operators with broken pointers. This test guards against the
+    same class of drift on any future doc move.
+    """
+    _, vault_root = vault_manager
+    readme_path = vault_root / "README.md"
+    assert readme_path.exists(), "vault README was not generated on start"
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    local_paths = _extract_local_paths(readme_text)
+
+    # Sanity: we should at least be picking up the operator-status pointer.
+    assert local_paths, (
+        "no local-doc paths extracted from generated README — did the README "
+        "format change? If so, update _extract_local_paths in this test."
+    )
+
+    missing = [
+        p for p in local_paths
+        if not (REPO_ROOT / p).exists()
+    ]
+    assert not missing, (
+        f"vault README references local docs that do not exist on disk: {missing}. "
+        f"Update helix_context/vault/__init__.py._write_readme or restore the "
+        f"missing file."
+    )
+
+
+def test_claude_code_doc_local_paths_resolve():
+    """Same guard applied to the Claude Code operator doc.
+
+    `docs/clients/claude-code.md` is the primary operator-facing intro and
+    must not contain broken local pointers either.
+    """
+    doc = REPO_ROOT / "docs" / "clients" / "claude-code.md"
+    text = doc.read_text(encoding="utf-8")
+    local_paths = _extract_local_paths(text)
+
+    missing: list[str] = []
+    for raw in local_paths:
+        # The doc lives at docs/clients/claude-code.md, so relative paths
+        # like ../ops/foo.md should resolve from the doc's directory.
+        candidate = (doc.parent / raw).resolve() if raw.startswith((".", "/")) \
+            else (REPO_ROOT / raw)
+        # Also accept absolute-from-repo paths verbatim.
+        if not candidate.exists() and not (REPO_ROOT / raw).exists():
+            # Try resolving from doc's directory as a fallback.
+            alt = (doc.parent / raw).resolve()
+            if not alt.exists():
+                missing.append(raw)
+    assert not missing, (
+        f"docs/clients/claude-code.md references local paths that do not "
+        f"exist: {missing}. Update the doc or restore the missing files."
+    )


### PR DESCRIPTION
## Summary

PR #37 shipped Obsidian vault export v1 with the generated vault README and
`docs/clients/claude-code.md` pointing at `docs/superpowers/specs/...`. Commit
`8c84f2d` later moved those specs to `docs/archive/`, leaving operators with
broken pointers (issue #100).

- Repoint the generated vault README (`helix_context/vault/__init__.py`) at a
  new operator-facing status note instead of the archived design spec.
- Update `docs/clients/claude-code.md` the same way, and surface the archived
  design specs explicitly for anyone who wants the historical context.
- Add `docs/ops/OBSIDIAN_VAULT_STATUS.md` — concise operator note covering:
  - v1 capabilities (export, traces, pin/unpin, `/vault/status`, `/export/obsidian`, `/vault/trace`).
  - v1.1+ deferred work (watcher, delta-sync, authored-field writeback).
  - Copy-pasteable smoke-test path (`helix-vault export --full`, `status`, trace pin/unpin cycle).
  - Link to archived design docs under `docs/archive/superpowers/specs/`.
- Add `tests/test_vault_docs.py` regression test — renders the vault README
  via `VaultManager`, extracts every local-doc path (backtick-quoted +
  markdown links), and asserts each one exists on disk. Same check applied
  to `docs/clients/claude-code.md`. Fails loudly if anyone moves docs again.

## Test plan

- [x] `python -m pytest tests/test_vault_e2e.py tests/test_vault_cli.py tests/test_vault_endpoints.py tests/test_vault_manager.py tests/test_vault_docs.py -v` — 19 passed
- [x] `git grep -n "docs/superpowers/specs/2026-05-06-obsidian"` returns only references inside `docs/archive/...` (the archived plan itself) and `.obsidian/workspace.json` (which already points at `docs/archive/`).

Closes #100