### PR TITLE
fix(sharded): skip abstain absolute floor under RRF (closes #115)

### DIFF
--- a/helix_context/pipeline/tier_logic.py
+++ b/helix_context/pipeline/tier_logic.py
@@ -96,6 +96,19 @@ def apply_budget_tiers(
     if len(gated) >= 3:
         candidates = gated
 
+    # -- Stage 3 transitional bypass (spec S9) --
+    # Under RRF, the score scale collapses to ~Sweight/(k+1) ~ 0.3
+    # max -- the absolute TIGHT/FOCUSED floors are calibrated for
+    # the additive scale and would force every query to BROAD.
+    # Stage 4 owns the recalibrated floors. Until then, RRF mode
+    # operates on ratio gates only.
+    #
+    # Issue #115: also gates the ABSTAIN absolute-floor clause below.
+    # ``ShardedGenomeAdapter`` declares ``_fusion_mode = "rrf"`` so the
+    # router's RRF-fused scores (~0.26-0.40) don't trip the BM25-calibrated
+    # 2.5 floor on every sharded query.
+    skip_absolute_floors = (fusion_mode == "rrf")
+
     # -- ABSTAIN gate --------------------------------------------------------
     # When retrieval is weak on BOTH the absolute floor AND the ratio,
     # inject a marker-only ContextWindow so the small model answers from
@@ -110,10 +123,14 @@ def apply_budget_tiers(
     # the hard-coded 2.5. mode='global' (default) preserves the
     # legacy constant byte-for-byte. ``cls_for_floors`` is hoisted
     # above (set from classifier_result so all branches see it).
+    #
+    # Under RRF (skip_absolute_floors=True), the absolute-score clause is
+    # bypassed; ratio<1.8 alone gates abstain. This mirrors the TIGHT /
+    # FOCUSED bypass below — same flag, same rationale.
     FOCUSED_SCORE_FLOOR_FOR_ABSTAIN = cls_floors.abstain_top
     if (
         abstain_enabled
-        and top_score < FOCUSED_SCORE_FLOOR_FOR_ABSTAIN
+        and (skip_absolute_floors or top_score < FOCUSED_SCORE_FLOOR_FOR_ABSTAIN)
         and ratio < 1.8
     ):
         try:
@@ -143,13 +160,7 @@ def apply_budget_tiers(
     # tight_top / focused_top for this query's class.
     TIGHT_SCORE_FLOOR = cls_floors.tight_top
     FOCUSED_SCORE_FLOOR = cls_floors.focused_top
-    # -- Stage 3 transitional bypass (spec S9) --
-    # Under RRF, the score scale collapses to ~Sweight/(k+1) ~ 0.3
-    # max -- the absolute TIGHT/FOCUSED floors are calibrated for
-    # the additive scale and would force every query to BROAD.
-    # Stage 4 owns the recalibrated floors. Until then, RRF mode
-    # operates on ratio gates only.
-    skip_absolute_floors = (fusion_mode == "rrf")
+    # skip_absolute_floors hoisted above the ABSTAIN gate (issue #115).
 
     budget_tier = "broad"
     budget_tokens_est = 15000

--- a/helix_context/sharding.py
+++ b/helix_context/sharding.py
@@ -171,6 +171,15 @@ class ShardedGenomeAdapter:
         ``hasattr(genome, '_sharded_adapter')``.
     """
 
+    # The router unconditionally builds its RRF Fuser at shard_router.py:236
+    # (`Fuser(k=60)` with no mode toggle), so any sharded read is RRF-fused.
+    # Expose this so context_manager._build_signals reads "rrf" via
+    # ``getattr(self.genome, "_fusion_mode", "additive")`` and the abstain
+    # gate / TIGHT-FOCUSED floor bypass in pipeline/tier_logic.py engage.
+    # Without this, sharded RRF scores (~0.26-0.40) trip the 2.5 absolute
+    # floor on 9/10 queries and abstain — see issue #115.
+    _fusion_mode: str = "rrf"
+
     def __init__(self, main_path: str, **genome_kwargs: Any) -> None:
         from .shard_router import ShardRouter
 

--- a/tests/test_abstain_tier.py
+++ b/tests/test_abstain_tier.py
@@ -252,6 +252,136 @@ def test_abstain_env_override_beats_config_flag(abstain_manager, monkeypatch):
     assert win.context_health.status != "abstain"
 
 
+# ── Issue #115: RRF fusion bypasses the absolute score floor ─────────────────
+#
+# After PR #106 switched ShardRouter.query_genes to RRF, sharded top-scores
+# compress to ~0.26-0.40. The ABSTAIN gate's absolute floor (2.5, calibrated
+# for BM25/additive) tripped on 9/10 sharded queries — even when the ratio
+# axis indicated a clear winner. The fix gates the absolute-score clause on
+# ``skip_absolute_floors = (fusion_mode == "rrf")``, matching the existing
+# TIGHT/FOCUSED bypass at tier_logic.py:152. Tests call apply_budget_tiers
+# directly with the same fixtures as the higher-level tests above.
+
+
+def _candidates_with_scores(top_score: float, ratio: float, n: int = 8):
+    """Shared helper: build n candidates whose scores yield (top_score, ratio).
+
+    Same math as ``_weak_setup`` but returns (candidates, scores_dict)
+    suitable for passing straight into ``apply_budget_tiers``.
+    """
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"rrf_{i}", gene_id=f"rrf_gene_{i:010d}")
+        for i in range(n)
+    ]
+    mean = top_score / ratio
+    rest = (n * mean - top_score) / (n - 1)
+    scores = {candidates[0].gene_id: top_score}
+    for c in candidates[1:]:
+        scores[c.gene_id] = rest
+    return candidates, scores
+
+
+def test_rrf_low_score_high_ratio_does_not_abstain():
+    """Issue #115: under RRF, low absolute scores + healthy ratio must NOT
+    abstain. RRF score scale is ~0.3 max; the 2.5 BM25 floor is meaningless.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    candidates, scores = _candidates_with_scores(top_score=0.4, ratio=2.0)
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result.abstain is False, (
+        f"RRF top=0.4 ratio=2.0 should NOT abstain; "
+        f"tier={result.budget_tier} (issue #115)"
+    )
+    # Ratio 2.0 lands in FOCUSED under the bypass.
+    assert result.budget_tier == "focused"
+
+
+def test_rrf_low_score_low_ratio_does_abstain():
+    """Issue #115: under RRF, ratio<1.8 still triggers abstain — the gate
+    is preserved for genuine "no clear winner" cases. Only the absolute
+    score floor is bypassed.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    candidates, scores = _candidates_with_scores(top_score=0.4, ratio=1.2)
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result.abstain is True, (
+        "RRF top=0.4 ratio=1.2 should abstain (ratio gate still active)"
+    )
+
+
+def test_additive_low_score_still_abstains():
+    """Issue #115 regression guard: additive mode must keep the original
+    behavior — low absolute scores + low ratio abstain. This pins the
+    fix so RRF bypass does not silently leak into the additive path.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    candidates, scores = _candidates_with_scores(top_score=0.4, ratio=1.2)
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="additive",
+    )
+    assert result.abstain is True, (
+        "additive top=0.4 ratio=1.2 must still abstain — RRF bypass "
+        "must not affect additive scoring"
+    )
+
+
+def test_rrf_above_abstain_floor_low_ratio_does_abstain():
+    """Issue #115 key differentiator: under RRF, the absolute-score
+    floor is meaningless (RRF scores cap ~0.3). Even if a score
+    happens to exceed 2.5, a tight ratio still indicates retrieval
+    uncertainty — the gate must trip on ratio alone.
+
+    This is the case that pre-fix code mis-handles: ``top=3.0 >= 2.5``
+    passes the score-floor short-circuit, so abstain skips even when
+    ratio says "no clear winner". Post-fix, ``skip_absolute_floors``
+    hoists above the abstain check so RRF mode uses ratio alone.
+
+    Under ``fusion_mode='additive'`` this same case must NOT abstain
+    (preserves legacy: top above floor → fall through to BROAD), which
+    is asserted by the companion test below.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    candidates, scores = _candidates_with_scores(top_score=3.0, ratio=1.5)
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result.abstain is True, (
+        "RRF top=3.0 ratio=1.5 must abstain — under RRF the absolute "
+        "score is meaningless and ratio<1.8 alone gates abstain"
+    )
+
+
+def test_additive_above_abstain_floor_low_ratio_does_not_abstain():
+    """Companion to the above: under additive, top=3.0 (>= floor)
+    short-circuits the abstain check regardless of ratio. This is
+    the legacy behavior that must NOT regress under the fix.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    candidates, scores = _candidates_with_scores(top_score=3.0, ratio=1.5)
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="additive",
+    )
+    assert result.abstain is False, (
+        "additive top=3.0 ratio=1.5 must NOT abstain — score floor "
+        "short-circuits the gate; legacy behavior must be preserved"
+    )
+
+
 def test_telemetry_counter_increments_with_abstain_label(
     abstain_manager, monkeypatch
 ):

--- a/tests/test_sharded_adapter_parity.py
+++ b/tests/test_sharded_adapter_parity.py
@@ -260,6 +260,21 @@ def test_adapter_get_doc_and_get_gene_are_same_callable(adapter):
     assert adapter.get_gene("nonexistent") is None
 
 
+def test_adapter_declares_fusion_mode_rrf(adapter):
+    """Issue #115: ShardRouter unconditionally builds an RRF Fuser
+    (``shard_router.py:236``), so the adapter must declare
+    ``_fusion_mode = "rrf"`` for ``context_manager._build_signals`` to
+    read RRF via ``getattr(self.genome, "_fusion_mode", "additive")``.
+    Without this, the abstain absolute-score floor (2.5, BM25-calibrated)
+    trips on every sharded query because RRF scores compress to ~0.3.
+    """
+    assert adapter._fusion_mode == "rrf", (
+        "ShardedGenomeAdapter must declare _fusion_mode='rrf' so the "
+        "TIGHT/FOCUSED and ABSTAIN floor bypass engages for sharded "
+        "reads (issue #115)."
+    )
+
+
 def test_adapter_covers_full_knowledgestore_surface(adapter):
     """Soft drift catcher: warn when KnowledgeStore gains a name the adapter
     doesn't expose, unless explicitly whitelisted.


### PR DESCRIPTION
## Summary

Closes #115. After PR #106 switched `ShardRouter.query_genes` to RRF, sharded top-scores compress to ~0.26-0.40 — well below the BM25-calibrated abstain floor of 2.5. Combined with a missing adapter flag, this tripped abstain on 9/10 sharded queries.

Two interlocking bugs:

1. **`ShardedGenomeAdapter` didn't expose `_fusion_mode`** — so `context_manager.py:1195`'s `getattr(self.genome, "_fusion_mode", "additive")` resolved to `"additive"` even though `shard_router.py:236` unconditionally builds `Fuser(k=60)`. The downstream `apply_budget_tiers` then ran with the wrong `fusion_mode`, defeating PR #106's `skip_absolute_floors` bypass.
2. **`skip_absolute_floors` (`tier_logic.py:152`) gated only the TIGHT/FOCUSED branches**, not the ABSTAIN block 25 lines above. Inconsistent semantics for the same flag.

## Fix

Both edits are minimal:

- **`helix_context/sharding.py`** — declare `_fusion_mode: str = "rrf"` as a class attribute on `ShardedGenomeAdapter`. The router is unconditionally RRF, so this is accurate.
- **`helix_context/pipeline/tier_logic.py`** — hoist `skip_absolute_floors` definition above the ABSTAIN gate and gate the `top_score < FOCUSED_SCORE_FLOOR_FOR_ABSTAIN` clause on it. Under RRF, `ratio < 1.8` alone gates abstain (preserves the "no clear winner" semantic). Under additive, the legacy two-axis check is byte-identical.

Production-code diff: 1 LOC added in `sharding.py`, ~3 LOC effective change in `tier_logic.py` (rest is comments documenting the refactor).

## Stash-and-retest evidence

Stashed the production-code changes (`helix_context/{sharding,pipeline/tier_logic}.py`) and ran the new tests against unfixed code:

| Test | Master | Branch |
|---|---|---|
| `test_adapter_declares_fusion_mode_rrf` | **FAIL** (`AttributeError: 'ShardedGenomeAdapter' object has no attribute '_fusion_mode'`) | PASS |
| `test_rrf_above_abstain_floor_low_ratio_does_abstain` | **FAIL** (`top=3.0, ratio=1.5, RRF` → no abstain under old logic) | PASS |
| `test_rrf_low_score_high_ratio_does_not_abstain` | PASS | PASS |
| `test_rrf_low_score_low_ratio_does_abstain` | PASS | PASS |
| `test_additive_low_score_still_abstains` | PASS | PASS |
| `test_additive_above_abstain_floor_low_ratio_does_not_abstain` | PASS | PASS |

The two failures on master prove the fixes are load-bearing; the four passes on both confirm the surrounding consistency guards work as designed under both old and new code.

## Test plan

- [x] `python -m pytest tests/test_abstain_tier.py tests/test_fusion_rrf.py tests/test_shard_router.py tests/test_sharded_adapter_parity.py tests/test_context_packet.py -v` → 74 passed
- [x] Stash-and-retest evidence captured (see above)
- [x] `python -m pytest tests/test_pipeline.py tests/test_telemetry_pipeline.py` → 35 passed (no regressions in nearby suites)

## Files changed

- `helix_context/sharding.py` — adapter declares `_fusion_mode = "rrf"`
- `helix_context/pipeline/tier_logic.py` — `skip_absolute_floors` gates abstain block too
- `tests/test_abstain_tier.py` — 5 new regression cases
- `tests/test_sharded_adapter_parity.py` — 1 new assertion for adapter contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)