### PR TITLE
fix(bench): parse agent.citations + legacy fallback (closes #101)

### DIFF
--- a/benchmarks/_citations.py
+++ b/benchmarks/_citations.py
@@ -1,0 +1,198 @@
+"""Shared citation parser for benchmarks + diagnostics.
+
+The modern `/context` response carries structured per-document metadata
+at ``response[0]["agent"]["citations"]``:
+
+    [
+      {
+        "name": "Helix Genome Context",
+        "content": "[gene=abc12345... ◆ fired=harmonic:2.3 1200→320c]\nspliced text...",
+        "agent": {
+          "citations": [
+            {"gene_id": "abc12345...", "source": "path/to/file.py", "score": 1.42},
+            ...
+          ],
+          ...
+        }
+      }
+    ]
+
+Historical JSONL/results files (pre-2026-05) embedded each delivered
+document as ``<GENE src="path/to/file.py" ...>...</GENE>`` inline in the
+``content``/``expressed_context`` string. The renderer no longer emits
+that markup -- it was replaced by ``[gene=...]`` legibility headers
+(see :mod:`helix_context.encoding.legibility`) -- but old JSONL captures
+must remain inspectable.
+
+This module is the single place benchmark/diagnostic code should look up
+"what sources did Helix actually deliver?". It prefers the structured
+``agent.citations`` payload and falls back to the legacy regex only when
+no structured citations are present.
+
+Issue: https://github.com/mbachaud/helix-context/issues/101
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+# Legacy assembly markup. Retained ONLY as a fallback for historical
+# JSONL files captured before the legibility header migration. The live
+# renderer no longer emits this -- new code must NOT regex this against
+# fresh /context responses.
+LEGACY_GENE_SRC_RE = re.compile(r'<GENE src="([^"]+)"[^>]*>', re.DOTALL)
+LEGACY_GENE_BLOCK_RE = re.compile(
+    r'<GENE src="([^"]+)"[^>]*>(.*?)</GENE>', re.DOTALL,
+)
+
+
+def _coerce_top_entry(payload: Any) -> dict:
+    """Return the first dict-like entry from a /context response.
+
+    `/context` returns a list (``[response]``). Some historical captures
+    serialized just the inner dict. Accept either form so callers can
+    pass `response.json()` directly without unwrapping.
+    """
+    if isinstance(payload, list):
+        return payload[0] if payload and isinstance(payload[0], dict) else {}
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def _extract_content(entry: dict) -> str:
+    """Best-effort content string for legacy fallback parsing."""
+    return (
+        entry.get("content")
+        or entry.get("expressed_context")
+        or ""
+    )
+
+
+def extract_citations(payload: Any) -> list[dict]:
+    """Return the structured ``agent.citations`` list, or [].
+
+    Preferred entry point for benchmarks that want per-document metadata
+    (gene_id + source + score). Returns ``[]`` for unrecognized payloads.
+    """
+    entry = _coerce_top_entry(payload)
+    agent = entry.get("agent") or {}
+    citations = agent.get("citations")
+    if isinstance(citations, list):
+        # Defensive: only keep dict entries
+        return [c for c in citations if isinstance(c, dict)]
+    return []
+
+
+def extract_sources(payload: Any) -> list[str]:
+    """Return delivered source identifiers from a /context response.
+
+    Priority:
+      1. ``agent.citations[].source`` -- modern, structured (since
+         routes_context.py introduced the citations payload).
+      2. Legacy ``<GENE src="...">`` regex against the content string
+         -- only used when no structured citations exist (historical
+         JSONL replays).
+
+    Empty / blank source strings are dropped. Order is preserved.
+    Duplicates are NOT deduplicated -- callers can dedupe if they need
+    set semantics; preserving order + multiplicity matches what the
+    previous regex-based code returned.
+    """
+    citations = extract_citations(payload)
+    if citations:
+        sources = [str(c.get("source") or "") for c in citations]
+        return [s for s in sources if s]
+
+    # Legacy fallback (historical JSONL files only).
+    entry = _coerce_top_entry(payload)
+    content = _extract_content(entry)
+    if not content:
+        return []
+    return LEGACY_GENE_SRC_RE.findall(content)
+
+
+def extract_gene_ids(payload: Any) -> list[str]:
+    """Return delivered gene_ids from the structured citations payload.
+
+    Legacy ``<GENE src=...>`` markup did not include gene_ids, so the
+    fallback path returns ``[]``.
+    """
+    citations = extract_citations(payload)
+    return [str(c.get("gene_id") or "") for c in citations if c.get("gene_id")]
+
+
+def parse_legacy_gene_blocks(content: str) -> list[tuple[str, str]]:
+    """Return (src, body) tuples from legacy ``<GENE src=...>`` markup.
+
+    Used by bench_needle.py's body-substring checks against historical
+    JSONL replays. For modern responses, the per-document body is not
+    inline in the content blob -- callers that need body text should
+    re-fetch via /context/expand or read the source file directly.
+    """
+    if not content:
+        return []
+    return LEGACY_GENE_BLOCK_RE.findall(content)
+
+
+# Modern legibility header (see helix_context/encoding/legibility.py):
+#   [gene=abc12345... ◆ fired=harmonic:2.3,lex_anchor:1.1 1200→320c]
+# The trailing chars in the gene_id may include any non-bracket chars; the
+# id field stops at the first space (legibility writes ``[gene={short} {symbol}``).
+LEGIBILITY_HEADER_RE = re.compile(r"\[gene=([^\s\]]+)[^\]]*\]", re.DOTALL)
+
+
+def extract_block_bodies(payload: Any) -> list[tuple[str, str, str]]:
+    """Return (source, gene_id, body) tuples for every delivered document.
+
+    For modern responses, the content blob is the assembled splice
+    output -- one legibility header line followed by spliced text, blocks
+    separated by ``\\n---\\n``. We split on ``---``, strip the header
+    from each block, and pair each body with the matching
+    ``agent.citations`` entry (by order, which is the contract: the
+    renderer writes citations in delivery order).
+
+    For legacy responses, falls back to ``<GENE src=...>...</GENE>``
+    block extraction with empty gene_ids.
+
+    Used by bench_needle.py to perform word-boundary matches against
+    each delivered document body (the "what the consumer actually sees"
+    metric).
+    """
+    citations = extract_citations(payload)
+    entry = _coerce_top_entry(payload)
+    content = _extract_content(entry)
+
+    if citations:
+        # Split content on the per-block separator. Some prefix material
+        # (e.g. an outer ``<expressed_context>`` wrapper) may precede the
+        # first block; ignore blocks whose body doesn't start with a
+        # legibility header, since they cannot be confidently paired.
+        raw_blocks = (content or "").split("\n---\n")
+        paired: list[tuple[str, str, str]] = []
+        body_iter = iter(raw_blocks)
+        for cit_obj in citations:
+            source = str(cit_obj.get("source") or "")
+            gene_id = str(cit_obj.get("gene_id") or "")
+            body = ""
+            for raw in body_iter:
+                stripped = raw.lstrip()
+                if LEGIBILITY_HEADER_RE.match(stripped):
+                    # Remove the header line from the body.
+                    body = LEGIBILITY_HEADER_RE.sub("", stripped, count=1).lstrip("\n")
+                    break
+            paired.append((source, gene_id, body))
+        return paired
+
+    # Legacy fallback: gene_id was never in the markup.
+    return [(src, "", body) for src, body in parse_legacy_gene_blocks(content)]
+
+
+def normalize_sources(sources: Iterable[str]) -> list[str]:
+    """Forward-slash normalize + lowercase for path comparison.
+
+    Convenience wrapper for callers that compare delivered paths
+    against gold-source substrings.
+    """
+    return [(s or "").replace("\\", "/").lower() for s in sources]

--- a/benchmarks/bench_helix_rag_composition.py
+++ b/benchmarks/bench_helix_rag_composition.py
@@ -72,7 +72,10 @@ MAIN_DB_PATH = os.environ.get(
     "HELIX_MAIN_DB_PATH",
     str(Path(__file__).resolve().parents[1] / "genomes" / "main.db"),
 )
-GENE_SRC_RE = re.compile(r'<GENE src="([^"]+)"')
+# All cells in this bench resolve delivered source_ids from
+# /context/packet items (already structured) rather than regexing the
+# /context content string. The legacy ``<GENE src=...>`` markup is no
+# longer in live responses (see issue #101 + benchmarks/_citations.py).
 
 # FTS5 has a tokenizer but natural-language queries aren't valid MATCH
 # syntax (operators like "what", "does" are fine as literal tokens but

--- a/benchmarks/bench_multi_needle.py
+++ b/benchmarks/bench_multi_needle.py
@@ -21,18 +21,22 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 import time
 from pathlib import Path
 from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import httpx  # noqa: E402
 
+import _citations  # noqa: E402
+
 HELIX_URL = os.environ.get("HELIX_URL", "http://127.0.0.1:11437")
-GENE_SRC_RE = re.compile(r'<GENE src="([^"]+)"')
+# Legacy regex retained for historical JSONL inspection only -- modern
+# /context responses surface sources via ``agent.citations`` (issue #101).
+GENE_SRC_RE = _citations.LEGACY_GENE_SRC_RE
 
 
 # Each needle requires ALL groups to be delivered for full recall.
@@ -119,7 +123,12 @@ def _norm(s: str) -> str:
 
 def fetch_delivered_srcs(client: httpx.Client, query: str,
                          task_type: str = "explain") -> tuple[list[str], dict]:
-    """Issue /context, return (delivered source_ids, context_health)."""
+    """Issue /context, return (delivered source_ids, context_health).
+
+    Sources come from ``agent.citations`` on modern responses; falls back
+    to legacy ``<GENE src=...>`` regex on historical JSONL inputs
+    (issue #101).
+    """
     r = client.post(
         f"{HELIX_URL}/context",
         json={"query": query, "task_type": task_type, "read_only": True},
@@ -127,18 +136,15 @@ def fetch_delivered_srcs(client: httpx.Client, query: str,
     )
     r.raise_for_status()
     payload = r.json()
+    # context_health lives on the first entry of the list-wrapped response.
     if isinstance(payload, list):
-        content = "\n".join(
-            b.get("content", "") for b in payload if isinstance(b, dict)
-        )
-        health = {}
+        first = payload[0] if payload and isinstance(payload[0], dict) else {}
+        health = first.get("context_health") or {}
     elif isinstance(payload, dict):
-        content = payload.get("expressed_context") or payload.get("content") or ""
         health = payload.get("context_health") or {}
     else:
-        content = ""
         health = {}
-    srcs = GENE_SRC_RE.findall(content)
+    srcs = _citations.extract_sources(payload)
     return srcs, health
 
 

--- a/benchmarks/bench_needle.py
+++ b/benchmarks/bench_needle.py
@@ -22,8 +22,12 @@ import os
 import re
 import sys
 import time
+from pathlib import Path
 
 import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _citations  # noqa: E402
 
 HELIX_URL = os.environ.get("HELIX_URL", "http://127.0.0.1:11437")
 
@@ -123,21 +127,33 @@ NEEDLES = [
 
 # ── Gold-gene delivery check (Waude diagnostic 2026-04-17) ────────────
 
-GENE_BLOCK_RE = re.compile(
-    r'<GENE src="([^"]+)"[^>]*>(.*?)</GENE>', re.DOTALL,
-)
+# Legacy assembly markup -- retained as a fallback for historical JSONL
+# inputs. The live /context renderer emits ``[gene=...]`` legibility
+# headers + structured ``agent.citations`` instead (see issue #101).
+# `benchmarks/_citations.py` is the canonical parser.
+GENE_BLOCK_RE = _citations.LEGACY_GENE_BLOCK_RE
 
 
 def parse_delivered_genes(content: str):
-    """Extract (src, body) tuples from the delivered /context payload.
+    """Extract (src, body) tuples from a legacy content string.
 
-    Helix embeds each expressed gene as ``<GENE src="path/to/file"
-    facts="...">BODY</GENE>``. Parsing these gives an honest list of
-    what was actually delivered, rather than relying on substring
-    match against the whole payload (which picks up URL ports and
-    compression metadata — see waude_diagnostic_2026-04-17.md).
+    Kept for historical JSONL inspection. For live /context responses,
+    use ``parse_delivered_genes_from_response`` -- modern payloads carry
+    structured citations at ``response[0]["agent"]["citations"]`` and no
+    longer embed ``<GENE src=...>`` markup in ``content``.
     """
-    return GENE_BLOCK_RE.findall(content or "")
+    return _citations.parse_legacy_gene_blocks(content or "")
+
+
+def parse_delivered_genes_from_response(payload):
+    """Extract (src, body) tuples from a /context response.
+
+    Prefers ``agent.citations`` + the corresponding per-block bodies
+    parsed from the legibility-headered content blob. Falls back to the
+    legacy ``<GENE>...</GENE>`` regex when no structured citations are
+    present (historical JSONL replays).
+    """
+    return [(src, body) for src, _gid, body in _citations.extract_block_bodies(payload)]
 
 
 def _body_contains_accept(body: str, accept) -> bool:
@@ -154,10 +170,15 @@ def _body_contains_accept(body: str, accept) -> bool:
     return False
 
 
-def check_gold_delivery(content: str, gold_sources, accept):
+def check_gold_delivery(content: str, gold_sources, accept, *, response=None):
     """Honest delivery check for a needle.
 
-    Returns a dict with two independent dimensions:
+    Pass ``response`` for live /context payloads (modern shape with
+    ``agent.citations``). ``content`` is retained as a fallback so the
+    helper still works on historical JSONL records whose only artifact
+    is the inline assembly string.
+
+    Returns a dict with these dimensions:
       - ``gold_delivered``: gold source file is in delivered top-K
         (the retrieval-rank metric — addresses D-category failures
         directly, per Waude diagnostic 2026-04-17)
@@ -170,7 +191,10 @@ def check_gold_delivery(content: str, gold_sources, accept):
         fires BUT no gene body has a word-boundary match (i.e.,
         the match is pure metadata/header/URL noise)
     """
-    blocks = parse_delivered_genes(content)
+    if response is not None:
+        blocks = parse_delivered_genes_from_response(response)
+    else:
+        blocks = parse_delivered_genes(content)
 
     def src_matches(src: str) -> bool:
         src_norm = src.replace("\\", "/").lower()
@@ -242,10 +266,17 @@ def find_needle(client, needle):
     # the answer's source file to be in the delivered gene set AND
     # that block's body to contain an accept substring. Fall back to
     # payload substring if a needle has no gold_source defined.
+    #
+    # The full ``data`` (list-wrapped response) is passed through so the
+    # citation parser can read ``agent.citations`` for modern responses
+    # and fall back to legacy ``<GENE src=...>`` markup automatically
+    # (issue #101).
     accept = needle.get("accept", [needle["expected"]])
     gold_sources = needle.get("gold_source", [])
     if gold_sources:
-        gold = check_gold_delivery(content, gold_sources, accept)
+        gold = check_gold_delivery(
+            content, gold_sources, accept, response=data,
+        )
         # Primary metric: does any delivered gene BODY contain the
         # answer with word-boundary match. This is what the consumer
         # actually sees, minus metadata/URL false positives.
@@ -261,7 +292,7 @@ def find_needle(client, needle):
         gold_has_answer = found_in_context
         false_positive = False
         n_gold_blocks = 0
-        n_delivered_blocks = len(parse_delivered_genes(content))
+        n_delivered_blocks = len(parse_delivered_genes_from_response(data))
 
     # Step 2: Full proxy query for answer accuracy
     t1 = time.time()

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -6,7 +6,9 @@ Full reference for all HTTP endpoints exposed by the helix server at `http://loc
 
 ### POST /context
 
-Retrieve and compress context for a query. Returns `expressed_context` (assembled, compressed window) and `ContextHealth` metadata.
+Retrieve and compress context for a query. Returns the assembled, compressed
+content blob, structured per-document citations, `ContextHealth` metadata,
+and an agent-mode `know`/`miss` block.
 
 **Request:**
 ```json
@@ -19,19 +21,48 @@ Retrieve and compress context for a query. Returns `expressed_context` (assemble
 }
 ```
 
-**Response:**
+**Response:** a single-element list wrapping the response dict.
+
 ```json
-{
-  "expressed_context": "<GENE src=\"...\">...</GENE>",
-  "genes_expressed": 5,
-  "budget_tier": "focused",
-  "context_health": {
-    "retrieval_rate": 1.0,
-    "top_score": 8.3,
-    "score_ratio": 4.1
+[
+  {
+    "name": "Helix Genome Context",
+    "description": "5 genes expressed, 4.2x compression, health=aligned (Δε=0.32)",
+    "content": "[gene=abc12345 ◆ fired=harmonic:2.3,lex_anchor:1.1 1200→320c]\nspliced text...\n---\n[gene=def67890 ◇ fired=sema_boost:1.8 180c]\n...",
+    "context_health": {
+      "status": "aligned",
+      "ellipticity": 0.32,
+      "genes_expressed": 5,
+      "genes_available": 12
+    },
+    "agent": {
+      "recommendation": "trust",
+      "hint": "Context is well-grounded. Use directly.",
+      "citations": [
+        {"gene_id": "abc12345abc1", "source": "path/to/file.py", "score": 1.42},
+        {"gene_id": "def67890def6", "source": "README.md", "score": 0.93}
+      ],
+      "latency_ms": 87.4,
+      "total_tokens_est": 1820,
+      "compression_ratio": 4.2,
+      "budget_tier": "focused"
+    },
+    "know": {"found": true, "confidence": 0.74, "gene_id_match": "abc12345abc1"}
   }
-}
+]
 ```
+
+Per-document metadata lives in `agent.citations[]` (gene_id, source,
+score, optional `authored_by_party`/`authored_by_handle`). The inline
+`[gene=...]` headers in `content` are the legibility-header format
+described in `helix_context/encoding/legibility.py`.
+
+> **Note (legacy format).** Helix used to embed each delivered document
+> as `<GENE src="...">BODY</GENE>` inside `expressed_context`. The live
+> renderer no longer emits that markup; parsers should consume
+> `agent.citations` instead. The `<GENE src=...>` form survives only in
+> historical JSONL captures -- see `benchmarks/_citations.py` for the
+> shared parser that handles both shapes.
 
 ### POST /context/packet
 

--- a/docs/architecture/KNOWLEDGE_GRAPH.md
+++ b/docs/architecture/KNOWLEDGE_GRAPH.md
@@ -188,16 +188,30 @@ Step 4 — Compression (Headroom)
     ...
 
 Step 5 — Assembly
-    <expressed_context>
-      <GENE src="fleet/skills/auth.py" score="0.89" facts="token_expiry=30m...">
-        compressed auth middleware content...
-      </GENE>
-      <GENE src="fleet/session_manager.py" score="0.72" facts="store=redis...">
-        compressed session content...
-      </GENE>
+    response[0].content:
+      [gene=abc12345 ◆ fired=harmonic:2.3,sema_boost:1.4 3200→980c]
+      compressed auth middleware content...
+      ---
+      [gene=def67890 ◇ fired=harmonic:1.8,working_set:0.5 2100→720c]
+      compressed session content...
       ...
-    </expressed_context>
+
+    response[0].agent.citations:
+      [
+        {"gene_id": "abc12345...", "source": "fleet/skills/auth.py",   "score": 0.89},
+        {"gene_id": "def67890...", "source": "fleet/session_manager.py", "score": 0.72},
+        ...
+      ]
 ```
+
+Per-document metadata (gene_id, source path, score, optional attribution)
+lives in `agent.citations[]`. The inline `[gene=...]` headers are the
+legibility-header format defined in `helix_context/encoding/legibility.py`.
+
+> The pre-2026-05 renderer emitted `<GENE src="..." score="..." facts="...">BODY</GENE>`
+> blocks inline. That markup is gone from live `/context` responses;
+> historical JSONL files still carry it and are parseable via the
+> legacy fallback in `benchmarks/_citations.py`.
 
 ---
 

--- a/docs/ops/SKILLS_BUNDLE.md
+++ b/docs/ops/SKILLS_BUNDLE.md
@@ -180,7 +180,12 @@ Retrieval query `"review this PR for security issues"` would:
 1. Match tags `code`, `review`, `security`
 2. Score via cymatics resonance on frequency spectrum
 3. Compress via Headroom Kompress to ~1000 chars
-4. Deliver as `<GENE src="skills/code_review.md">...</GENE>`
+4. Deliver under `response[0].content` with a `[gene=a7f3b2c1 ◆ fired=...]`
+   legibility header, plus a `{"gene_id": "a7f3b2c1...", "source":
+   "skills/code_review.md", "score": ...}` entry in
+   `response[0].agent.citations[]`. (The legacy `<GENE src=...>...</GENE>`
+   inline markup is retained only for historical JSONL inspection -- see
+   `benchmarks/_citations.py`.)
 
 ---
 

--- a/scripts/diagnose_file_grain.py
+++ b/scripts/diagnose_file_grain.py
@@ -14,38 +14,37 @@ Usage:
 from __future__ import annotations
 
 import json
-import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "benchmarks"))
 
 import httpx  # noqa: E402
+
+import _citations  # noqa: E402
 
 from benchmarks.bench_needle import NEEDLES  # noqa: E402
 from helix_context.accel import extract_query_signals  # noqa: E402
 from helix_context.genome import file_tokens, path_tokens  # noqa: E402
 
 HELIX_URL = "http://localhost:11437"
-GENE_SRC_RE = re.compile(r'<GENE src="([^"]+)"')
 
 
 def fetch_delivered_srcs(client: httpx.Client, query: str) -> list[str]:
+    """Return delivered source paths from /context for `query`.
+
+    Sources come from the structured ``agent.citations`` payload on
+    modern responses; falls back to legacy ``<GENE src=...>`` regex on
+    historical JSONL replays (issue #101).
+    """
     r = client.post(
         f"{HELIX_URL}/context",
         json={"query": query, "task_type": "explain"},
         timeout=60,
     )
     r.raise_for_status()
-    payload = r.json()
-    # /context returns list-of-blocks; each has .content with embedded <GENE> tags
-    if isinstance(payload, list):
-        content = "\n".join(b.get("content", "") for b in payload if isinstance(b, dict))
-    elif isinstance(payload, dict):
-        content = payload.get("expressed_context") or payload.get("content") or ""
-    else:
-        content = ""
-    return GENE_SRC_RE.findall(content)
+    return _citations.extract_sources(r.json())
 
 
 def coverage(q_set: set, srcs: list[str], token_fn) -> float:

--- a/tests/test_bench_citations.py
+++ b/tests/test_bench_citations.py
@@ -1,0 +1,237 @@
+"""Regression tests for the shared benchmark citation parser.
+
+Closes https://github.com/mbachaud/helix-context/issues/101 -- the bench
+parsers were still regexing for legacy ``<GENE src="...">`` markup that
+the live renderer no longer emits, causing retrieval hit-rates to look
+artificially low. The helper now prefers ``agent.citations[].source``
+and falls back to the legacy regex only for historical JSONL inputs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make benchmarks/ importable without packaging it (matches the
+# convention used by test_bench_harvest.py).
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+sys.path.insert(0, str(BENCH_DIR))
+
+import _citations as cit  # noqa: E402
+
+
+# ─── Fixtures: minimal but realistic /context response shapes ──────────
+
+
+def _modern_response() -> list[dict]:
+    """Approximation of the live /context response shape.
+
+    Source: helix_context/server/routes_context.py builds ``response``
+    as a dict and returns ``[response]`` at line 533. The ``agent.citations``
+    payload is populated from genes table rows (see lines 317-359).
+    """
+    return [{
+        "name": "Helix Genome Context",
+        "description": "2 genes expressed, 4.2x compression",
+        "content": (
+            "[gene=abc12345... ◆ fired=harmonic:2.3,lex_anchor:1.1 1200→320c]\n"
+            "spliced text from document 1\n"
+            "---\n"
+            "[gene=def67890... ◇ fired=sema_boost:1.8 180c]\n"
+            "spliced text from document 2\n"
+        ),
+        "context_health": {"status": "aligned", "ellipticity": 0.32},
+        "agent": {
+            "recommendation": "trust",
+            "hint": "Context is well-grounded. Use directly.",
+            "citations": [
+                {
+                    "gene_id": "abc12345abc12345",
+                    "source": "helix-context/helix.toml",
+                    "score": 1.42,
+                },
+                {
+                    "gene_id": "def67890def67890",
+                    "source": "helix-context/README.md",
+                    "score": 0.93,
+                },
+            ],
+        },
+    }]
+
+
+def _legacy_response() -> list[dict]:
+    """Pre-migration capture: legibility headers + agent.citations absent.
+
+    This is what historical JSONL files look like -- only the inline
+    ``<GENE src=...>...</GENE>`` markup survives in the content blob.
+    """
+    return [{
+        "name": "Helix Genome Context",
+        "content": (
+            "<expressed_context>\n"
+            '<GENE src="helix-context/helix.toml" facts="port=11437">\n'
+            "The helix proxy listens on port 11437.\n"
+            "</GENE>\n"
+            '<GENE src="helix-context/README.md" facts="pipeline=6">\n'
+            "Six-step expression pipeline.\n"
+            "</GENE>\n"
+            "</expressed_context>\n"
+        ),
+        "context_health": {"status": "aligned"},
+    }]
+
+
+# ─── Modern shape: structured citations win ────────────────────────────
+
+
+def test_modern_response_returns_citation_sources():
+    sources = cit.extract_sources(_modern_response())
+    assert sources == [
+        "helix-context/helix.toml",
+        "helix-context/README.md",
+    ]
+
+
+def test_modern_response_returns_gene_ids():
+    ids = cit.extract_gene_ids(_modern_response())
+    assert ids == ["abc12345abc12345", "def67890def67890"]
+
+
+def test_modern_response_returns_full_citation_dicts():
+    citations = cit.extract_citations(_modern_response())
+    assert len(citations) == 2
+    assert citations[0]["source"] == "helix-context/helix.toml"
+    assert citations[0]["score"] == 1.42
+
+
+def test_modern_response_unwrapped_dict_also_works():
+    """Some callers may pass response[0] directly instead of the wrapper list."""
+    entry = _modern_response()[0]
+    assert cit.extract_sources(entry) == [
+        "helix-context/helix.toml",
+        "helix-context/README.md",
+    ]
+
+
+# ─── Legacy fallback: regex on content string ──────────────────────────
+
+
+def test_legacy_response_falls_back_to_regex():
+    """No agent.citations → use <GENE src="..."> markup from content."""
+    sources = cit.extract_sources(_legacy_response())
+    assert sources == [
+        "helix-context/helix.toml",
+        "helix-context/README.md",
+    ]
+
+
+def test_legacy_response_no_gene_ids_returned():
+    """Legacy markup doesn't carry gene_ids; helper must return empty."""
+    ids = cit.extract_gene_ids(_legacy_response())
+    assert ids == []
+
+
+def test_legacy_block_parser_returns_src_and_body():
+    """parse_legacy_gene_blocks is used by needle body-substring checks."""
+    content = _legacy_response()[0]["content"]
+    blocks = cit.parse_legacy_gene_blocks(content)
+    assert len(blocks) == 2
+    assert blocks[0][0] == "helix-context/helix.toml"
+    assert "port 11437" in blocks[0][1]
+
+
+# ─── Edge cases: empty / malformed inputs must not crash ───────────────
+
+
+def test_empty_response_returns_empty_list():
+    assert cit.extract_sources([]) == []
+    assert cit.extract_sources({}) == []
+    assert cit.extract_sources(None) == []
+
+
+def test_empty_citations_array_returns_empty_list():
+    payload = [{"content": "", "agent": {"citations": []}}]
+    assert cit.extract_sources(payload) == []
+
+
+def test_citations_with_empty_source_strings_filtered():
+    payload = [{
+        "agent": {
+            "citations": [
+                {"gene_id": "a", "source": ""},
+                {"gene_id": "b", "source": "real/path.py"},
+                {"gene_id": "c"},  # missing source key
+            ]
+        }
+    }]
+    assert cit.extract_sources(payload) == ["real/path.py"]
+
+
+def test_no_content_and_no_citations_returns_empty():
+    """A degenerate response with neither structured citations nor any
+    content string must not raise."""
+    payload = [{"name": "Helix Genome Context"}]
+    assert cit.extract_sources(payload) == []
+    assert cit.extract_citations(payload) == []
+    assert cit.extract_gene_ids(payload) == []
+
+
+def test_unrecognized_payload_type_returns_empty():
+    assert cit.extract_sources("not a dict or list") == []
+    assert cit.extract_sources(42) == []
+
+
+def test_normalize_sources_lowercases_and_forward_slashes():
+    raw = ["Helix-Context\\helix.toml", "EDUCATION/CLAUDE.md", ""]
+    assert cit.normalize_sources(raw) == [
+        "helix-context/helix.toml",
+        "education/claude.md",
+        "",
+    ]
+
+
+# ─── Cross-check: agent.citations always wins over inline legacy markup ──
+
+
+def test_modern_response_with_legacy_markup_still_in_content():
+    """A response that has BOTH structured citations AND (somehow)
+    leftover legacy markup in content must prefer the structured path."""
+    payload = [{
+        "content": '<GENE src="WRONG/legacy.py">stale</GENE>',
+        "agent": {
+            "citations": [
+                {"gene_id": "x", "source": "CORRECT/modern.py"},
+            ],
+        },
+    }]
+    assert cit.extract_sources(payload) == ["CORRECT/modern.py"]
+
+
+# ─── Block-body extraction: pair citations with spliced text ───────────
+
+
+def test_modern_block_bodies_paired_with_citations():
+    """Modern responses: split content on ``---``, strip legibility
+    headers, pair each body with its citation by order."""
+    blocks = cit.extract_block_bodies(_modern_response())
+    assert len(blocks) == 2
+    assert blocks[0][0] == "helix-context/helix.toml"        # source
+    assert blocks[0][1] == "abc12345abc12345"                 # gene_id
+    assert "spliced text from document 1" in blocks[0][2]    # body
+    assert blocks[1][0] == "helix-context/README.md"
+    assert "spliced text from document 2" in blocks[1][2]
+
+
+def test_legacy_block_bodies_fallback():
+    """Legacy responses: bodies come from <GENE>...</GENE>; gene_id empty."""
+    blocks = cit.extract_block_bodies(_legacy_response())
+    assert len(blocks) == 2
+    assert blocks[0][0] == "helix-context/helix.toml"
+    assert blocks[0][1] == ""  # legacy markup has no gene_id
+    assert "port 11437" in blocks[0][2]
+
+
+def test_empty_block_bodies_no_crash():
+    assert cit.extract_block_bodies([]) == []
+    assert cit.extract_block_bodies({}) == []


### PR DESCRIPTION
## Summary

Benchmark + diagnostic parsers were still regexing `<GENE src="...">` from the `/context` content blob, but the live renderer migrated to `[gene=...]` legibility headers + structured `agent.citations` long ago. The legacy regex matched nothing on modern responses, so retrieval hit-rates looked artificially low (issue #101 cites "1-3/10" as a possible bogus reading).

- New shared helper: `benchmarks/_citations.py` -- prefers `agent.citations[].source`, falls back to legacy regex for historical JSONL replays only.
- Refactors:
  - `benchmarks/bench_needle.py` -- routes `parse_delivered_genes` + `check_gold_delivery` through the helper; new `parse_delivered_genes_from_response` pairs citations with spliced bodies via the `[gene=...]` headers.
  - `benchmarks/bench_multi_needle.py` -- `fetch_delivered_srcs` now reads `agent.citations`.
  - `benchmarks/bench_helix_rag_composition.py` -- removed a dead `GENE_SRC_RE` constant (the cells already used structured `/context/packet` items; the regex was unreferenced).
  - `scripts/diagnose_file_grain.py` -- pulls sources from citations.
- Docs refresh: `docs/api/endpoints.md`, `docs/architecture/KNOWLEDGE_GRAPH.md`, `docs/ops/SKILLS_BUNDLE.md` now describe the modern shape and note the legacy form is retained only for JSONL inspection.

## Test plan

- [x] `python -m pytest tests/test_bench_citations.py -v` -- 17 new tests cover modern, legacy, empty, malformed, and mixed payloads.
- [x] `python -m pytest tests/test_bench_harvest.py tests/test_clean_isolation.py -v` -- adjacent bench tests still pass (41 total).
- [x] `python -m pytest tests/test_server.py::TestContextCitationEnrichment -v` -- existing live citation enrichment tests unaffected.
- [x] `git grep '<GENE src' -- '*.py' '*.md'` outside `docs/archive/`: only docstring/comment mentions remain, all explicitly describing the legacy-fallback contract.

Live benchmark runs were intentionally skipped (slow/expensive); the regression test fixtures cover the parse paths the live runs exercise.

Closes #101

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>