### PR TITLE
fix(packet): plumb genome.last_tier_contributions into /context/packet know/miss block

### DIFF
--- a/helix_context/context_packet.py
+++ b/helix_context/context_packet.py
@@ -491,6 +491,17 @@ def build_context_packet(
         max_genes=max_genes,
         read_only=read_only,
     )
+    # Per-tier contribution map for the Stage 6 lexical_dense_agree
+    # signal. _query_genes prefers the router over the genome; mirror
+    # that precedence here so we read the handle that actually ran the
+    # query. ``last_tier_contributions`` is set by knowledge_store.py /
+    # shard_router.py after query_docs(). ``getattr`` default keeps this
+    # graceful when the attribute is absent (same shape as the /context
+    # route at server/helpers.py:265).
+    _retrieval_handle = router if router is not None else genome
+    tier_contributions = (
+        getattr(_retrieval_handle, "last_tier_contributions", {}) or {}
+    )
     packet = ContextPacket(task_type=task_type, query=query)
 
     if effective_main_conn is None:
@@ -573,6 +584,7 @@ def build_context_packet(
             genes=genes,
             score_map=score_map,
             coordinate_confidence=coordinate_confidence,
+            tier_contributions=tier_contributions,
         )
     except Exception:
         import logging
@@ -595,12 +607,20 @@ def _attach_know_or_miss(
     genes: list,
     score_map: dict,
     coordinate_confidence: float,
+    tier_contributions: dict | None = None,
 ) -> None:
     """Compute decide_know_or_miss and stash on packet.know / packet.miss.
 
     Mirror of the /context route logic in server._compute_know_or_miss_block
     but works directly with the locals already accumulated in
     ``build_context_packet`` instead of re-fetching from the knowledge store.
+
+    ``tier_contributions`` is the ``{gene_id: {tier_name: score}}`` map
+    ``build_context_packet`` lifts off the genome/router after the query
+    (``genome.last_tier_contributions``). It drives the
+    ``lexical_dense_agree`` discriminator signal. Defaults to ``None``
+    (treated as empty) so direct callers / older tests keep working —
+    they just get the no-agreement-signal direction, which is safe.
     """
     from .scoring.know_calibration import load_calibration_from_toml
     from .scoring.know_decision import (
@@ -661,18 +681,14 @@ def _attach_know_or_miss(
         metadata={"query": query, "ratio": ratio},
     )
 
-    # Tier contributions for lex/dense agreement. The packet builder
-    # does not currently capture per-tier contribs (it only takes the
-    # post-fusion score_map). Best-effort: pull off the knowledge store if the
-    # caller wired one through. Otherwise treat as no-agreement signal.
-    tier_contrib = {}
-    # documents elements may be Document objects from genome.query_genes, which
-    # don't carry tier-level info. The router/genome's last_tier_-
-    # contributions is the source of truth — we expect the route to
-    # have set it. The packet builder does NOT currently surface the
-    # knowledge store handle past _query_genes; until that's plumbed, we leave
-    # this False, which is the safe direction (no false-positive
-    # confidence boost).
+    # Tier contributions for lex/dense agreement. ``build_context_packet``
+    # surfaces the genome/router's ``last_tier_contributions`` (the
+    # {gene_id: {tier_name: score}} map set by knowledge_store.py /
+    # shard_router.py after the query) and plumbs it through here. This
+    # mirrors the /context route at server/helpers.py:265. When the
+    # caller passes nothing (older direct callers / tests), we fall back
+    # to an empty dict — the safe no-agreement-signal direction.
+    tier_contrib = tier_contributions or {}
     lex_dense_agree = _agree_from_tier_contributions(tier_contrib, k=3)
 
     cal = load_calibration_from_toml()

--- a/tests/test_know_miss_block.py
+++ b/tests/test_know_miss_block.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 
 from helix_context import context_manager as cm
 from helix_context.agent_prompt import HELIX_NO_MATCH_FRAGMENT
-from helix_context.context_packet import _attach_know_or_miss
+from helix_context.context_packet import _attach_know_or_miss, build_context_packet
 from helix_context.scoring.know_calibration import (
     DEFAULT_BETAS,
     DEFAULT_EMIT_FLOOR,
@@ -168,6 +168,24 @@ class _SyntheticGene:
     def __init__(self, gid, sid):
         self.gene_id = gid
         self.source_id = sid
+
+
+def _make_packet_gene(content: str, domain: str, *, gene_id: str | None = None):
+    """A complete Gene for end-to-end build_context_packet tests.
+
+    build_context_packet reads gene-local metadata (content, epigenetics,
+    promoter, source_id) so a slots-only stub like _SyntheticGene is not
+    enough — we reuse conftest.make_gene and pin a source_id so the
+    coordinate signals resolve.
+    """
+    from tests.conftest import make_gene
+
+    gene = make_gene(content, domains=[domain], gene_id=gene_id)
+    gene.source_id = f"F:/Projects/helix-context/helix_context/{domain}.py"
+    gene.source_kind = "code"
+    gene.volatility_class = "stable"
+    gene.authority_class = "primary"
+    return gene
 
 
 def test_gene_id_match_beacon_only_on_exact_filename_match():
@@ -514,6 +532,180 @@ def test_packet_attach_miss_on_no_genes():
     assert p.know is None
     assert p.miss.reason == "no_promoter_match"
     assert len(p.miss.escalate_to) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Packet-side: lexical_dense_agree must reflect the tier contributions
+#
+# Regression for the 2026-05-16 pipeline deep review, finding #3
+# (docs/reviews/2026-05-16-deep-review/pipeline-03-scoring-conflict.md).
+# _attach_know_or_miss used to hard-code ``tier_contrib = {}``, which
+# pinned lexical_dense_agree to False for every /context/packet block.
+# build_context_packet now plumbs genome.last_tier_contributions through
+# the ``tier_contributions`` kwarg; these tests pin both directions.
+# ─────────────────────────────────────────────────────────────────────
+
+def test_packet_attach_lexical_dense_agree_true_on_agreeing_tiers():
+    """Lexical (fts5/tag_exact) + dense (splade/sema_boost) tiers that
+    both rank the same gene_id at the top must yield
+    KnowBlock.lexical_dense_agree=True."""
+    g = _SyntheticGene(
+        "g1", "F:/Projects/helix-context/helix_context/context_manager.py"
+    )
+    # g1 wins both the lexical and the dense ranker -> intersection
+    # non-empty -> lexical_dense_agree must be True.
+    tier_contributions = {
+        "g1": {"fts5": 0.9, "tag_exact": 0.8, "splade": 0.7, "sema_boost": 0.6},
+        "g2": {"fts5": 0.1, "splade": 0.1},
+    }
+    p = ContextPacket(task_type="explain", query="context_manager")
+    _attach_know_or_miss(
+        p,
+        query="context_manager",
+        genes=[g],
+        score_map={"g1": 2.5, "g2": 1.0},
+        coordinate_confidence=0.8,
+        tier_contributions=tier_contributions,
+    )
+    assert p.know is not None
+    assert p.miss is None
+    assert p.know.lexical_dense_agree is True
+
+
+def test_packet_attach_lexical_dense_agree_false_on_disjoint_tiers():
+    """When the lexical ranker tops g1 but the dense ranker tops g2
+    (no top-K intersection), lexical_dense_agree must be False — the
+    safe no-agreement direction. Pins the negative case so the
+    plumbing fix can't regress into a false-positive boost."""
+    g = _SyntheticGene(
+        "g1", "F:/Projects/helix-context/helix_context/context_manager.py"
+    )
+    g2 = _SyntheticGene(
+        "g2", "F:/Projects/helix-context/helix_context/codons.py"
+    )
+    # Lexical tiers favour g1; dense tiers favour g2. Disjoint top-K.
+    tier_contributions = {
+        "g1": {"fts5": 0.9, "tag_exact": 0.8},
+        "g2": {"splade": 0.9, "sema_boost": 0.8},
+    }
+    p = ContextPacket(task_type="explain", query="context_manager")
+    _attach_know_or_miss(
+        p,
+        query="context_manager",
+        genes=[g, g2],
+        score_map={"g1": 2.5, "g2": 1.0},
+        coordinate_confidence=0.8,
+        tier_contributions=tier_contributions,
+    )
+    assert p.know is not None
+    assert p.miss is None
+    assert p.know.lexical_dense_agree is False
+
+
+def test_packet_attach_lexical_dense_agree_false_when_no_tiers_passed():
+    """Back-compat: a caller that passes nothing for tier_contributions
+    still works and lands on the safe False direction (no KeyError, no
+    crash) — guards the older direct-caller path."""
+    g = _SyntheticGene(
+        "g1", "F:/Projects/helix-context/helix_context/context_manager.py"
+    )
+    p = ContextPacket(task_type="explain", query="context_manager")
+    _attach_know_or_miss(
+        p,
+        query="context_manager",
+        genes=[g],
+        score_map={"g1": 2.5, "g2": 1.0},
+        coordinate_confidence=0.8,
+        # tier_contributions intentionally omitted.
+    )
+    assert p.know is not None
+    assert p.know.lexical_dense_agree is False
+
+
+def test_build_context_packet_plumbs_tier_contributions_from_genome():
+    """End-to-end: build_context_packet must lift
+    ``last_tier_contributions`` off the genome handle and feed it into
+    the know/miss block. A genome whose query surfaces agreeing
+    lexical+dense tiers must produce a packet with
+    know.lexical_dense_agree=True. This is the plumbing the
+    2026-05-16 deep review finding #3 was about."""
+
+    class _FakeGenome:
+        """Minimal genome stand-in: query_docs returns one document and
+        publishes the agreeing tier map on ``last_tier_contributions``,
+        exactly as knowledge_store.py / shard_router.py would."""
+
+        def __init__(self):
+            self.last_query_scores: dict = {}
+            self.last_tier_contributions: dict = {}
+
+        def query_docs(self, *, domains, entities, max_genes, read_only):
+            gene = _make_packet_gene(
+                "context manager orchestrates the pipeline",
+                "context_manager",
+            )
+            self.last_query_scores = {gene.gene_id: 2.6}
+            # Lexical and dense rankers agree on this gene_id.
+            self.last_tier_contributions = {
+                gene.gene_id: {
+                    "fts5": 0.9,
+                    "tag_exact": 0.8,
+                    "splade": 0.7,
+                    "sema_boost": 0.6,
+                }
+            }
+            return [gene]
+
+    genome = _FakeGenome()
+    packet = build_context_packet(
+        "context_manager",
+        task_type="explain",
+        genome=genome,
+        now_ts=10_000.0,
+    )
+    assert packet.know is not None
+    assert packet.miss is None
+    assert packet.know.lexical_dense_agree is True
+
+
+def test_build_context_packet_lexical_dense_agree_false_on_disjoint_genome_tiers():
+    """End-to-end negative: a genome whose lexical and dense rankers
+    disagree must yield know.lexical_dense_agree=False (the packet
+    builder must not invent agreement)."""
+
+    class _FakeGenome:
+        def __init__(self):
+            self.last_query_scores: dict = {}
+            self.last_tier_contributions: dict = {}
+
+        def query_docs(self, *, domains, entities, max_genes, read_only):
+            g1 = _make_packet_gene(
+                "context manager orchestrates the pipeline",
+                "context_manager",
+                gene_id="g_ctx",
+            )
+            g2 = _make_packet_gene(
+                "codons chunk and encode fragments",
+                "codons",
+                gene_id="g_cod",
+            )
+            self.last_query_scores = {"g_ctx": 2.6, "g_cod": 1.1}
+            # Lexical tiers favour g_ctx; dense tiers favour g_cod.
+            self.last_tier_contributions = {
+                "g_ctx": {"fts5": 0.9, "tag_exact": 0.8},
+                "g_cod": {"splade": 0.9, "sema_boost": 0.8},
+            }
+            return [g1, g2]
+
+    genome = _FakeGenome()
+    packet = build_context_packet(
+        "context_manager",
+        task_type="explain",
+        genome=genome,
+        now_ts=10_000.0,
+    )
+    assert packet.know is not None
+    assert packet.know.lexical_dense_agree is False
 
 
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

`_attach_know_or_miss` in `helix_context/context_packet.py` (~lines 664-676) hard-coded `tier_contrib = {}` and then computed `lex_dense_agree = _agree_from_tier_contributions(tier_contrib, k=3)`. Since `_agree_from_tier_contributions` returns `False` on an empty dict, the `lexical_dense_agree` feature was **permanently pinned to False** for every `/context/packet` know/miss block.

Why it matters: `lexical_dense_agree` (beta3, weight 0.7) is one of only three signals in `compute_confidence` (`helix_context/scoring/know_calibration.py`) that can lift an RRF-scale retrieval above `emit_floor=0.55`. With it forced False, packet retrievals were biased toward `MissBlock(reason="sparse")` even when gold was at rank 1.

The `/context` route already did this correctly — `helix_context/server/helpers.py:265` reads `getattr(helix.genome, "last_tier_contributions", {})`. The packet builder just never plumbed it through.

Surfaced by the 2026-05-16 pipeline deep review, finding #3 (`pipeline-03-scoring-conflict.md`).

## The fix

Minimal plumbing, no calibration changes:

- `build_context_packet` now lifts `last_tier_contributions` off the retrieval handle right after `_query_genes` runs. It picks the router over the genome — mirroring `_query_genes`'s own precedence — so it reads the handle that actually ran the query.
- `_attach_know_or_miss` gains a `tier_contributions` keyword arg (defaults to `None`). The hard-coded empty dict is replaced with `tier_contributions or {}`.
- `getattr(handle, "last_tier_contributions", {})` keeps it graceful when the attribute is absent, exactly like the `/context` route.

Older direct callers of `_attach_know_or_miss` (and existing tests) keep working unchanged — they just get the safe no-agreement-signal direction.

## Note for reviewers — possible follow-up bucketing gap (NOT fixed here)

`_agree_from_tier_contributions` in `helix_context/scoring/know_decision.py` buckets tier names via `_DENSE_TIERS = {"splade", "sema_boost", "sema_cold"}`. But `knowledge_store.py:1939` also writes a `"dense"` tier (the BGE-M3 dense cosine recall) — the primary dense retrieval signal under RRF mode — and `"dense"` is **not** in `_DENSE_TIERS`. So a retrieval where the dense signal comes purely from BGE-M3 (no SPLADE/SEMA) still won't register lexical/dense agreement.

Per the scope of this PR I did not change the bucketing — flagging it for a separate decision. The lexical bucket looks correct (`tag_exact`, `tag_prefix`, `fts5`, `pki` all match names written in `knowledge_store.py`).

## Tests

Added 5 tests to `tests/test_know_miss_block.py`, pinning both directions:

- `test_packet_attach_lexical_dense_agree_true_on_agreeing_tiers` — agreeing lexical+dense tiers → `KnowBlock.lexical_dense_agree=True`
- `test_packet_attach_lexical_dense_agree_false_on_disjoint_tiers` — disjoint top-K → `False`
- `test_packet_attach_lexical_dense_agree_false_when_no_tiers_passed` — back-compat: kwarg omitted → safe `False`, no crash
- `test_build_context_packet_plumbs_tier_contributions_from_genome` — end-to-end through `build_context_packet` with a fake genome publishing agreeing tiers → `True`
- `test_build_context_packet_lexical_dense_agree_false_on_disjoint_genome_tiers` — end-to-end negative

The first test would fail against pre-fix code (empty dict → `False`), confirming the fix is load-bearing.

## Test plan

- [x] `python -m pytest tests/ -m "not live" -k "packet or know" -v` — 127 passed
- [x] `python -m pytest tests/test_context_packet.py tests/test_know_miss_block.py tests/test_cli_packet.py -m "not live"` — 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)