### PR TITLE
fix(bench): populate source_index in build_fixture_matrix

### DIFF
--- a/docs/benchmarks/GENOME_FIXTURE_MATRIX.md
+++ b/docs/benchmarks/GENOME_FIXTURE_MATRIX.md
@@ -100,3 +100,33 @@ The expected testing shape is:
 
 That yields six total test genomes when sharded coverage is active: four
 variable-size monolithic blobs plus two sharded variants.
+
+## Sharded main.db indexes
+
+When `scripts/build_fixture_matrix.py` runs in sharded mode it writes two
+tables into `main.genome.db` so bench code matches the surface the live
+ingest path (`scripts/ingest_all.py`) produces:
+
+- **`fingerprint_index`** — one row per gene_id, used by
+  `ShardRouter.route` to decide which shards to open for a query.
+- **`source_index`** — one row per (gene_id, shard_name), used by
+  `helix_context/context_packet.py::_lookup_source_row` for packet
+  freshness and authority decisions (PR #113).
+
+`source_index` rows are written alongside the fingerprint payload from the
+shard's `genes` table, with conservative defaults for any field the
+shard build didn't observe yet:
+
+| Field | Build-time value |
+|---|---|
+| `observed_at` | shard `genes.observed_at` if set, else build time |
+| `last_verified_at` | shard `genes.last_verified_at` if set, else build time |
+| `mtime`, `content_hash`, `repo_root`, `source_kind`, `support_span` | passed through from the shard's `genes` row (may be NULL) |
+| `volatility_class` | shard value or `'medium'` |
+| `authority_class` | shard value or `'primary'` |
+| `invalidated_at` | always NULL at build time |
+| `updated_at` | build time |
+
+These defaults are conservative on purpose: a bench fixture exercises
+freshness logic without forcing every classifier to run during the build.
+A real ingest path will overwrite the row on its next observation cycle.

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -741,14 +741,21 @@ def _build_one_shard(
             byte_size = 0
         elapsed = round(time.perf_counter() - s_stats["t0"], 1)
 
-        # Build fingerprint payload here (with the shard still open) so the
-        # parent process can write to main.db without re-opening the shard.
+        # Build fingerprint + source_index payloads here (with the shard
+        # still open) so the parent process can write to main.db without
+        # re-opening the shard. Mirrors the column set copied by
+        # ``scripts/ingest_all.py:_copy_indexes_from_shard`` so bench
+        # fixtures exercise the same packet-freshness path that real
+        # ingest produces (PR #113 + follow-up).
         fp_rows = shard.conn.execute(
-            "SELECT gene_id, source_id, promoter, key_values, is_fragment "
+            "SELECT gene_id, source_id, repo_root, source_kind, observed_at, "
+            "mtime, content_hash, volatility_class, authority_class, "
+            "support_span, last_verified_at, promoter, key_values, is_fragment "
             "FROM genes"
         ).fetchall()
         now = time.time()
         fp_payload = []
+        si_payload = []
         for r in fp_rows:
             promoter_blob = r["promoter"]
             domains_json = None
@@ -765,6 +772,27 @@ def _build_one_shard(
                 domains_json, entities_json, r["key_values"],
                 0 if r["is_fragment"] else 1, None, now,
             ))
+            # source_index row -- defaults match the table DDL so build-time
+            # rows look like a real ingest's "never observed/verified yet"
+            # state. ``observed_at`` / ``last_verified_at`` fall back to
+            # build time so freshness logic has a non-NULL timestamp to
+            # reason about; volatility_class / authority_class default
+            # to ``medium`` / ``primary`` per the column defaults.
+            observed_at = r["observed_at"] if r["observed_at"] is not None else now
+            last_verified_at = (
+                r["last_verified_at"]
+                if r["last_verified_at"] is not None
+                else now
+            )
+            si_payload.append((
+                r["gene_id"], label, r["source_id"], r["repo_root"],
+                r["source_kind"], observed_at, r["mtime"], r["content_hash"],
+                r["volatility_class"] or "medium",
+                r["authority_class"] or "primary",
+                r["support_span"], last_verified_at,
+                None,  # invalidated_at
+                now,   # updated_at
+            ))
 
         return {
             "label": label,
@@ -779,6 +807,7 @@ def _build_one_shard(
             "errors": s_stats["errors"],
             "missing_roots": s_stats["missing_roots"],
             "fingerprint_payload": fp_payload,
+            "source_index_payload": si_payload,
         }
     finally:
         shard.close()
@@ -938,11 +967,27 @@ def build_profile_sharded(
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 res["fingerprint_payload"],
             )
+        si_payload = res.get("source_index_payload") or []
+        if si_payload:
+            # Mirror ``ingest_all._copy_indexes_from_shard`` so bench fixtures
+            # exercise the same packet-freshness path as real ingest. Without
+            # this the table is empty and ``context_packet._lookup_source_row``
+            # returns None for every gene_id (PR #113).
+            main_conn.executemany(
+                "INSERT OR REPLACE INTO source_index "
+                "(gene_id, shard_name, source_id, repo_root, source_kind, "
+                "observed_at, mtime, content_hash, volatility_class, "
+                "authority_class, support_span, last_verified_at, "
+                "invalidated_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                si_payload,
+            )
         main_conn.commit()
         log.info(
-            "  %s: %d genes, %d fingerprint rows, %.1f MB (%.1fs)",
+            "  %s: %d genes, %d fingerprint rows, %d source rows, %.1f MB (%.1fs)",
             res["label"], res["gene_count"],
             len(res["fingerprint_payload"]),
+            len(si_payload),
             res["byte_size"] / 1_048_576, res["elapsed_s"],
         )
         totals["shards"].append({
@@ -951,6 +996,7 @@ def build_profile_sharded(
             "path": res["shard_db_path"],
             "genes": res["gene_count"],
             "fingerprint_rows": len(res["fingerprint_payload"]),
+            "source_index_rows": len(si_payload),
             "bytes": res["byte_size"],
             "elapsed_s": res["elapsed_s"],
         })

--- a/tests/test_build_fixture_matrix_parallel.py
+++ b/tests/test_build_fixture_matrix_parallel.py
@@ -431,3 +431,180 @@ def test_build_profile_sharded_preserves_order_when_disabled(tmp_path, monkeypat
     assert captured_order == [a_slug, b_slug]
     assert stats["sort_largest_first"] is False
 
+
+# ── source_index population on sharded builds (PR #113 follow-up) ─────────
+
+
+def test_sharded_build_populates_source_index(tmp_path, monkeypatch):
+    """Sharded build must write rows to ``main.genome.db:source_index``.
+
+    Prior to this regression test the build path only populated
+    ``fingerprint_index``. ``helix_context/context_packet.py::_lookup_source_row``
+    (added in PR #113) reads from ``source_index`` for packet freshness +
+    authority, so bench fixtures with an empty ``source_index`` silently
+    skipped that path.
+
+    Uses a stubbed ``_shard_worker_entry`` so the test stays under the
+    ``slow`` threshold -- no SPLADE / spaCy loading.
+    """
+    import build_fixture_matrix as bfm
+
+    a = tmp_path / "rootA"
+    b = tmp_path / "rootB"
+    a.mkdir()
+    b.mkdir()
+    (a / "alpha.py").write_text("def alpha():\n    return 1\n", encoding="utf-8")
+    (b / "beta.py").write_text("def beta():\n    return 2\n", encoding="utf-8")
+
+    now = 1_700_000_000.0
+
+    def fake_entry(task):
+        # Mimic the real ``_build_one_shard`` return: a fingerprint payload
+        # and a source_index payload, both keyed on a synthetic gene_id.
+        label = task["label"]
+        gid = f"g_{label}_0"
+        fp_row = (gid, label, "src/0", None, None, None, 1, None, now)
+        si_row = (
+            gid, label, "src/0", task["root"], "code",
+            now, now, "deadbeef", "medium", "primary",
+            None, now, None, now,
+        )
+        return {
+            "label": label, "root": task["root"],
+            "shard_db_path": task["shard_db_path"],
+            "gene_count": 1, "byte_size": 0, "elapsed_s": 0.0,
+            "files": 1, "genes": 1, "skipped": 0, "errors": 0,
+            "missing_roots": [],
+            "fingerprint_payload": [fp_row],
+            "source_index_payload": [si_row],
+        }
+
+    monkeypatch.setattr(bfm, "_shard_worker_entry", fake_entry)
+    monkeypatch.setattr(bfm, "PROFILES", {
+        "tiny_si": {
+            "label": "source_index regression",
+            "active_roots": 2,
+            "roots": [str(a), str(b)],
+            "extra_skip_dirs": set(),
+            "extra_filename_filters": [],
+        }
+    })
+
+    out = tmp_path / "out"
+    stats = bfm.build_profile_sharded(
+        "tiny_si", str(out),
+        shard_workers=1, shard_file_workers=1, batch_size=8,
+    )
+
+    main_db = out / "main.genome.db"
+    assert main_db.exists()
+    conn = sqlite3.connect(str(main_db))
+    try:
+        si_count = conn.execute(
+            "SELECT COUNT(*) FROM source_index"
+        ).fetchone()[0]
+        # Two shards × one synthetic gene_id each.
+        assert si_count == 2, (
+            f"source_index should have 2 rows, got {si_count}"
+        )
+
+        # Spot-check the schema fields landed correctly.
+        rows = conn.execute(
+            "SELECT gene_id, shard_name, source_id, repo_root, source_kind, "
+            "observed_at, mtime, content_hash, volatility_class, "
+            "authority_class, last_verified_at, invalidated_at, updated_at "
+            "FROM source_index ORDER BY gene_id"
+        ).fetchall()
+        assert len(rows) == 2
+        for row in rows:
+            (gid, shard, src_id, repo_root, source_kind, observed_at,
+             mtime, content_hash, vol, auth, last_verif, invalidated,
+             updated_at) = row
+            assert gid.startswith("g_")
+            assert shard in {bfm._slug_for_root(str(a)),
+                             bfm._slug_for_root(str(b))}
+            assert src_id == "src/0"
+            assert repo_root in {str(a), str(b)}
+            assert source_kind == "code"
+            assert vol == "medium"
+            assert auth == "primary"
+            assert observed_at == now
+            assert mtime == now
+            assert content_hash == "deadbeef"
+            assert last_verif == now
+            assert invalidated is None
+            assert updated_at is not None
+    finally:
+        conn.close()
+
+    # The per-shard manifest entry should also include the count.
+    assert all("source_index_rows" in s for s in stats["shards"])
+    assert sum(s["source_index_rows"] for s in stats["shards"]) == 2
+
+
+def test_sharded_build_source_index_lookup_returns_row(tmp_path, monkeypatch):
+    """``context_packet._lookup_source_row`` must find a row for a gene_id
+    written by the sharded build path. This is the failure mode PR #113
+    surfaced — empty ``source_index`` makes the lookup return None for
+    every gene_id in a matrix-built fixture."""
+    import build_fixture_matrix as bfm
+    from helix_context.context_packet import _lookup_source_row
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "alpha.py").write_text("def f(): pass\n", encoding="utf-8")
+
+    now = 1_700_000_000.0
+    target_gid = "test_lookup_gene_id"
+
+    def fake_entry(task):
+        label = task["label"]
+        fp_row = (target_gid, label, "src/0", None, None, None, 1, None, now)
+        si_row = (
+            target_gid, label, "src/0", task["root"], "code",
+            now, now, "abcd1234", "medium", "primary",
+            None, now, None, now,
+        )
+        return {
+            "label": label, "root": task["root"],
+            "shard_db_path": task["shard_db_path"],
+            "gene_count": 1, "byte_size": 0, "elapsed_s": 0.0,
+            "files": 1, "genes": 1, "skipped": 0, "errors": 0,
+            "missing_roots": [],
+            "fingerprint_payload": [fp_row],
+            "source_index_payload": [si_row],
+        }
+
+    monkeypatch.setattr(bfm, "_shard_worker_entry", fake_entry)
+    monkeypatch.setattr(bfm, "PROFILES", {
+        "tiny_si2": {
+            "label": "source_index lookup regression",
+            "active_roots": 1,
+            "roots": [str(root)],
+            "extra_skip_dirs": set(),
+            "extra_filename_filters": [],
+        }
+    })
+
+    out = tmp_path / "out"
+    bfm.build_profile_sharded(
+        "tiny_si2", str(out),
+        shard_workers=1, shard_file_workers=1, batch_size=8,
+    )
+
+    conn = sqlite3.connect(str(out / "main.genome.db"))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = _lookup_source_row(conn, target_gid)
+    finally:
+        conn.close()
+
+    assert row is not None, (
+        "expected _lookup_source_row to return a row for a sharded-build "
+        "gene_id, got None (source_index likely empty)"
+    )
+    assert row["gene_id"] == target_gid
+    assert row["volatility_class"] == "medium"
+    assert row["authority_class"] == "primary"
+    assert row["content_hash"] == "abcd1234"
+


### PR DESCRIPTION
## Summary

PR #113 added `helix_context/context_packet.py::_lookup_source_row` which reads from `source_index` for packet freshness and authority. The sharded build path in `scripts/build_fixture_matrix.py` only wrote `fingerprint_index`, leaving `source_index` empty -- so matrix-built bench fixtures silently skipped the new packet-freshness path.

**Verified before fix** (medium-sharded fixture, 2026-05-14):
- `fingerprint_index`: 17,396 rows
- `source_index`: 0 rows

After this fix, both tables are populated alongside one another.

## Approach

**Approach A (per-shard payload extension).** The shard worker already opens the shard DB to build the fingerprint payload; the `genes` table carries every source_index field directly, so extending the SELECT to include `repo_root`, `source_kind`, `observed_at`, `mtime`, `content_hash`, `volatility_class`, `authority_class`, `support_span`, `last_verified_at` adds one zero-cost projection and avoids re-opening the shard in the parent. This mirrors the proven pattern in `scripts/ingest_all.py::_copy_indexes_from_shard`.

## Changes

- `scripts/build_fixture_matrix.py`:
  - `_build_one_shard` now selects the full source_index column set from the shard's `genes` table and returns a `source_index_payload` list of 14-tuples alongside `fingerprint_payload`.
  - `_commit_shard_result` bulk-inserts source_index rows with `executemany`, matches the composite PK `(gene_id, shard_name)` from PR #113, and reports the row count in both the log line and the per-shard manifest entry.
- `tests/test_build_fixture_matrix_parallel.py`: two new regression tests (fast, no slow marker) using a stubbed `_shard_worker_entry` so the test doesn't load SPLADE/spaCy.
- `docs/benchmarks/GENOME_FIXTURE_MATRIX.md`: new "Sharded main.db indexes" section explaining what `source_index` is populated with at build time, including the conservative defaults for fields the shard build couldn't observe.

## Build-time defaults

| Field | Build-time value |
|---|---|
| `observed_at` / `last_verified_at` | shard value if set, else build time |
| `mtime`, `content_hash`, `repo_root`, `source_kind`, `support_span` | passed through from shard `genes` (may be NULL) |
| `volatility_class` | shard value or `'medium'` |
| `authority_class` | shard value or `'primary'` |
| `invalidated_at` | always NULL at build time |
| `updated_at` | build time |

Conservative on purpose: bench fixtures exercise freshness logic without forcing every classifier to run at build time. Real ingest overwrites on its next observation cycle.

## Test plan

- [x] `python -m pytest tests/test_build_fixture_matrix_parallel.py tests/test_shard_schema.py tests/test_context_packet.py -v -m "not live and not slow"` -> 44 passed, 2 deselected
- [x] New tests: `test_sharded_build_populates_source_index`, `test_sharded_build_source_index_lookup_returns_row`
- [x] Existing tests with `fake_entry` stubs (no `source_index_payload`) still pass; the commit code uses `res.get("source_index_payload") or []`.

Refs PR #113.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>