### PR TITLE
fix(bench): orchestrator port-free restart + health pid check (closes #127)

### DIFF
--- a/benchmarks/bench_orchestrator.py
+++ b/benchmarks/bench_orchestrator.py
@@ -50,6 +50,7 @@ import json
 import logging
 import os
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -69,6 +70,13 @@ DEFAULT_HEALTH_POLL_S = 0.5
 DEFAULT_SHUTDOWN_TIMEOUT_S = 10.0
 DEFAULT_SWAP_TIMEOUT_S = 60.0
 DEFAULT_REQUEST_TIMEOUT_S = 15.0
+# How long to wait for the OS to release the listen port after a stop()
+# before spawning the replacement uvicorn. On Windows the socket can
+# linger (TIME_WAIT, or a child the OS hasn't fully reaped) past
+# proc.wait() returning, so the next bind loses the race with Errno
+# 10048. See issue #127.
+DEFAULT_PORT_FREE_TIMEOUT_S = 15.0
+DEFAULT_PORT_FREE_POLL_S = 0.25
 
 # Windows: prevent console-window flash on subprocess spawn (per CLAUDE.md
 # global "Subprocess Safety (Windows)" rule).
@@ -86,12 +94,19 @@ class Fixture:
 
     ``read_only`` defaults True so a bench run can't accidentally mutate
     the fixture (PR #91 ``read_only`` guard).
+
+    ``expect_nonempty`` defaults True: every fixture in the bench matrix
+    has thousands of genes, so a server reporting ``genes=0`` after a
+    swap/restart is always a harness failure (issue #127 — sharded DB
+    opened in blob mode). Set False only for a deliberately empty
+    fixture.
     """
     name: str
     db: str
     sharded: bool = False
     read_only: bool = True
     extra_env: dict[str, str] = field(default_factory=dict)
+    expect_nonempty: bool = True
 
 
 @dataclass
@@ -177,6 +192,10 @@ class BenchServer(AbstractContextManager["BenchServer"]):
             return self.switch(fixture)
 
         t0 = time.time()
+        # Issue #127: even on a cold start, a leftover uvicorn from a
+        # crashed prior run can still hold the port. Confirm it is free
+        # (or fail loudly) before spawning into a possible bind race.
+        self._wait_port_free()
         self._spawn(fixture)
         self._wait_healthy()
 
@@ -186,6 +205,7 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         swap = self._post_swap(fixture)
         elapsed = time.time() - t0
         self._current = fixture
+        self._guard_genes(fixture, swap)
         return SwapResult(
             fixture=fixture, mechanism="start",
             elapsed_s=round(elapsed, 3),
@@ -210,25 +230,49 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         return self._hot_swap(fixture)
 
     def stop(self) -> None:
-        """Terminate uvicorn. Best-effort; kills if graceful exit fails."""
+        """Terminate uvicorn and confirm the process tree is gone.
+
+        ``proc.terminate()`` only kills the named pid. uvicorn under
+        ``python -m uvicorn`` can spawn child/worker processes; on Windows
+        a surviving child keeps the listen socket bound, so the next
+        ``_spawn()`` loses the bind race (Errno 10048) and the orchestrator
+        ends up talking to a stale server. This kills the whole tree and
+        verifies teardown before returning. See issue #127.
+        """
         if self._proc is None:
             return
         proc, self._proc = self._proc, None
         if proc.poll() is not None:
             self._close_log()
+            self._current = None
             return
         try:
             if os.name == "nt":
-                # CTRL_BREAK won't reach the child without
-                # CREATE_NEW_PROCESS_GROUP at spawn time; terminate() maps
-                # to TerminateProcess which is the right hammer on Windows.
-                proc.terminate()
+                # taskkill /T walks and kills the whole process tree;
+                # /F forces it. terminate() (TerminateProcess) would only
+                # reach the top-level pid and orphan any uvicorn children
+                # that may still hold port %s.
+                self._taskkill_tree(proc.pid)
+                try:
+                    proc.wait(timeout=self.shutdown_timeout_s)
+                except subprocess.TimeoutExpired:
+                    log.warning(
+                        "uvicorn pid=%s still alive after taskkill /T /F; "
+                        "falling back to proc.kill()", proc.pid,
+                    )
+                    proc.kill()
             else:
                 proc.send_signal(signal.SIGINT)
-            proc.wait(timeout=self.shutdown_timeout_s)
-        except subprocess.TimeoutExpired:
-            log.warning("uvicorn did not exit cleanly; killing pid=%s", proc.pid)
-            proc.kill()
+                try:
+                    proc.wait(timeout=self.shutdown_timeout_s)
+                except subprocess.TimeoutExpired:
+                    log.warning(
+                        "uvicorn did not exit on SIGINT; killing pid=%s", proc.pid,
+                    )
+                    proc.kill()
+            # Reap so the OS releases the pid + socket handles. On POSIX
+            # this prevents a zombie holding the descriptor; on Windows it
+            # ensures the handle close completes before we poll the port.
             try:
                 proc.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
@@ -238,6 +282,38 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         finally:
             self._close_log()
             self._current = None
+        # Loud failure beats a silent stale-server attach: if the process
+        # is somehow still alive, callers must not spawn a replacement.
+        if proc.poll() is None:
+            raise BenchServerError(
+                f"failed to terminate uvicorn pid={proc.pid}; "
+                "refusing to spawn a replacement into a live process"
+            )
+
+    @staticmethod
+    def _taskkill_tree(pid: int) -> None:
+        """Windows-only: kill ``pid`` and its whole process tree.
+
+        Uses ``taskkill /T /F``. ``CREATE_NO_WINDOW`` keeps the helper from
+        flashing a console (project Windows subprocess convention).
+        """
+        try:
+            res = subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(pid)],
+                capture_output=True, text=True,
+                creationflags=_NO_WINDOW,
+                timeout=15.0,
+            )
+            if res.returncode != 0:
+                # rc 128 == process not found; benign if it already exited.
+                log.warning(
+                    "taskkill /T /F /PID %s exited rc=%s: %s",
+                    pid, res.returncode, (res.stderr or res.stdout or "").strip(),
+                )
+        except subprocess.TimeoutExpired:
+            log.warning("taskkill /T /F /PID %s timed out", pid)
+        except Exception:
+            log.warning("taskkill /T /F /PID %s raised", pid, exc_info=True)
 
     def health(self) -> dict[str, Any]:
         """Fetch ``/health``. Raises if unreachable."""
@@ -283,19 +359,67 @@ class BenchServer(AbstractContextManager["BenchServer"]):
             close_fds=(os.name != "nt"),
         )
 
+    def _wait_port_free(
+        self, timeout_s: float = DEFAULT_PORT_FREE_TIMEOUT_S,
+    ) -> None:
+        """Block until ``(host, port)`` refuses connections, then return.
+
+        ``stop()`` returning does not guarantee the OS has released the
+        listen socket — on Windows it can linger in TIME_WAIT or wait on a
+        not-fully-reaped child. Spawning the replacement uvicorn before the
+        port is free makes it lose the bind race (Errno 10048); the new
+        process dies and ``_wait_healthy`` then talks to the *stale*
+        server. So we poll until ``connect_ex`` no longer returns 0 (0 ==
+        a listener accepted the connection == port still occupied).
+
+        Raises ``BenchServerError`` on timeout rather than letting the
+        caller spawn into a doomed bind. See issue #127.
+        """
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(1.0)
+                # connect_ex returns 0 only if something is *listening*.
+                # Anything else (ECONNREFUSED / WSAECONNREFUSED, timeout)
+                # means the port is free for us to bind.
+                if sock.connect_ex((self.host, self.port)) != 0:
+                    return
+            time.sleep(DEFAULT_PORT_FREE_POLL_S)
+        raise BenchServerError(
+            f"port {self.host}:{self.port} still occupied after "
+            f"{timeout_s}s; refusing to spawn uvicorn into a doomed bind "
+            "(a stale server is likely still holding the socket)"
+        )
+
     def _wait_healthy(self) -> None:
         deadline = time.time() + self.health_timeout_s
         last_err: Optional[Exception] = None
+        expected_pid = self._proc.pid if self._proc is not None else None
         while time.time() < deadline:
             if self._proc is not None and self._proc.poll() is not None:
                 rc = self._proc.returncode
                 raise BenchServerError(f"uvicorn exited during startup (rc={rc})")
             try:
-                self.health()
-                return
+                payload = self.health()
             except Exception as exc:
                 last_err = exc
                 time.sleep(DEFAULT_HEALTH_POLL_S)
+                continue
+            # Identity check: a stale uvicorn that won the bind race will
+            # also answer /health. If the responder's pid is not the
+            # process we just spawned, fail loudly — proceeding would run
+            # the whole bench against the wrong (e.g. blob-mode) server
+            # and silently report genes=0. See issue #127.
+            responder_pid = payload.get("pid")
+            if expected_pid is not None and responder_pid is not None:
+                if int(responder_pid) != int(expected_pid):
+                    raise BenchServerError(
+                        f"/health answered by pid={responder_pid}, but the "
+                        f"spawned uvicorn is pid={expected_pid}; a stale "
+                        "server is holding the port. Aborting rather than "
+                        "running the bench against the wrong process."
+                    )
+            return
         raise BenchServerError(
             f"uvicorn did not become healthy within {self.health_timeout_s}s "
             f"(last error: {last_err})"
@@ -305,6 +429,7 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         t0 = time.time()
         result = self._post_swap(fixture)
         self._current = fixture
+        self._guard_genes(fixture, result)
         return SwapResult(
             fixture=fixture, mechanism="hot_swap",
             elapsed_s=round(time.time() - t0, 3),
@@ -319,10 +444,15 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         )
         t0 = time.time()
         self.stop()
+        # Issue #127: do not spawn until the OS has actually released the
+        # listen port. Otherwise the new uvicorn loses the bind race and
+        # _wait_healthy attaches to the stale (wrong-mode) server.
+        self._wait_port_free()
         self._spawn(fixture)
         self._wait_healthy()
         swap = self._post_swap(fixture)
         self._current = fixture
+        self._guard_genes(fixture, swap)
         return SwapResult(
             fixture=fixture, mechanism="restart",
             elapsed_s=round(time.time() - t0, 3),
@@ -341,6 +471,30 @@ class BenchServer(AbstractContextManager["BenchServer"]):
             raise BenchServerError(
                 f"hot-swap to {fixture.name} ({fixture.db}) failed: {exc}"
             ) from exc
+
+    @staticmethod
+    def _guard_genes(fixture: Fixture, swap: dict[str, Any]) -> None:
+        """Fail loudly if a non-empty fixture reports ``genes=0``.
+
+        A ``start``/``restart``/``hot_swap`` that yields zero genes for a
+        fixture the manifest says has content is always a harness failure
+        — the canonical case (issue #127) is a sharded routing DB opened
+        in blob mode because ``HELIX_USE_SHARDS`` did not take effect, so
+        ``stats()`` reads the empty local ``genes`` table. Without this
+        guard the bench silently produces a 0/N result that looks like a
+        retrieval regression.
+        """
+        if not fixture.expect_nonempty:
+            return
+        genes = int(swap.get("genes", 0))
+        if genes == 0:
+            raise BenchServerError(
+                f"fixture {fixture.name} ({fixture.db}) reported genes=0 "
+                "after swap, but the manifest marks it non-empty. This is a "
+                "harness failure (likely a sharded DB opened in blob mode — "
+                "HELIX_USE_SHARDS not in effect, or a stale server answered). "
+                "Refusing to run a bench that would silently score 0/N."
+            )
 
     def _http(
         self,
@@ -391,6 +545,12 @@ def load_manifest(path: Path) -> list[Fixture]:
     Each entry must have ``name`` and ``db``. Optional: ``sharded`` (bool,
     default False), ``read_only`` (bool, default True), ``env`` (dict of
     extra env vars to inject when this fixture is active).
+
+    The optional ``_genes`` metadata key (the matrix manifest records the
+    expected gene count there) drives the ``expect_nonempty`` guard: an
+    entry with ``"_genes": 0`` is treated as a deliberately empty fixture
+    and exempt from the ``genes=0`` failure (issue #127). Any other value
+    — or its absence — keeps the default non-empty expectation.
     """
     with path.open("r", encoding="utf-8") as f:
         raw = json.load(f)
@@ -400,12 +560,16 @@ def load_manifest(path: Path) -> list[Fixture]:
     for i, entry in enumerate(raw):
         if "name" not in entry or "db" not in entry:
             raise ValueError(f"fixture #{i} missing 'name' or 'db'")
+        # Only an explicit "_genes": 0 marks a fixture as legitimately
+        # empty. Absent metadata defaults to expecting content.
+        expect_nonempty = entry.get("_genes", None) != 0
         fixtures.append(Fixture(
             name=str(entry["name"]),
             db=str(entry["db"]),
             sharded=bool(entry.get("sharded", False)),
             read_only=bool(entry.get("read_only", True)),
             extra_env={str(k): str(v) for k, v in (entry.get("env") or {}).items()},
+            expect_nonempty=expect_nonempty,
         ))
     return fixtures
 

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Dict, Optional
 
 from fastapi import FastAPI, HTTPException, Request
@@ -459,6 +460,11 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
         return {
             "status": status,
             "message": message,
+            # OS pid of the process answering this request. Lets callers
+            # (e.g. the bench orchestrator's _wait_healthy) confirm they
+            # are talking to the process they just spawned, not a stale
+            # server that lost a port-bind race. See issue #127.
+            "pid": os.getpid(),
             "ribosome": ribosome_model,
             "ribosome_backend": config.ribosome.effective_backend,
             "ribosome_configured_backend": configured_backend,

--- a/tests/test_bench_orchestrator.py
+++ b/tests/test_bench_orchestrator.py
@@ -1,0 +1,381 @@
+"""Unit tests for bench_orchestrator.py — the issue #127 fixes.
+
+Issue #127: a cross-mode bench restart (blob -> sharded) could fail to
+free port 11437 before spawning the replacement uvicorn. The new process
+lost the bind race (Errno 10048), exited, and ``_wait_healthy()`` then
+talked to the *stale* blob-mode server still holding the port. Every
+sharded query returned ``genes=0``.
+
+These tests pin the four hardening fixes — they are pure unit tests:
+the socket / subprocess / HTTP boundaries are mocked, no real uvicorn is
+spawned.
+
+  1. ``stop()`` kills the whole process tree and confirms teardown
+     (raises if the process is somehow still alive).
+  2. ``_wait_port_free()`` returns once the port refuses connections and
+     raises ``BenchServerError`` on timeout.
+  3. ``_wait_healthy()`` rejects a ``/health`` responder whose pid does
+     not match the process just spawned.
+  4. ``_guard_genes()`` raises when a non-empty fixture reports
+     ``genes=0`` after a swap.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make benchmarks/ importable as a flat module path, matching the
+# convention in tests/test_benchmark_monitor_preflight.py.
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+if str(BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCH_DIR))
+
+from bench_orchestrator import (  # noqa: E402
+    BenchServer,
+    BenchServerError,
+    Fixture,
+    load_manifest,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _fake_proc(pid: int = 4242, *, alive: bool = True) -> MagicMock:
+    """A stand-in for ``subprocess.Popen`` with controllable liveness.
+
+    ``poll()`` returns ``None`` while ``alive`` is True, then the exit
+    code once flipped. ``wait()`` flips it to dead (simulating a
+    successful kill) unless ``wait_raises`` is set.
+    """
+    proc = MagicMock()
+    proc.pid = pid
+    state = {"alive": alive, "rc": None}
+
+    def poll():
+        return None if state["alive"] else state["rc"]
+
+    def wait(timeout=None):
+        if state.get("wait_raises"):
+            raise subprocess.TimeoutExpired(cmd="uvicorn", timeout=timeout)
+        state["alive"] = False
+        state["rc"] = 0
+        return 0
+
+    def kill():
+        state["alive"] = False
+        state["rc"] = -9
+
+    proc.poll.side_effect = poll
+    proc.wait.side_effect = wait
+    proc.kill.side_effect = kill
+    proc._state = state  # test hook
+    return proc
+
+
+# ── Fix 1: stop() — process-tree kill + teardown confirmation ─────────
+
+
+def test_stop_noop_when_no_process() -> None:
+    """stop() on a server that never started is a quiet no-op."""
+    srv = BenchServer()
+    srv.stop()  # must not raise
+
+
+def test_stop_kills_process_tree_on_windows() -> None:
+    """On Windows stop() shells out to ``taskkill /T /F`` (tree kill).
+
+    ``proc.terminate()`` (TerminateProcess) only reaches the named pid
+    and would orphan uvicorn children still holding the port.
+    """
+    srv = BenchServer()
+    proc = _fake_proc(pid=9001)
+    srv._proc = proc
+
+    fake_run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    with patch("bench_orchestrator.os") as fake_os, \
+            patch("bench_orchestrator.subprocess.run", fake_run):
+        fake_os.name = "nt"
+        srv.stop()
+
+    assert fake_run.called, "expected taskkill to be invoked on Windows"
+    argv = fake_run.call_args[0][0]
+    assert argv[0] == "taskkill"
+    assert "/T" in argv and "/F" in argv
+    assert "9001" in argv, "taskkill must target the spawned pid"
+    assert srv._proc is None
+
+
+def test_stop_confirms_process_death() -> None:
+    """After stop() the process is reaped (poll() reports an exit code)."""
+    srv = BenchServer()
+    proc = _fake_proc(pid=9002)
+    srv._proc = proc
+
+    with patch("bench_orchestrator.os") as fake_os, \
+            patch("bench_orchestrator.subprocess.run",
+                  MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))):
+        fake_os.name = "nt"
+        srv.stop()
+
+    assert proc.poll() is not None, "process must be dead after stop()"
+
+
+def test_stop_raises_if_process_survives() -> None:
+    """A stop() that fails to kill the process raises — a live server
+    must never silently be left holding the port for the next spawn."""
+    srv = BenchServer()
+    # Process that refuses to die: poll() always None, wait() always
+    # times out, kill() is a no-op.
+    proc = MagicMock()
+    proc.pid = 9003
+    proc.poll.return_value = None
+    proc.wait.side_effect = subprocess.TimeoutExpired(cmd="uvicorn", timeout=5)
+    proc.kill.return_value = None
+    srv._proc = proc
+
+    with patch("bench_orchestrator.os") as fake_os, \
+            patch("bench_orchestrator.subprocess.run",
+                  MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))):
+        fake_os.name = "nt"
+        with pytest.raises(BenchServerError, match="failed to terminate"):
+            srv.stop()
+
+
+def test_stop_posix_uses_sigint() -> None:
+    """On POSIX stop() keeps the SIGINT-then-reap path (no taskkill)."""
+    srv = BenchServer()
+    proc = _fake_proc(pid=9004)
+    srv._proc = proc
+
+    fake_run = MagicMock()
+    with patch("bench_orchestrator.os") as fake_os, \
+            patch("bench_orchestrator.subprocess.run", fake_run):
+        fake_os.name = "posix"
+        srv.stop()
+
+    assert not fake_run.called, "taskkill must not run on POSIX"
+    assert proc.send_signal.called, "POSIX path must signal the process"
+    assert proc.poll() is not None
+
+
+# ── Fix 2: _wait_port_free() ──────────────────────────────────────────
+
+
+def test_wait_port_free_returns_when_port_refuses() -> None:
+    """_wait_port_free returns once connect_ex no longer returns 0
+    (0 == a listener accepted == port still occupied)."""
+    srv = BenchServer()
+    fake_sock = MagicMock()
+    # First poll: port still bound (0). Second poll: refused (non-zero).
+    fake_sock.connect_ex.side_effect = [0, 111]
+    fake_sock.__enter__ = MagicMock(return_value=fake_sock)
+    fake_sock.__exit__ = MagicMock(return_value=False)
+
+    with patch("bench_orchestrator.socket.socket", return_value=fake_sock), \
+            patch("bench_orchestrator.time.sleep"):
+        srv._wait_port_free(timeout_s=5.0)
+
+    assert fake_sock.connect_ex.call_count == 2
+
+
+def test_wait_port_free_returns_immediately_if_free() -> None:
+    """If the port is already free, _wait_port_free returns on poll #1."""
+    srv = BenchServer()
+    fake_sock = MagicMock()
+    fake_sock.connect_ex.return_value = 111  # refused == free
+    fake_sock.__enter__ = MagicMock(return_value=fake_sock)
+    fake_sock.__exit__ = MagicMock(return_value=False)
+
+    with patch("bench_orchestrator.socket.socket", return_value=fake_sock), \
+            patch("bench_orchestrator.time.sleep"):
+        srv._wait_port_free(timeout_s=5.0)
+
+    assert fake_sock.connect_ex.call_count == 1
+
+
+def test_wait_port_free_raises_on_timeout() -> None:
+    """A port that stays bound past the timeout raises BenchServerError
+    rather than letting the caller spawn into a doomed bind."""
+    srv = BenchServer()
+    fake_sock = MagicMock()
+    fake_sock.connect_ex.return_value = 0  # always occupied
+    fake_sock.__enter__ = MagicMock(return_value=fake_sock)
+    fake_sock.__exit__ = MagicMock(return_value=False)
+
+    # Drive a deterministic timeout: time advances past the deadline on
+    # the second read.
+    times = iter([1000.0, 1000.0, 9999.0, 9999.0])
+    with patch("bench_orchestrator.socket.socket", return_value=fake_sock), \
+            patch("bench_orchestrator.time.sleep"), \
+            patch("bench_orchestrator.time.time", side_effect=lambda: next(times)):
+        with pytest.raises(BenchServerError, match="still occupied"):
+            srv._wait_port_free(timeout_s=15.0)
+
+
+# ── Fix 3: _wait_healthy() identity check ─────────────────────────────
+
+
+def test_wait_healthy_accepts_matching_pid() -> None:
+    """_wait_healthy succeeds when /health reports the spawned pid."""
+    srv = BenchServer()
+    srv._proc = _fake_proc(pid=5555)
+
+    with patch.object(srv, "health", return_value={"status": "ok", "pid": 5555}):
+        srv._wait_healthy()  # must not raise
+
+
+def test_wait_healthy_rejects_mismatched_pid() -> None:
+    """A /health responder with the *wrong* pid (a stale server that won
+    the bind race) must cause a loud failure, not silent success."""
+    srv = BenchServer()
+    srv._proc = _fake_proc(pid=5555)
+
+    # Stale blob-mode server answering on the port reports a different pid.
+    with patch.object(srv, "health", return_value={"status": "ok", "pid": 38068}):
+        with pytest.raises(BenchServerError, match="stale server"):
+            srv._wait_healthy()
+
+
+def test_wait_healthy_tolerates_health_without_pid() -> None:
+    """If /health omits ``pid`` (older server build), _wait_healthy does
+    not crash — it just cannot perform the identity assertion."""
+    srv = BenchServer()
+    srv._proc = _fake_proc(pid=5555)
+
+    with patch.object(srv, "health", return_value={"status": "ok"}):
+        srv._wait_healthy()  # must not raise
+
+
+def test_wait_healthy_raises_if_process_exits() -> None:
+    """If the spawned uvicorn exits during startup, _wait_healthy raises
+    (e.g. the new process lost the bind race and shut itself down)."""
+    srv = BenchServer()
+    proc = _fake_proc(pid=5556)
+    proc._state["alive"] = False  # process already dead
+    proc._state["rc"] = 1
+    srv._proc = proc
+
+    with pytest.raises(BenchServerError, match="exited during startup"):
+        srv._wait_healthy()
+
+
+# ── Fix 4: _guard_genes() ─────────────────────────────────────────────
+
+
+def test_guard_genes_raises_on_zero_for_nonempty_fixture() -> None:
+    """genes=0 on a fixture the manifest marks non-empty is a harness
+    failure (sharded DB opened in blob mode) and must raise."""
+    fx = Fixture(name="medium-sharded", db="x/main.genome.db",
+                 sharded=True, expect_nonempty=True)
+    with pytest.raises(BenchServerError, match="genes=0"):
+        BenchServer._guard_genes(fx, {"genes": 0})
+
+
+def test_guard_genes_passes_for_nonempty_result() -> None:
+    """A non-empty fixture reporting real genes passes the guard."""
+    fx = Fixture(name="medium-sharded", db="x/main.genome.db",
+                 sharded=True, expect_nonempty=True)
+    BenchServer._guard_genes(fx, {"genes": 17396})  # must not raise
+
+
+def test_guard_genes_skips_when_fixture_marked_empty() -> None:
+    """A fixture explicitly flagged ``expect_nonempty=False`` is exempt."""
+    fx = Fixture(name="empty", db="x/empty.db", expect_nonempty=False)
+    BenchServer._guard_genes(fx, {"genes": 0})  # must not raise
+
+
+def test_guard_genes_treats_missing_genes_key_as_zero() -> None:
+    """A swap response missing ``genes`` entirely is treated as 0 and
+    fails the guard for a non-empty fixture."""
+    fx = Fixture(name="medium", db="x/medium.db", expect_nonempty=True)
+    with pytest.raises(BenchServerError, match="genes=0"):
+        BenchServer._guard_genes(fx, {})
+
+
+# ── load_manifest() — expect_nonempty derivation ──────────────────────
+
+
+def test_load_manifest_defaults_expect_nonempty_true(tmp_path: Path) -> None:
+    """Manifest entries without ``_genes`` metadata default to expecting
+    content (the bench-matrix invariant)."""
+    manifest = tmp_path / "fixtures.json"
+    manifest.write_text(
+        '[{"name": "small", "db": "x/small.db", "sharded": false}]',
+        encoding="utf-8",
+    )
+    fixtures = load_manifest(manifest)
+    assert len(fixtures) == 1
+    assert fixtures[0].expect_nonempty is True
+
+
+def test_load_manifest_honors_explicit_empty_marker(tmp_path: Path) -> None:
+    """An entry with ``"_genes": 0`` is treated as a deliberately empty
+    fixture (expect_nonempty=False); a positive count keeps it True."""
+    manifest = tmp_path / "fixtures.json"
+    manifest.write_text(
+        '[{"name": "empty", "db": "x/e.db", "_genes": 0},'
+        ' {"name": "medium", "db": "x/m.db", "_genes": 17324}]',
+        encoding="utf-8",
+    )
+    fixtures = load_manifest(manifest)
+    by_name = {f.name: f for f in fixtures}
+    assert by_name["empty"].expect_nonempty is False
+    assert by_name["medium"].expect_nonempty is True
+
+
+# ── integration of the fixes inside _restart_for_fixture ──────────────
+
+
+def test_restart_waits_for_port_then_spawns_in_order() -> None:
+    """The cross-mode restart path must stop -> wait-for-free-port ->
+    spawn, in that order, so the new uvicorn never races a held port."""
+    srv = BenchServer()
+    srv._proc = _fake_proc(pid=7000)
+
+    calls: list[str] = []
+    blob = Fixture(name="small", db="x/small.db", sharded=False)
+    sharded = Fixture(name="medium-sharded", db="x/main.genome.db", sharded=True)
+    srv._current = blob
+
+    def rec(label):
+        def _inner(*_a, **_k):
+            calls.append(label)
+        return _inner
+
+    with patch.object(srv, "stop", side_effect=rec("stop")), \
+            patch.object(srv, "_wait_port_free", side_effect=rec("wait_port_free")), \
+            patch.object(srv, "_spawn", side_effect=rec("spawn")), \
+            patch.object(srv, "_wait_healthy", side_effect=rec("wait_healthy")), \
+            patch.object(srv, "_post_swap", return_value={"genes": 17396}):
+        result = srv._restart_for_fixture(sharded, blob)
+
+    assert calls == ["stop", "wait_port_free", "spawn", "wait_healthy"], calls
+    assert result.mechanism == "restart"
+    assert result.genes == 17396
+
+
+def test_restart_fails_loudly_when_sharded_fixture_yields_zero_genes() -> None:
+    """End-to-end of the #127 failure mode: the restart completes but the
+    swap reports genes=0 (sharded DB opened in blob mode). The orchestrator
+    must raise instead of returning a SwapResult with genes=0."""
+    srv = BenchServer()
+    srv._proc = _fake_proc(pid=7001)
+    blob = Fixture(name="small", db="x/small.db", sharded=False)
+    sharded = Fixture(name="medium-sharded", db="x/main.genome.db",
+                      sharded=True, expect_nonempty=True)
+    srv._current = blob
+
+    with patch.object(srv, "stop"), \
+            patch.object(srv, "_wait_port_free"), \
+            patch.object(srv, "_spawn"), \
+            patch.object(srv, "_wait_healthy"), \
+            patch.object(srv, "_post_swap", return_value={"genes": 0}):
+        with pytest.raises(BenchServerError, match="genes=0"):
+            srv._restart_for_fixture(sharded, blob)


### PR DESCRIPTION
## Summary

Fixes #127. The bench orchestrator's cross-mode restart (blob↔sharded) could fail to free port 11437 before spawning the replacement uvicorn. The new process lost the bind race (`Errno 10048`), shut itself down, and `_wait_healthy()` then talked to the **stale blob-mode server still holding the port** — so every sharded query returned `genes=0`, silently invalidating all sharded fixtures in a multi-fixture run.

## The 4 fixes (`benchmarks/bench_orchestrator.py`)

1. **`stop()` — full process-tree kill on Windows.** `proc.terminate()` (TerminateProcess) only reaches the named pid and orphans any uvicorn children that keep the listen socket bound. Now uses `taskkill /T /F /PID <pid>` (tree kill, `CREATE_NO_WINDOW`), reaps the process, and **raises if the process is somehow still alive** rather than leaving a live server for the next spawn. POSIX keeps the existing SIGINT-then-kill path.

2. **`_wait_port_free()` — port-free wait before `_spawn()`.** Polls `socket.connect_ex(('127.0.0.1', port))` until it no longer returns `0` (0 == a listener accepted == port still occupied), with a 15s timeout. Raises `BenchServerError` on timeout instead of spawning into a doomed bind. Wired into both `start()` and `_restart_for_fixture()`.

3. **`_wait_healthy()` identity check.** `/health` had **no pid field** — added one (see below). `_wait_healthy()` now asserts the responder's pid equals the spawned process's pid. A stale server answering causes a **loud failure**, not silent success. Tolerates an older server build that omits `pid`.

4. **`_guard_genes()` — `genes=0` guard.** After `start`/`restart`/`hot_swap`, raises if a fixture the manifest marks non-empty reports `genes=0` (the canonical sharded-DB-opened-in-blob-mode failure). `load_manifest()` derives `expect_nonempty` from the manifest's `_genes` metadata key (`"_genes": 0` exempts a deliberately empty fixture).

## `/health` pid field

`/health` previously exposed **no pid**. Added `"pid": os.getpid()` to the response payload in `helix_context/server/routes_admin.py` (3-line change + `import os`). Backward compatible — `_wait_healthy()` skips the identity assertion if `pid` is absent.

## Integration validation (the key proof)

Ran a real cross-mode restart sequence (`blob → sharded → blob`) against the patched orchestrator, spawning real uvicorn processes:

```
==== INTEGRATION VALIDATION SUMMARY (issue #127) ====
  1-start-blob(small)             mechanism=start    genes=   1237  health.pid=32988  swap.pid=32988  status=degraded
  2-switch-blob->sharded(medium)  mechanism=restart  genes=  17396  health.pid=46468  swap.pid=46468  status=degraded
  3-switch-sharded->blob(medium)  mechanism=restart  genes=  17324  health.pid=29556  swap.pid=29556  status=degraded

RESULT: PASS — cross-mode restart yields genes>0, health pid matches
```

- **Step 2 (blob→sharded restart): `genes=17396`** — the expected sharded gene count, **NOT 0**. `HELIX_USE_SHARDS=1` took effect; the sharded adapter aggregated all 6 shards. This is exactly where the prior 50-needle matrix run failed.
- Every step: `health.pid == swap.pid` — the orchestrator confirmed it spoke to the freshly spawned process, never a stale one.
- All 3 restarts bound the port cleanly — no `Errno 10048`.

(`status=degraded` is just Ollama being down — upstream unreachable, irrelevant to retrieval/genes.)

## Test plan

- [x] New `tests/test_bench_orchestrator.py` — 20 unit tests covering all 4 fixes (process-tree kill, teardown confirmation, port-free wait + timeout, pid identity match/mismatch, `genes=0` guard, manifest `expect_nonempty` derivation). Socket/subprocess/HTTP mocked — no real uvicorn spawned.
- [x] `python -m pytest tests/test_bench_orchestrator.py tests/test_benchmark_monitor_preflight.py tests/test_bench_citations.py` → **45 passed**.
- [x] `tests/test_server.py tests/test_status.py` → **82 passed** (confirms the `/health` `pid` addition is backward compatible).
- [x] `tests/test_bench_determinism.py tests/test_bench_harvest.py tests/test_bench_needles.py` → **38 passed**.
- [x] Integration: real blob→sharded→blob restart yields `genes>0` and matching pid (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)