### PR TITLE
fix(sharding): composite PK on source_index for cross-shard gene_ids

### DIFF
--- a/helix_context/context_packet.py
+++ b/helix_context/context_packet.py
@@ -60,11 +60,24 @@ def _lookup_source_row(
     main_conn: sqlite3.Connection | None,
     gene_id: str,
 ) -> sqlite3.Row | None:
+    """Fetch the most-recently-verified source_index row for this gene_id.
+
+    source_index PK is composite (gene_id, shard_name) — the same
+    content-addressed gene_id can live in multiple shards (identical
+    content under different source roots). For packet-builder purposes
+    we want the freshest provenance copy, so we order by
+    ``last_verified_at`` (then ``updated_at`` as tiebreaker) descending
+    and take the first row. Falls back to ``updated_at`` when the row
+    has never been verified. Returns None if the table is unavailable
+    or no row matches.
+    """
     if main_conn is None:
         return None
     try:
         return main_conn.execute(
-            "SELECT * FROM source_index WHERE gene_id = ?",
+            "SELECT * FROM source_index WHERE gene_id = ? "
+            "ORDER BY COALESCE(last_verified_at, 0) DESC, updated_at DESC "
+            "LIMIT 1",
             (gene_id,),
         ).fetchone()
     except sqlite3.OperationalError:

--- a/helix_context/shard_schema.py
+++ b/helix_context/shard_schema.py
@@ -132,10 +132,17 @@ def _create_source_index(cur: sqlite3.Cursor) -> None:
     Lightweight metadata only. This lets the agent-context layer answer
     freshness and authority questions without reopening every shard or
     loading bulk document content.
+
+    PK is composite (gene_id, shard_name): gene_id is content-addressed
+    (sha256 of content), so the same content under different source roots
+    yields the same gene_id in different shards. Keying on gene_id alone
+    would overwrite cross-shard duplicates and silently lose per-shard
+    provenance (source_id, repo_root, mtime, observed_at). Same fix as
+    PR #103 applied to fingerprint_index.
     """
     cur.execute("""
     CREATE TABLE IF NOT EXISTS source_index (
-        gene_id           TEXT PRIMARY KEY,
+        gene_id           TEXT NOT NULL,
         shard_name        TEXT NOT NULL REFERENCES shards(shard_name),
         source_id         TEXT,
         repo_root         TEXT,
@@ -148,7 +155,8 @@ def _create_source_index(cur: sqlite3.Cursor) -> None:
         support_span      TEXT,
         last_verified_at  REAL,
         invalidated_at    REAL,
-        updated_at        REAL NOT NULL
+        updated_at        REAL NOT NULL,
+        PRIMARY KEY (gene_id, shard_name)
     )
     """)
     cur.execute(

--- a/tests/test_context_packet.py
+++ b/tests/test_context_packet.py
@@ -110,6 +110,75 @@ def test_source_index_metadata_overrides_gene_metadata():
         genome.close()
 
 
+def test_source_index_cross_shard_lookup_picks_freshest_verified():
+    """When the same gene_id has source_index rows in multiple shards
+    (content-addressed gene_id ingested under different source roots),
+    _lookup_source_row must pick the freshest-verified copy
+    deterministically, not whichever fetchone() happens to surface.
+
+    Regression for the source_index cross-shard composite-PK fix: prior
+    to that change, only one row survived. After the fix, the reader
+    selects the one with the highest last_verified_at.
+    """
+    now_ts = 40_000.0
+    genome = Genome(":memory:")
+    main_conn = open_main_db(":memory:")
+    init_main_db(main_conn)
+    register_shard(main_conn, "stale_shard", "reference", ":memory:")
+    register_shard(main_conn, "fresh_shard", "reference", ":memory:")
+
+    try:
+        gene = make_gene("JWT configuration lives here", domains=["jwt", "config"])
+        gene.source_id = "/repo/docs/auth.md"
+        gene.source_kind = "doc"
+        gene.volatility_class = "stable"
+        gene.authority_class = "primary"
+        gene.last_verified_at = now_ts - 60.0
+        gene_id = genome.upsert_gene(gene, apply_gate=False)
+
+        # Stale copy in one shard
+        upsert_source_index(
+            main_conn,
+            gene_id=gene_id,
+            shard_name="stale_shard",
+            source_id="/stale/auth.toml",
+            repo_root="/projects/stale",
+            source_kind="config",
+            volatility_class="hot",
+            authority_class="primary",
+            last_verified_at=now_ts - 10_000.0,
+        )
+        # Fresher copy in another shard
+        upsert_source_index(
+            main_conn,
+            gene_id=gene_id,
+            shard_name="fresh_shard",
+            source_id="/fresh/auth.toml",
+            repo_root="/projects/fresh",
+            source_kind="config",
+            volatility_class="hot",
+            authority_class="primary",
+            last_verified_at=now_ts - 100.0,
+        )
+
+        packet = build_context_packet(
+            "jwt config",
+            task_type="edit",
+            genome=genome,
+            main_conn=main_conn,
+            now_ts=now_ts,
+        )
+
+        # The freshest copy (fresh_shard) wins; stale_shard's
+        # /stale/auth.toml must NOT be the item's source_id.
+        items = packet.verified + packet.stale_risk
+        assert len(items) == 1
+        assert items[0].source_id == "/fresh/auth.toml"
+    finally:
+        main_conn.close()
+        genome.close()
+
+
 def test_file_grain_downgrades_same_folder_wrong_file():
     """File-grain coord signal catches wrong-file-right-folder silent miss.
 

--- a/tests/test_shard_schema.py
+++ b/tests/test_shard_schema.py
@@ -294,6 +294,104 @@ def test_upsert_source_index_writes_and_replaces(main_db):
     assert row["authority_class"] == "derived"
 
 
+def test_source_index_keeps_same_gene_id_across_shards(main_db):
+    """A content-addressed gene_id can live in multiple shards (identical
+    content under different source roots). The source_index PK must be
+    (gene_id, shard_name) so per-shard provenance (source_id, repo_root,
+    observed_at) is not silently overwritten.
+
+    Mirrors the cross-shard duplicate fix applied to fingerprint_index in
+    PR #103. Without the composite PK, the second shard's
+    INSERT OR REPLACE on the same gene_id wins and the first shard's
+    provenance (e.g. its repo_root) is lost — packet builder then attaches
+    the wrong source_id / repo_root to that gene_id when the retriever
+    serves the first-shard copy.
+    """
+    register_shard(main_db, "education", "reference", "/edu.db")
+    register_shard(main_db, "helix-context", "reference", "/hc.db")
+
+    upsert_source_index(
+        main_db,
+        gene_id="63ab90e26082c8ec",
+        shard_name="education",
+        source_id="/edu/audit_baseline.json",
+        repo_root="/projects/education",
+        source_kind="doc",
+        observed_at=100.0,
+        mtime=90.0,
+        content_hash="abc123",
+    )
+    upsert_source_index(
+        main_db,
+        gene_id="63ab90e26082c8ec",
+        shard_name="helix-context",
+        source_id="/hc/audit_baseline.json",
+        repo_root="/projects/helix-context",
+        source_kind="doc",
+        observed_at=200.0,
+        mtime=190.0,
+        content_hash="abc123",
+    )
+
+    count = main_db.execute(
+        "SELECT COUNT(*) AS n FROM source_index WHERE gene_id = ?",
+        ("63ab90e26082c8ec",),
+    ).fetchone()["n"]
+    assert count == 2, (
+        "Both shards should keep their source_index provenance row; got "
+        f"{count} row(s) instead of 2."
+    )
+
+    rows = main_db.execute(
+        "SELECT shard_name, repo_root FROM source_index WHERE gene_id = ?",
+        ("63ab90e26082c8ec",),
+    ).fetchall()
+    by_shard = {r["shard_name"]: r["repo_root"] for r in rows}
+    assert by_shard == {
+        "education": "/projects/education",
+        "helix-context": "/projects/helix-context",
+    }
+
+
+def test_source_index_replaces_same_shard_same_gene(main_db):
+    """Re-ingesting the same (gene_id, shard_name) pair must still replace,
+    not duplicate. Guards against the composite-PK change leaking duplicate
+    rows on shard rebuilds.
+    """
+    register_shard(main_db, "education", "reference", "/edu.db")
+
+    upsert_source_index(
+        main_db,
+        gene_id="63ab90e26082c8ec",
+        shard_name="education",
+        source_id="/edu/v1.json",
+        repo_root="/projects/education",
+        source_kind="doc",
+        observed_at=100.0,
+        volatility_class="medium",
+    )
+    upsert_source_index(
+        main_db,
+        gene_id="63ab90e26082c8ec",
+        shard_name="education",
+        source_id="/edu/v2.json",
+        repo_root="/projects/education",
+        source_kind="config",
+        observed_at=200.0,
+        volatility_class="hot",
+    )
+
+    rows = main_db.execute(
+        "SELECT source_id, source_kind, volatility_class "
+        "FROM source_index WHERE gene_id = ? AND shard_name = ?",
+        ("63ab90e26082c8ec", "education"),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == "/edu/v2.json"
+    assert rows[0]["source_kind"] == "config"
+    assert rows[0]["volatility_class"] == "hot"
+
+
 def test_shard_categories_constant():
     assert "participant" in SHARD_CATEGORIES
     assert "agent" in SHARD_CATEGORIES


### PR DESCRIPTION
## Summary

Same fix as #103 applied to `source_index`. `gene_id` is content-addressed (sha256 of content), so identical content under different source roots yields the same gene_id in different shards. The old PK on `gene_id` alone silently overwrote per-shard provenance (source_id, repo_root, mtime, observed_at) on the second write.

## Evidence

Probe (two `upsert_source_index` calls for the same `gene_id` under shards `education` and `helix-context`):

| Schema | Rows after 2 writes | Survived shard |
|---|---|---|
| Old (`gene_id PRIMARY KEY`) | 1 | only `helix-context` (overwrote `education`) |
| New (`PRIMARY KEY (gene_id, shard_name)`) | 2 | both, distinct `repo_root` preserved |

## Writer / Reader audit

- **Writer** (`scripts/ingest_all.py:_copy_indexes_from_shard` -> `upsert_source_index`): uses `INSERT OR REPLACE`, carries `shard_name`. With the composite PK it now keeps both per-shard rows. Same-shard re-ingest still replaces correctly.
- **Reader** (`helix_context/context_packet.py:_lookup_source_row`): previously `SELECT * WHERE gene_id = ? .. fetchone()` -- arbitrary winner when duplicates exist. Updated to `ORDER BY COALESCE(last_verified_at, 0) DESC, updated_at DESC LIMIT 1` so the packet builder deterministically picks the freshest-verified provenance copy. `Gene` carries no `shard_name`, so freshest-copy is the principled fallback at this seam.

## Tests

Three regressions added:
- `test_source_index_keeps_same_gene_id_across_shards` -- mirrors `test_fingerprint_index_keeps_same_gene_id_across_shards` from #103.
- `test_source_index_replaces_same_shard_same_gene` -- rebuild safety.
- `test_source_index_cross_shard_lookup_picks_freshest_verified` -- reader determinism in the dup case.

## Test plan

- [x] `python -m pytest tests/test_shard_schema.py tests/test_shard_router.py tests/test_sharded_adapter_parity.py tests/test_build_fixture_matrix_parallel.py tests/test_context_packet.py -v -m "not live"` -- 68 passed (`test_sharding.py` does not exist in the tree; substituted `test_sharded_adapter_parity.py`)
- [x] Broader sweep `-k "source_index or fingerprint_index or shard or packet or sharded"` -- 108 passed
- [ ] Live medium-fixture rebuild (not run; probe is sufficient ground truth)

## Notes

- Stayed scoped to `source_index`. `fingerprint_index` untouched.
- One follow-up worth flagging (non-blocking): `Gene` / `Document` schema doesn't carry `shard_name`. Plumbing it through would let the packet reader do exact-shard lookups instead of freshest-verified fallback. Out of scope for this fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>