### PR TITLE
fix(retrieval): synonym map expansion for sharded-bench misses (#124)

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -426,6 +426,16 @@ slate = ["answer_slate", "kv_facts", "front_loaded", "extraction", "moe"]
 decoder = ["decoder_mode", "condensed", "moe", "ribosome_prompt", "instructions"]
 maintenance = ["admin", "vacuum", "refresh", "checkpoint", "compact"]
 
+# Fix #124: unmapped query tokens from sharded-bench misses. Each key is a
+# token produced by extract_query_signals() for a documented miss query that
+# previously had NO synonym entry — so it could only match via raw FTS.
+fleet = ["biged", "biged-rs", "agents", "workers", "supervisor", "skills"]
+ribosome = ["decoder", "ribosome_prompt", "compressor", "splice", "budget", "tokens"]
+expression = ["pipeline", "stages", "steps", "expressed_context", "decoder"]
+agents = ["agent", "fleet", "conductor", "worker", "orchestration", "biged"]
+dashboard = ["port", "ui", "frontend", "server", "fleet"]
+tables = ["database", "db", "sqlite", "schema", "ddl"]
+
 # ── Vault export (Obsidian) — opt-in, off by default ────────────────────
 # Renders the genome as a browsable markdown vault for operators.
 # v1: read-only export + diagnostic /context traces. Curation/inbox in v1.1.


### PR DESCRIPTION
Closes #124.

## Summary

Several sharded-bench miss queries produce keyword tokens that had **no entry** in the `[synonyms]` map. `_expand_terms` (`helix_context/knowledge_store.py`) keys on single lowercased query tokens emitted by `extract_query_signals` (`helix_context/accel.py`); an unmapped token contributes nothing beyond raw FTS. This PR fills six confirmed gaps.

Config-only — `helix.toml` is the sole changed file. Fully reversible.

## Mappings added (with rationale)

Each key is a token verified to be emitted by `extract_query_signals()` for a documented miss query in the 50-needle set (`benchmarks/bench_claude_matrix.py`), and verified to have had no prior `[synonyms]` key:

| Key | Mapping | Rationale |
|---|---|---|
| `fleet` | `biged, biged-rs, agents, workers, supervisor, skills` | Token in 4+ BigEd needles (`biged_skills_count`, `biged_dashboard_port`, `biged_db_tables`, `biged_max_workers`). The BigEd fleet's primary domain, yet `fleet` only existed as a *value* under other keys — never a key itself. |
| `ribosome` | `decoder, ribosome_prompt, compressor, splice, budget, tokens` | Token in `helix_ribosome_budget` ("ribosome decoder prompt"). The answer is the decoder-prompt token budget; `ribosome` had no key, so the answer-bearing concept was unreachable via tag expansion. |
| `expression` | `pipeline, stages, steps, expressed_context, decoder` | Token in `helix_pipeline_steps` ("Helix **expression** pipeline"). The answer is the 6-stage expression pipeline; `expression` was only a value under `pipeline`/`budget`. |
| `agents` | `agent, fleet, conductor, worker, orchestration, biged` | Token in `biged_core_agents` and `biged_default_model` ("conductor agents/tasks"). `conductor` was keyed but the plural `agents` token itself had no key. |
| `dashboard` | `port, ui, frontend, server, fleet` | Token in `biged_dashboard_port` ("BigEd fleet **dashboard** ... port"). No prior key; the port answer doc is dashboard-config-shaped. |
| `tables` | `database, db, sqlite, schema, ddl` | Token in `biged_db_tables` ("database **tables**"). `db` was keyed but `tables`/`database` tokens were not, so the table-count query under-expanded. |

No speculative mappings — every key addresses an identified unmapped token from a real miss query. Multi-word keys were deliberately avoided: `_expand_terms` matches single tokens only, so a key like `"expression pipeline"` would never fire.

## Test plan

- [x] `python -m pytest tests/ -m "not live" -k synonym -v` — 10/10 pass. Synonym tests use fixture maps (`tests/conftest.py`) independent of `helix.toml`, so config edits cannot regress them.
- [x] `python -m pytest tests/ -m "not live" -k config -q` — 54/54 pass (`helix.toml` parses, loader accepts the new keys).
- [x] `helix.toml` parses via `tomllib` + `helix_context.config.load_config`; expansion simulated for all 5 issue-table queries — each previously-unmapped token now expands.
- [ ] **Bench validation against the 50-needle set is pending — orchestrator** will run `bench_claude_matrix.py` (medium / medium-sharded / medium-blob) post-merge. The issue body's "5/10 → 6+/10" targets are from the old 10-needle set and do not apply to the current 50-needle bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)