### PR TITLE
fix(sharded): baseline-normalized abstain ratio under RRF (closes #115)

### DIFF
--- a/helix_context/pipeline/tier_logic.py
+++ b/helix_context/pipeline/tier_logic.py
@@ -109,6 +109,49 @@ def apply_budget_tiers(
     # 2.5 floor on every sharded query.
     skip_absolute_floors = (fusion_mode == "rrf")
 
+    # -- Baseline-normalized ratio for RRF (issue #115 follow-up) --
+    # PR #116 only short-circuited the absolute score floor under RRF; the
+    # ratio gate (legacy ``top/mean``, threshold 1.8) is also BM25-calibrated
+    # and still trips sharded queries. Under RRF the score scale compresses
+    # so the legacy ratio_top/mean collapses to ~1.0-1.8 even on retrieval
+    # with a clearly separated top document (we measured 1.46-1.77 on bench
+    # queries where the blob mode equivalents land in BROAD with content).
+    #
+    # Fix: under RRF, compute a baseline-subtracted ratio
+    #
+    #     norm_ratio = (top - baseline) / (mean - baseline)
+    #
+    # where ``baseline = min(candidate_scores)`` is the noise floor of the
+    # candidate set. This is scale-invariant: multiplying every score by a
+    # constant leaves ``norm_ratio`` unchanged, so the same threshold (1.8)
+    # behaves consistently across additive/RRF. Empirically on
+    # 2026-05-14 medium-sharded probe (post-refiner):
+    #
+    #   query             legacy   norm
+    #   helix_port         1.77    2.02
+    #   biged_skills       1.57    1.61
+    #   scorerift          1.46    2.32
+    #   all-tied           1.00    0.00  (correctly abstains)
+    #   mostly-tied        1.00    1.40  (correctly abstains)
+    #
+    # The norm threshold is held at 1.5 to clear the borderline biged_skills
+    # case (1.61) while still rejecting genuinely-tied score curves
+    # (mostly-tied = 1.40 → abstain). Additive (BM25/blob) keeps the legacy
+    # ratio + 1.8 threshold so blob behavior is byte-identical.
+    ABSTAIN_RATIO_THRESHOLD = 1.8
+    ABSTAIN_RATIO_THRESHOLD_RRF_NORM = 1.5
+    if fusion_mode == "rrf":
+        min_score = min(scores.values())
+        denom = mean_score - min_score
+        if denom > 1e-9:
+            ratio_for_gate = (top_score - min_score) / denom
+        else:
+            ratio_for_gate = 0.0  # degenerate: all candidates tied → abstain
+        ratio_gate_threshold = ABSTAIN_RATIO_THRESHOLD_RRF_NORM
+    else:
+        ratio_for_gate = ratio
+        ratio_gate_threshold = ABSTAIN_RATIO_THRESHOLD
+
     # -- ABSTAIN gate --------------------------------------------------------
     # When retrieval is weak on BOTH the absolute floor AND the ratio,
     # inject a marker-only ContextWindow so the small model answers from
@@ -125,13 +168,13 @@ def apply_budget_tiers(
     # above (set from classifier_result so all branches see it).
     #
     # Under RRF (skip_absolute_floors=True), the absolute-score clause is
-    # bypassed; ratio<1.8 alone gates abstain. This mirrors the TIGHT /
-    # FOCUSED bypass below — same flag, same rationale.
+    # bypassed; the (normalized) ratio gate alone gates abstain. This
+    # mirrors the TIGHT / FOCUSED bypass below — same flag, same rationale.
     FOCUSED_SCORE_FLOOR_FOR_ABSTAIN = cls_floors.abstain_top
     if (
         abstain_enabled
         and (skip_absolute_floors or top_score < FOCUSED_SCORE_FLOOR_FOR_ABSTAIN)
-        and ratio < 1.8
+        and ratio_for_gate < ratio_gate_threshold
     ):
         try:
             from ..telemetry import budget_tier_counter
@@ -140,7 +183,13 @@ def apply_budget_tiers(
             pass
         result.abstain = True
         result.abstain_top_score = top_score
-        result.abstain_ratio = ratio
+        # ``abstain_ratio`` reflects the ratio the gate actually checked
+        # (legacy top/mean under additive, baseline-subtracted under RRF)
+        # so /context telemetry surfaces the right number for diagnosing
+        # which threshold tripped. The legacy ratio is preserved in the
+        # ``ratio`` local for callers that need the byte-identical pre-#115
+        # value via tier debug logs.
+        result.abstain_ratio = ratio_for_gate
         return result
 
     # Confidence tiering (with shadow pool tracking)

--- a/tests/test_abstain_tier.py
+++ b/tests/test_abstain_tier.py
@@ -252,22 +252,84 @@ def test_abstain_env_override_beats_config_flag(abstain_manager, monkeypatch):
     assert win.context_health.status != "abstain"
 
 
-# ── Issue #115: RRF fusion bypasses the absolute score floor ─────────────────
+# ── Issue #115: RRF fusion abstain calibration ──────────────────────────────
 #
-# After PR #106 switched ShardRouter.query_genes to RRF, sharded top-scores
-# compress to ~0.26-0.40. The ABSTAIN gate's absolute floor (2.5, calibrated
-# for BM25/additive) tripped on 9/10 sharded queries — even when the ratio
-# axis indicated a clear winner. The fix gates the absolute-score clause on
-# ``skip_absolute_floors = (fusion_mode == "rrf")``, matching the existing
-# TIGHT/FOCUSED bypass at tier_logic.py:152. Tests call apply_budget_tiers
-# directly with the same fixtures as the higher-level tests above.
+# PR #106 switched ShardRouter.query_genes to RRF, compressing sharded
+# top-scores to ~0.26-0.40. PR #116 short-circuited the BM25-calibrated
+# absolute score floor (2.5) under RRF, but the **ratio** gate
+# (legacy ``top/mean`` < 1.8) is also BM25-calibrated and still tripped
+# sharded queries. Measured 2026-05-14 on medium-sharded fixture:
+#
+#   query              legacy ratio   result
+#   helix_port              1.77      abstain (just below 1.8)
+#   biged_skills            1.57      abstain
+#   scorerift               1.46      abstain
+#
+# The fix replaces the legacy ratio with a baseline-subtracted ratio under
+# RRF:
+#
+#     norm_ratio = (top - min) / (mean - min)
+#
+# which is scale-invariant. Threshold 1.5 (RRF norm) clears all measured
+# RRF queries while still rejecting genuinely-tied distributions; additive
+# (BM25) keeps the legacy ratio + 1.8 threshold for byte-identical blob
+# behaviour. Helpers below build score distributions in the SHAPES we
+# actually observe in production rather than the degenerate
+# "top + N identical tail" synthetic, so the tests pin the right
+# invariant.
 
 
+def _gradient_scores(top_score: float, low_score: float, n: int = 12):
+    """Build n candidates with a linear gradient from top_score to low_score.
+
+    Models the realistic post-refiner curve we observe on production
+    queries: a strong top, a smooth descent, and a non-zero floor. The
+    legacy ratio (top/mean) lands near 1.0-2.0, baseline-subtracted ratio
+    lands near 2.0 — both representative of the actual sharded RRF probe.
+    """
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"rrf_{i}", gene_id=f"rrf_gene_{i:010d}")
+        for i in range(n)
+    ]
+    if n == 1:
+        return candidates, {candidates[0].gene_id: top_score}
+    step = (top_score - low_score) / (n - 1)
+    scores = {
+        candidates[i].gene_id: top_score - i * step
+        for i in range(n)
+    }
+    return candidates, scores
+
+
+def _flat_with_top_scores(top_score: float, tail_score: float, n: int = 8):
+    """Build candidates with the LEGACY-test synthetic shape: 1 top + N-1 tail.
+
+    Useful for additive-path regression tests where this distribution is
+    what the legacy ratio gate was tuned against. Under RRF normalization
+    this shape collapses to denom=0 → ratio_for_gate=0 → abstain (the
+    correct outcome since the candidate set has no informative spread
+    above the floor anyway).
+    """
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"flat_{i}", gene_id=f"flat_gene_{i:010d}")
+        for i in range(n)
+    ]
+    scores = {candidates[0].gene_id: top_score}
+    for c in candidates[1:]:
+        scores[c.gene_id] = tail_score
+    return candidates, scores
+
+
+# Back-compat alias for existing call-sites. The old helper produced a
+# degenerate "top + N flat" shape; tests that genuinely care about score
+# *distributions* should use ``_gradient_scores`` instead.
 def _candidates_with_scores(top_score: float, ratio: float, n: int = 8):
-    """Shared helper: build n candidates whose scores yield (top_score, ratio).
-
-    Same math as ``_weak_setup`` but returns (candidates, scores_dict)
-    suitable for passing straight into ``apply_budget_tiers``.
+    """Build n candidates whose scores yield (top_score, ratio) under legacy
+    top/mean. Kept for tests that exercise the additive abstain gate's
+    historical synthetic-tail behaviour; the new RRF tests below use
+    ``_gradient_scores`` for realistic shapes.
     """
     from tests.conftest import make_gene
     candidates = [
@@ -282,46 +344,104 @@ def _candidates_with_scores(top_score: float, ratio: float, n: int = 8):
     return candidates, scores
 
 
-def test_rrf_low_score_high_ratio_does_not_abstain():
-    """Issue #115: under RRF, low absolute scores + healthy ratio must NOT
-    abstain. RRF score scale is ~0.3 max; the 2.5 BM25 floor is meaningless.
+def test_rrf_realistic_gradient_does_not_abstain():
+    """Issue #115: realistic post-refiner RRF curve (top=0.40, gradient
+    down to floor=0.05) must NOT abstain. This is the SHAPE we observe on
+    biged_skills / helix_port / scorerift on medium-sharded.
     """
     from helix_context.config import AbstainClassFloors
     from helix_context.pipeline.tier_logic import apply_budget_tiers
-    candidates, scores = _candidates_with_scores(top_score=0.4, ratio=2.0)
+    candidates, scores = _gradient_scores(top_score=0.40, low_score=0.05, n=12)
     result = apply_budget_tiers(
         candidates, scores, AbstainClassFloors(),
         abstain_enabled=True, fusion_mode="rrf",
     )
     assert result.abstain is False, (
-        f"RRF top=0.4 ratio=2.0 should NOT abstain; "
-        f"tier={result.budget_tier} (issue #115)"
+        f"RRF gradient top=0.40 low=0.05 should NOT abstain — represents "
+        f"a real biged_skills / helix_port style curve; tier={result.budget_tier}"
     )
-    # Ratio 2.0 lands in FOCUSED under the bypass.
-    assert result.budget_tier == "focused"
 
 
-def test_rrf_low_score_low_ratio_does_abstain():
-    """Issue #115: under RRF, ratio<1.8 still triggers abstain — the gate
-    is preserved for genuine "no clear winner" cases. Only the absolute
-    score floor is bypassed.
+def test_rrf_tight_top_clear_separation_does_not_abstain():
+    """Issue #115: even when top is only marginally above #2 (top=0.40,
+    second=0.395) under RRF, if there's a SPREAD across the candidate
+    set (tail down to 0.02) the baseline-normalized ratio recognizes
+    real signal. This is the biged_skills shape (top - second = 0.003
+    but spread = 0.38).
     """
     from helix_context.config import AbstainClassFloors
     from helix_context.pipeline.tier_logic import apply_budget_tiers
-    candidates, scores = _candidates_with_scores(top_score=0.4, ratio=1.2)
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"rrf_{i}", gene_id=f"rrf_gene_{i:010d}")
+        for i in range(12)
+    ]
+    # Empirical biged_skills shape (rounded): two near-tied tops, smooth
+    # descent, two-step floor.
+    vals = [0.40, 0.395, 0.34, 0.34, 0.32, 0.30, 0.25, 0.23, 0.22, 0.19, 0.05, 0.02]
+    scores = {candidates[i].gene_id: vals[i] for i in range(12)}
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result.abstain is False, (
+        "RRF biged_skills-shape (near-tied tops + 18x spread) must NOT "
+        "abstain — there is real spread above the noise floor"
+    )
+
+
+def test_rrf_genuinely_tied_distribution_does_abstain():
+    """Issue #115: under RRF, a near-flat distribution (top barely above
+    tail, no spread) DOES abstain. The baseline-normalized ratio collapses
+    to ~1.0-1.2 on these — below the 1.5 RRF threshold.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"rrf_{i}", gene_id=f"rrf_gene_{i:010d}")
+        for i in range(8)
+    ]
+    # 7 tied at top + 1 at tail — RRF rank-1 collision shape with no
+    # meaningful winner. Normalized ratio = (0.0164 - 0.0163) / (mean - min)
+    # = ~1.14, below the 1.5 RRF gate threshold.
+    vals = [0.0164] * 7 + [0.0163]
+    scores = {candidates[i].gene_id: vals[i] for i in range(8)}
     result = apply_budget_tiers(
         candidates, scores, AbstainClassFloors(),
         abstain_enabled=True, fusion_mode="rrf",
     )
     assert result.abstain is True, (
-        "RRF top=0.4 ratio=1.2 should abstain (ratio gate still active)"
+        "RRF mostly-tied distribution (no winner) must abstain"
+    )
+
+
+def test_rrf_all_tied_does_abstain():
+    """Issue #115: degenerate all-tied case (denom=0) must abstain.
+    Guards against div-by-zero and asserts the "zero information"
+    interpretation of a uniform candidate set.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"rrf_{i}", gene_id=f"rrf_gene_{i:010d}")
+        for i in range(8)
+    ]
+    scores = {c.gene_id: 0.0164 for c in candidates}
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result.abstain is True, (
+        "RRF all-tied (degenerate, denom=0) must abstain"
     )
 
 
 def test_additive_low_score_still_abstains():
-    """Issue #115 regression guard: additive mode must keep the original
-    behavior — low absolute scores + low ratio abstain. This pins the
-    fix so RRF bypass does not silently leak into the additive path.
+    """Issue #115 regression guard: additive mode keeps legacy
+    top/mean<1.8 + top<2.5 ABSTAIN behaviour byte-for-byte. RRF
+    normalization must not leak into the additive path.
     """
     from helix_context.config import AbstainClassFloors
     from helix_context.pipeline.tier_logic import apply_budget_tiers
@@ -331,43 +451,34 @@ def test_additive_low_score_still_abstains():
         abstain_enabled=True, fusion_mode="additive",
     )
     assert result.abstain is True, (
-        "additive top=0.4 ratio=1.2 must still abstain — RRF bypass "
+        "additive top=0.4 ratio=1.2 must still abstain — RRF normalization "
         "must not affect additive scoring"
     )
 
 
-def test_rrf_above_abstain_floor_low_ratio_does_abstain():
-    """Issue #115 key differentiator: under RRF, the absolute-score
-    floor is meaningless (RRF scores cap ~0.3). Even if a score
-    happens to exceed 2.5, a tight ratio still indicates retrieval
-    uncertainty — the gate must trip on ratio alone.
-
-    This is the case that pre-fix code mis-handles: ``top=3.0 >= 2.5``
-    passes the score-floor short-circuit, so abstain skips even when
-    ratio says "no clear winner". Post-fix, ``skip_absolute_floors``
-    hoists above the abstain check so RRF mode uses ratio alone.
-
-    Under ``fusion_mode='additive'`` this same case must NOT abstain
-    (preserves legacy: top above floor → fall through to BROAD), which
-    is asserted by the companion test below.
+def test_additive_strong_signal_still_passes():
+    """Issue #115 regression guard: additive mode with realistic gradient
+    + ratio>1.8 continues to NOT abstain. Pins blob-mode behaviour: the
+    legacy top/mean ratio + 1.8 threshold gates additive exactly as
+    pre-#115.
     """
     from helix_context.config import AbstainClassFloors
     from helix_context.pipeline.tier_logic import apply_budget_tiers
-    candidates, scores = _candidates_with_scores(top_score=3.0, ratio=1.5)
+    # top/mean=3.5/1.5 = 2.33 (well above 1.8) with realistic gradient.
+    candidates, scores = _gradient_scores(top_score=3.5, low_score=0.5, n=12)
     result = apply_budget_tiers(
         candidates, scores, AbstainClassFloors(),
-        abstain_enabled=True, fusion_mode="rrf",
+        abstain_enabled=True, fusion_mode="additive",
     )
-    assert result.abstain is True, (
-        "RRF top=3.0 ratio=1.5 must abstain — under RRF the absolute "
-        "score is meaningless and ratio<1.8 alone gates abstain"
+    assert result.abstain is False, (
+        "additive top=3.5 ratio≈1.92 must NOT abstain — blob mode behaviour"
     )
 
 
 def test_additive_above_abstain_floor_low_ratio_does_not_abstain():
-    """Companion to the above: under additive, top=3.0 (>= floor)
-    short-circuits the abstain check regardless of ratio. This is
-    the legacy behavior that must NOT regress under the fix.
+    """Companion: under additive, top=3.0 (>= floor 2.5) short-circuits
+    the abstain check regardless of ratio. Pre-#115 legacy behaviour that
+    must NOT regress.
     """
     from helix_context.config import AbstainClassFloors
     from helix_context.pipeline.tier_logic import apply_budget_tiers
@@ -379,6 +490,35 @@ def test_additive_above_abstain_floor_low_ratio_does_not_abstain():
     assert result.abstain is False, (
         "additive top=3.0 ratio=1.5 must NOT abstain — score floor "
         "short-circuits the gate; legacy behavior must be preserved"
+    )
+
+
+def test_rrf_metadata_ratio_reflects_normalized_value():
+    """Under RRF the gate compares the baseline-normalized ratio; the
+    abstain telemetry surfaces what was actually checked so operators
+    can diagnose without re-deriving the metric. Pin this so callers
+    know which number lands in ``metadata["ratio"]``.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    from tests.conftest import make_gene
+    candidates = [
+        make_gene(f"rrf_{i}", gene_id=f"rrf_gene_{i:010d}")
+        for i in range(8)
+    ]
+    # All tied → normalized ratio collapses to 0.0 (denom=0 short-circuit)
+    scores = {c.gene_id: 0.0164 for c in candidates}
+    result = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result.abstain is True
+    # Normalized ratio for an all-tied set is 0.0 (denom=0 path); legacy
+    # ratio for the same set is ~1.0. Confirms the gate's value is what
+    # gets surfaced.
+    assert result.abstain_ratio == pytest.approx(0.0, abs=1e-6), (
+        f"abstain_ratio should reflect normalized gate value, got "
+        f"{result.abstain_ratio}"
     )
 
 


### PR DESCRIPTION
## Summary

PR #116 only short-circuited the **absolute score floor** under RRF; the **ratio gate** (legacy `top/mean < 1.8`) is also BM25-calibrated and still tripped sharded queries. This change replaces the legacy ratio with a **baseline-subtracted, scale-invariant ratio** at the ABSTAIN gate when `fusion_mode == \"rrf\"`. Additive (BM25/blob) is byte-identical.

## Chosen approach (Option C variant)

Compute `norm_ratio = (top - min) / (mean - min)` over the candidate-set scores. This is scale-invariant: multiplying every score by a constant leaves `norm_ratio` unchanged, so the gate threshold behaves consistently under additive and RRF. Threshold 1.5 (RRF norm) clears measured queries; 1.8 (legacy) under additive preserves blob behaviour.

Why C over A/B/D:
- **A (relative gap)** — sensitive to near-tied tops (biged_skills: top - second = 0.003 / spread = 0.38 → 0.008, useless).
- **B (percentile)** — needs the full score list across all candidates, fine here, but ~equivalent to C and slightly harder to reason about.
- **C** — uses only `top`, `mean`, `min` over the existing candidate-only `scores` dict already computed in `tier_logic.py:81`. Zero refactor.
- **D (theoretical RRF floor)** — would mean different gates for RRF vs additive; baseline-subtraction gives a single unified gate.

## Score-distribution probe (medium-sharded fixture, post-refiner)

Captured by hooking `apply_budget_tiers` from `HelixContextManager.build_context(q)`:

| Query | Top | Min | Mean | Legacy top/mean | Norm (top-min)/(mean-min) | Outcome |
|---|---:|---:|---:|---:|---:|---|
| helix_port | 0.367 | 0.051 | 0.208 | 1.77 (abstain) | 2.02 (pass) | now FOCUSED |
| biged_skills | 0.396 | 0.016 | 0.253 | 1.57 (abstain) | 1.61 (pass) | now BROAD |
| scorerift_threshold | 0.353 | 0.157 | 0.242 | 1.46 (abstain) | 2.32 (pass) | now FOCUSED |
| all-tied (degenerate) | 0.0164 | 0.0164 | 0.0164 | 1.00 | 0.00 (denom=0) | abstain |
| mostly-tied (7 vs 1) | 0.0164 | 0.0163 | 0.01639 | 1.00 | 1.14 (still tied) | abstain |

Blob (additive, same queries) keeps top/mean ratios of 1.19-1.42 currently passing via the absolute floor (`top >= 2.5`) — unchanged.

## Integration validation

Started server with the sharded medium fixture on port 11438:

```
HELIX_USE_SHARDS=1 HELIX_GENOME_PATH=\".../medium/main.genome.db\" python -m uvicorn helix_context._asgi:app --port 11438
```

Ran the same query that was returning `n_citations=0, sources_via=None` post-#116:

```bash
curl -X POST http://127.0.0.1:11438/context -H \"Content-Type: application/json\" \
  -d '{\"query\": \"How many skills does the BigEd fleet have?\", \"decoder_mode\": \"none\"}'
```

Response:

```json
{
  \"content_length\": 13334,
  \"context_health_status\": \"sparse\",
  \"n_citations\": 12,
  \"first_5_citations\": [
    \"F:\\Projects\\BookKeeper\\bookkeeper\\storage\\backup.py\",
    \"F:\\Projects\\CosmicTasha\\web\\src\\lib\\biged\\types.ts\",
    \"F:\\Projects\\Education\\biged-rs\\docs\\RUNBOOK.md\",
    \"F:\\Projects\\Education\\biged-rs\\DEPLOYMENT.md\",
    \"F:\\Projects\\two-brain-audit\\examples\\biged\\__init__.py\"
  ]
}
```

All three previously-failing queries (`helix_port`, `biged_skills_count`, `scorerift_threshold`) now return populated citations (5, 12, 5 respectively) instead of `n_citations=0`.

## Stash-and-retest evidence

Stashed `helix_context/pipeline/tier_logic.py` (keeping tests in place) and ran the new RRF tests against master:

```
FAILED tests/test_abstain_tier.py::test_rrf_realistic_gradient_does_not_abstain
FAILED tests/test_abstain_tier.py::test_rrf_tight_top_clear_separation_does_not_abstain
FAILED tests/test_abstain_tier.py::test_rrf_metadata_ratio_reflects_normalized_value
========== 3 failed, 3 passed in 6.87s ==========
```

Restored fix → all 6 pass. The 3 that pass on master pass because they exercise behaviour PR #116 already provides (genuinely-tied → abstain, additive strong-signal → pass).

## Tests

- `python -m pytest tests/test_abstain_tier.py tests/test_fusion_rrf.py tests/test_shard_router.py tests/test_sharded_adapter_parity.py tests/test_pipeline.py tests/test_foveated_splice.py tests/test_caller_model_class.py -v` → **120 passed**
- Full suite `python -m pytest tests/ -m \"not live\" --ignore=tests/test_observability_docs.py` → **2025 passed, 15 skipped, 2 xfailed** (the ignored file fails on master pre-#115, unrelated)

## What contradicts the diagnosis

The diagnosis in #115 cites `top_score=0.38, ratio=1.69` for `helix_port` etc. My direct adapter probe (no refiners) shows `top=0.0164, ratio=1.0` — score scale 20x lower. The discrepancy is the **refiner pipeline** between `ShardedGenomeAdapter.query_docs` and `apply_budget_tiers`: cymatics, harmonic-bin, TCM, etc. multiply the raw RRF scores up. Once I hooked the FULL pipeline (via `HelixContextManager.build_context`), I observed the diagnostic's numbers exactly (top ~0.36-0.40, legacy ratios 1.46-1.77). Both metrics fail the legacy 1.8 ratio gate; the diagnosis was correct, my initial probe just sampled the wrong layer.

## Constraints honored

- Blob-mode behavior unchanged: additive path still uses legacy `top/mean` + 1.8 threshold + 2.5 absolute floor.
- No changes to citation enrichment (PR #106).
- No changes to `shard_router` RRF logic (PR #106).
- 25 lines of production code in `tier_logic.py`; rest is test updates.