### PR TITLE
docs: ADR for spec-vs-code design questions (closes #64)

### DIFF
--- a/docs/agent-sdk-fragment.md
+++ b/docs/agent-sdk-fragment.md
@@ -57,6 +57,16 @@ HELIX KNOW/MISS retrieval returns one of two top-level blocks at every
 The agent's compliance with this contract is the load-bearing piece;
 without it the structured tags are noise. Every `miss` row that
 produces a fabricated answer fails the eval.
+
+NOTE: the `<helix:no_match/>` inline tag is a legacy-compat surface
+that only carries the four Stage-6 reasons listed above. Stage-7
+freshness-gate reasons (`stale`, `cold`, `superseded`) appear ONLY
+in the structured `miss.reason` field (alongside non-empty
+expressed_context and a populated `refresh_targets` list). Always
+prefer reading the structured `know`/`miss` blocks over scraping
+the inline tag — the structured envelope is the canonical contract.
+See docs/architecture/adr/2026-05-14-spec-vs-code-design-decisions.md
+for the design rationale.
 ```
 
 ---

--- a/docs/api/context-endpoint.md
+++ b/docs/api/context-endpoint.md
@@ -370,32 +370,44 @@ The `content` field of the response contains the assembled
 `<expressed_context>...</expressed_context>` tags. Three special
 inline tokens may appear:
 
-### 6.1 `<helix:no_match/>` — Stage 6 miss token
+### 6.1 `<helix:no_match/>` — Stage 6 miss token (legacy-compat surface)
 
 Self-closing tag injected by `_no_match_token` at
 [`context_manager.py:221-236`](../../helix_context/context_manager.py#L221).
 Lowercase tag name, attributes in fixed order (`reason` then
 `do_not_answer`), no whitespace inside the tag, `do_not_answer="true"`
-literal:
+literal. **Only four reasons are ever emitted by the inline tag:**
 
 ```
 <helix:no_match reason="abstain"           do_not_answer="true"/>
 <helix:no_match reason="denatured"         do_not_answer="true"/>
 <helix:no_match reason="sparse"            do_not_answer="true"/>
 <helix:no_match reason="no_promoter_match" do_not_answer="true"/>
-<helix:no_match reason="stale"             do_not_answer="true"/>
-<helix:no_match reason="cold"              do_not_answer="true"/>
-<helix:no_match reason="superseded"        do_not_answer="true"/>
 ```
 
-**Implementation note:** the `_no_match_token` helper currently only
-formats the four Stage-6 reasons (abstain, denatured, sparse,
-no_promoter_match); an unknown reason falls back to the abstain form
-(`context_manager.py:233-236`). The Stage-7 reasons (`stale`, `cold`,
-`superseded`) are surfaced via `MissBlock.reason` and
-`agent.recommendation = "refresh"` rather than a distinct
-`expressed_context` byte. Clients should branch on the structured
-`miss.reason` field, not on the `<helix:no_match/>` reason attribute.
+The tag is emitted only on the three "expressed context is empty"
+branches in `context_manager.py` (lines 1153, 2116, 2345); an unknown
+reason falls back to the abstain form (`context_manager.py:233-236`).
+
+**Stage 7 freshness-gate reasons (`stale`, `cold`, `superseded`) are
+NOT emitted as `<helix:no_match/>` tags by design.** They surface
+via:
+
+- `MissBlock.reason` in the structured envelope, with
+  `MissBlock.refresh_targets` populated.
+- `agent.recommendation = "refresh"` at the route layer.
+- A populated `stale_risk` list on `/context/packet` (the expressed
+  context is non-empty in this case — the data is shown, but tagged
+  as needing a refresh).
+
+The inline `<helix:no_match/>` tag is a legacy-compat surface for
+regex-based clients written before Stage 6 / Stage 7. Its
+"empty + do_not_answer" semantics are incompatible with Stage 7's
+"non-empty + stale + refresh" UX, which is why the Stage 7 reasons
+live in the structured envelope. New clients should branch on the
+structured `miss.reason` / `know` fields and treat the inline tag as
+the legacy fallback. Design decision recorded in
+[ADR 2026-05-14](../architecture/adr/2026-05-14-spec-vs-code-design-decisions.md#q3-stage-7-reasons-in-missblockreason-but-not-in-inline-helixno_match).
 
 ### 6.2 `<helix:slate>` — Stage 5 small-MoE answer slate
 

--- a/docs/api/context-endpoint.md
+++ b/docs/api/context-endpoint.md
@@ -553,12 +553,33 @@ Returns tier-score breakdowns per candidate document (`gene_id`, `score`,
 
 ### 9.4 `POST /consolidate` — session memory consolidation
 
-Handler: [`server.py:2672-2690`](../../helix_context/server.py#L2672).
+Handler:
+[`helix_context/server/routes_ingest.py:134-148`](../../helix_context/server/routes_ingest.py#L134).
 No request body. Distills the session buffer into consolidated
 knowledge documents, extracting only new facts, decisions, and
 discoveries. Returns `{"facts_extracted": int, "gene_ids":
 list[str]}`. On error returns 500 with `{"error": ..., "facts_extracted":
 0, "gene_ids": []}`.
+
+**Why session-scoped (no body).** `/consolidate` operates over the
+active in-process session buffer, not a single document. Any request
+body is silently ignored. This is intentional — consolidation is an
+aggregate-over-the-buffer operation, not a per-gene rewrite. For the
+per-gene rewrite case, the supported path is:
+
+1. Call `POST /context/refresh-plan` (or read `MissBlock.refresh_targets`
+   from a `/context/packet` response) to get the source paths that need
+   to be re-read.
+2. Re-read those sources in the calling agent.
+3. Re-`POST /ingest` the refreshed content.
+
+Targeted per-gene re-consolidation as a server-side endpoint is
+deliberately not implemented. The reserved shape for that
+hypothetical future endpoint is `POST /consolidate/gene/{gene_id}`
+(path-scoped, no body) — recorded in
+[ADR 2026-05-14](../architecture/adr/2026-05-14-spec-vs-code-design-decisions.md#q2-consolidate-ignores-request-body)
+so a later contributor doesn't re-debate adding `{"gene_id": ...}` to
+the body of `/consolidate` itself.
 
 ### 9.5 `POST /sessions/register` — participant registration
 

--- a/docs/architecture/FEDERATION_LOCAL.md
+++ b/docs/architecture/FEDERATION_LOCAL.md
@@ -193,6 +193,39 @@ Order of precedence, each axis:
 3. **OS-derived value** (`getpass.getuser()`, `socket.gethostname()`)
 4. **Sensible default** (`org='local'`, `agent=None`)
 
+### `HELIX_DEVICE` parse rules (overload with the hardware picker)
+
+The same `HELIX_DEVICE` env var is read by two consumers, and they
+parse it differently. The overload is intentional and safe — this
+section documents the parse rules so operators don't have to read
+both consumers' code. Design decision recorded in
+[ADR 2026-05-14](../adr/2026-05-14-spec-vs-code-design-decisions.md#q1-helix_device-overloaded-between-hardware-picker-and-federation-attribution).
+
+| Consumer | Source | Parse rule |
+|---|---|---|
+| Hardware picker | `helix_context/hardware.py::_resolve_requested_device` | Lowercase, then check against the whitelist `{"auto", "cuda", "rocm", "mps", "cpu"}`. Any non-whitelisted value logs `WARNING` and is ignored — the picker continues to `[hardware] device` from `helix.toml`, then to `"auto"`. Never raises, never blocks startup. |
+| Federation attribution | `helix_context/server/helpers.py::_local_attribution_defaults`, `helix_context/identity/registry.py` | Used as a free-form device-handle string. Any non-empty value is accepted as-is. Falls back to `HELIX_PARTY`, then `socket.gethostname()`. |
+
+Concrete behavior matrix:
+
+| `HELIX_DEVICE=` value | HW picker | Federation |
+|---|---|---|
+| `cuda` / `cpu` / `mps` / `rocm` / `auto` | Used as device kind | Used as device handle (literal value) |
+| Any other string (e.g., `my-laptop`, `swift_wing21`) | WARNING logged, ignored; picker falls through to `[hardware] device` / `"auto"` | Used as device handle |
+| Unset | Falls through to `[hardware] device` / `"auto"` | Falls through to `HELIX_PARTY` or `socket.gethostname()` |
+
+**To silence the HW-picker WARNING when you want `HELIX_DEVICE` for
+federation only:** set `[hardware] device = "cpu"` (or your preferred
+device) explicitly in `helix.toml`, and move the federation label to
+`HELIX_PARTY`:
+
+```bash
+export HELIX_PARTY="my-laptop"   # federation device handle
+unset HELIX_DEVICE               # picker uses helix.toml's [hardware] device
+```
+
+This preserves attribution while avoiding the overload entirely.
+
 Tokens are normalized: lowercased, whitespace-stripped, length-capped at
 64 chars. Conservative because these become primary-key components.
 

--- a/docs/architecture/adr/2026-05-14-spec-vs-code-design-decisions.md
+++ b/docs/architecture/adr/2026-05-14-spec-vs-code-design-decisions.md
@@ -1,0 +1,245 @@
+# ADR 2026-05-14: Spec-vs-code design decisions
+
+Status: Accepted
+Date: 2026-05-14
+Closes: [#64](https://github.com/mbachaud/helix-context/issues/64)
+Source: post-Stage-7 spec-vs-code audit (PR #60, disc-4 / disc-7 / disc-8)
+
+## Context
+
+PR #60's spec-vs-code audit flagged three places where the shipped code
+disagrees with what a strict reading of the spec implies. Each could be
+"fix the code", "fix the docs", or "leave as is + document the
+rationale". They share the "needs a design decision before any code
+moves" property, so we resolve them in one ADR.
+
+## Decisions
+
+| Question | Decision | Why |
+|---|---|---|
+| Q1: `HELIX_DEVICE` overloaded | **B — document parse rules** | Already safe by construction (HW picker whitelists; federation accepts any string). Renaming would force a deprecation cycle on every existing operator setup for zero functional gain. |
+| Q2: `/consolidate` ignores request body | **B — document session-scoped behavior; defer targeted re-consolidate** | Endpoint is intentionally session-scoped; targeted re-consolidate has no current consumer asking for it. Documenting closes the spec gap; adding a parser or new route would invent surface area. |
+| Q3: Inline `<helix:no_match/>` missing Stage 7 reasons | **C — document inline tag as legacy-compat surface** | The inline tag fires only when expressed context is empty; Stage 7 demotions ship `stale_risk` + `refresh_targets` instead (non-empty). Extending the tag would require new emission semantics with regex-matcher risk for no clear consumer benefit. |
+
+---
+
+## Q1: `HELIX_DEVICE` overloaded between hardware picker and federation attribution
+
+### Current behavior (verified)
+
+- **Hardware picker** (`helix_context/hardware.py:30-54`,
+  `_resolve_requested_device`): reads `HELIX_DEVICE`, normalizes to
+  lowercase, accepts only the whitelist
+  `{"auto", "cuda", "rocm", "mps", "cpu"}`. Any other value logs
+  `WARNING` and falls through to `[hardware] device` in `helix.toml`,
+  then to `"auto"`. Never raises, never blocks startup.
+- **Federation attribution** (`helix_context/server/helpers.py:139-148`
+  and `helix_context/identity/registry.py:266`): reads `HELIX_DEVICE`
+  as a free-form device-handle string, falling back to
+  `HELIX_PARTY`, then `socket.gethostname()`. Accepts any non-empty
+  value.
+
+### Concrete behavior matrix
+
+| `HELIX_DEVICE=` value | HW picker | Federation |
+|---|---|---|
+| `cuda` / `cpu` / `mps` / `rocm` / `auto` | Used as device kind | Used as device handle (literally `"cuda"`, etc.) |
+| Any other string (e.g., `my-laptop`, `swift_wing21`) | Logged WARNING, ignored; HW picker continues to `[hardware] device` / `"auto"` | Used as device handle |
+| Unset | Falls through to TOML / auto | Falls through to `HELIX_PARTY` or `socket.gethostname()` |
+
+The two consumers are non-interacting in practice: the HW picker is
+intentionally tolerant of unknown values, and the only "bad" outcome of
+setting `HELIX_DEVICE=my-laptop` is one warning at startup. The
+federation layer always gets the value it wants.
+
+### Options considered
+
+- **A — Rename** (`HELIX_DEVICE_LABEL` + `HELIX_HARDWARE`): correct in
+  principle, but every operator already configured with `HELIX_DEVICE`
+  for federation would need to migrate, including the multi-device
+  attribution example in `docs/architecture/FEDERATION_LOCAL.md:154`
+  and the `docs/clients/claude-code.md:48` MCP config snippet. A
+  deprecation cycle adds churn for zero behavior change.
+- **B — Document** (chosen): publish the parse rules so operators stop
+  treating the overload as ambiguous.
+- **C — Leave as is**: documentation gap remains.
+
+### Decision
+
+Adopt **B**. Add a "`HELIX_DEVICE` parse rules" subsection to
+`docs/architecture/FEDERATION_LOCAL.md` that:
+
+1. States the whitelist used by the HW picker.
+2. States that any value not in the whitelist is treated as a
+   federation-only label and the HW picker silently continues to
+   `[hardware] device`.
+3. Calls out that the WARNING log at startup is expected when using a
+   custom device label, and how to silence it via the picker route
+   (set `[hardware] device = "cpu"` explicitly in `helix.toml` and
+   move the label into `HELIX_PARTY` if you want zero log noise).
+
+### Consequences
+
+- No code change, no test impact.
+- Documentation is the single source of truth for the overload. If
+  consumers report churn from the WARNING log, we revisit (rename or
+  drop the WARNING on the "looks like a device label" branch).
+
+---
+
+## Q2: `/consolidate` ignores request body
+
+### Current behavior (verified)
+
+- Handler: `helix_context/server/routes_ingest.py:134-148`.
+- Signature: `async def consolidate_endpoint()` — no parameters. The
+  request body is not parsed at all (FastAPI doesn't bind it to any
+  argument).
+- Calls `helix.consolidate_session_async()`
+  (`helix_context/context_manager.py:1657-1748`) which distills the
+  active in-process session buffer.
+- Existing documentation
+  (`docs/api/context-endpoint.md:554-561`,
+  `docs/operator-runbooks.md:715-755`) already says "No request body"
+  and "operates on the session buffer aggregate, not a single
+  document".
+
+### Note on the issue premise
+
+The issue states: _"Docs and some integrations assume
+`{"gene_id": "..."}` for targeted re-consolidation."_ We could not
+locate any in-repo doc or integration that makes this assumption.
+The existing docs correctly describe the no-body behavior. The gap is
+that they describe "what" without describing "why this is the design
+on purpose, and what to use instead for per-gene re-consolidation".
+
+### Options considered
+
+- **A — Add body parsing for `{"gene_id"?: str, "session"?: str}`**:
+  no current consumer is asking for it, and there's no internal flow
+  that ingests "rewrite this one gene from its source" (that path is
+  the freshness gate's `refresh_targets` payload + the agent
+  re-reading from source and re-`POST /ingest`-ing).
+- **B — Document the session-buffer-only behavior explicitly**
+  (chosen): make the design-intent explicit in the docs that already
+  document the endpoint, and call out the alternative path
+  (`/context/refresh-plan` → agent re-read → `/ingest`) for the
+  targeted case.
+- **C — Add `/consolidate/gene/{gene_id}`**: invents new endpoint
+  surface for a hypothetical consumer. If real demand surfaces, we
+  add this later — the path is reserved.
+
+### Decision
+
+Adopt **B**. Append a "Why session-scoped?" note to
+`docs/api/context-endpoint.md:554`'s `/consolidate` section that:
+
+1. Restates the no-body contract.
+2. Explains the design intent (consolidation is over the active
+   buffer; per-gene rewrites are a different shape that go through
+   `/ingest` after the agent re-reads the source).
+3. Calls out the path forward if targeted re-consolidate is ever
+   needed: a future `/consolidate/gene/{gene_id}` endpoint is the
+   reserved shape (Option C). It is intentionally not implemented now.
+
+### Consequences
+
+- No code change, no test impact.
+- If a future consumer needs per-gene re-consolidation, this ADR
+  records that the reserved shape is `/consolidate/gene/{gene_id}`
+  (not body-on-`/consolidate`). That avoids a later debate.
+
+---
+
+## Q3: Stage 7 reasons in `MissBlock.reason` but not in inline `<helix:no_match/>`
+
+### Current behavior (verified)
+
+- The structured `MissBlock.reason` enum
+  (`helix_context/schemas.py:481-490`):
+  `{"abstain", "denatured", "sparse", "no_promoter_match", "stale",
+  "cold", "superseded"}`.
+- The inline tag `<helix:no_match reason="..." do_not_answer="true"/>`
+  is emitted by `_no_match_token(reason)`
+  (`helix_context/context_manager.py:221-236`), which whitelists
+  `{"abstain", "denatured", "sparse", "no_promoter_match"}` and
+  defaults unknown reasons to `"abstain"`.
+- The inline tag is only emitted on three branches
+  (`helix_context/context_manager.py:1153`, `2116`, `2345`), all of
+  which correspond to **empty expressed context** (zero candidates
+  survived, abstain tier fired, or no promoter-tier match).
+- Stage 7 demotions (stale / cold / superseded) **do not produce
+  empty expressed context**. They populate `ContextPacket.stale_risk`
+  and `ContextPacket.refresh_targets` and ship the structured
+  `MissBlock` in the envelope, alongside any verified items. The
+  inline tag is never invoked with Stage 7 reasons in current code.
+
+### What the gap actually is
+
+The inline tag is, by construction, the pre-Stage-7 contract for
+"there is nothing to show, do not answer". Stage 7 added a third
+state — "there is something to show, but it's stale, please refresh"
+— that doesn't fit the inline-tag's "empty + do-not-answer" semantics.
+Extending the inline tag would either:
+
+1. Force the tag to emit alongside content (semantically incompatible
+   with `do_not_answer="true"`), or
+2. Force Stage 7 demotions to ship empty contexts (regresses the
+   "stale-but-actionable" UX that motivated Stage 7).
+
+Neither is desirable.
+
+### Options considered
+
+- **A — Extend the inline tag** with Stage 7 reasons: changes the
+  emission contract (would need to emit alongside content for stale /
+  cold / superseded). Risk: legacy regex matchers parsing the tag
+  would see a `reason` value they don't recognize.
+- **B — New tags** (`<helix:stale_match/>`, `<helix:cold_match/>`,
+  `<helix:superseded_match/>`): preserves backwards compat at the
+  parser layer but adds vocabulary that overlaps with the structured
+  envelope without adding signal a Stage-7-aware client doesn't
+  already have via `KnowBlock.soft_stale` /
+  `MissBlock.refresh_targets`.
+- **C — Document as legacy-compat** (chosen): the inline tag stays
+  what it is — a pre-Stage-7 "do not answer, empty context" signal.
+  Stage-7-aware clients read the structured envelope where the
+  freshness reasons live by design.
+
+### Decision
+
+Adopt **C**. Update three docs:
+
+1. `docs/api/context-endpoint.md` — add an "Inline tag is legacy
+   contract" callout in the section that describes the inline tag.
+2. `docs/agent-sdk-fragment.md` — add a one-line note recommending
+   new clients read `know` / `miss` rather than scrape the inline
+   tag.
+3. The `_no_match_token` docstring in
+   `helix_context/context_manager.py` — add a note that the four
+   whitelisted reasons are the legacy-compat set by design, and
+   point at this ADR.
+
+### Consequences
+
+- No behavior change. Legacy regex matchers continue to work
+  unchanged.
+- New client examples in the docs route through `KnowBlock` /
+  `MissBlock` (which they already do; this just makes the
+  recommendation explicit).
+- If a future use case genuinely needs an inline signal for
+  Stage-7-style demotions (e.g., a frontier agent that consumes only
+  the `expressed_context` text and ignores the JSON envelope), we
+  revisit by adding new tag shapes (Option B), not by extending
+  `<helix:no_match/>`.
+
+---
+
+## Cross-cutting note
+
+All three decisions follow the lowest-risk-that-closes-the-issue
+heuristic from issue #64. The substantive change in every case is a
+doc clarification, not a code change. We deliberately did not bundle
+opportunistic refactors (e.g., dropping the WARNING log in Q1, adding
+a stub `/consolidate/gene/...` for Q2) — those remain available as
+follow-ups if a real consumer surfaces demand.

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -229,6 +229,18 @@ def _no_match_token(reason: str) -> str:
     reasons are MissBlock.reason values; passing anything else returns
     the abstain form (defensive default — the discriminator never
     feeds an unknown reason here in practice).
+
+    Legacy-compat surface (ADR 2026-05-14, Q3). The four whitelisted
+    reasons are the pre-Stage-7 contract. Stage 7 added
+    ``stale``/``cold``/``superseded`` to ``MissBlock.reason``; those
+    reasons are NOT emitted as inline ``<helix:no_match/>`` tags by
+    design, because Stage 7 demotions ship non-empty expressed context
+    (the data is shown with ``stale_risk`` + ``refresh_targets``),
+    which is semantically incompatible with the tag's
+    ``do_not_answer="true"`` contract. New clients should branch on
+    the structured ``MissBlock.reason`` / ``KnowBlock`` fields rather
+    than scraping this tag. See
+    ``docs/architecture/adr/2026-05-14-spec-vs-code-design-decisions.md``.
     """
     valid = {"abstain", "denatured", "sparse", "no_promoter_match"}
     if reason not in valid:


### PR DESCRIPTION
Closes #64.

## Summary

PR #60's spec-vs-code audit surfaced three open design questions
(disc-4 / disc-7 / disc-8). This PR resolves them via a single ADR
plus the minimum doc changes consistent with each decision. No code
behavior changes; one docstring expanded in `_no_match_token`.

## Decisions

| Q | Decision | One-line reasoning |
|---|---|---|
| **Q1 — `HELIX_DEVICE` overloaded** | **B — document parse rules** | Already safe by construction (HW picker whitelists; federation accepts any string). Renaming would force migration on every existing operator setup for zero functional gain. |
| **Q2 — `/consolidate` ignores body** | **B — document session-scoped intent** | Endpoint is intentionally session-scoped; no in-tree integration assumes a `{gene_id}` body. Documenting closes the spec gap; adding a parser or new route would invent surface area. |
| **Q3 — Inline `<helix:no_match/>` missing Stage 7 reasons** | **C — document inline tag as legacy-compat surface** | The inline tag fires only on empty expressed context; Stage 7 demotions ship non-empty context (data + `refresh_targets`), which is semantically incompatible with the tag's `do_not_answer="true"` contract. Stage 7 reasons live in `MissBlock.reason` by design. |

All three decisions follow the lowest-risk-that-closes-the-issue
heuristic from #64.

## What changed

- `docs/architecture/adr/2026-05-14-spec-vs-code-design-decisions.md`
  (new) — the full ADR.
- `docs/architecture/FEDERATION_LOCAL.md` — new "HELIX_DEVICE parse
  rules" subsection with behavior matrix and the
  `HELIX_PARTY`-fallback workaround for silencing the picker WARNING.
- `docs/api/context-endpoint.md` — added "Why session-scoped" note on
  `/consolidate`; rewrote `<helix:no_match/>` section to remove the
  misleading Stage-7 reasons from the example block (they are never
  emitted as inline tags) and make the legacy-compat framing
  explicit.
- `docs/agent-sdk-fragment.md` — one-line note steering new clients
  to the structured envelope.
- `helix_context/context_manager.py` — `_no_match_token` docstring
  expanded with the legacy-compat rationale and ADR pointer (the
  only non-doc edit; pure docstring).

## Premises in the issue that turned out to be wrong

- **Q1's "silently ignored" framing**: the HW picker actually logs a
  `WARNING` and tolerates unknown values cleanly (whitelist +
  fall-through). It does not crash and does not "silently" ignore
  invalid values. ADR documents this concretely.
- **Q2's "docs and some integrations assume `{gene_id}` body"**:
  could not locate any in-repo doc or integration making that
  assumption. The existing
  `docs/api/context-endpoint.md:557` already said "No request body".
  The gap was "why this is the design on purpose", which the ADR
  and the updated docs now cover.
- **Q3's "inline tag only emits sparse/abstain"**: the whitelist is
  actually 4 reasons (`abstain`, `denatured`, `sparse`,
  `no_promoter_match`). More importantly, Stage 7 reasons aren't
  blocked from the inline tag by the whitelist — they're
  structurally inapplicable, because Stage 7 demotions don't produce
  empty expressed context (the tag's only emission trigger). The
  existing example in `context-endpoint.md` that listed all 7
  reasons was misleading; this PR trims it.

## Test plan

- [x] `python -m pytest tests/test_abstain_tier.py tests/test_know_miss_block.py -m "not live" -v` — 43 passed (covers `_no_match_token`, the abstain marker constant, and the KnowBlock/MissBlock contract).
- [ ] Manual: rendered the new ADR + updated docs locally; cross-links resolve.

## Deferred / flagged

- The `HELIX_DEVICE`-picker WARNING log on custom federation labels
  is documented as expected; if it becomes noisy in real operator
  feedback we can drop it on the "looks like a label, not a device
  kind" branch in a follow-up. The ADR lists this as a follow-up,
  not a current requirement.
- `/consolidate/gene/{gene_id}` is reserved as a future endpoint
  shape if targeted per-gene re-consolidation ever has a real
  consumer. Not implemented now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)