### PR TITLE
fix(sharded): deterministic citation lookup across cross-shard gene_ids

### DIFF
--- a/helix_context/sharding.py
+++ b/helix_context/sharding.py
@@ -304,13 +304,22 @@ class ShardedGenomeAdapter:
             return {}
         import json as _json
         ph = ",".join("?" * len(gene_ids))
+        # PR #103's composite PK (gene_id, shard_name) lets the same
+        # content-addressed id live in multiple shards. ORDER BY
+        # gene_id, shard_name + first-row-wins below picks the
+        # lexicographically smallest shard for each gene so the displayed
+        # source_id stays stable across calls and across runs.
         rows = self._router.main_conn.execute(
             f"SELECT gene_id, source_id, domains, entities "
-            f"FROM fingerprint_index WHERE gene_id IN ({ph})",
+            f"FROM fingerprint_index WHERE gene_id IN ({ph}) "
+            f"ORDER BY gene_id, shard_name",
             gene_ids,
         ).fetchall()
         out: dict = {}
         for r in rows:
+            gid = r["gene_id"]
+            if gid in out:
+                continue
             domains: List = []
             entities: List = []
             if r["domains"]:
@@ -323,7 +332,7 @@ class ShardedGenomeAdapter:
                     entities = list(_json.loads(r["entities"]) or [])
                 except Exception:
                     pass
-            out[r["gene_id"]] = {
+            out[gid] = {
                 "source_id": r["source_id"] or "",
                 "domains": domains,
                 "entities": entities,

--- a/tests/test_shard_router.py
+++ b/tests/test_shard_router.py
@@ -322,6 +322,79 @@ def test_sharded_get_citation_rows_unknown_id(two_shard_setup):
         adapter.close()
 
 
+def test_sharded_get_citation_rows_is_deterministic_across_shards(tmp_path):
+    """Regression for cross-shard non-determinism (follow-up to PR #103).
+
+    PR #103 changed ``fingerprint_index`` PK to composite
+    ``(gene_id, shard_name)``, so the same content-addressed gene_id may
+    legally appear in multiple shards (same byte stream ingested under
+    two source roots). ``get_citation_rows`` then sees N rows for that
+    id and the dict-build loop ``out[gid] = ...`` keeps whichever row
+    SQLite emits last — bench-reproducibility hazard even though the
+    citation content is byte-identical.
+
+    Contract: per gene_id, the row with the lexicographically smallest
+    ``shard_name`` wins. Stable across calls, stable across runs.
+    """
+    from helix_context.shard_schema import (
+        init_main_db,
+        open_main_db,
+        register_shard,
+        upsert_fingerprint,
+    )
+    from helix_context.sharding import ShardedGenomeAdapter
+
+    main_path = str(tmp_path / "main.db")
+    shard_a_path = str(tmp_path / "shard_a.db")
+    shard_b_path = str(tmp_path / "shard_b.db")
+
+    main = open_main_db(main_path)
+    init_main_db(main)
+    register_shard(main, "shard_a", "reference", shard_a_path, gene_count=1)
+    register_shard(main, "shard_b", "participant", shard_b_path, gene_count=1)
+
+    # Same gene_id, both shards, different source_ids — legal under
+    # composite PK. Insert ``shard_a`` first so the lexicographically
+    # smaller name has the *lower* rowid: with no ORDER BY the unfixed
+    # loop overwrites shard_a's row with shard_b's and reports the
+    # wrong (lex-larger) source_id.
+    gid = "d" * 64  # looks like a sha256 hex digest
+    upsert_fingerprint(
+        main, gene_id=gid, shard_name="shard_a",
+        source_id="/path/in/shard_a.md",
+        domains_json=json.dumps(["from_a"]),
+        entities_json=json.dumps(["a_entity"]),
+        key_values_json="[]",
+    )
+    upsert_fingerprint(
+        main, gene_id=gid, shard_name="shard_b",
+        source_id="/path/in/shard_b.md",
+        domains_json=json.dumps(["from_b"]),
+        entities_json=json.dumps(["b_entity"]),
+        key_values_json="[]",
+    )
+    main.close()
+
+    adapter = ShardedGenomeAdapter(main_path=main_path)
+    try:
+        results = [adapter.get_citation_rows([gid]) for _ in range(10)]
+    finally:
+        adapter.close()
+
+    # Stability: all 10 calls return identical maps.
+    first = results[0]
+    for i, r in enumerate(results[1:], start=1):
+        assert r == first, (
+            f"call {i} differs from call 0: "
+            f"{r[gid]['source_id']!r} vs {first[gid]['source_id']!r}"
+        )
+
+    # Determinism rule: smallest shard_name lexicographically wins.
+    assert first[gid]["source_id"] == "/path/in/shard_a.md"
+    assert first[gid]["domains"] == ["from_a"]
+    assert first[gid]["entities"] == ["a_entity"]
+
+
 def test_sharded_get_doc_alias_matches_get_gene(two_shard_setup):
     """`get_doc` and `get_gene` must be polymorphic with Genome so callers
     in routes_context / helpers don't have to branch on adapter type.


### PR DESCRIPTION
## Summary

- `ShardedGenomeAdapter.get_citation_rows` now uses `ORDER BY gene_id, shard_name` + first-row-wins, so the same content-addressed gene_id resolves to the same `source_id` every call.
- Regression test seeds one gene_id into two shards with different `source_id`s and asserts both stability across 10 calls and the lex-min determinism rule.

## Why

PR #103 changed `fingerprint_index`'s PK to composite `(gene_id, shard_name)`, which legitimately allows the same gene_id to live in multiple shards (same byte stream ingested under two source roots). After that change, `get_citation_rows` issued `WHERE gene_id IN (...)` with no ORDER BY and overwrote in a plain `out[gid] = ...` loop, so the displayed `source_id` depended on SQLite read order. The citation content is byte-identical so behavior was correct, but the non-determinism is a bench-reproducibility hazard. Flagged as non-blocking by the PR #103 review; this is the follow-up.

## What changed

`helix_context/sharding.py` — `get_citation_rows`:
- Added `ORDER BY gene_id, shard_name` to the SELECT.
- Added `if gid in out: continue` so the first row per gene wins (= lex-smallest shard).
- Inline comment explaining the determinism rule and the PR #103 link.

`tests/test_shard_router.py` — new test `test_sharded_get_citation_rows_is_deterministic_across_shards`:
- Manually seeds main.db with two registered shards and two `fingerprint_index` rows sharing the same gene_id but different `source_id`s.
- Inserts `shard_a` *first* so its rowid is lower than `shard_b`'s — defeats SQLite's typical rowid-order behavior so a regression in the loop overwrite would surface as the wrong (lex-larger) source.
- Calls `get_citation_rows([gid])` 10 times, asserts identical results across calls and asserts source_id == `/path/in/shard_a.md` (the lex-min rule).

## Verification

Verified RED→GREEN under TDD:
- Pre-fix: `AssertionError: assert '/path/in/shard_b.md' == '/path/in/shard_a.md'`
- Post-fix: passes.

Test suites run clean:
- `tests/test_shard_router.py` + `tests/test_shard_schema.py` + `tests/test_sharded_adapter_parity.py`: 45 / 45 pass.
- Broader citation/sharding sweep (`pytest -k "citation or sharding or shard" -m "not live"`): 84 / 84 pass.

## Test plan

- [x] New regression test fails before the fix, passes after.
- [x] All existing `get_citation_rows` / sharding tests still pass.
- [x] No change to `Genome.get_citation_rows` (single-shard path) — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)