### PR TITLE
fix(know): bucket BGE-M3 "dense" tier into _DENSE_TIERS

### DIFF
--- a/helix_context/scoring/know_decision.py
+++ b/helix_context/scoring/know_decision.py
@@ -227,10 +227,18 @@ _LEXICAL_TIERS: frozenset[str] = frozenset({
     "pki",
 })
 
+# ``dense`` is the BGE-M3 dense-cosine recall tier — written into the
+# tier-contribution map by knowledge_store.py (blob path, ~L1939:
+# ``tier_contrib[gid]["dense"]``) and copied verbatim by shard_router.py
+# (sharded path, ~L508/L613, which re-publishes each source shard's
+# ``last_tier_contributions`` unchanged). It was missing here, so
+# ``lexical_dense_agree`` never fired for a BGE-M3 dense retrieval.
+# Follow-up to PR #135 (the plumbing fix that surfaced this signal).
 _DENSE_TIERS: frozenset[str] = frozenset({
     "splade",
     "sema_boost",
     "sema_cold",
+    "dense",
 })
 
 

--- a/tests/test_know_miss_block.py
+++ b/tests/test_know_miss_block.py
@@ -31,6 +31,7 @@ from helix_context.scoring.know_calibration import (
     fit_betas_from_features,
     load_calibration_from_toml,
 )
+from helix_context.scoring import know_decision as know_decision_module
 from helix_context.scoring.know_decision import (
     _agree_from_tier_contributions,
     _gene_id_beacon,
@@ -405,6 +406,54 @@ def test_agree_from_tier_contributions():
     # Empty → False (safe default).
     assert _agree_from_tier_contributions({}, k=3) is False
     assert _agree_from_tier_contributions(None, k=3) is False
+
+
+def test_agree_from_tier_contributions_dense_tier_bucketed():
+    """Regression for the BGE-M3 dense-tier bucket gap (follow-up to
+    PR #135). ``knowledge_store.py`` writes the dense-cosine recall
+    score under the tier name ``"dense"`` (blob path ~L1939), and
+    ``shard_router.py`` re-publishes that map verbatim (~L508/L613), so
+    sharded mode emits the same name. ``_DENSE_TIERS`` must contain
+    ``"dense"`` or ``lexical_dense_agree`` can never fire for a BGE-M3
+    dense retrieval — it could only agree via SPLADE/SEMA.
+    """
+    # g1 tops the lexical ranker (fts5) AND the dense ranker (dense).
+    # The intersection of the per-ranker top-K is non-empty → agree.
+    contribs = {
+        "g1": {"fts5": 1.0, "dense": 0.82},
+        "g2": {"fts5": 0.5},
+        "g3": {"dense": 0.40},
+    }
+    assert _agree_from_tier_contributions(contribs, k=3) is True
+
+    # Pin the failure direction: this same map yields False against the
+    # pre-fix dense-tier set (which omitted "dense"). We simulate the
+    # old set rather than re-import a frozen copy so the assertion
+    # documents exactly which name closed the gap.
+    pre_fix_dense_tiers = frozenset({"splade", "sema_boost", "sema_cold"})
+    lex_tiers = know_decision_module._LEXICAL_TIERS
+
+    def _agree_with(dense_tiers, tier_contributions, k=3):
+        lex_scores, dense_scores = [], []
+        for gid, tier_map in tier_contributions.items():
+            lex = sum(float(tier_map.get(t, 0.0)) for t in lex_tiers)
+            dense = sum(float(tier_map.get(t, 0.0)) for t in dense_tiers)
+            if lex > 0:
+                lex_scores.append((gid, lex))
+            if dense > 0:
+                dense_scores.append((gid, dense))
+        lex_scores.sort(key=lambda kv: kv[1], reverse=True)
+        dense_scores.sort(key=lambda kv: kv[1], reverse=True)
+        lex_top = {gid for gid, _ in lex_scores[:k]}
+        dense_top = {gid for gid, _ in dense_scores[:k]}
+        return bool(lex_top & dense_top)
+
+    # Pre-fix set: "dense" is unrecognized → dense ranker is empty →
+    # no intersection → the signal silently never fires.
+    assert _agree_with(pre_fix_dense_tiers, contribs) is False
+    # Post-fix set (the live one) agrees, confirming the fix is what
+    # closes the gap.
+    assert _agree_with(know_decision_module._DENSE_TIERS, contribs) is True
 
 
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to **PR #135**, which plumbed `last_tier_contributions` through to the know/miss discriminator and surfaced a latent bug noted in #135's PR body.

`_agree_from_tier_contributions` in `helix_context/scoring/know_decision.py` derives the `lexical_dense_agree` signal by checking whether a retrieval's tier-contribution map spans **both** a lexical tier and a dense tier. Its dense-tier set, `_DENSE_TIERS`, was:

```python
{"splade", "sema_boost", "sema_cold"}
```

It **omitted `"dense"`** — the tier name the BGE-M3 dense-cosine recall path writes into `last_tier_contributions`. As a result, `lexical_dense_agree` could **never** register agreement for a BGE-M3 dense retrieval; it could only agree via SPLADE/SEMA. Any pure BGE-M3-vs-lexical agreement was silently dropped, mildly under-weighting `KnowBlock.confidence`.

## The fix

Add `"dense"` to `_DENSE_TIERS`. One-line set membership change plus an explanatory comment. Scope deliberately limited to closing this gap — the lexical-tier set (`_LEXICAL_TIERS`) and the calibration betas in `know_calibration.py` are untouched.

## Verification — which tier name, both modes

I checked every `tier_contrib` write in `knowledge_store.py` and confirmed there is exactly **one** BGE-M3 dense tier name, `"dense"` (no variant):

- **Blob path** — `knowledge_store.py` ~L1907–1939 ("Stage 2/3: dense recall as RRF participant"): `query_docs_dense_recall` results go to `fuser.add_tier("dense", dense_hits, ...)` (~L1933) and `tier_contrib.setdefault(gid, {})["dense"] = float(cosine)` (~L1939).
- **Sharded path** — `shard_router.py` ~L508 and ~L612–614: the router does **not** invent its own tier names. It copies each source shard's `last_tier_contributions` verbatim (`dict(shard.last_tier_contributions.get(doc.gene_id, {}))`) into the merged map. Each shard is itself a blob `Genome`, so it emits the dense tier under the **same** name `"dense"`. **There is no sharded-mode rename** — the single fix covers both modes.

## Tests

Added `test_agree_from_tier_contributions_dense_tier_bucketed` to `tests/test_know_miss_block.py` (next to the existing `test_agree_from_tier_contributions`). It:

1. Asserts a tier-contribution map with a `"dense"` tier plus an agreeing lexical tier (`fts5`) yields `lexical_dense_agree=True`.
2. Pins the failure direction: it re-runs the same bucketing logic against the **pre-fix** dense set `{"splade", "sema_boost", "sema_cold"}` and asserts it yields `False` — documenting that adding `"dense"` is exactly what closes the gap.

`python -m pytest tests/ -m "not live" -k "know or packet" -v` → **128 passed, 2020 deselected**.

## Open question (flagged, not changed — out of scope)

`"splade"` is a learned **sparse** signal (SPLADE = sparse lexical expansion), yet it sits in `_DENSE_TIERS` alongside the genuinely-dense BGE-M3 `"dense"` and the SEMA tiers. That bucketing predates this PR and may be semantically wrong — for `lexical_dense_agree` to mean "the lexical ranker and the *dense* ranker agree", SPLADE arguably belongs with the lexical cluster (or in its own sparse bucket). I have **not** changed it; this PR only closes the missing-`"dense"` gap. Worth a separate discussion on whether `_DENSE_TIERS` should be re-partitioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
