### PR TITLE
chore(backfill): configurable BGE-M3 device via BGEM3_DEVICE env var

### DIFF
--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -92,7 +92,10 @@ def main() -> int:
     print(f"[backfill] DB: {db_path}")
     print(f"[backfill] dim={dim} expected_bytes_per_row={expected_bytes}")
 
-    codec = BGEM3Codec(dim=dim)
+    import os
+    device = os.environ.get("BGEM3_DEVICE", "cuda")
+    codec = BGEM3Codec(dim=dim, device=device)
+    print(f"[backfill] device={device}")
     conn = sqlite3.connect(db_path, timeout=30)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")


### PR DESCRIPTION
## Summary
- `scripts/backfill_bgem3_v2.py` hardcoded `BGEM3Codec(dim=dim)`; the device is now read from a `BGEM3_DEVICE` env var (default `cuda`), and the resolved device is printed.
- Lets an operator run the v2 dense backfill on GPU without editing the script — ~16-26x faster than the CPU path observed during the actual v2 backfill.

## Notes
- Default is `cuda`; CPU-only hosts should set `BGEM3_DEVICE=cpu`.
- Operator-only tooling — not exercised by the CI test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)