### PR TITLE
fix(sharded): deterministic get_citation_rows for multi-shard gene_ids

### DIFF
--- a/helix_context/sharding.py
+++ b/helix_context/sharding.py
@@ -297,6 +297,17 @@ class ShardedGenomeAdapter:
         on the main routing connection's read path. Missing ids are
         absent from the returned map.
 
+        Determinism contract (PR #103 + #106 follow-up):
+            ``fingerprint_index`` PK is composite ``(gene_id, shard_name)``,
+            so the same content-addressed gene_id may appear in multiple
+            shards. We ``ORDER BY shard_name ASC`` and use ``setdefault``
+            in the dict-build loop, so the lexicographically minimum
+            ``shard_name`` always wins. Content is byte-identical across
+            shards (gene_id is sha256 of content), so the picked
+            ``source_id`` is a valid citation regardless — but the choice
+            is now stable across re-runs against the same fixture, which
+            matters for bench reproducibility.
+
         Return shape (per gene_id):
             ``{"source_id": str, "domains": list[str], "entities": list[str]}``
         """
@@ -306,11 +317,16 @@ class ShardedGenomeAdapter:
         ph = ",".join("?" * len(gene_ids))
         rows = self._router.main_conn.execute(
             f"SELECT gene_id, source_id, domains, entities "
-            f"FROM fingerprint_index WHERE gene_id IN ({ph})",
+            f"FROM fingerprint_index WHERE gene_id IN ({ph}) "
+            f"ORDER BY shard_name ASC",
             gene_ids,
         ).fetchall()
         out: dict = {}
         for r in rows:
+            # First-seen wins: rows are sorted by shard_name ASC above,
+            # so setdefault keeps the lexicographically minimum shard.
+            if r["gene_id"] in out:
+                continue
             domains: List = []
             entities: List = []
             if r["domains"]:

--- a/tests/test_shard_router.py
+++ b/tests/test_shard_router.py
@@ -322,6 +322,113 @@ def test_sharded_get_citation_rows_unknown_id(two_shard_setup):
         adapter.close()
 
 
+def test_sharded_get_citation_rows_multi_shard_is_deterministic(tmp_path):
+    """Regression for cross-shard duplicate gene_id determinism.
+
+    PR #103 changed ``fingerprint_index`` PK to composite
+    ``(gene_id, shard_name)``, making same-content cross-shard
+    duplicates legal rows. PR #106's ``ShardedGenomeAdapter
+    .get_citation_rows`` used ``WHERE gene_id IN (...)`` with no
+    ordering, so the row that survived the dict-build loop depended
+    on whatever order SQLite happened to return — non-deterministic
+    across runs (bench-reproducibility hazard).
+
+    Contract: lexicographically minimum ``shard_name`` wins. With
+    seeded shards ``shard_a`` and ``shard_b`` sharing the same
+    gene_id, the citation must always resolve to ``shard_a``'s
+    ``source_id`` no matter how many times we call.
+    """
+    import json
+    from helix_context.shard_schema import (
+        init_main_db,
+        open_main_db,
+        register_shard,
+        upsert_fingerprint,
+    )
+    from helix_context.sharding import ShardedGenomeAdapter
+
+    root = tmp_path
+    main_path = str(root / "main.db")
+    shard_a_path = str(root / "shard_a.db")
+    shard_b_path = str(root / "shard_b.db")
+
+    # Same content => same gene_id in both shards (content-addressed sha256).
+    content = "Cross-shard duplicate doc. Content is byte-identical."
+    ga = Genome(shard_a_path)
+    gene_a = _mk_gene(
+        content,
+        domains=["docs"],
+        entities=["helix"],
+        source="/shard_a/doc.md",
+    )
+    gid_a = ga.upsert_gene(gene_a, apply_gate=False)
+    ga.conn.close()
+    if ga._reader:
+        ga._reader.close()
+
+    gb = Genome(shard_b_path)
+    gene_b = _mk_gene(
+        content,
+        domains=["docs"],
+        entities=["helix"],
+        source="/shard_b/doc.md",
+    )
+    gid_b = gb.upsert_gene(gene_b, apply_gate=False)
+    gb.conn.close()
+    if gb._reader:
+        gb._reader.close()
+
+    # Both shards must produce the same gene_id (content-addressed). If
+    # this ever flips, the underlying assumption is broken and the test
+    # is no longer exercising the cross-shard duplicate path.
+    assert gid_a == gid_b, (
+        "test invariant: same content must produce same gene_id"
+    )
+    gene_id = gid_a
+
+    main = open_main_db(main_path)
+    init_main_db(main)
+    register_shard(main, "shard_a", "reference", shard_a_path, gene_count=1)
+    register_shard(main, "shard_b", "participant", shard_b_path, gene_count=1)
+    # Two fingerprint rows for the same gene_id — distinguishable only
+    # by shard_name and source_id.
+    upsert_fingerprint(
+        main, gene_id=gene_id, shard_name="shard_a",
+        source_id="/shard_a/doc.md",
+        domains_json=json.dumps(["docs"]),
+        entities_json=json.dumps(["helix"]),
+        key_values_json="[]",
+    )
+    upsert_fingerprint(
+        main, gene_id=gene_id, shard_name="shard_b",
+        source_id="/shard_b/doc.md",
+        domains_json=json.dumps(["docs"]),
+        entities_json=json.dumps(["helix"]),
+        key_values_json="[]",
+    )
+    main.close()
+
+    adapter = ShardedGenomeAdapter(main_path=main_path)
+    try:
+        seen_sources: set[str] = set()
+        for _ in range(10):
+            rows = adapter.get_citation_rows([gene_id])
+            assert gene_id in rows
+            seen_sources.add(rows[gene_id]["source_id"])
+
+        # Determinism: source_id never varies across 10 calls.
+        assert len(seen_sources) == 1, (
+            f"non-deterministic source_id across calls: {seen_sources}"
+        )
+        # Contract: lexicographically minimum shard_name wins.
+        # shard_a < shard_b, so /shard_a/doc.md must be the citation.
+        assert seen_sources == {"/shard_a/doc.md"}, (
+            f"expected shard_a source to win, got {seen_sources}"
+        )
+    finally:
+        adapter.close()
+
+
 def test_sharded_get_doc_alias_matches_get_gene(two_shard_setup):
     """`get_doc` and `get_gene` must be polymorphic with Genome so callers
     in routes_context / helpers don't have to branch on adapter type.


### PR DESCRIPTION
## Summary
- `ShardedGenomeAdapter.get_citation_rows` was non-deterministic when a `gene_id` lived in multiple shards. PR #103 made composite-PK `(gene_id, shard_name)` legal in `fingerprint_index`; PR #106 introduced `get_citation_rows` with `WHERE gene_id IN (...)` and no ordering. The dict-build loop silently kept whichever row SQLite happened to read last — fine for content (byte-identical across shards) but a bench-reproducibility hazard.
- Fix adds `ORDER BY shard_name ASC` and short-circuits already-populated keys (first-seen wins). Contract: the lexicographically minimum `shard_name` owns the citation.
- Blob `Genome.get_citation_rows` is untouched — the `genes` table is keyed on `gene_id` alone, so no cross-shard duplicate risk exists there.
- Regression test seeds two shards with the same content (so the same content-addressed `gene_id` appears twice in `fingerprint_index`), calls `get_citation_rows` 10x, and asserts the returned `source_id` is identical across all calls and points to the lexicographically minimum shard.

## Strategy
SQL `ORDER BY shard_name ASC` + Python `setdefault`-via-`continue` (first-seen wins). Simplest correct approach — single-line SQL change plus a guard in the loop. No window functions, no Python post-sort. Lex-min `shard_name` chosen as the deterministic winner because it's the most natural for SQLite to order on cheaply and is trivially explainable to future readers.

## Files changed
- `helix_context/sharding.py` — add `ORDER BY shard_name ASC`, skip already-populated keys, expand docstring with the determinism contract.
- `tests/test_shard_router.py` — add `test_sharded_get_citation_rows_multi_shard_is_deterministic`.

## Test plan
- [x] `python -m pytest tests/test_shard_router.py tests/test_shard_schema.py tests/test_sharded_adapter_parity.py -v` — 45/45 pass on this branch.
- [x] Stash `sharding.py`, run new test against unfixed master: fails with `AssertionError: expected shard_a source to win, got {'/shard_b/doc.md'}` — confirms the test catches the original bug.
- [x] Unstash, re-run: passes.
- [x] Existing single-shard `get_citation_rows` tests + blob-path test still pass — no regression.

## Context
- PR #103: changed `fingerprint_index` PK from `gene_id` to `(gene_id, shard_name)`, made cross-shard duplicates legal.
- PR #106: introduced `ShardedGenomeAdapter.get_citation_rows` polymorphic with `Genome.get_citation_rows`.
- This PR closes the determinism gap between those two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)