### PR TITLE
Tier-0: BGE-M3 dense semantic retrieval, end-to-end

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -322,6 +322,12 @@ dense_weight = 1.0                      # Stage 2 dense recall, RRF participant
 # BM25-comparable (tag_exact_weight is 3.0). Unused under RRF, where dense
 # ranks are fused rather than summed.
 dense_additive_weight = 4.0
+# Tier-0 review fix (2026-05-16): noise floor for the additive-mode dense
+# merge. A dense hit whose cosine is below this does not contribute to the
+# gene_scores accumulator (it is still kept as a candidate with negligible
+# weight). Consistent with the cold tier's 0.15 min_cosine; deliberately
+# gentle so it removes only noise-grade hits, not weak-but-real matches.
+dense_additive_min_cosine = 0.15
 pki_weight = 1.0                        # path-key-index tier, RRF participant
 # Note: filename_anchor_weight (above) and sr_weight (above) are reused.
 

--- a/helix.toml
+++ b/helix.toml
@@ -195,6 +195,12 @@ rerank_model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 rerank_enabled = false                  # Phase 3: enable pretrained cross-encoder reranking
 colbert_enabled = false                 # Phase 4: ColBERT late interaction (optional)
 entity_graph = true                     # Phase 5: entity-based co-activation links
+# Compute BGE-M3 dense vectors (genes.embedding_dense_v2) inline at ingest
+# so every ingested genome is dense-populated without a separate backfill.
+# Set false for latency-sensitive callers to defer encoding to
+# scripts/backfill_bgem3_v2.py. Write path only — retrieval still gates on
+# [retrieval] dense_embedding_enabled (default false).
+dense_embed_on_ingest = true            # Tier-0 PR-1 (2026-05-16)
 
 [context]
 # Cold-tier retrieval (C.2 of B->C, 2026-04-10)

--- a/helix.toml
+++ b/helix.toml
@@ -278,7 +278,11 @@ entity_graph_retrieval_enabled = false
 # dim=256 truncation collapsed random-pair cosine to ~0.6, sabotaging the
 # threshold. Stage 4 will recalibrate ann_similarity_threshold at 1024-dim.
 # dense_pool_size decouples recall breadth from the final cut (max_genes).
-dense_embedding_enabled = false
+# Tier-0 PR-3 (2026-05-16): flipped to true. PR-1 computes
+# embedding_dense_v2 at ingest and PR-3 decoupled dense recall from
+# fusion_mode (knowledge_store.query_docs), so dense recall now fires as a
+# retrieval signal under the shipped additive default — not only under RRF.
+dense_embedding_enabled = true
 dense_embedding_dim = 1024
 ann_similarity_threshold = 0.35           # legacy / fallback when calibration row missing
 ann_threshold_min_genes = 1
@@ -312,6 +316,12 @@ lex_anchor_weight = 1.5                 # IDF anchor multiplier
 harmonic_weight = 1.0                   # Tier 5 per-link weight
 entity_graph_weight = 0.5               # Tier 5b entity boost
 dense_weight = 1.0                      # Stage 2 dense recall, RRF participant
+# Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight. Under
+# fusion_mode == "additive" (the default below), a dense hit's cosine is
+# scaled by this before it enters the gene_scores accumulator —
+# BM25-comparable (tag_exact_weight is 3.0). Unused under RRF, where dense
+# ranks are fused rather than summed.
+dense_additive_weight = 4.0
 pki_weight = 1.0                        # path-key-index tier, RRF participant
 # Note: filename_anchor_weight (above) and sr_weight (above) are reused.
 

--- a/helix.toml
+++ b/helix.toml
@@ -199,7 +199,7 @@ entity_graph = true                     # Phase 5: entity-based co-activation li
 # so every ingested genome is dense-populated without a separate backfill.
 # Set false for latency-sensitive callers to defer encoding to
 # scripts/backfill_bgem3_v2.py. Write path only — retrieval still gates on
-# [retrieval] dense_embedding_enabled (default false).
+# [retrieval] dense_embedding_enabled (default true).
 dense_embed_on_ingest = true            # Tier-0 PR-1 (2026-05-16)
 
 [context]

--- a/helix_context/backends/bgem3_codec.py
+++ b/helix_context/backends/bgem3_codec.py
@@ -23,6 +23,31 @@ _QUERY_PREFIX = "Represent this sentence for searching relevant passages: "
 # tries dim=256 again sees the calibration risk.
 _SANCTIONED_DIMS = frozenset({1024, 768, 512})
 
+# Passage encode length cap. BGE-M3 has max_length=512 tokens; ~2k chars is a
+# safe upper bound. Both the inline ingest path (knowledge_store.upsert_doc /
+# context_manager.ingest) and the offline backfill script bound passages to
+# this so the two encodings stay byte-identical. See PR-1 of the 2026-05-16
+# Tier-0 plan.
+PASSAGE_CHAR_CAP = 2000
+
+
+def vec_to_blob(vec, dim: int) -> bytes:
+    """Pack a float vector as a raw little-endian fp32 BLOB of ``dim*4`` bytes.
+
+    This is the single canonical encoding for the ``genes.embedding_dense_v2``
+    column. Both ``scripts/backfill_bgem3_v2.py`` and
+    ``knowledge_store.upsert_doc`` call it so the inline-ingest write and the
+    offline-backfill write cannot drift — a genome built through the ingest
+    path must satisfy the backfill script's ``length(blob) == dim*4``
+    idempotency skip-clause.
+    """
+    arr = np.asarray(vec, dtype="<f4")
+    if arr.ndim != 1 or arr.shape[0] != dim:
+        raise ValueError(
+            f"vector dim {getattr(arr, 'shape', None)} != expected ({dim},)"
+        )
+    return arr.tobytes(order="C")
+
 
 class BGEM3Codec:
     # Track which non-sanctioned dim values we've already warned for so we
@@ -79,6 +104,41 @@ class BGEM3Codec:
         if norm > 0:
             vec = vec / norm
         return vec.tolist()
+
+    def encode_batch(self, texts: list[str], task: str = "passage") -> list[list[float]]:
+        """Encode many texts in one model call. Same contract as ``encode``.
+
+        Tier-0 PR-1 (2026-05-16): the ingest path encodes every strand of a
+        document in a single batched call rather than one ``encode`` per
+        strand. Each output row is Matryoshka-truncated to ``self.dim`` and
+        L2-renormalised exactly as ``encode`` does, so a vector produced here
+        is byte-identical to one produced by ``encode`` for the same text.
+
+        task='query' prepends the retrieval instruction prefix to every text;
+        task='passage' is bare.
+        """
+        if not texts:
+            return []
+        self._load()
+        prepared = (
+            [_QUERY_PREFIX + t for t in texts] if task == "query" else list(texts)
+        )
+        if self._backend == "flagembedding":
+            raw = self._model.encode(prepared, max_length=512)["dense_vecs"]
+            mat = np.asarray(raw, dtype=np.float32)
+        else:
+            mat = np.asarray(
+                self._model.encode(
+                    prepared, normalize_embeddings=True, show_progress_bar=False,
+                ),
+                dtype=np.float32,
+            )
+        # Matryoshka truncate + per-row L2 renormalise.
+        mat = mat[:, : self.dim]
+        norms = np.linalg.norm(mat, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        mat = mat / norms
+        return mat.tolist()
 
     def similarity(self, vec_a: list[float], vec_b: list[float]) -> float:
         a = np.array(vec_a, dtype=np.float32)

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -188,6 +188,14 @@ class IngestionConfig:
     rerank_enabled: bool = False    # Phase 3: enable cross-encoder reranking
     colbert_enabled: bool = False   # Phase 4: ColBERT late interaction (optional)
     entity_graph: bool = False      # Phase 5: entity-based co-activation links
+    # Tier-0 PR-1 (2026-05-16): compute BGE-M3 dense vectors
+    # (genes.embedding_dense_v2) inline at ingest. Default true so a genome
+    # built by `helix ingest` / `/ingest` / context_manager.ingest is
+    # dense-populated without a separate backfill pass. Latency-sensitive
+    # callers can set false to defer encoding to scripts/backfill_bgem3_v2.py.
+    # This is purely the WRITE path — retrieval still gates on
+    # [retrieval] dense_embedding_enabled (default false).
+    dense_embed_on_ingest: bool = True
 
 
 @dataclass
@@ -646,6 +654,9 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             rerank_enabled=i.get("rerank_enabled", cfg.ingestion.rerank_enabled),
             colbert_enabled=i.get("colbert_enabled", cfg.ingestion.colbert_enabled),
             entity_graph=i.get("entity_graph", cfg.ingestion.entity_graph),
+            dense_embed_on_ingest=i.get(
+                "dense_embed_on_ingest", cfg.ingestion.dense_embed_on_ingest
+            ),
         )
 
     # Context (cold-tier retrieval knobs — C.2 of B->C, 2026-04-10)

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -284,8 +284,11 @@ class RetrievalConfig:
     # to entity overlap. Dark ship — flip to true for A/B.
     entity_graph_retrieval_enabled: bool = False
     # Step 4 — BGE-M3 dense vectors + ANN threshold-based dynamic document counts
-    # (2026-05-08). Dark ship — all flags off by default.
-    dense_embedding_enabled: bool = False
+    # (2026-05-08). Tier-0 PR-3 (2026-05-16) flipped this default to true:
+    # PR-1 computes embedding_dense_v2 at ingest and PR-3 decoupled dense
+    # recall from fusion_mode, so dense recall is now a shipped retrieval
+    # signal in both additive and RRF mode.
+    dense_embedding_enabled: bool = True
     # Stage 2 (2026-05-08): default dim raised from 256 -> 1024. Full BGE-M3
     # Matryoshka. dim=256 collapsed random-pair cosine to ~0.6, sabotaging
     # threshold semantics. Stage 4 will recalibrate ann_similarity_threshold
@@ -324,6 +327,11 @@ class RetrievalConfig:
     harmonic_weight: float = 1.0            # current per-link weight
     entity_graph_weight: float = 0.5        # current 1.0·0.5 implicit
     dense_weight: float = 1.0               # Stage 2 dense recall, RRF participant
+    # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight. Under
+    # fusion_mode == "additive" a dense hit's cosine is scaled by this
+    # before entering the gene_scores accumulator. BM25-comparable
+    # (tag_exact_weight is 3.0). Unused under RRF.
+    dense_additive_weight: float = 4.0
     pki_weight: float = 1.0                 # PKI tier, RRF participant
     # Note: filename_anchor_weight, sr_weight reuse their existing knobs above.
 
@@ -734,6 +742,8 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             harmonic_weight=float(r.get("harmonic_weight", cfg.retrieval.harmonic_weight)),
             entity_graph_weight=float(r.get("entity_graph_weight", cfg.retrieval.entity_graph_weight)),
             dense_weight=float(r.get("dense_weight", cfg.retrieval.dense_weight)),
+            # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight.
+            dense_additive_weight=float(r.get("dense_additive_weight", cfg.retrieval.dense_additive_weight)),
             pki_weight=float(r.get("pki_weight", cfg.retrieval.pki_weight)),
         )
 

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -194,7 +194,7 @@ class IngestionConfig:
     # dense-populated without a separate backfill pass. Latency-sensitive
     # callers can set false to defer encoding to scripts/backfill_bgem3_v2.py.
     # This is purely the WRITE path — retrieval still gates on
-    # [retrieval] dense_embedding_enabled (default false).
+    # [retrieval] dense_embedding_enabled (default true).
     dense_embed_on_ingest: bool = True
 
 
@@ -332,6 +332,12 @@ class RetrievalConfig:
     # before entering the gene_scores accumulator. BM25-comparable
     # (tag_exact_weight is 3.0). Unused under RRF.
     dense_additive_weight: float = 4.0
+    # Tier-0 review fix (2026-05-16): noise floor for the additive-mode
+    # dense merge. A dense hit whose cosine is below this does not
+    # contribute to gene_scores (it is still kept as a candidate with
+    # negligible weight). Consistent with the cold tier's 0.15 min_cosine;
+    # deliberately gentle so it removes only noise-grade hits. Unused under RRF.
+    dense_additive_min_cosine: float = 0.15
     pki_weight: float = 1.0                 # PKI tier, RRF participant
     # Note: filename_anchor_weight, sr_weight reuse their existing knobs above.
 
@@ -744,6 +750,8 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             dense_weight=float(r.get("dense_weight", cfg.retrieval.dense_weight)),
             # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight.
             dense_additive_weight=float(r.get("dense_additive_weight", cfg.retrieval.dense_additive_weight)),
+            # Tier-0 review fix (2026-05-16): additive-mode dense merge noise floor.
+            dense_additive_min_cosine=float(r.get("dense_additive_min_cosine", cfg.retrieval.dense_additive_min_cosine)),
             pki_weight=float(r.get("pki_weight", cfg.retrieval.pki_weight)),
         )
 

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -508,6 +508,8 @@ class HelixContextManager:
             harmonic_weight=config.retrieval.harmonic_weight,
             entity_graph_weight=config.retrieval.entity_graph_weight,
             dense_weight=config.retrieval.dense_weight,
+            # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight.
+            dense_additive_weight=config.retrieval.dense_additive_weight,
             pki_weight=config.retrieval.pki_weight,
         )
 

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -450,6 +450,13 @@ class HelixContextManager:
         except Exception:
             log.warning("ΣĒMA codec failed to load", exc_info=True)
 
+        # BGE-M3 dense codec (Tier-0 PR-1, 2026-05-16). Lazy-loaded on the
+        # first ingest when [ingestion] dense_embed_on_ingest is true, so a
+        # manager that never ingests (or runs with the knob off) pays no
+        # model-load cost. ingest() batch-encodes all strands of a document
+        # through this and passes each vector to genome.upsert_doc.
+        self._dense_codec = None  # type: ignore[var-annotated]
+
         # KnowledgeStore (SQLite storage) — swapped for a ShardedGenomeAdapter when
         # HELIX_USE_SHARDS=1 and the configured path is a routing DB. Writes
         # become no-ops in that mode; suitable for read-heavy serving and
@@ -461,6 +468,8 @@ class HelixContextManager:
             sema_codec=self._sema_codec,
             splade_enabled=config.ingestion.splade_enabled,
             entity_graph=config.ingestion.entity_graph,
+            # Tier-0 PR-1 (2026-05-16): inline BGE-M3 dense write at ingest.
+            dense_embed_on_ingest=config.ingestion.dense_embed_on_ingest,
             sr_enabled=config.retrieval.sr_enabled,
             sr_gamma=config.retrieval.sr_gamma,
             sr_k_steps=config.retrieval.sr_k_steps,
@@ -675,6 +684,34 @@ class HelixContextManager:
         # Compaction timer
         self._last_compact = time.time()
 
+    # -- Dense codec lazy-loader (Tier-0 PR-1, 2026-05-16) ----------------------
+
+    def _get_dense_codec(self):
+        """Lazy-load the BGE-M3 dense codec for inline ingest encoding.
+
+        Returns the codec, or ``None`` if dense-on-ingest is disabled or the
+        codec cannot be constructed (e.g. sentence-transformers / FlagEmbedding
+        not installed). ingest() treats ``None`` as "skip dense encoding" and
+        the genome stores rows with a NULL ``embedding_dense_v2`` column.
+        """
+        if not self.config.ingestion.dense_embed_on_ingest:
+            return None
+        if self._dense_codec is None:
+            try:
+                from .backends.bgem3_codec import BGEM3Codec
+                self._dense_codec = BGEM3Codec(
+                    dim=self.config.retrieval.dense_embedding_dim
+                )
+                log.info("BGE-M3 dense codec loaded — dense vectors written at ingest")
+            except Exception:
+                log.warning(
+                    "BGE-M3 dense codec failed to load — ingest will store "
+                    "NULL embedding_dense_v2 (backfill later)",
+                    exc_info=True,
+                )
+                return None
+        return self._dense_codec
+
     # -- Ingest: add new content to the knowledge store -------------------------
 
     def ingest(self, content: str, content_type: str = "text", metadata: Optional[Dict] = None) -> List[str]:
@@ -703,6 +740,31 @@ class HelixContextManager:
                 sema_vectors = self._sema_codec.encode_batch(texts)
             except Exception:
                 log.debug("ΣĒMA batch encoding failed, skipping")
+
+        # Batch-encode BGE-M3 dense vectors (Tier-0 PR-1, 2026-05-16). One
+        # codec call for every strand of the document — far cheaper than the
+        # per-strand encode upsert_doc would otherwise do. Bound each passage
+        # to PASSAGE_CHAR_CAP with task="passage" (the codec contract). Soft-
+        # fails: on any error dense_vectors stays None and upsert_doc stores
+        # NULL embedding_dense_v2. Disabled entirely when the config knob is
+        # off (_get_dense_codec returns None). Write path only — retrieval
+        # still gates on [retrieval] dense_embedding_enabled.
+        dense_vectors = None
+        dense_codec = self._get_dense_codec()
+        if dense_codec is not None:
+            try:
+                from .backends.bgem3_codec import PASSAGE_CHAR_CAP
+                dense_texts = [s.content[:PASSAGE_CHAR_CAP] for s in strands]
+                dense_vectors = dense_codec.encode_batch(
+                    dense_texts, task="passage"
+                )
+            except Exception:
+                log.warning(
+                    "BGE-M3 dense batch encoding failed — strands stored with "
+                    "NULL embedding_dense_v2 (backfill later)",
+                    exc_info=True,
+                )
+                dense_vectors = None
 
         use_cpu = (
             self._cpu_tagger is not None
@@ -753,13 +815,23 @@ class HelixContextManager:
             if sema_vectors is not None and i < len(sema_vectors):
                 gene.embedding = sema_vectors[i]
 
+            # Tier-0 PR-1 (2026-05-16): hand the precomputed BGE-M3 dense
+            # vector to upsert_doc so it persists embedding_dense_v2 without
+            # re-encoding per strand. None when dense-on-ingest is disabled
+            # or the batch encode failed — upsert_doc then stores NULL.
+            dense_vec = (
+                dense_vectors[i]
+                if dense_vectors is not None and i < len(dense_vectors)
+                else None
+            )
+
             # Density gate now lives in genome.upsert_doc() itself so that
             # bulk ingest scripts (ingest_steam.py, ingest_all.py, etc.)
             # that call upsert_gene directly also respect it. The gate
             # reads the final lifecycle tier back onto the document object
             # and sets compression_tier accordingly during the INSERT.
             # See helix_context/genome.py:apply_density_gate for the logic.
-            gid = self.genome.upsert_doc(gene)
+            gid = self.genome.upsert_doc(gene, embedding_dense_v2=dense_vec)
             gene_ids.append(gid)
 
             # If the gate demoted the document to heterochromatin, the content

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -510,6 +510,8 @@ class HelixContextManager:
             dense_weight=config.retrieval.dense_weight,
             # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight.
             dense_additive_weight=config.retrieval.dense_additive_weight,
+            # Tier-0 review fix (2026-05-16): additive-mode dense merge noise floor.
+            dense_additive_min_cosine=config.retrieval.dense_additive_min_cosine,
             pki_weight=config.retrieval.pki_weight,
         )
 

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -371,6 +371,12 @@ class KnowledgeStore:
         harmonic_weight: float = 1.0,
         entity_graph_weight: float = 0.5,
         dense_weight: float = 1.0,
+        # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight.
+        # Under fusion_mode == "additive", a dense hit's cosine is
+        # multiplied by this before it enters gene_scores. BM25-comparable
+        # (tag-exact weight is 3.0). Unused under RRF, where dense ranks
+        # are fused, not summed.
+        dense_additive_weight: float = 4.0,
         pki_weight: float = 1.0,
         main_conn: Optional[sqlite3.Connection] = None,
         shard_name: str = "main",
@@ -455,6 +461,8 @@ class KnowledgeStore:
         self._harmonic_weight: float = float(harmonic_weight)
         self._entity_graph_weight: float = float(entity_graph_weight)
         self._dense_weight: float = float(dense_weight)
+        # Tier-0 PR-3: additive-mode dense merge weight (see ctor param).
+        self._dense_additive_weight: float = float(dense_additive_weight)
         self._pki_weight: float = float(pki_weight)
         self._threshold_dim_warned: bool = False
         # Phase 2 claims layer (2026-04-19). Optional hook — when a main.db
@@ -1936,22 +1944,28 @@ class KnowledgeStore:
             except Exception:
                 log.debug("ΣĒMA retrieval failed, continuing without")
 
-        # ── Stage 2/3: dense recall as RRF participant ──────────────
+        # ── Stage 2/3: dense recall — first-class in BOTH modes ─────
         # Stage 2's query_genes_dense_recall returns [(gid, cosine), ...]
-        # already sorted descending. We feed it directly as a tier so
-        # the Fuser can rank-fuse it with the lex tiers under RRF mode.
-        # This also seeds gene_scores in additive mode so the dense
-        # contribution survives the back-compat path — but at the
-        # cosine·dense_weight scale it's roughly noise next to the lex
-        # weights (3.0+), which is why Stage 2 didn't merge it into
-        # query_genes() in the first place. Under RRF, cosine ordering
-        # is what matters and the rank-1 dense hit gets the same
-        # 1/(k+1) weight as the rank-1 FTS hit.
-        # Dense participation runs only under RRF mode. In additive mode
-        # we skip it to keep byte-identical compatibility with pre-Stage-3
-        # ranking — pre-Stage-3 query_genes() never called dense recall
-        # (dense was query_genes_ann's job). Stage 4 may revisit this.
-        if self._dense_embedding_enabled and self._fusion_mode == "rrf":
+        # already sorted descending.
+        #
+        # Tier-0 PR-3 (2026-05-16): dense recall is decoupled from
+        # ``fusion_mode``. The old gate (``and self._fusion_mode ==
+        # "rrf"``) meant dense recall never ran under the default
+        # ``additive`` mode — so the BGE-M3 vectors PR-1 computes at
+        # ingest were dark in the shipped configuration. The gate is now
+        # ``self._dense_embedding_enabled`` alone; the *mode* only
+        # decides HOW dense hits enter the ranking:
+        #   - RRF mode: feed the Fuser as a tier so cosine ordering
+        #     rank-fuses with the lex tiers (the rank-1 dense hit gets
+        #     the same 1/(k+1) weight as the rank-1 FTS hit).
+        #   - additive mode: merge each dense hit into ``gene_scores``
+        #     with ``cosine * self._dense_additive_weight``. The weight
+        #     (default 4.0, BM25-comparable — tag-exact is 3.0) puts the
+        #     dense contribution on the same scale as the lex tiers
+        #     instead of the ``cosine·1.0`` epsilon-noise the old
+        #     comment correctly flagged. The lexical accumulator is
+        #     otherwise byte-identical; dense is purely *added* on top.
+        if self._dense_embedding_enabled:
             try:
                 _dense_t0 = time.monotonic()
                 dense_hits = self.query_docs_dense_recall(
@@ -1960,22 +1974,32 @@ class KnowledgeStore:
                     party_id=party_id,
                     read_only=read_only,
                 )
-                # Stage 3: feed Fuser. raw_score = cosine.
-                fuser.add_tier(
-                    "dense", dense_hits, weight=self._dense_weight,
-                )
-                # Also record in tier_contrib for telemetry (raw cosine,
-                # not multiplied — matches the rule "telemetry observes
-                # raw pre-RRF scores", spec §6).
-                for gid, cosine in dense_hits:
-                    tier_contrib.setdefault(gid, {})["dense"] = float(cosine)
-                    # Ensure dense-only documents appear in gene_scores so
-                    # they survive the eligible_ids gate at the sort.
-                    # Use a tiny epsilon so we don't perturb additive
-                    # ranking (which is unreachable in this branch
-                    # anyway). The actual ordering comes from the Fuser.
-                    if gid not in gene_scores:
-                        gene_scores[gid] = 1e-9
+                if self._fusion_mode == "rrf":
+                    # Stage 3: feed Fuser. raw_score = cosine.
+                    fuser.add_tier(
+                        "dense", dense_hits, weight=self._dense_weight,
+                    )
+                    for gid, cosine in dense_hits:
+                        # Telemetry observes raw cosine, not multiplied
+                        # (spec §6 "raw pre-RRF scores").
+                        tier_contrib.setdefault(gid, {})["dense"] = float(cosine)
+                        # Ensure dense-only documents appear in
+                        # gene_scores so they survive the eligible_ids
+                        # gate at the sort. A tiny epsilon is enough —
+                        # the actual ordering comes from the Fuser.
+                        if gid not in gene_scores:
+                            gene_scores[gid] = 1e-9
+                else:
+                    # Additive mode: merge dense hits into the score
+                    # accumulator at a BM25-comparable weight so a
+                    # semantic-only match can surface alongside lexical
+                    # hits. ``tier_contrib`` records the *weighted*
+                    # contribution so telemetry reflects what actually
+                    # entered the additive sum.
+                    for gid, cosine in dense_hits:
+                        contribution = float(cosine) * self._dense_additive_weight
+                        gene_scores[gid] = gene_scores.get(gid, 0.0) + contribution
+                        tier_contrib.setdefault(gid, {})["dense"] = contribution
                 try:
                     from .telemetry import genome_signal_histogram
                     genome_signal_histogram().record(

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -336,6 +336,11 @@ class KnowledgeStore:
         # Stage 2 (2026-05-08): default dim raised from 256 -> 1024 (full
         # BGE-M3 Matryoshka). dim=256 collapsed random-pair cosine.
         dense_embedding_dim: int = 1024,
+        # Tier-0 PR-1 (2026-05-16): when true, upsert_doc computes and
+        # persists genes.embedding_dense_v2 inline (unless the caller passes
+        # a precomputed vector). This is the WRITE path only and is
+        # independent of dense_embedding_enabled, which gates RETRIEVAL.
+        dense_embed_on_ingest: bool = False,
         ann_similarity_threshold: float = 0.35,
         ann_threshold_min_genes: int = 1,
         ann_threshold_max_genes: int = 12,
@@ -400,6 +405,9 @@ class KnowledgeStore:
         # Step 4 — BGE-M3 dense vectors + ANN threshold (2026-05-08).
         self._dense_embedding_enabled: bool = bool(dense_embedding_enabled)
         self._dense_embedding_dim: int = int(dense_embedding_dim)
+        # Tier-0 PR-1 (2026-05-16): inline dense-vector write at ingest.
+        # Independent of _dense_embedding_enabled (retrieval gate).
+        self._dense_embed_on_ingest: bool = bool(dense_embed_on_ingest)
         self._ann_threshold: float = float(ann_similarity_threshold)
         self._ann_min_genes: int = int(ann_threshold_min_genes)
         self._ann_max_genes: int = int(ann_threshold_max_genes)
@@ -1004,6 +1012,7 @@ class KnowledgeStore:
         gene: Gene,
         apply_gate: bool = True,
         splade_sparse: Optional[Dict[str, float]] = None,
+        embedding_dense_v2: Optional[List[float]] = None,
     ) -> str:
         """
         Insert or replace a document in the knowledge store.
@@ -1014,6 +1023,19 @@ class KnowledgeStore:
         setup scripts, explicit backfill tools, manual `compact_genome`
         re-runs — can pass ``apply_gate=False`` to preserve the incoming
         lifecycle tier as-is.
+
+        ``embedding_dense_v2`` (Tier-0 PR-1, 2026-05-16) is an optional
+        precomputed BGE-M3 dense vector (a ``dense_embedding_dim``-length
+        float list). A batched caller — e.g. ``context_manager.ingest()`` —
+        encodes all strands in one codec call and passes each vector here so
+        per-document encoding is not repeated. When it is *not* supplied and
+        ``dense_embed_on_ingest`` is true on this store, the vector is
+        computed lazily via the store's BGE-M3 codec. When the knob is false
+        and no vector is passed, the ``embedding_dense_v2`` column is left
+        NULL (callers can backfill later via
+        ``scripts/backfill_bgem3_v2.py``). This is purely the *write* path —
+        dense recall during ``query_docs`` is gated separately on
+        ``dense_embedding_enabled``.
 
         Returns the gene_id (content-addressed if not pre-populated).
         """
@@ -1076,14 +1098,22 @@ class KnowledgeStore:
             else (observed_at if observed_at is not None else time.time())
         )
 
+        # Tier-0 PR-1 (2026-05-16): compute the BGE-M3 dense vector inline so
+        # every ingest path populates genes.embedding_dense_v2. Uses the
+        # caller-supplied vector when present (batched ingest), else encodes
+        # lazily iff dense_embed_on_ingest is set; NULL otherwise. Soft-fails.
+        dense_v2_blob = self._encode_dense_v2_blob(
+            gene.content, precomputed=embedding_dense_v2
+        )
+
         cur.execute(
             "INSERT OR REPLACE INTO genes "
             "(gene_id, content, complement, codons, promoter, epigenetics, "
             "chromatin, is_fragment, embedding, source_id, repo_root, source_kind, "
             "observed_at, mtime, content_hash, volatility_class, authority_class, "
             "support_span, last_verified_at, version, supersedes, key_values, "
-            "compression_tier, last_seen) "
-            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            "compression_tier, last_seen, embedding_dense_v2) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (
                 gene_id,
                 gene.content,
@@ -1109,6 +1139,8 @@ class KnowledgeStore:
                 json_dumps(gene.key_values) if gene.key_values else None,
                 tier,
                 time.time(),  # last_seen: always stamp current epoch on every upsert
+                # Tier-0 PR-1: raw little-endian fp32 BGE-M3 vector, or NULL.
+                sqlite3.Binary(dense_v2_blob) if dense_v2_blob is not None else None,
             ),
         )
         # Invalidate parse cache for this document's promoter/epigenetics
@@ -2383,6 +2415,55 @@ class KnowledgeStore:
                     )
                     self._threshold_dim_warned = True
         return self._dense_codec
+
+    def _encode_dense_v2_blob(
+        self,
+        content: Optional[str],
+        precomputed: Optional[List[float]] = None,
+    ) -> Optional[bytes]:
+        """Return the ``embedding_dense_v2`` BLOB for an ingest row, or None.
+
+        Tier-0 PR-1 (2026-05-16). Resolution order:
+
+        1. If ``precomputed`` is supplied (a batched caller already encoded
+           the vector), pack and return it.
+        2. Otherwise, only if ``self._dense_embed_on_ingest`` is true,
+           lazy-load the BGE-M3 codec and encode ``content`` as a passage.
+        3. Otherwise return ``None`` — the column stays NULL and a later
+           ``scripts/backfill_bgem3_v2.py`` run can populate it.
+
+        Encoding is bounded to ``PASSAGE_CHAR_CAP`` chars and uses
+        ``task="passage"`` — the same contract as the offline backfill, so
+        an inline-ingested genome satisfies the backfill's
+        ``length(blob) == dim*4`` idempotency skip-clause. Packing goes
+        through the shared ``vec_to_blob`` helper so the two write paths
+        cannot drift.
+
+        Encode failures are soft — ingest must never break because the dense
+        model is unavailable; the row is stored with a NULL v2 column and a
+        WARN is logged.
+        """
+        from .backends.bgem3_codec import PASSAGE_CHAR_CAP, vec_to_blob
+
+        dim = self._dense_embedding_dim
+        try:
+            if precomputed is not None:
+                return vec_to_blob(precomputed, dim)
+            if not self._dense_embed_on_ingest:
+                return None
+            text = (content or "").strip()
+            if not text:
+                return None
+            codec = self._get_dense_codec()
+            vec = codec.encode(text[:PASSAGE_CHAR_CAP], task="passage")
+            return vec_to_blob(vec, dim)
+        except Exception:
+            log.warning(
+                "dense v2 encode failed at ingest — storing row with NULL "
+                "embedding_dense_v2 (backfill later)",
+                exc_info=True,
+            )
+            return None
 
     def _invalidate_dense_matrix(self, force: bool = False) -> None:
         """Drop the in-memory dense matrix so it rebuilds on next query.

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -377,6 +377,12 @@ class KnowledgeStore:
         # (tag-exact weight is 3.0). Unused under RRF, where dense ranks
         # are fused, not summed.
         dense_additive_weight: float = 4.0,
+        # Tier-0 review fix (2026-05-16): noise floor for the additive-mode
+        # dense merge. A dense hit whose cosine is below this does not
+        # contribute to gene_scores (still kept as a candidate with
+        # negligible weight). Consistent with query_cold_tier's 0.15
+        # min_cosine. Unused under RRF.
+        dense_additive_min_cosine: float = 0.15,
         pki_weight: float = 1.0,
         main_conn: Optional[sqlite3.Connection] = None,
         shard_name: str = "main",
@@ -463,6 +469,8 @@ class KnowledgeStore:
         self._dense_weight: float = float(dense_weight)
         # Tier-0 PR-3: additive-mode dense merge weight (see ctor param).
         self._dense_additive_weight: float = float(dense_additive_weight)
+        # Tier-0 review fix: additive-mode dense merge noise floor (see ctor param).
+        self._dense_additive_min_cosine: float = float(dense_additive_min_cosine)
         self._pki_weight: float = float(pki_weight)
         self._threshold_dim_warned: bool = False
         # Phase 2 claims layer (2026-04-19). Optional hook — when a main.db
@@ -1996,10 +2004,24 @@ class KnowledgeStore:
                     # hits. ``tier_contrib`` records the *weighted*
                     # contribution so telemetry reflects what actually
                     # entered the additive sum.
+                    #
+                    # Tier-0 review fix (2026-05-16): apply a min-cosine
+                    # noise floor, consistent with the cosine cutoffs the
+                    # sibling recall paths (query_cold_tier, query_docs_ann)
+                    # already enforce. A below-floor hit does NOT contribute
+                    # to the score, but is still seeded as a candidate with
+                    # a 1e-9 epsilon (same set-membership treatment the RRF
+                    # branch above gives dense-only genes); its tier_contrib
+                    # is recorded as 0.0 so telemetry stays coherent with
+                    # what entered the sum.
                     for gid, cosine in dense_hits:
-                        contribution = float(cosine) * self._dense_additive_weight
-                        gene_scores[gid] = gene_scores.get(gid, 0.0) + contribution
-                        tier_contrib.setdefault(gid, {})["dense"] = contribution
+                        if float(cosine) >= self._dense_additive_min_cosine:
+                            contribution = float(cosine) * self._dense_additive_weight
+                            gene_scores[gid] = gene_scores.get(gid, 0.0) + contribution
+                            tier_contrib.setdefault(gid, {})["dense"] = contribution
+                        else:
+                            gene_scores.setdefault(gid, 1e-9)
+                            tier_contrib.setdefault(gid, {})["dense"] = 0.0
                 try:
                     from .telemetry import genome_signal_histogram
                     genome_signal_histogram().record(

--- a/helix_context/pipeline/tier_logic.py
+++ b/helix_context/pipeline/tier_logic.py
@@ -104,9 +104,12 @@ def apply_budget_tiers(
     # operates on ratio gates only.
     #
     # Issue #115: also gates the ABSTAIN absolute-floor clause below.
-    # ``ShardedGenomeAdapter`` declares ``_fusion_mode = "rrf"`` so the
-    # router's RRF-fused scores (~0.26-0.40) don't trip the BM25-calibrated
-    # 2.5 floor on every sharded query.
+    # ``ShardedGenomeAdapter`` declares ``_fusion_mode = "additive"`` (Tier-0
+    # PR-3, the honest label — the router publishes IDF-corrected additive-
+    # scale scores, never RRF-scale numbers; see ShardedGenomeAdapter), so on
+    # the sharded path ``skip_absolute_floors`` is False and the BM25-
+    # calibrated absolute floors run, interpreting the scores on the scale
+    # they were calibrated for.
     skip_absolute_floors = (fusion_mode == "rrf")
 
     # -- Baseline-normalized ratio for RRF (issue #115 follow-up) --

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -924,6 +924,19 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
             except Exception:
                 log.warning("swap-db: failed to repoint registry genome", exc_info=True)
 
+            # Tier-0 follow-up #4 (2026-05-17): repoint the VaultManager at
+            # the new store too. Like the Registry above, VaultManager
+            # captures helix.genome at construction (app.py:
+            # VaultManager(genome=helix.genome)); its pruner thread runs
+            # refresh_stale_view(genome=self.genome) on a timer, so without
+            # this repoint a post-swap prune cycle would hit the closed old
+            # store — the same closed-database failure. Vault is opt-in, so
+            # this only bites when vault.enabled=true. Runs BEFORE close().
+            try:
+                request.app.state.vault.genome = new_store
+            except Exception:
+                log.warning("swap-db: failed to repoint vault genome", exc_info=True)
+
             # Close old store (best-effort)
             try:
                 old_store.close()

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -909,6 +909,21 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
             helix.genome = new_store
             helix.genome.last_query_scores = {}
 
+            # Tier-0 fix (2026-05-17): repoint the session Registry at the
+            # new store. The Registry captures a genome reference at app
+            # construction (app.py: Registry(helix.genome)) and uses
+            # genome.conn directly for every read/write — including the
+            # background sweep task. Without this repoint, after a swap the
+            # Registry still holds the OLD store, which old_store.close()
+            # below then closes; the next _background_registry_sweep tick
+            # raises "sqlite3.ProgrammingError: Cannot operate on a closed
+            # database". Must run BEFORE old_store.close() so a sweep that
+            # fires mid-swap never observes a closed connection.
+            try:
+                registry.genome = new_store
+            except Exception:
+                log.warning("swap-db: failed to repoint registry genome", exc_info=True)
+
             # Close old store (best-effort)
             try:
                 old_store.close()

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -878,6 +878,25 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
                 sr_weight=config.retrieval.sr_weight,
                 sr_cap=config.retrieval.sr_cap,
                 seeded_edges_enabled=config.retrieval.seeded_edges_enabled,
+                # Tier-0 fix (2026-05-18): forward the dense / ANN / fusion
+                # retrieval knobs. Without these a hot-swapped fixture reverts
+                # to the KnowledgeStore defaults (dense_embedding_enabled=False)
+                # and dense recall silently goes dark — the boot path
+                # (context_manager.open_read_source) passes them, but this
+                # swap path had drifted out of sync.
+                dense_embedding_enabled=config.retrieval.dense_embedding_enabled,
+                dense_embedding_dim=config.retrieval.dense_embedding_dim,
+                ann_similarity_threshold=config.retrieval.ann_similarity_threshold,
+                ann_threshold_min_genes=config.retrieval.ann_threshold_min_genes,
+                ann_threshold_max_genes=config.retrieval.ann_threshold_max_genes,
+                ann_threshold_mode=config.retrieval.ann_threshold_mode,
+                ann_threshold_sigma_multiplier=config.retrieval.ann_threshold_sigma_multiplier,
+                dense_pool_size=config.retrieval.dense_pool_size,
+                fusion_mode=config.retrieval.fusion_mode,
+                rrf_k=config.retrieval.rrf_k,
+                dense_weight=config.retrieval.dense_weight,
+                dense_additive_weight=config.retrieval.dense_additive_weight,
+                dense_additive_min_cosine=config.retrieval.dense_additive_min_cosine,
             )
             new_store.read_only = read_only
 

--- a/helix_context/sharding.py
+++ b/helix_context/sharding.py
@@ -171,14 +171,30 @@ class ShardedGenomeAdapter:
         ``hasattr(genome, '_sharded_adapter')``.
     """
 
-    # The router unconditionally builds its RRF Fuser at shard_router.py:236
-    # (`Fuser(k=60)` with no mode toggle), so any sharded read is RRF-fused.
-    # Expose this so context_manager._build_signals reads "rrf" via
-    # ``getattr(self.genome, "_fusion_mode", "additive")`` and the abstain
-    # gate / TIGHT-FOCUSED floor bypass in pipeline/tier_logic.py engage.
-    # Without this, sharded RRF scores (~0.26-0.40) trip the 2.5 absolute
-    # floor on 9/10 queries and abstain — see issue #115.
-    _fusion_mode: str = "rrf"
+    # Score-scale label consumed by the downstream gates via
+    # ``getattr(self.genome, "_fusion_mode", "additive")`` —
+    # ``pipeline/tier_logic.py`` (abstain / TIGHT / FOCUSED floors) and,
+    # transitively, ``scoring/know_calibration.py``.
+    #
+    # Tier-0 PR-3 (2026-05-16) — Decision 2 Option (b): this is now
+    # ``"additive"``, and that is the *honest* label. The ShardRouter
+    # builds an RRF ``Fuser`` (shard_router.py), but it uses the RRF
+    # ``all_scores()`` map *only* as a secondary sort tiebreaker — the
+    # primary sort key and the published ``last_query_scores`` map are the
+    # IDF-corrected *additive*-scale ``corrected`` scores (BM25-ish:
+    # ``additive × IDF[0.5,3.0] × doc-boost[1.0,1.15]``). The router never
+    # publishes RRF-scale numbers.
+    #
+    # The previous ``"rrf"`` label (issue #115) was a misdiagnosis: it made
+    # ``tier_logic`` skip its absolute floors on every sharded query
+    # because RRF-scale scores would have tripped the BM25-calibrated 2.5
+    # floor. But the scores were never RRF-scale — so skipping the floors
+    # treated a symptom. With the correct ``"additive"`` label the gates
+    # interpret the BM25-ish scores on the scale they were calibrated for:
+    # ``skip_absolute_floors`` is False and the absolute floors run, and
+    # ``compute_confidence``'s BM25 betas (``s_ref = 1.0``) match the
+    # input. Fully reversible — one string.
+    _fusion_mode: str = "additive"
 
     def __init__(self, main_path: str, **genome_kwargs: Any) -> None:
         from .shard_router import ShardRouter

--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -125,95 +125,101 @@ def backfill_dense_db(
     if codec is None:
         codec = BGEM3Codec(dim=dim)
 
+    # Single connection for the whole backfill. Wrapped in try/finally so a
+    # raise anywhere below (most likely ``codec.encode_batch`` when the model
+    # is unavailable) still closes it — a leaked WAL connection holds
+    # ``-wal``/``-shm`` locks on Windows.
     conn = sqlite3.connect(db_path, timeout=30)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout=30000")
-    _ensure_v2_schema(conn)
-    cur = conn.cursor()
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        _ensure_v2_schema(conn)
+        cur = conn.cursor()
 
-    total = cur.execute("SELECT COUNT(*) AS c FROM genes").fetchone()["c"]
-    populated_before = cur.execute(
-        "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL"
-    ).fetchone()["c"]
-    log_fn(
-        f"[backfill] {db_path}: genes total={total} "
-        f"v2_populated_before={populated_before} dim={dim}"
-    )
-
-    # Idempotency: skip rows that already have a v2 BLOB of the right length.
-    # ``length(blob) != expected_bytes`` guards half-written rows from an
-    # earlier crash or a dim-change re-run, and agrees with the inline-ingest
-    # write path's encoding so a PR-1-built genome selects 0 rows here.
-    sql = (
-        "SELECT gene_id, content FROM genes "
-        "WHERE embedding_dense_v2 IS NULL "
-        "   OR length(embedding_dense_v2) != ?"
-    )
-    params: tuple = (expected_bytes,)
-    if limit is not None:
-        sql += " LIMIT ?"
-        params = (expected_bytes, int(limit))
-    rows = cur.execute(sql, params).fetchall()
-    log_fn(f"[backfill] {db_path}: rows to process: {len(rows)}")
-
-    t0 = time.monotonic()
-    processed = 0
-    skipped = 0
-    for start in range(0, len(rows), max(1, batch)):
-        chunk = rows[start:start + max(1, batch)]
-        encodable = [
-            (r["gene_id"], (r["content"] or ""))
-            for r in chunk
-            if (r["content"] or "").strip()
-        ]
-        skipped += len(chunk) - len(encodable)
-        if not encodable:
-            continue
-        # Match the inline-ingest encode behaviour: bound each passage at
-        # PASSAGE_CHAR_CAP and batch-encode with task="passage". The real
-        # ``BGEM3Codec`` exposes ``encode_batch`` (PR-1) — the preferred,
-        # one-model-call path; fall back to per-text ``encode`` for any
-        # codec that predates it. ``encode_batch`` is byte-identical to a
-        # sequence of ``encode`` calls (see bgem3_codec.encode_batch), so
-        # the fallback does not change the stored vectors.
-        texts = [content[:PASSAGE_CHAR_CAP] for _gid, content in encodable]
-        if hasattr(codec, "encode_batch"):
-            vecs = codec.encode_batch(texts, task="passage")
-        else:
-            vecs = [codec.encode(t, task="passage") for t in texts]
-        updates = []
-        for (gene_id, _content), vec in zip(encodable, vecs):
-            try:
-                blob = vec_to_blob(vec, dim)
-            except ValueError as e:
-                log_fn(f"[backfill] WARN: gene_id={gene_id} dim mismatch: {e}")
-                skipped += 1
-                continue
-            updates.append((sqlite3.Binary(blob), gene_id))
-        if updates:
-            cur.executemany(
-                "UPDATE genes SET embedding_dense_v2 = ? WHERE gene_id = ?",
-                updates,
-            )
-            processed += len(updates)
-        conn.commit()
-        elapsed = time.monotonic() - t0
-        rate = processed / elapsed if elapsed > 0 else 0.0
+        total = cur.execute("SELECT COUNT(*) AS c FROM genes").fetchone()["c"]
+        populated_before = cur.execute(
+            "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()["c"]
         log_fn(
-            f"[backfill] {db_path}: {min(start + len(chunk), len(rows))}/{len(rows)} "
-            f"processed={processed} skipped={skipped} rate={rate:.1f} genes/s"
+            f"[backfill] {db_path}: genes total={total} "
+            f"v2_populated_before={populated_before} dim={dim}"
         )
 
-    conn.commit()
-    elapsed = time.monotonic() - t0
+        # Idempotency: skip rows that already have a v2 BLOB of the right length.
+        # ``length(blob) != expected_bytes`` guards half-written rows from an
+        # earlier crash or a dim-change re-run, and agrees with the inline-ingest
+        # write path's encoding so a PR-1-built genome selects 0 rows here.
+        sql = (
+            "SELECT gene_id, content FROM genes "
+            "WHERE embedding_dense_v2 IS NULL "
+            "   OR length(embedding_dense_v2) != ?"
+        )
+        params: tuple = (expected_bytes,)
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (expected_bytes, int(limit))
+        rows = cur.execute(sql, params).fetchall()
+        log_fn(f"[backfill] {db_path}: rows to process: {len(rows)}")
 
-    populated_after = cur.execute(
-        "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL "
-        "AND length(embedding_dense_v2) = ?",
-        (expected_bytes,),
-    ).fetchone()["c"]
-    conn.close()
+        t0 = time.monotonic()
+        processed = 0
+        skipped = 0
+        for start in range(0, len(rows), max(1, batch)):
+            chunk = rows[start:start + max(1, batch)]
+            encodable = [
+                (r["gene_id"], (r["content"] or ""))
+                for r in chunk
+                if (r["content"] or "").strip()
+            ]
+            skipped += len(chunk) - len(encodable)
+            if not encodable:
+                continue
+            # Match the inline-ingest encode behaviour: bound each passage at
+            # PASSAGE_CHAR_CAP and batch-encode with task="passage". The real
+            # ``BGEM3Codec`` exposes ``encode_batch`` (PR-1) — the preferred,
+            # one-model-call path; fall back to per-text ``encode`` for any
+            # codec that predates it. ``encode_batch`` is byte-identical to a
+            # sequence of ``encode`` calls (see bgem3_codec.encode_batch), so
+            # the fallback does not change the stored vectors.
+            texts = [content[:PASSAGE_CHAR_CAP] for _gid, content in encodable]
+            if hasattr(codec, "encode_batch"):
+                vecs = codec.encode_batch(texts, task="passage")
+            else:
+                vecs = [codec.encode(t, task="passage") for t in texts]
+            updates = []
+            for (gene_id, _content), vec in zip(encodable, vecs):
+                try:
+                    blob = vec_to_blob(vec, dim)
+                except ValueError as e:
+                    log_fn(f"[backfill] WARN: gene_id={gene_id} dim mismatch: {e}")
+                    skipped += 1
+                    continue
+                updates.append((sqlite3.Binary(blob), gene_id))
+            if updates:
+                cur.executemany(
+                    "UPDATE genes SET embedding_dense_v2 = ? WHERE gene_id = ?",
+                    updates,
+                )
+                processed += len(updates)
+            conn.commit()
+            elapsed = time.monotonic() - t0
+            rate = processed / elapsed if elapsed > 0 else 0.0
+            log_fn(
+                f"[backfill] {db_path}: {min(start + len(chunk), len(rows))}/{len(rows)} "
+                f"processed={processed} skipped={skipped} rate={rate:.1f} genes/s"
+            )
+
+        conn.commit()
+        elapsed = time.monotonic() - t0
+
+        populated_after = cur.execute(
+            "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL "
+            "AND length(embedding_dense_v2) = ?",
+            (expected_bytes,),
+        ).fetchone()["c"]
+    finally:
+        conn.close()
 
     coverage = (populated_after / total) if total else 0.0
     log_fn(

--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -27,16 +27,17 @@ from __future__ import annotations
 
 import argparse
 import sqlite3
-import struct
 import sys
 import time
 from pathlib import Path
 
-import numpy as np
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from helix_context.backends.bgem3_codec import BGEM3Codec
+from helix_context.backends.bgem3_codec import (
+    PASSAGE_CHAR_CAP,
+    BGEM3Codec,
+    vec_to_blob,
+)
 from helix_context.config import load_config
 
 
@@ -55,12 +56,11 @@ def _ensure_v2_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
-def _vec_to_blob(vec, dim: int) -> bytes:
-    """Pack a float vector as raw little-endian fp32 of length ``dim*4``."""
-    arr = np.asarray(vec, dtype="<f4")
-    if arr.shape[0] != dim:
-        raise ValueError(f"vector dim {arr.shape[0]} != expected {dim}")
-    return arr.tobytes(order="C")
+# ``_vec_to_blob`` is kept as a thin alias of the canonical
+# ``helix_context.backends.bgem3_codec.vec_to_blob`` so the inline-ingest
+# write path (knowledge_store.upsert_doc) and this offline backfill share one
+# encoding and cannot drift. See PR-1 of the 2026-05-16 Tier-0 plan.
+_vec_to_blob = vec_to_blob
 
 
 def main() -> int:
@@ -131,9 +131,10 @@ def main() -> int:
         if not content.strip():
             skipped += 1
             continue
-        # Match production encode behaviour: bound passage length at 2000
-        # chars (BGE-M3 max_length=512 tokens, ~2k chars is a safe cap).
-        vec = codec.encode(content[:2000], task="passage")
+        # Match production encode behaviour: bound passage length at
+        # PASSAGE_CHAR_CAP (BGE-M3 max_length=512 tokens, ~2k chars is a safe
+        # cap). The inline-ingest path uses the same cap.
+        vec = codec.encode(content[:PASSAGE_CHAR_CAP], task="passage")
         try:
             blob = _vec_to_blob(vec, dim)
         except ValueError as e:

--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -22,6 +22,15 @@ Operator runbook (post-merge):
 Wall-clock estimate at 18.9k genes on CPU sentence-transformers BGE-M3:
 ~30-90 minutes. With FlagEmbedding + GPU, ~5-15 minutes. Resumable via the
 idempotent skip-clause.
+
+Shared backfill loop
+--------------------
+The encode-and-pack loop lives in :func:`backfill_dense_db`. Tier-0 PR-2
+(2026-05-16) made ``scripts/build_fixture_matrix.py`` import that function
+and run it as a post-build pass on every freshly-built fixture ``.db`` so
+the bench measures the real (dense-populated) pipeline rather than a
+dense-dark one. The fixture builder and this operator script therefore
+share a single backfill implementation and cannot drift.
 """
 from __future__ import annotations
 
@@ -63,6 +72,169 @@ def _ensure_v2_schema(conn: sqlite3.Connection) -> None:
 _vec_to_blob = vec_to_blob
 
 
+def backfill_dense_db(
+    db_path: str,
+    *,
+    dim: int | None = None,
+    batch: int = 64,
+    limit: int | None = None,
+    codec=None,
+    log_fn=print,
+) -> dict:
+    """Backfill ``genes.embedding_dense_v2`` on the SQLite DB at ``db_path``.
+
+    This is the single shared implementation of the "open a ``.db``, find
+    ``genes`` rows whose ``embedding_dense_v2`` is NULL or wrong-length,
+    batch-encode their content, UPDATE the column" loop. Both this script's
+    :func:`main` and ``scripts/build_fixture_matrix.py`` (Tier-0 PR-2) call
+    it so the operator backfill and the fixture-builder post-build pass
+    cannot drift.
+
+    The loop reuses PR-1's canonical helpers from
+    ``helix_context.backends.bgem3_codec``: :data:`PASSAGE_CHAR_CAP` (the
+    passage input char cap), :meth:`BGEM3Codec.encode_batch` (the batch
+    encoder) and :func:`vec_to_blob` (the fp32 packer). A genome backfilled
+    here therefore satisfies the same ``length(blob) == dim*4`` idempotency
+    skip-clause as one written by the inline-ingest path.
+
+    Idempotent: rows that already carry a v2 BLOB of exactly ``dim*4`` bytes
+    are not re-encoded, so a re-run reports ``rows_processed == 0``.
+
+    Args:
+        db_path: path to the genome ``.db`` to backfill in place.
+        dim: dense vector dimension. ``None`` → ``retrieval.dense_embedding_dim``
+            from ``helix.toml``.
+        batch: encode + commit batch size. Default 64.
+        limit: optional cap on rows to process (smoke tests).
+        codec: an object exposing ``encode_batch(texts, task=...)``. ``None``
+            → a fresh :class:`BGEM3Codec` at ``dim``. Tests inject a fake.
+        log_fn: callable taking one string for progress lines. Default
+            :func:`print`; pass a no-op (``lambda _msg: None``) to silence.
+
+    Returns:
+        A coverage report dict with keys: ``db_path``, ``dim``,
+        ``expected_bytes``, ``total`` (genes rows), ``populated_before``,
+        ``populated_after`` (rows with a correct-length v2 BLOB),
+        ``rows_processed``, ``rows_skipped``, ``dense_coverage`` (float in
+        ``[0.0, 1.0]`` = ``populated_after / total``) and ``elapsed_s``.
+    """
+    if dim is None:
+        dim = int(load_config().retrieval.dense_embedding_dim)
+    dim = int(dim)
+    expected_bytes = dim * 4
+    if codec is None:
+        codec = BGEM3Codec(dim=dim)
+
+    conn = sqlite3.connect(db_path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
+    _ensure_v2_schema(conn)
+    cur = conn.cursor()
+
+    total = cur.execute("SELECT COUNT(*) AS c FROM genes").fetchone()["c"]
+    populated_before = cur.execute(
+        "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+    ).fetchone()["c"]
+    log_fn(
+        f"[backfill] {db_path}: genes total={total} "
+        f"v2_populated_before={populated_before} dim={dim}"
+    )
+
+    # Idempotency: skip rows that already have a v2 BLOB of the right length.
+    # ``length(blob) != expected_bytes`` guards half-written rows from an
+    # earlier crash or a dim-change re-run, and agrees with the inline-ingest
+    # write path's encoding so a PR-1-built genome selects 0 rows here.
+    sql = (
+        "SELECT gene_id, content FROM genes "
+        "WHERE embedding_dense_v2 IS NULL "
+        "   OR length(embedding_dense_v2) != ?"
+    )
+    params: tuple = (expected_bytes,)
+    if limit is not None:
+        sql += " LIMIT ?"
+        params = (expected_bytes, int(limit))
+    rows = cur.execute(sql, params).fetchall()
+    log_fn(f"[backfill] {db_path}: rows to process: {len(rows)}")
+
+    t0 = time.monotonic()
+    processed = 0
+    skipped = 0
+    for start in range(0, len(rows), max(1, batch)):
+        chunk = rows[start:start + max(1, batch)]
+        encodable = [
+            (r["gene_id"], (r["content"] or ""))
+            for r in chunk
+            if (r["content"] or "").strip()
+        ]
+        skipped += len(chunk) - len(encodable)
+        if not encodable:
+            continue
+        # Match the inline-ingest encode behaviour: bound each passage at
+        # PASSAGE_CHAR_CAP and batch-encode with task="passage". The real
+        # ``BGEM3Codec`` exposes ``encode_batch`` (PR-1) — the preferred,
+        # one-model-call path; fall back to per-text ``encode`` for any
+        # codec that predates it. ``encode_batch`` is byte-identical to a
+        # sequence of ``encode`` calls (see bgem3_codec.encode_batch), so
+        # the fallback does not change the stored vectors.
+        texts = [content[:PASSAGE_CHAR_CAP] for _gid, content in encodable]
+        if hasattr(codec, "encode_batch"):
+            vecs = codec.encode_batch(texts, task="passage")
+        else:
+            vecs = [codec.encode(t, task="passage") for t in texts]
+        updates = []
+        for (gene_id, _content), vec in zip(encodable, vecs):
+            try:
+                blob = vec_to_blob(vec, dim)
+            except ValueError as e:
+                log_fn(f"[backfill] WARN: gene_id={gene_id} dim mismatch: {e}")
+                skipped += 1
+                continue
+            updates.append((sqlite3.Binary(blob), gene_id))
+        if updates:
+            cur.executemany(
+                "UPDATE genes SET embedding_dense_v2 = ? WHERE gene_id = ?",
+                updates,
+            )
+            processed += len(updates)
+        conn.commit()
+        elapsed = time.monotonic() - t0
+        rate = processed / elapsed if elapsed > 0 else 0.0
+        log_fn(
+            f"[backfill] {db_path}: {min(start + len(chunk), len(rows))}/{len(rows)} "
+            f"processed={processed} skipped={skipped} rate={rate:.1f} genes/s"
+        )
+
+    conn.commit()
+    elapsed = time.monotonic() - t0
+
+    populated_after = cur.execute(
+        "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL "
+        "AND length(embedding_dense_v2) = ?",
+        (expected_bytes,),
+    ).fetchone()["c"]
+    conn.close()
+
+    coverage = (populated_after / total) if total else 0.0
+    log_fn(
+        f"[backfill] {db_path}: DONE processed={processed} skipped={skipped} "
+        f"v2_populated_after={populated_after} "
+        f"coverage={100.0 * coverage:.2f}% elapsed={elapsed:.1f}s"
+    )
+    return {
+        "db_path": db_path,
+        "dim": dim,
+        "expected_bytes": expected_bytes,
+        "total": total,
+        "populated_before": populated_before,
+        "populated_after": populated_after,
+        "rows_processed": processed,
+        "rows_skipped": skipped,
+        "dense_coverage": coverage,
+        "elapsed_s": round(elapsed, 1),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Backfill BGE-M3 v2 BLOBs.")
     parser.add_argument(
@@ -87,91 +259,19 @@ def main() -> int:
     cfg = load_config()
     db_path = args.db_path or str(repo_root / cfg.genome.path)
     dim = int(args.dim if args.dim is not None else cfg.retrieval.dense_embedding_dim)
-    expected_bytes = dim * 4
 
     print(f"[backfill] DB: {db_path}")
-    print(f"[backfill] dim={dim} expected_bytes_per_row={expected_bytes}")
+    print(f"[backfill] dim={dim} expected_bytes_per_row={dim * 4}")
 
-    codec = BGEM3Codec(dim=dim)
-    conn = sqlite3.connect(db_path, timeout=30)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout=30000")
-    _ensure_v2_schema(conn)
-
-    cur = conn.cursor()
-
-    # Pre-flight coverage report.
-    total = cur.execute("SELECT COUNT(*) AS c FROM genes").fetchone()["c"]
-    populated_before = cur.execute(
-        "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL"
-    ).fetchone()["c"]
-    print(f"[backfill] genes total={total} v2_populated_before={populated_before}")
-
-    # Idempotency: skip rows that already have a v2 BLOB of the right length.
-    # ``length(blob) == expected_bytes`` guards against half-written rows from
-    # an earlier crash or a dim-change re-run.
-    sql = (
-        "SELECT gene_id, content FROM genes "
-        "WHERE embedding_dense_v2 IS NULL "
-        "   OR length(embedding_dense_v2) != ?"
+    # Delegate to the shared backfill loop so this operator script and the
+    # fixture builder (build_fixture_matrix.py, Tier-0 PR-2) cannot drift.
+    backfill_dense_db(
+        db_path,
+        dim=dim,
+        batch=args.batch,
+        limit=args.limit,
+        log_fn=print,
     )
-    params: tuple = (expected_bytes,)
-    if args.limit is not None:
-        sql += " LIMIT ?"
-        params = (expected_bytes, int(args.limit))
-    rows = cur.execute(sql, params).fetchall()
-    print(f"[backfill] rows to process: {len(rows)}")
-
-    t0 = time.monotonic()
-    processed = 0
-    skipped = 0
-    for i, row in enumerate(rows):
-        content = row["content"] or ""
-        if not content.strip():
-            skipped += 1
-            continue
-        # Match production encode behaviour: bound passage length at
-        # PASSAGE_CHAR_CAP (BGE-M3 max_length=512 tokens, ~2k chars is a safe
-        # cap). The inline-ingest path uses the same cap.
-        vec = codec.encode(content[:PASSAGE_CHAR_CAP], task="passage")
-        try:
-            blob = _vec_to_blob(vec, dim)
-        except ValueError as e:
-            print(f"[backfill] WARN: gene_id={row['gene_id']} dim mismatch: {e}")
-            skipped += 1
-            continue
-        cur.execute(
-            "UPDATE genes SET embedding_dense_v2 = ? WHERE gene_id = ?",
-            (sqlite3.Binary(blob), row["gene_id"]),
-        )
-        processed += 1
-        if (i + 1) % args.batch == 0:
-            conn.commit()
-            elapsed = time.monotonic() - t0
-            rate = processed / elapsed if elapsed > 0 else 0.0
-            print(
-                f"[backfill] {i+1}/{len(rows)} "
-                f"processed={processed} skipped={skipped} "
-                f"rate={rate:.1f} genes/s"
-            )
-
-    conn.commit()
-    elapsed = time.monotonic() - t0
-
-    # Post-flight coverage report.
-    populated_after = cur.execute(
-        "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL "
-        "AND length(embedding_dense_v2) = ?",
-        (expected_bytes,),
-    ).fetchone()["c"]
-    coverage_pct = 100.0 * populated_after / total if total else 0.0
-    print(
-        f"[backfill] DONE. processed={processed} skipped={skipped} "
-        f"v2_populated_after={populated_after} coverage={coverage_pct:.2f}% "
-        f"elapsed={elapsed:.1f}s"
-    )
-    conn.close()
     return 0
 
 

--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -123,7 +123,19 @@ def backfill_dense_db(
     dim = int(dim)
     expected_bytes = dim * 4
     if codec is None:
-        codec = BGEM3Codec(dim=dim)
+        # Auto-detect CUDA so the dense backfill runs on the GPU when one is
+        # present. ``BGEM3Codec`` defaults to ``device="cpu"``; on CPU this
+        # encode-and-pack loop is a half-day job at ~19k genes, vs ~5-15 min
+        # on a GPU (the speeds this script's header advertises). The codec's
+        # sentence-transformers backend forwards ``device`` to the model, so
+        # picking "cuda" here is all that's needed. Falls back to CPU when no
+        # GPU is visible. Tests inject their own ``codec`` and bypass this.
+        try:
+            import torch
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception:  # noqa: BLE001 — torch missing → CPU is the only option
+            device = "cpu"
+        codec = BGEM3Codec(dim=dim, device=device)
 
     # Single connection for the whole backfill. Wrapped in try/finally so a
     # raise anywhere below (most likely ``codec.encode_batch`` when the model

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -75,6 +75,10 @@ from pathlib import Path
 from typing import Iterable
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# Also put this ``scripts/`` dir on the path so the sibling-module import of
+# ``backfill_bgem3_v2`` resolves whether this file is run directly or
+# imported as a module (e.g. by the test suite). See Tier-0 PR-2.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from helix_context.tagger import CpuTagger
 from helix_context.genome import Genome
@@ -85,6 +89,11 @@ from helix_context.shard_schema import (
     open_main_db,
     register_shard,
 )
+
+# Tier-0 PR-2 (2026-05-16): reuse the operator backfill script's shared
+# encode-and-pack loop so the fixture builder's post-build dense pass and
+# ``scripts/backfill_bgem3_v2.py`` share one implementation and cannot drift.
+from backfill_bgem3_v2 import backfill_dense_db
 
 
 logging.basicConfig(
@@ -538,6 +547,58 @@ def ingest_tree(
 # ── Build one profile ─────────────────────────────────────────────────────
 
 
+def _backfill_dense(db_path: str) -> dict:
+    """Post-build pass: populate ``genes.embedding_dense_v2`` on ``db_path``.
+
+    Tier-0 PR-2 (2026-05-16). The fixture builder's per-gene write path
+    (``Genome.upsert_doc`` via the batched-SPLADE writer) is deliberately
+    kept lean — it does not encode dense vectors inline. Instead, once a
+    profile or shard ``.db`` is fully built and closed, this runs an
+    explicit BGE-M3 dense backfill over it so the bench fixtures exercise
+    the real (dense-populated) retrieval pipeline rather than a
+    dense-dark one.
+
+    Delegates to :func:`backfill_bgem3_v2.backfill_dense_db` — the shared
+    encode-and-pack loop also used by the standalone operator backfill
+    script — so the two paths cannot drift. ``dim`` defaults to
+    ``retrieval.dense_embedding_dim`` from ``helix.toml``.
+
+    Call sites:
+      * blob mode — at the end of :func:`build_profile`, after
+        ``genome.close()``, on ``<profile>.db``.
+      * sharded mode — in :func:`_build_one_shard`, after the shard's
+        ``Genome`` is closed, on each per-shard ``.db``. The cross-shard
+        ``main.genome.db`` routing DB holds no ``genes`` rows and is not
+        backfilled.
+
+    Returns the coverage report dict from :func:`backfill_dense_db`
+    (includes ``dense_coverage`` in ``[0.0, 1.0]``). On any failure the
+    error is logged and a degraded report with ``dense_coverage = 0.0``
+    and an ``error`` key is returned, so a dense-encode failure surfaces
+    in the manifest rather than silently producing a dense-dark fixture.
+    """
+    log.info("dense backfill: %s", db_path)
+    try:
+        report = backfill_dense_db(db_path, log_fn=lambda msg: log.info("%s", msg))
+    except Exception as exc:  # noqa: BLE001 — model load / encode failure
+        log.error("dense backfill FAILED for %s: %s", db_path, exc)
+        return {
+            "db_path": db_path,
+            "dense_coverage": 0.0,
+            "rows_processed": 0,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    log.info(
+        "dense backfill done: %s coverage=%.1f%% (%d/%d genes, %d processed)",
+        db_path,
+        100.0 * report["dense_coverage"],
+        report["populated_after"],
+        report["total"],
+        report["rows_processed"],
+    )
+    return report
+
+
 def build_profile(
     name: str,
     db_path: str,
@@ -654,6 +715,15 @@ def build_profile(
         log.warning("  missing roots: %s", stats["missing_roots"])
 
     genome.close()
+
+    # Tier-0 PR-2: post-build dense pass. The builder's per-gene write path
+    # is lean (no inline BGE-M3 encode); populate ``embedding_dense_v2`` here
+    # now that the ``.db`` is fully written and closed.
+    dense_report = _backfill_dense(db_path)
+    stats["dense_coverage"] = dense_report["dense_coverage"]
+    stats["dense_genes_populated"] = dense_report.get("populated_after", 0)
+    if dense_report.get("error"):
+        stats["dense_error"] = dense_report["error"]
 
     # Drop perf_counter t0 before serializing
     stats.pop("t0", None)
@@ -794,7 +864,7 @@ def _build_one_shard(
                 now,   # updated_at
             ))
 
-        return {
+        result = {
             "label": label,
             "root": root,
             "shard_db_path": str(p),
@@ -811,6 +881,18 @@ def _build_one_shard(
         }
     finally:
         shard.close()
+
+    # Tier-0 PR-2: post-build dense pass on this per-shard ``.db`` — run
+    # only after the shard's ``Genome`` has been closed above. The
+    # cross-shard ``main.genome.db`` routing DB is NOT backfilled here: it
+    # carries no ``genes`` rows (only fingerprint_index / source_index), so
+    # per-shard dense recall reads each shard's own ``embedding_dense_v2``.
+    dense_report = _backfill_dense(str(p))
+    result["dense_coverage"] = dense_report["dense_coverage"]
+    result["dense_genes_populated"] = dense_report.get("populated_after", 0)
+    if dense_report.get("error"):
+        result["dense_error"] = dense_report["error"]
+    return result
 
 
 def _shard_worker_entry(task: dict) -> dict:
@@ -990,7 +1072,7 @@ def build_profile_sharded(
             len(si_payload),
             res["byte_size"] / 1_048_576, res["elapsed_s"],
         )
-        totals["shards"].append({
+        shard_entry = {
             "name": res["label"],
             "root": res["root"],
             "path": res["shard_db_path"],
@@ -999,7 +1081,14 @@ def build_profile_sharded(
             "source_index_rows": len(si_payload),
             "bytes": res["byte_size"],
             "elapsed_s": res["elapsed_s"],
-        })
+            # Tier-0 PR-2: per-shard dense coverage from the post-build
+            # backfill that ran inside ``_build_one_shard``.
+            "dense_coverage": res.get("dense_coverage", 0.0),
+            "dense_genes_populated": res.get("dense_genes_populated", 0),
+        }
+        if res.get("dense_error"):
+            shard_entry["dense_error"] = res["dense_error"]
+        totals["shards"].append(shard_entry)
         for k in ("files", "genes", "skipped", "errors"):
             totals[k] += res[k]
         totals["missing_roots"].extend(res["missing_roots"])
@@ -1042,12 +1131,26 @@ def build_profile_sharded(
     totals["total_genes"] = sum(s["genes"] for s in totals["shards"])
     totals["shard_count"] = len(totals["shards"])
 
+    # Tier-0 PR-2: profile-level dense coverage = populated genes across all
+    # per-shard ``.db`` files / total genes across all shards. The cross-shard
+    # ``main.genome.db`` carries no ``genes`` rows and is excluded by
+    # construction (it is never passed to ``_backfill_dense``).
+    dense_populated = sum(
+        s.get("dense_genes_populated", 0) for s in totals["shards"]
+    )
+    totals["dense_genes_populated"] = dense_populated
+    totals["dense_coverage"] = (
+        dense_populated / totals["total_genes"]
+        if totals["total_genes"] else 0.0
+    )
+
     log.info("=" * 60)
     log.info("DONE %s-sharded in %.1fs", name, elapsed)
     log.info(
-        "  shards=%d genes=%d bytes=%d (main_db=%d)",
+        "  shards=%d genes=%d bytes=%d (main_db=%d) dense_coverage=%.1f%%",
         totals["shard_count"], totals["total_genes"],
         totals["total_bytes"], totals["main_db_bytes"],
+        100.0 * totals["dense_coverage"],
     )
     if totals["missing_roots"]:
         log.warning("  missing roots: %s", totals["missing_roots"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared fixtures for Helix Context tests."""
 
+import hashlib
 import os
+import random
 import pytest
 from pathlib import Path
 
@@ -15,6 +17,153 @@ from helix_context.schemas import Gene, PromoterTags, EpigeneticMarkers, Chromat
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+# ── Fake BGE-M3 dense codec (shared test stand-in) ───────────────────
+#
+# Tier-0 PR-3 (2026-05-16) flipped `[retrieval] dense_embedding_enabled`
+# from false to true. As a result `knowledge_store.query_docs` now routes
+# into `query_docs_dense_recall`, which calls `_get_dense_codec()` — and
+# the real `_get_dense_codec` lazy-builds a `BGEM3Codec`, pulling the
+# ~2 GB BGE-M3 weights via sentence-transformers / FlagEmbedding. On any
+# machine with the model cached, every non-`live` test that runs retrieval
+# against a v2-populated genome would load and run the real model, taking
+# the non-live suite from minutes to hours.
+#
+# `FakeBGEM3Codec` is a pure-numpy, hash-seeded, deterministic stand-in
+# with the exact interface the real `BGEM3Codec` exposes (`encode`,
+# `encode_batch`, `similarity`, plus the `task=` kwarg). The `_stub_dense_codec`
+# autouse fixture below installs it for every non-`live` test. It is the
+# single definition of the fake — `tests/test_dense_recall.py` and
+# `tests/test_ingest_dense_v2.py` import it from here instead of each
+# carrying a private `_FakeCodec` copy.
+
+
+def hash_vec(text: str, dim: int = 1024):
+    """Deterministic L2-normalised fp32 vector seeded from ``text``.
+
+    SHA-256-seeded gaussian draw, then L2-normalised — exactly the shape
+    contract of a real BGE-M3 encode (unit-norm fp32 of the given dim).
+    Two distinct texts produce near-orthogonal vectors (E[cosine] ≈ 0,
+    std ≈ 1/sqrt(dim)), so the fake reproduces the real codec's
+    random-pair statistics well enough for retrieval-quality assertions.
+    """
+    import numpy as np
+
+    out = np.zeros(dim, dtype=np.float32)
+    seed = hashlib.sha256(text.encode("utf-8")).digest()
+    rng = random.Random(int.from_bytes(seed[:8], "little"))
+    for i in range(dim):
+        out[i] = rng.gauss(0.0, 1.0)
+    n = np.linalg.norm(out)
+    if n > 0:
+        out /= n
+    return out
+
+
+class FakeBGEM3Codec:
+    """Deterministic, in-process stand-in for ``BGEM3Codec``.
+
+    Mirrors the real codec's public surface so it is a drop-in for both
+    the retrieval path (``encode(query, task="query")``) and the ingest
+    path (``encode_batch(texts, task="passage")``):
+
+    - ``encode(text, task=...)``  → unit-norm fp32 list of length ``dim``
+    - ``encode_batch(texts, task=...)`` → list of such lists
+    - ``similarity(a, b)``        → dot product (cosine for unit vectors)
+    - ``dim``                     → embedding dimension
+
+    ``query_target``: when set, ``encode(text, task="query")`` returns the
+    vector for ``query_target`` instead of for ``text`` — this lets a test
+    stage a deterministic "this query matches document X" relationship
+    (the query encodes to exactly X's passage vector, so cosine == 1.0).
+
+    ``encode_calls`` / ``batch_calls`` count invocations so call-count
+    assertions (e.g. tests/test_ingest_dense_v2.py) keep working.
+
+    No model, no I/O — sub-millisecond per encode.
+    """
+
+    def __init__(self, dim: int = 1024, query_target: str | None = None):
+        self.dim = dim
+        self._query_target = query_target
+        self.encode_calls = 0
+        self.batch_calls = 0
+
+    def encode(self, text: str, task: str = "passage"):
+        self.encode_calls += 1
+        if task == "query" and self._query_target is not None:
+            return hash_vec(self._query_target, self.dim).tolist()
+        return hash_vec(text, self.dim).tolist()
+
+    def encode_batch(self, texts, task: str = "passage"):
+        self.batch_calls += 1
+        if not texts:
+            return []
+        return [hash_vec(t, self.dim).tolist() for t in texts]
+
+    def similarity(self, a, b) -> float:
+        import numpy as np
+
+        return float(np.dot(np.asarray(a), np.asarray(b)))
+
+
+@pytest.fixture(autouse=True)
+def _stub_dense_codec(request, monkeypatch):
+    """Autouse: replace the BGE-M3 dense codec with ``FakeBGEM3Codec``.
+
+    For every test NOT marked ``live``, this monkeypatches the dense-codec
+    accessor on both seams that construct a real ``BGEM3Codec``:
+
+    - ``knowledge_store.KnowledgeStore._get_dense_codec``
+    - ``context_manager.HelixContextManager._get_dense_codec``
+
+    Both originally do ``from .backends.bgem3_codec import BGEM3Codec`` and
+    ``BGEM3Codec(dim=...)`` — that construction (and its lazy ``_load()``,
+    which pulls the ~2 GB weights) is the only place the real model enters
+    a non-live test. The replacements keep each method's original
+    None-check contract exactly — they only swap the *class that gets
+    constructed* — so:
+
+    - a test that pre-assigns ``g._dense_codec = ...`` still wins (the
+      replacement returns the already-set codec untouched);
+    - ``HelixContextManager._get_dense_codec`` still returns ``None`` when
+      ``config.ingestion.dense_embed_on_ingest`` is false.
+
+    ``live``-marked tests are skipped entirely by this fixture — they must
+    still exercise the real BGE-M3 model.
+    """
+    if request.node.get_closest_marker("live") is not None:
+        # Real-model integration tests: do not stub.
+        return
+
+    from helix_context import context_manager as _cm
+    from helix_context import knowledge_store as _ks
+
+    def _fake_store_codec(self):
+        # Mirrors KnowledgeStore._get_dense_codec: lazy-build + cache,
+        # but constructs the fake instead of the real BGEM3Codec.
+        if self._dense_codec is None:
+            self._dense_codec = FakeBGEM3Codec(dim=self._dense_embedding_dim)
+        return self._dense_codec
+
+    def _fake_manager_codec(self):
+        # Mirrors HelixContextManager._get_dense_codec: the dense-on-ingest
+        # gate still applies, only the constructed class changes.
+        if not self.config.ingestion.dense_embed_on_ingest:
+            return None
+        if self._dense_codec is None:
+            self._dense_codec = FakeBGEM3Codec(
+                dim=self.config.retrieval.dense_embedding_dim
+            )
+        return self._dense_codec
+
+    monkeypatch.setattr(
+        _ks.KnowledgeStore, "_get_dense_codec", _fake_store_codec
+    )
+    monkeypatch.setattr(
+        _cm.HelixContextManager, "_get_dense_codec", _fake_manager_codec
+    )
 
 
 @pytest.fixture

--- a/tests/test_dense_recall.py
+++ b/tests/test_dense_recall.py
@@ -215,11 +215,26 @@ def test_query_genes_ann_pool_size_independent_of_max_genes(dense_genome):
         pool_size=500,
     )
 
-    # The union (lex_pool ∪ dense_pool) must have reached at least 100.
+    # ``query_docs_ann`` builds its lex pool with exactly one
+    # ``query_docs`` call.
     assert len(lex_pool_sizes) == 1
-    assert len(dense_pool_sizes) == 1
-    assert lex_pool_sizes[0] + dense_pool_sizes[0] >= 100, (
-        f"union pool too small: lex={lex_pool_sizes[0]} dense={dense_pool_sizes[0]}"
+    # Dense recall now fires at least once. Tier-0 PR-3 (2026-05-16)
+    # decoupled dense recall from ``fusion_mode``, so ``query_docs``
+    # itself runs dense recall internally (it is a hybrid retriever in
+    # both additive and RRF mode). ``query_docs_ann`` therefore triggers
+    # dense recall twice: once nested inside its ``query_docs`` lex-pool
+    # call, and once directly for the union pool. Pre-PR-3 the additive
+    # ``query_docs`` skipped dense recall entirely, so this was exactly
+    # one — that count encoded the now-superseded gated behavior, not
+    # the spec's pool-size contract.
+    assert len(dense_pool_sizes) >= 1
+    # The union (lex_pool ∪ dense_pool) must have reached at least 100.
+    # ``query_docs_ann``'s own dense pool is the LAST recorded call (the
+    # directly-issued one); the lex pool is the single ``query_docs``
+    # call. Both draw on the full 150-gene corpus here.
+    assert lex_pool_sizes[0] + dense_pool_sizes[-1] >= 100, (
+        f"union pool too small: lex={lex_pool_sizes[0]} "
+        f"dense={dense_pool_sizes[-1]}"
     )
     # Final cut respects max_genes.
     assert len(out) <= 12, f"max_genes cap violated: {len(out)}"
@@ -432,3 +447,269 @@ def test_dense_recall_empty_v2_returns_empty_with_warn(dense_genome, caplog):
     assert not any("embedding_dense_v2 coverage" in rec.message for rec in caplog.records), (
         "fallback warn should be one-time"
     )
+
+
+# ── Tier-0 PR-3: dense recall decoupled from fusion_mode ─────────────
+#
+# Plan: docs/reviews/2026-05-16-deep-review/00-tier0-implementation-plan.md
+# §PR-3, Decision 1 = Option B. Pre-PR-3, query_docs only ran dense
+# recall under fusion_mode == "rrf"; the default additive mode never
+# touched the BGE-M3 vectors. PR-3 changes the gate to
+# dense_embedding_enabled alone and merges dense hits into gene_scores
+# in additive mode with a real (cosine * dense_additive_weight) weight,
+# not the 1e-9 epsilon the RRF path uses for set-membership only.
+
+
+def _additive_dense_genome(dense_additive_weight: float = 4.0) -> Genome:
+    """In-memory genome: dense ON, additive fusion (the shipped default)."""
+    g = Genome(
+        path=":memory:",
+        dense_embedding_enabled=True,
+        dense_embedding_dim=1024,
+        dense_pool_size=500,
+        fusion_mode="additive",
+        dense_additive_weight=dense_additive_weight,
+    )
+    _orig = g.upsert_doc
+    def _ungated(gene, apply_gate=False):
+        return _orig(gene, apply_gate=apply_gate)
+    g.upsert_doc = _ungated
+    g.upsert_gene = _ungated
+    return g
+
+
+def test_query_docs_additive_mode_merges_dense_with_real_weight():
+    """PR-3 Decision 1 Option B: in additive mode a dense-surfaced gene
+    lands in gene_scores with contribution == cosine * dense_additive_weight
+    — a real BM25-comparable weight, not the 1e-9 epsilon.
+
+    The needle shares no surface tokens with the query, so its only path
+    into gene_scores is the dense merge; tier_contrib['dense'] therefore
+    equals the merged contribution exactly.
+    """
+    weight = 4.0
+    g = _additive_dense_genome(dense_additive_weight=weight)
+    try:
+        # Distractors share the query's lex token; needle does not.
+        for i in range(8):
+            g.upsert_gene(_make_gene(
+                f"alpha distractor body {i}", domains=["alpha"],
+                gene_id=f"dist-{i:03d}",
+            ))
+        g.upsert_gene(_make_gene(
+            "wholly disjoint surface tokens for the needle body",
+            domains=["needle"], gene_id="needle-add",
+        ))
+        # Needle's v2 vector == what the query encoder will produce.
+        target = "additive dense target vector"
+        _populate_v2(g, "needle-add", _hash_vec(target, 1024))
+        for row in g.conn.execute(
+            "SELECT gene_id FROM genes WHERE gene_id != 'needle-add'"
+        ).fetchall():
+            _populate_v2(g, row[0], _hash_vec(row[0] + "-noise", 1024))
+
+        g._dense_codec = _FakeCodec(dim=1024, query_target=target)
+
+        docs = g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        ids = {d.gene_id for d in docs}
+        assert "needle-add" in ids, (
+            f"dense-only needle should surface in additive mode; got {sorted(ids)}"
+        )
+
+        # gene_scores carries a real, non-epsilon contribution.
+        scores = g.last_query_scores
+        assert "needle-add" in scores
+        assert scores["needle-add"] > 1e-3, (
+            f"additive dense merge must be a real weight, not epsilon; "
+            f"got {scores['needle-add']}"
+        )
+        # The needle is token-disjoint from the query, so 'dense' is its
+        # only tier; its recorded contribution == cosine * weight, and the
+        # FakeCodec maps query->needle so cosine == 1.0.
+        dense_contrib = g.last_tier_contributions["needle-add"]["dense"]
+        assert dense_contrib == pytest.approx(1.0 * weight, abs=1e-4), (
+            f"dense contribution should be cosine*dense_additive_weight; "
+            f"got {dense_contrib}"
+        )
+    finally:
+        g.close()
+
+
+def test_dense_additive_weight_scales_the_contribution():
+    """PR-3: the dense_additive_weight knob is honoured — a higher weight
+    yields a proportionally larger gene_scores contribution.
+    """
+    target = "weight-scaling dense target"
+
+    def _run(weight: float) -> float:
+        g = _additive_dense_genome(dense_additive_weight=weight)
+        try:
+            g.upsert_gene(_make_gene(
+                "alpha lexical anchor doc", domains=["alpha"], gene_id="anchor",
+            ))
+            g.upsert_gene(_make_gene(
+                "token-disjoint needle body", domains=["needle"],
+                gene_id="needle-w",
+            ))
+            _populate_v2(g, "needle-w", _hash_vec(target, 1024))
+            _populate_v2(g, "anchor", _hash_vec("anchor-noise", 1024))
+            g._dense_codec = _FakeCodec(dim=1024, query_target=target)
+            g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+            return g.last_tier_contributions["needle-w"]["dense"]
+
+        finally:
+            g.close()
+
+    low = _run(2.0)
+    high = _run(8.0)
+    # cosine is identical (FakeCodec query->needle == 1.0) so the only
+    # variable is the weight: 8.0 / 2.0 == 4x.
+    assert high == pytest.approx(low * 4.0, rel=1e-4), (
+        f"dense_additive_weight should scale the contribution linearly; "
+        f"low(w=2)={low} high(w=8)={high}"
+    )
+
+
+def test_query_docs_rrf_mode_dense_still_fuser_tier():
+    """PR-3 Decision 1 Option B: RRF mode keeps the pre-PR-3 behaviour —
+    dense hits enter via the Fuser tier and dense-only genes get the
+    1e-9 set-membership epsilon in gene_scores (ordering comes from the
+    Fuser, not the epsilon).
+    """
+    g = Genome(
+        path=":memory:",
+        dense_embedding_enabled=True,
+        dense_embedding_dim=1024,
+        dense_pool_size=500,
+        fusion_mode="rrf",
+    )
+    _orig = g.upsert_doc
+    g.upsert_doc = g.upsert_gene = lambda gene, apply_gate=False: _orig(
+        gene, apply_gate=apply_gate
+    )
+    try:
+        for i in range(6):
+            g.upsert_gene(_make_gene(
+                f"alpha body {i}", domains=["alpha"], gene_id=f"a-{i}",
+            ))
+        g.upsert_gene(_make_gene(
+            "token-disjoint needle for rrf", domains=["needle"],
+            gene_id="needle-rrf",
+        ))
+        target = "rrf dense target"
+        _populate_v2(g, "needle-rrf", _hash_vec(target, 1024))
+        for row in g.conn.execute(
+            "SELECT gene_id FROM genes WHERE gene_id != 'needle-rrf'"
+        ).fetchall():
+            _populate_v2(g, row[0], _hash_vec(row[0] + "-noise", 1024))
+        g._dense_codec = _FakeCodec(dim=1024, query_target=target)
+
+        docs = g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        assert any(d.gene_id == "needle-rrf" for d in docs), (
+            "dense-only needle should still surface under RRF fusion"
+        )
+        # Telemetry records the RAW cosine for the dense tier under RRF
+        # (spec §6), NOT a weighted score — this is the additive-vs-RRF
+        # contract difference.
+        dense_contrib = g.last_tier_contributions["needle-rrf"]["dense"]
+        assert dense_contrib == pytest.approx(1.0, abs=1e-4), (
+            f"RRF dense tier_contrib is raw cosine (~1.0); got {dense_contrib}"
+        )
+    finally:
+        g.close()
+
+
+def test_query_docs_additive_dense_null_v2_degrades_to_lexical():
+    """PR-3: with dense ON + additive mode but NULL embedding_dense_v2,
+    query_docs degrades to lexical-only — no crash — and the one-time
+    coverage WARN fires (dense recall returns []).
+    """
+    import logging
+    g = _additive_dense_genome()
+    try:
+        for i in range(5):
+            g.upsert_gene(_make_gene(
+                f"alpha lexical doc {i}", domains=["alpha"], gene_id=f"lex-{i}",
+            ))
+        # Deliberately do NOT populate embedding_dense_v2.
+        g._dense_codec = _FakeCodec(dim=1024)
+
+        caplog_records: list = []
+        handler = logging.Handler()
+        handler.emit = lambda rec: caplog_records.append(rec)
+        ks_log = logging.getLogger("helix_context.knowledge_store")
+        ks_log.addHandler(handler)
+        try:
+            docs = g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        finally:
+            ks_log.removeHandler(handler)
+
+        # Lexical path still returns the alpha docs.
+        assert len(docs) == 5, f"expected lexical-only fallback, got {len(docs)}"
+        # One-time coverage WARN fired from query_docs_dense_recall.
+        assert any(
+            "embedding_dense_v2 coverage" in rec.getMessage()
+            for rec in caplog_records
+        ), "expected the one-time empty-coverage WARN under additive mode"
+    finally:
+        g.close()
+
+
+def test_dense_additive_weight_default_and_plumbing():
+    """PR-3: dense_additive_weight defaults to 4.0 on a bare genome and
+    is stored as _dense_additive_weight; an explicit value overrides it.
+    """
+    g_default = Genome(path=":memory:")
+    g_custom = Genome(path=":memory:", dense_additive_weight=6.5)
+    try:
+        assert g_default._dense_additive_weight == pytest.approx(4.0)
+        assert g_custom._dense_additive_weight == pytest.approx(6.5)
+    finally:
+        g_default.close()
+        g_custom.close()
+
+
+# ── 8. live — real BGE-M3 dense recall through query_docs (additive) ─
+
+
+@pytest.mark.live
+def test_live_additive_dense_recall_through_query_docs():
+    """PR-3 live path: with the real BGE-M3 codec, a semantically-related
+    but lexically-disjoint document is surfaced by query_docs in additive
+    mode. Skipped automatically when the model is unavailable.
+    """
+    g = Genome(
+        path=":memory:",
+        dense_embedding_enabled=True,
+        dense_embed_on_ingest=True,
+        dense_embedding_dim=1024,
+        fusion_mode="additive",
+    )
+    try:
+        try:
+            g._get_dense_codec()  # force the real load up front
+        except Exception as exc:  # noqa: BLE001 — model download/import failure
+            pytest.skip(f"BGE-M3 model unavailable: {exc}")
+
+        # Lexical distractors share the query tag; the needle does not —
+        # its only route into the candidate set is real dense similarity.
+        for i in range(6):
+            g.upsert_doc(_make_gene(
+                f"unrelated filler passage number {i}", domains=["topic"],
+                gene_id=f"live-dist-{i}",
+            ), apply_gate=False)
+        g.upsert_doc(_make_gene(
+            "a database stores rows on disk and answers SQL queries",
+            domains=["storage"], gene_id="live-needle",
+        ), apply_gate=False)
+
+        docs = g.query_docs(domains=["topic"], entities=[], max_genes=12)
+        # The needle is token-disjoint from the "topic" tag; if it shows
+        # up, real dense recall merged it into the additive accumulator.
+        assert any(d.gene_id == "live-needle" for d in docs) or \
+            "live-needle" in g.last_query_scores, (
+            "real BGE-M3 dense recall should surface the semantically "
+            "related needle in additive mode"
+        )
+    finally:
+        g.close()

--- a/tests/test_dense_recall.py
+++ b/tests/test_dense_recall.py
@@ -640,6 +640,109 @@ def test_dense_additive_weight_default_and_plumbing():
         g_custom.close()
 
 
+# ── Tier-0 review fix: additive-mode dense merge min-cosine noise floor ─
+#
+# Review fix (2026-05-16): the additive-mode dense merge had no
+# min-cosine floor, so noise-grade hits (very low cosine) still entered
+# gene_scores — inconsistent with query_cold_tier (floors at 0.15) and
+# query_docs_ann_recall. The floor (`dense_additive_min_cosine`, default
+# 0.15) makes a below-floor hit contribute 0 to the score while still
+# being kept as a candidate via the 1e-9 set-membership epsilon.
+
+
+def test_additive_dense_merge_floors_noise_grade_cosines():
+    """A dense hit whose cosine is BELOW dense_additive_min_cosine (0.15)
+    adds ~0 to gene_scores — only the 1e-9 set-membership epsilon — while
+    an ABOVE-floor hit adds the full cosine * dense_additive_weight.
+
+    The dense hit list is injected directly (monkeypatching
+    query_docs_dense_recall) so cosines can be staged to straddle 0.15
+    precisely; the real codec's hash vectors only yield ~1.0 (query_target
+    match) or ~0 (random pair), which cannot exercise the floor boundary.
+    """
+    weight = 4.0
+    g = _additive_dense_genome(dense_additive_weight=weight)
+    try:
+        # A lexical anchor so query_docs has at least one tag hit and does
+        # not raise PromoterMismatch before the dense merge runs.
+        g.upsert_gene(_make_gene(
+            "alpha lexical anchor body", domains=["alpha"], gene_id="anchor",
+        ))
+        # Four token-disjoint genes reachable ONLY via the dense merge.
+        for gid in ("below-lo", "below-hi", "above-lo", "above-hi"):
+            g.upsert_gene(_make_gene(
+                f"token-disjoint body for {gid}", domains=["needle"],
+                gene_id=gid,
+            ))
+
+        # Cosines straddling the 0.15 floor: two below, two above.
+        staged_hits = [
+            ("above-hi", 0.90),   # well above floor
+            ("above-lo", 0.16),   # just above floor
+            ("below-hi", 0.14),   # just below floor
+            ("below-lo", 0.02),   # noise-grade, well below floor
+        ]
+        g.query_docs_dense_recall = lambda *a, **kw: list(staged_hits)
+        # query_docs_dense_recall is also exposed under the legacy alias.
+        g.query_genes_dense_recall = g.query_docs_dense_recall
+
+        g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        scores = g.last_query_scores
+        contribs = g.last_tier_contributions
+
+        # The dense merge's effect is isolated in tier_contrib["dense"] —
+        # query_docs also applies a flat per-candidate "authority" boost
+        # that lands in last_query_scores, so we assert the *dense* tier
+        # contribution (what the floor actually governs), exactly as the
+        # sibling additive tests in this file do.
+
+        # Above-floor hits: dense tier contributes cosine * weight.
+        for gid, cosine in (("above-hi", 0.90), ("above-lo", 0.16)):
+            expected = cosine * weight
+            assert contribs[gid]["dense"] == pytest.approx(expected, abs=1e-4), (
+                f"above-floor hit {gid} (cosine={cosine}) dense contribution "
+                f"should be cosine*weight={expected}; got {contribs[gid].get('dense')}"
+            )
+
+        # Below-floor hits: dense tier contributes 0.0 — the cosine is
+        # noise-grade and must not enter the additive sum.
+        for gid in ("below-hi", "below-lo"):
+            assert contribs[gid]["dense"] == 0.0, (
+                f"below-floor hit {gid} dense contribution should be 0.0 "
+                f"(cosine below the {g._dense_additive_min_cosine} floor); "
+                f"got {contribs[gid].get('dense')}"
+            )
+            # ...but the hit is still kept as a candidate: it appears in
+            # gene_scores via the 1e-9 set-membership epsilon. Its score
+            # carries NO weighted dense term — only the epsilon plus the
+            # flat authority boost — so it sits well below even the
+            # smallest above-floor dense contribution (0.16*weight).
+            assert gid in scores, (
+                f"below-floor hit {gid} should still be a candidate "
+                f"(1e-9 set-membership epsilon)"
+            )
+            assert scores[gid] < 0.16 * weight, (
+                f"below-floor hit {gid} must not carry a weighted dense "
+                f"term; got score {scores.get(gid)}"
+            )
+    finally:
+        g.close()
+
+
+def test_dense_additive_min_cosine_default_and_plumbing():
+    """dense_additive_min_cosine defaults to 0.15 on a bare genome and is
+    stored as _dense_additive_min_cosine; an explicit value overrides it.
+    """
+    g_default = Genome(path=":memory:")
+    g_custom = Genome(path=":memory:", dense_additive_min_cosine=0.3)
+    try:
+        assert g_default._dense_additive_min_cosine == pytest.approx(0.15)
+        assert g_custom._dense_additive_min_cosine == pytest.approx(0.3)
+    finally:
+        g_default.close()
+        g_custom.close()
+
+
 # ── 8. live — real BGE-M3 dense recall through query_docs (additive) ─
 
 

--- a/tests/test_dense_recall.py
+++ b/tests/test_dense_recall.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import random
 import sqlite3
 import struct
 import subprocess
@@ -38,40 +37,12 @@ from helix_context.schemas import (
     ChromatinState, EpigeneticMarkers, Gene, PromoterTags,
 )
 
-
-# ── Test helpers ─────────────────────────────────────────────────────
-
-
-def _hash_vec(text: str, dim: int) -> np.ndarray:
-    """Deterministic L2-normalised fp32 vector seeded from text."""
-    out = np.zeros(dim, dtype=np.float32)
-    seed = hashlib.sha256(text.encode("utf-8")).digest()
-    rng = random.Random(int.from_bytes(seed[:8], "little"))
-    for i in range(dim):
-        out[i] = rng.gauss(0.0, 1.0)
-    n = np.linalg.norm(out)
-    if n > 0:
-        out /= n
-    return out
-
-
-class _FakeCodec:
-    """Test stand-in for BGEM3Codec; same shape contract."""
-
-    def __init__(self, dim: int = 1024, query_target: str | None = None):
-        self.dim = dim
-        # If query_target is set, encode("query") returns the same vector
-        # as encode(query_target, "passage") — this lets tests stage a
-        # deterministic "query matches X" relationship.
-        self._query_target = query_target
-
-    def encode(self, text: str, task: str = "passage"):
-        if task == "query" and self._query_target is not None:
-            return _hash_vec(self._query_target, self.dim).tolist()
-        return _hash_vec(text, self.dim).tolist()
-
-    def similarity(self, a, b) -> float:
-        return float(np.dot(np.asarray(a), np.asarray(b)))
+# The deterministic fake BGE-M3 codec lives in tests/conftest.py — it is the
+# single shared definition (the `_stub_dense_codec` autouse fixture installs
+# the same class for every non-live test). `_hash_vec` / `_FakeCodec` remain
+# as local aliases so this file's many call sites stay unchanged.
+from tests.conftest import FakeBGEM3Codec as _FakeCodec
+from tests.conftest import hash_vec as _hash_vec
 
 
 def _make_gene(content: str, *, domains=None, entities=None, gene_id=None) -> Gene:

--- a/tests/test_fixture_dense_backfill.py
+++ b/tests/test_fixture_dense_backfill.py
@@ -1,0 +1,414 @@
+"""Tier-0 PR-2 (2026-05-16): the fixture builder's post-build dense pass.
+
+Plan: ``docs/reviews/2026-05-16-deep-review/00-tier0-implementation-plan.md``
+§PR-2. PR-2 makes ``scripts/build_fixture_matrix.py`` produce bench
+fixtures whose ``genes.embedding_dense_v2`` column is fully populated, in
+both blob and sharded mode, via an explicit post-build BGE-M3 backfill
+pass (the builder's per-gene write path stays lean).
+
+The encode-and-pack loop is factored into ONE shared function,
+``scripts.backfill_bgem3_v2.backfill_dense_db``, that both the standalone
+operator backfill script and the fixture builder
+(``build_fixture_matrix._backfill_dense``) call — so the two paths cannot
+drift. These tests exercise that shared loop and the builder wrapper.
+
+Cases covered:
+
+1. ``test_backfill_populates_every_gene`` — every ``genes`` row of a
+   small hand-built ``.db`` gets a non-NULL ``embedding_dense_v2``.
+2. ``test_blob_bytes_are_dim_times_four`` — each BLOB is exactly
+   ``dim*4`` raw little-endian fp32 bytes and round-trips.
+3. ``test_coverage_reported_correctly`` — the report dict's
+   ``dense_coverage`` == populated / total.
+4. ``test_idempotent_skips_populated_rows`` — a second run re-processes
+   0 rows (already-populated rows of the right length are skipped).
+5. ``test_wrong_length_blob_is_reencoded`` — a row carrying a
+   wrong-length BLOB is treated as needing a backfill.
+6. ``test_blank_content_rows_skipped`` — rows with empty/whitespace
+   content are skipped, not encoded, and do not crash.
+7. ``test_backfill_dense_builder_wrapper`` — ``_backfill_dense`` (the
+   builder's wrapper) returns the coverage report and populates the DB.
+8. ``test_backfill_dense_wrapper_handles_failure`` — an encode failure
+   surfaces as ``dense_coverage == 0.0`` + an ``error`` key rather than
+   raising.
+9. ``test_partial_coverage_db`` — a DB pre-seeded with some rows already
+   dense reports the correct final coverage.
+10. ``test_live_*`` (``live``-marked) — build the ``small`` blob profile
+    with the real BGE-M3 model and assert 100% dense coverage +
+    ``manifest.json`` ``dense_coverage == 1.0``. Self-skips when the
+    model (or a source root) is unavailable.
+
+The codec is mocked with deterministic hash-seeded vectors so the suite
+runs without BGE-M3 weights (mirrors ``tests/test_dense_recall.py`` and
+``tests/test_ingest_dense_v2.py``).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import random
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# ``scripts/`` is not a package — put it on the path so the PR-2 modules
+# under test import cleanly (mirrors how the scripts add the repo root).
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from backfill_bgem3_v2 import backfill_dense_db  # noqa: E402
+import build_fixture_matrix as bfm  # noqa: E402
+
+DIM = 64  # small dim keeps the fake-vector tests fast; not a sanctioned
+# BGE-M3 Matryoshka breakpoint, but the fake codec never loads the model.
+
+
+# ── Test helpers (mirror tests/test_ingest_dense_v2.py) ──────────────
+
+
+def _hash_vec(text: str, dim: int = DIM) -> np.ndarray:
+    """Deterministic L2-normalised fp32 vector seeded from text."""
+    out = np.zeros(dim, dtype=np.float32)
+    seed = hashlib.sha256(text.encode("utf-8")).digest()
+    rng = random.Random(int.from_bytes(seed[:8], "little"))
+    for i in range(dim):
+        out[i] = rng.gauss(0.0, 1.0)
+    n = np.linalg.norm(out)
+    if n > 0:
+        out /= n
+    return out
+
+
+class _FakeCodec:
+    """Test stand-in for BGEM3Codec — same shape contract as the real
+    codec's ``encode_batch`` (the only method the backfill loop calls).
+    """
+
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.batch_calls = 0
+        self.encoded_texts: list[str] = []
+
+    def encode_batch(self, texts, task: str = "passage"):
+        self.batch_calls += 1
+        self.encoded_texts.extend(texts)
+        return [_hash_vec(t, self.dim).tolist() for t in texts]
+
+
+class _ExplodingCodec:
+    """Codec whose ``encode_batch`` always raises — models a missing /
+    broken BGE-M3 model so the builder's failure path can be exercised.
+    """
+
+    dim = DIM
+
+    def encode_batch(self, texts, task: str = "passage"):
+        raise RuntimeError("BGE-M3 model unavailable (simulated)")
+
+
+def _make_genes_db(
+    tmp_path: Path,
+    contents: list[str],
+    *,
+    name: str = "fixture.db",
+    preseed_dense: dict[int, bytes] | None = None,
+) -> str:
+    """Build a minimal ``genes`` SQLite DB by hand.
+
+    The schema is the subset of ``helix_context.storage.ddl`` columns the
+    backfill loop touches (``gene_id``, ``content``, ``embedding_dense_v2``)
+    plus ``chromatin`` — the partial index ``_ensure_v2_schema`` creates
+    references ``chromatin``, so the column must exist.
+
+    ``preseed_dense`` maps a row index to a raw BLOB to write into
+    ``embedding_dense_v2`` up front (used to test partial-coverage and
+    idempotency).
+    """
+    db_path = str(tmp_path / name)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE genes ("
+        "  gene_id TEXT PRIMARY KEY,"
+        "  content TEXT,"
+        "  chromatin INTEGER,"
+        "  embedding_dense_v2 BLOB"
+        ")"
+    )
+    for i, content in enumerate(contents):
+        blob = (preseed_dense or {}).get(i)
+        conn.execute(
+            "INSERT INTO genes (gene_id, content, chromatin, embedding_dense_v2) "
+            "VALUES (?, ?, ?, ?)",
+            (f"g{i}", content, 0, sqlite3.Binary(blob) if blob else None),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _dense_rows(db_path: str) -> list[tuple[str, bytes | None]]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT gene_id, embedding_dense_v2 FROM genes ORDER BY gene_id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+# ── 1. every gene populated ──────────────────────────────────────────
+
+
+def test_backfill_populates_every_gene(tmp_path):
+    """``backfill_dense_db`` writes a non-NULL ``embedding_dense_v2`` for
+    every ``genes`` row of a freshly-built dense-dark ``.db``.
+    """
+    contents = ["alpha doc body", "beta doc body", "gamma doc body"]
+    db = _make_genes_db(tmp_path, contents)
+    fake = _FakeCodec(DIM)
+
+    report = backfill_dense_db(db, dim=DIM, codec=fake, log_fn=lambda _m: None)
+
+    rows = _dense_rows(db)
+    assert len(rows) == 3
+    for gene_id, blob in rows:
+        assert blob is not None, f"{gene_id} left dense-dark"
+    assert report["total"] == 3
+    assert report["populated_after"] == 3
+    assert report["rows_processed"] == 3
+
+
+# ── 2. BLOB length + round-trip ──────────────────────────────────────
+
+
+def test_blob_bytes_are_dim_times_four(tmp_path):
+    """Each stored BLOB is exactly ``dim*4`` raw little-endian fp32 bytes
+    and decodes back to a unit-norm vector of length ``dim``.
+    """
+    db = _make_genes_db(tmp_path, ["only doc"])
+    backfill_dense_db(db, dim=DIM, codec=_FakeCodec(DIM), log_fn=lambda _m: None)
+
+    _gid, blob = _dense_rows(db)[0]
+    assert len(blob) == DIM * 4, f"expected {DIM*4} bytes, got {len(blob)}"
+    vec = np.frombuffer(blob, dtype="<f4")
+    assert vec.shape == (DIM,)
+    expected = _hash_vec("only doc", DIM)
+    assert np.allclose(vec, expected, atol=1e-6), "stored BLOB did not round-trip"
+
+
+# ── 3. coverage reported correctly ───────────────────────────────────
+
+
+def test_coverage_reported_correctly(tmp_path):
+    """``dense_coverage`` in the report == populated / total, and is 1.0
+    once a fully dense-dark DB is backfilled.
+    """
+    db = _make_genes_db(tmp_path, ["d1", "d2", "d3", "d4"])
+    report = backfill_dense_db(db, dim=DIM, codec=_FakeCodec(DIM), log_fn=lambda _m: None)
+
+    assert report["dense_coverage"] == pytest.approx(1.0)
+    assert report["populated_before"] == 0
+    assert report["populated_after"] == report["total"] == 4
+    # Coverage is the exact ratio.
+    assert report["dense_coverage"] == pytest.approx(
+        report["populated_after"] / report["total"]
+    )
+
+
+# ── 4. idempotency ───────────────────────────────────────────────────
+
+
+def test_idempotent_skips_populated_rows(tmp_path):
+    """A second backfill over an already-populated DB re-processes 0 rows
+    — the ``length(blob) == dim*4`` skip-clause matches its own output.
+    """
+    db = _make_genes_db(tmp_path, ["doc one", "doc two"])
+    first = backfill_dense_db(db, dim=DIM, codec=_FakeCodec(DIM), log_fn=lambda _m: None)
+    assert first["rows_processed"] == 2
+
+    before = _dense_rows(db)
+    fake2 = _FakeCodec(DIM)
+    second = backfill_dense_db(db, dim=DIM, codec=fake2, log_fn=lambda _m: None)
+
+    assert second["rows_processed"] == 0, "idempotent re-run must process 0 rows"
+    assert second["dense_coverage"] == pytest.approx(1.0)
+    assert fake2.batch_calls == 0, "no rows to encode ⇒ codec untouched"
+    assert _dense_rows(db) == before, "idempotent re-run must not mutate BLOBs"
+
+
+# ── 5. wrong-length BLOB is re-encoded ───────────────────────────────
+
+
+def test_wrong_length_blob_is_reencoded(tmp_path):
+    """A row whose ``embedding_dense_v2`` is the wrong byte length (e.g. a
+    half-written row from an earlier crash, or a dim change) is selected
+    for re-backfill and overwritten with a correct ``dim*4`` BLOB.
+    """
+    garbage = b"\x00\x01\x02\x03"  # 4 bytes, not DIM*4
+    db = _make_genes_db(
+        tmp_path, ["good doc", "stale doc"], preseed_dense={1: garbage}
+    )
+    report = backfill_dense_db(db, dim=DIM, codec=_FakeCodec(DIM), log_fn=lambda _m: None)
+
+    # The wrong-length row counts as un-populated for the correct-length
+    # ``populated_after`` tally, so both rows end at dim*4.
+    rows = dict(_dense_rows(db))
+    assert len(rows["g0"]) == DIM * 4
+    assert len(rows["g1"]) == DIM * 4, "wrong-length BLOB was not re-encoded"
+    assert report["rows_processed"] == 2
+    assert report["dense_coverage"] == pytest.approx(1.0)
+
+
+# ── 6. blank content skipped ─────────────────────────────────────────
+
+
+def test_blank_content_rows_skipped(tmp_path):
+    """Rows with empty / whitespace-only content have nothing to encode —
+    they are skipped (not crashed on) and excluded from the encode batch.
+    """
+    db = _make_genes_db(tmp_path, ["real body", "   ", ""])
+    fake = _FakeCodec(DIM)
+    report = backfill_dense_db(db, dim=DIM, codec=fake, log_fn=lambda _m: None)
+
+    rows = dict(_dense_rows(db))
+    assert rows["g0"] is not None, "non-blank row should be populated"
+    assert rows["g1"] is None and rows["g2"] is None, "blank rows stay NULL"
+    assert report["rows_skipped"] == 2
+    assert report["populated_after"] == 1
+    assert fake.encoded_texts == ["real body"], "only non-blank text encoded"
+    # Coverage counts blank rows in the denominator (they are genes rows).
+    assert report["dense_coverage"] == pytest.approx(1.0 / 3.0)
+
+
+# ── 7. builder wrapper ───────────────────────────────────────────────
+
+
+def test_backfill_dense_builder_wrapper(tmp_path, monkeypatch):
+    """``build_fixture_matrix._backfill_dense`` (the builder's post-build
+    wrapper) returns the coverage report and populates every gene.
+
+    The wrapper has no codec parameter — it calls ``backfill_dense_db``
+    with the real ``BGEM3Codec``. Patch the shared loop so the test runs
+    without BGE-M3 weights while still exercising the wrapper's plumbing
+    (logging, report mapping, error guard).
+    """
+    db = _make_genes_db(tmp_path, ["wrap one", "wrap two", "wrap three"])
+
+    def _fake_backfill(db_path, **kwargs):
+        return backfill_dense_db(
+            db_path, dim=DIM, codec=_FakeCodec(DIM), log_fn=lambda _m: None
+        )
+
+    monkeypatch.setattr(bfm, "backfill_dense_db", _fake_backfill)
+    report = bfm._backfill_dense(db)
+
+    assert report["dense_coverage"] == pytest.approx(1.0)
+    assert report["populated_after"] == 3
+    assert "error" not in report
+    for _gid, blob in _dense_rows(db):
+        assert blob is not None and len(blob) == DIM * 4
+
+
+# ── 8. builder wrapper failure path ──────────────────────────────────
+
+
+def test_backfill_dense_wrapper_handles_failure(tmp_path, monkeypatch):
+    """If the dense encode fails, ``_backfill_dense`` returns a degraded
+    report (``dense_coverage == 0.0`` + an ``error`` key) instead of
+    raising — so a model failure surfaces in the manifest rather than
+    silently shipping a dense-dark fixture.
+    """
+    db = _make_genes_db(tmp_path, ["doc"])
+
+    def _exploding_backfill(db_path, **kwargs):
+        return backfill_dense_db(
+            db_path, dim=DIM, codec=_ExplodingCodec(), log_fn=lambda _m: None
+        )
+
+    monkeypatch.setattr(bfm, "backfill_dense_db", _exploding_backfill)
+    report = bfm._backfill_dense(db)
+
+    assert report["dense_coverage"] == 0.0
+    assert "error" in report
+    assert "RuntimeError" in report["error"]
+    # The DB is left dense-dark (the encode never produced a vector).
+    assert _dense_rows(db)[0][1] is None
+
+
+# ── 9. partial pre-coverage ──────────────────────────────────────────
+
+
+def test_partial_coverage_db(tmp_path):
+    """A DB where some rows already carry a correct-length dense BLOB
+    reports the right final coverage and only encodes the missing rows.
+    """
+    # Pre-seed row 0 with a valid DIM*4 BLOB; rows 1 and 2 are dense-dark.
+    good_blob = _hash_vec("preseeded", DIM).astype("<f4").tobytes()
+    assert len(good_blob) == DIM * 4
+    db = _make_genes_db(
+        tmp_path, ["preseeded", "needs one", "needs two"],
+        preseed_dense={0: good_blob},
+    )
+    fake = _FakeCodec(DIM)
+    report = backfill_dense_db(db, dim=DIM, codec=fake, log_fn=lambda _m: None)
+
+    assert report["populated_before"] == 1
+    assert report["rows_processed"] == 2, "only the 2 dark rows are encoded"
+    assert report["populated_after"] == 3
+    assert report["dense_coverage"] == pytest.approx(1.0)
+    # The pre-seeded row was left untouched.
+    assert dict(_dense_rows(db))["g0"] == good_blob
+    assert set(fake.encoded_texts) == {"needs one", "needs two"}
+
+
+# ── 10. live — real BGE-M3 small-profile fixture build ───────────────
+
+
+@pytest.mark.live
+def test_live_small_blob_profile_full_dense_coverage(tmp_path):
+    """Build the ``small`` blob profile with the real BGE-M3 model and
+    assert every ``genes`` row is dense-populated and the manifest
+    records ``dense_coverage == 1.0``.
+
+    Self-skips when the BGE-M3 model is unavailable or when none of the
+    ``small`` profile's source roots exist on this machine.
+    """
+    profile = bfm.PROFILES["small"]
+    if not any(os.path.exists(r) for r in profile["roots"]):
+        pytest.skip("no 'small' profile source roots present on this machine")
+
+    out_dir = str(tmp_path / "matrix")
+    os.makedirs(out_dir, exist_ok=True)
+    db_path = os.path.join(out_dir, "small.db")
+
+    try:
+        stats = bfm.build_profile("small", db_path)
+    except Exception as exc:  # noqa: BLE001 — BGE-M3 download / import failure
+        pytest.skip(f"build_profile(small) failed (model unavailable?): {exc}")
+
+    if stats.get("dense_error"):
+        pytest.skip(f"dense backfill unavailable: {stats['dense_error']}")
+
+    # Every genes row is dense-populated.
+    conn = sqlite3.connect(db_path)
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+        populated = conn.execute(
+            "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert total > 0, "small profile produced no genes"
+    assert populated == total, f"{total - populated} genes left dense-dark"
+    assert stats["dense_coverage"] == pytest.approx(1.0)
+
+    # Manifest records dense_coverage == 1.0 for the profile.
+    bfm.update_manifest(out_dir, stats, mode="blob")
+    with open(os.path.join(out_dir, "manifest.json"), encoding="utf-8") as f:
+        manifest = json.load(f)
+    assert manifest["targets"]["small"]["dense_coverage"] == pytest.approx(1.0)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -97,12 +97,34 @@ class TestContextHealth:
         assert health.genes_available == 3
 
     def test_no_match_shows_denatured(self, seeded_health_helix):
-        """Query that matches zero genes despite genome having content."""
+        """Query lexically disjoint from the genome → denatured health.
+
+        Tier-0 PR-3 (2026-05-16) decoupled BGE-M3 dense recall from
+        ``fusion_mode``, so ``query_docs`` now runs dense recall in the
+        default additive mode. ``query_docs_dense_recall`` has no minimum
+        cosine cutoff — it returns the top-k by cosine — so a content-full
+        genome surfaces a few weakly-similar genes for *any* query. The
+        pre-PR-3 ``genes_expressed == 0`` assertion encoded the dense-dark
+        world where the additive path never touched dense vectors; that is
+        no longer reachable for a non-empty genome (true zero-retrieval is
+        covered by ``test_empty_genome_is_sparse``).
+
+        The substantive invariant the health monitor must still uphold:
+        a lexically-disjoint query yields near-zero ``ellipticity`` and a
+        ``denatured`` status — the dense neighbours are weak enough that
+        retrieval quality is correctly flagged as bad.
+        """
         window = seeded_health_helix.build_context("quantum entanglement physics")
         health = window.context_health
-        assert health.genes_expressed == 0
         assert health.genes_available == 3
         assert health.status == "denatured"
+        # Dense recall may surface a few weak semantic neighbours; the
+        # health signal must still classify this retrieval as denatured,
+        # which requires ellipticity below the 0.3 'sparse' threshold.
+        assert health.ellipticity < 0.3, (
+            f"lexically-disjoint query must yield denatured-grade "
+            f"ellipticity; got {health.ellipticity}"
+        )
 
     def test_health_in_metadata(self, seeded_health_helix):
         window = seeded_health_helix.build_context("auth security jwt")

--- a/tests/test_ingest_dense_v2.py
+++ b/tests/test_ingest_dense_v2.py
@@ -1,0 +1,535 @@
+"""Tier-0 PR-1 (2026-05-16): BGE-M3 dense vectors written at ingest.
+
+Plan: ``docs/reviews/2026-05-16-deep-review/00-tier0-implementation-plan.md``
+§PR-1. PR-1 is the WRITE path only — it makes ``upsert_doc`` (and therefore
+every ingest path) compute and persist ``genes.embedding_dense_v2``. It does
+NOT enable dense retrieval (that is PR-3); these tests only assert the
+column is populated, never that recall uses it.
+
+Cases covered:
+
+1. ``test_upsert_doc_explicit_vector_persists_blob`` — an explicit
+   ``embedding_dense_v2=`` arg is packed and stored; round-trips at
+   ``dim*4`` bytes.
+2. ``test_upsert_doc_lazy_compute_when_knob_on`` — no dense arg +
+   ``dense_embed_on_ingest=True`` ⇒ non-NULL vector.
+3. ``test_upsert_doc_null_when_knob_off`` — no dense arg +
+   ``dense_embed_on_ingest=False`` ⇒ NULL column.
+4. ``test_fresh_genome_has_dense_v2_column`` — R10: a freshly created
+   in-memory ``Genome`` has the column and round-trips a dense vector.
+5. ``test_context_manager_ingest_populates_all_strands`` — a multi-strand
+   ``ingest()`` ⇒ every resulting ``genes`` row has a non-NULL vector of
+   the right length.
+6. ``test_ingest_corpus_full_dense_coverage`` — ingest a small corpus,
+   ``COUNT(embedding_dense_v2 IS NOT NULL) == COUNT(*)``.
+7. ``test_pr1_genome_satisfies_backfill_skip_clause`` — a PR-1-built
+   genome makes the backfill script's
+   ``length(blob) != expected_bytes`` skip-clause select 0 rows.
+8. ``test_vec_to_blob_shared_helper_*`` — the shared fp32 packer.
+9. ``test_encode_batch_matches_encode`` — codec batch path equals the
+   single-encode path.
+10. ``test_live_*`` (``live``-marked) — real BGE-M3 encode + pack
+    round-trip; skipped when the model is unavailable.
+
+The codec is mocked with deterministic hash-seeded vectors so the suite
+runs without BGE-M3 weights (mirrors ``tests/test_dense_recall.py``).
+"""
+from __future__ import annotations
+
+import hashlib
+import random
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from helix_context.backends.bgem3_codec import (
+    PASSAGE_CHAR_CAP,
+    BGEM3Codec,
+    vec_to_blob,
+)
+from helix_context.config import HelixConfig
+from helix_context.context_manager import HelixContextManager
+from helix_context.genome import Genome
+from helix_context.schemas import (
+    ChromatinState, EpigeneticMarkers, Gene, PromoterTags,
+)
+
+DIM = 1024
+
+
+# ── Test helpers (mirror tests/test_dense_recall.py) ─────────────────
+
+
+def _hash_vec(text: str, dim: int = DIM) -> np.ndarray:
+    """Deterministic L2-normalised fp32 vector seeded from text."""
+    out = np.zeros(dim, dtype=np.float32)
+    seed = hashlib.sha256(text.encode("utf-8")).digest()
+    rng = random.Random(int.from_bytes(seed[:8], "little"))
+    for i in range(dim):
+        out[i] = rng.gauss(0.0, 1.0)
+    n = np.linalg.norm(out)
+    if n > 0:
+        out /= n
+    return out
+
+
+class _FakeCodec:
+    """Test stand-in for BGEM3Codec; same shape contract.
+
+    Exposes both ``encode`` (used by the lazy upsert_doc path) and
+    ``encode_batch`` (used by context_manager.ingest).
+    """
+
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.encode_calls = 0
+        self.batch_calls = 0
+
+    def encode(self, text: str, task: str = "passage"):
+        self.encode_calls += 1
+        return _hash_vec(text, self.dim).tolist()
+
+    def encode_batch(self, texts, task: str = "passage"):
+        self.batch_calls += 1
+        return [_hash_vec(t, self.dim).tolist() for t in texts]
+
+    def similarity(self, a, b) -> float:
+        return float(np.dot(np.asarray(a), np.asarray(b)))
+
+
+def _make_gene(content: str, *, gene_id: str | None = None) -> Gene:
+    return Gene(
+        gene_id=gene_id or Genome.make_gene_id(content),
+        content=content,
+        complement="",
+        codons=[],
+        promoter=PromoterTags(),
+        epigenetics=EpigeneticMarkers(),
+        chromatin=ChromatinState.OPEN,
+        is_fragment=False,
+    )
+
+
+def _blob_len(genome: Genome, gene_id: str):
+    row = genome.conn.execute(
+        "SELECT length(embedding_dense_v2) FROM genes WHERE gene_id = ?",
+        (gene_id,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+# ── 1. explicit vector persists ──────────────────────────────────────
+
+
+def test_upsert_doc_explicit_vector_persists_blob():
+    """An explicit ``embedding_dense_v2=`` arg is packed to a dim*4 BLOB
+    and round-trips to the same float values within fp32 epsilon.
+    """
+    g = Genome(path=":memory:", dense_embed_on_ingest=False, dense_embedding_dim=DIM)
+    try:
+        vec = _hash_vec("explicit-passage").tolist()
+        g.upsert_doc(
+            _make_gene("explicit vector doc", gene_id="x1"),
+            apply_gate=False,
+            embedding_dense_v2=vec,
+        )
+        blob = g.conn.execute(
+            "SELECT embedding_dense_v2 FROM genes WHERE gene_id='x1'"
+        ).fetchone()[0]
+        assert blob is not None
+        assert len(blob) == DIM * 4, f"expected {DIM*4} bytes, got {len(blob)}"
+        back = np.frombuffer(blob, dtype="<f4")
+        assert back.shape == (DIM,)
+        assert np.allclose(back, np.asarray(vec, dtype=np.float32), atol=1e-7), (
+            "explicit vector did not round-trip"
+        )
+    finally:
+        g.close()
+
+
+def test_upsert_doc_explicit_vector_persists_even_with_knob_off():
+    """An explicit vector is honoured regardless of dense_embed_on_ingest:
+    the knob only governs *lazy* compute, not a caller-supplied vector.
+    """
+    g = Genome(path=":memory:", dense_embed_on_ingest=False, dense_embedding_dim=DIM)
+    try:
+        vec = _hash_vec("knob-off-explicit").tolist()
+        g.upsert_doc(
+            _make_gene("knob off but explicit", gene_id="x2"),
+            apply_gate=False,
+            embedding_dense_v2=vec,
+        )
+        assert _blob_len(g, "x2") == DIM * 4
+    finally:
+        g.close()
+
+
+# ── 2. lazy compute when knob on ─────────────────────────────────────
+
+
+def test_upsert_doc_lazy_compute_when_knob_on():
+    """No dense arg + dense_embed_on_ingest=True ⇒ upsert_doc encodes the
+    vector lazily via the store's codec and stores a non-NULL BLOB.
+    """
+    g = Genome(path=":memory:", dense_embed_on_ingest=True, dense_embedding_dim=DIM)
+    fake = _FakeCodec(DIM)
+    g._dense_codec = fake  # inject so no BGE-M3 weights are pulled
+    try:
+        g.upsert_doc(
+            _make_gene("lazily encoded body", gene_id="l1"),
+            apply_gate=False,
+        )
+        assert _blob_len(g, "l1") == DIM * 4
+        assert fake.encode_calls == 1, "lazy path should call encode exactly once"
+    finally:
+        g.close()
+
+
+# ── 3. NULL when knob off ────────────────────────────────────────────
+
+
+def test_upsert_doc_null_when_knob_off():
+    """No dense arg + dense_embed_on_ingest=False ⇒ column stays NULL.
+    The codec must not even be consulted.
+    """
+    g = Genome(path=":memory:", dense_embed_on_ingest=False, dense_embedding_dim=DIM)
+    fake = _FakeCodec(DIM)
+    g._dense_codec = fake
+    try:
+        g.upsert_doc(
+            _make_gene("knob off doc", gene_id="o1"),
+            apply_gate=False,
+        )
+        val = g.conn.execute(
+            "SELECT embedding_dense_v2 FROM genes WHERE gene_id='o1'"
+        ).fetchone()[0]
+        assert val is None, "knob-off ingest must leave embedding_dense_v2 NULL"
+        assert fake.encode_calls == 0, "knob-off must not invoke the codec"
+    finally:
+        g.close()
+
+
+def test_upsert_doc_empty_content_stays_null_even_with_knob_on():
+    """Blank content has nothing to encode — column is NULL, no crash."""
+    g = Genome(path=":memory:", dense_embed_on_ingest=True, dense_embedding_dim=DIM)
+    g._dense_codec = _FakeCodec(DIM)
+    try:
+        g.upsert_doc(_make_gene("   ", gene_id="e1"), apply_gate=False)
+        val = g.conn.execute(
+            "SELECT embedding_dense_v2 FROM genes WHERE gene_id='e1'"
+        ).fetchone()[0]
+        assert val is None
+    finally:
+        g.close()
+
+
+# ── 4. R10 — fresh genome has the column ─────────────────────────────
+
+
+def test_fresh_genome_has_dense_v2_column():
+    """R10: a freshly created in-memory Genome's ``genes`` table declares
+    ``embedding_dense_v2`` (init_db's migration adds it) — no separate
+    ALTER needed before the first dense write.
+    """
+    g = Genome(path=":memory:")
+    try:
+        cols = {
+            row[1] for row in g.conn.execute("PRAGMA table_info(genes)").fetchall()
+        }
+        assert "embedding_dense_v2" in cols, (
+            "R10 regression: fresh genome lacks embedding_dense_v2 column"
+        )
+    finally:
+        g.close()
+
+
+def test_fresh_genome_round_trips_dense_vector():
+    """R10 continued: a fresh genome can write *and* read back a dense
+    vector end-to-end — proves the column is a real BLOB column.
+    """
+    g = Genome(path=":memory:", dense_embed_on_ingest=False, dense_embedding_dim=DIM)
+    try:
+        vec = _hash_vec("fresh-genome-roundtrip").tolist()
+        g.upsert_doc(
+            _make_gene("fresh genome doc", gene_id="r1"),
+            apply_gate=False,
+            embedding_dense_v2=vec,
+        )
+        blob = g.conn.execute(
+            "SELECT embedding_dense_v2 FROM genes WHERE gene_id='r1'"
+        ).fetchone()[0]
+        back = np.frombuffer(blob, dtype="<f4")
+        assert back.shape == (DIM,)
+        assert np.allclose(back, np.asarray(vec, dtype=np.float32), atol=1e-7)
+    finally:
+        g.close()
+
+
+# ── 5. context_manager.ingest populates every strand ─────────────────
+
+
+def _make_manager(*, dense_on: bool) -> HelixContextManager:
+    cfg = HelixConfig()
+    cfg.genome.path = ":memory:"
+    cfg.ingestion.backend = "cpu"
+    cfg.ingestion.dense_embed_on_ingest = dense_on
+    mgr = HelixContextManager(cfg)
+    mgr._dense_codec = _FakeCodec(cfg.retrieval.dense_embedding_dim)
+    return mgr
+
+
+def test_context_manager_ingest_populates_all_strands():
+    """A multi-strand document ingested through context_manager.ingest()
+    yields ``genes`` rows that ALL have a non-NULL ``embedding_dense_v2``
+    of the configured dim*4 bytes — including the file-level parent doc.
+    """
+    mgr = _make_manager(dense_on=True)
+    try:
+        # Large enough to chunk into >= 2 strands (chunker cap is 4000 chars).
+        big = " ".join(
+            f"strand body paragraph number {i} with enough real words to "
+            f"form a substantive chunk of document text."
+            for i in range(400)
+        )
+        ids = mgr.ingest(big, content_type="text", metadata={"path": "F:/t/doc.txt"})
+        assert len(ids) >= 2, f"expected a multi-strand chunking, got {len(ids)}"
+
+        expected = mgr.config.retrieval.dense_embedding_dim * 4
+        rows = mgr.genome.conn.execute(
+            "SELECT gene_id, embedding_dense_v2 FROM genes"
+        ).fetchall()
+        assert len(rows) >= 2
+        for gene_id, blob in rows:
+            assert blob is not None, f"gene {gene_id} has NULL embedding_dense_v2"
+            assert len(blob) == expected, (
+                f"gene {gene_id}: blob len {len(blob)} != {expected}"
+            )
+    finally:
+        mgr.genome.close()
+
+
+def test_context_manager_ingest_null_when_knob_off():
+    """With dense_embed_on_ingest=False the manager skips dense encoding
+    entirely and every ingested row keeps a NULL column.
+    """
+    mgr = _make_manager(dense_on=False)
+    try:
+        mgr.ingest("a single short strand of text", content_type="text")
+        nonnull = mgr.genome.conn.execute(
+            "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()[0]
+        assert nonnull == 0, "knob-off ingest must not write any dense vectors"
+    finally:
+        mgr.genome.close()
+
+
+# ── 6. small-corpus full coverage ────────────────────────────────────
+
+
+def test_ingest_corpus_full_dense_coverage():
+    """Ingest a small corpus of separate documents; assert
+    ``COUNT(embedding_dense_v2 IS NOT NULL) == COUNT(*)``.
+    """
+    mgr = _make_manager(dense_on=True)
+    try:
+        for i in range(8):
+            mgr.ingest(
+                f"corpus document number {i}: distinct content body for the "
+                f"needle-in-a-haystack retrieval store entry {i}.",
+                content_type="text",
+                metadata={"path": f"F:/corpus/doc_{i}.txt"},
+            )
+        total = mgr.genome.conn.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+        nonnull = mgr.genome.conn.execute(
+            "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()[0]
+        assert total >= 8
+        assert nonnull == total, (
+            f"dense coverage {nonnull}/{total} — not every gene was populated"
+        )
+    finally:
+        mgr.genome.close()
+
+
+# ── 7. backfill idempotency skip-clause ──────────────────────────────
+
+
+def test_pr1_genome_satisfies_backfill_skip_clause(tmp_path):
+    """A genome built through the PR-1 ingest write path must make the
+    backfill script's idempotency skip-clause select ZERO rows — i.e.
+    re-running ``scripts/backfill_bgem3_v2.py`` over it reports 0 rows to
+    process. The skip-clause is::
+
+        WHERE embedding_dense_v2 IS NULL
+           OR length(embedding_dense_v2) != ?   -- expected_bytes (dim*4)
+    """
+    db_path = tmp_path / "pr1_built.db"
+    g = Genome(
+        path=str(db_path), dense_embed_on_ingest=True, dense_embedding_dim=DIM,
+    )
+    g._dense_codec = _FakeCodec(DIM)
+    try:
+        for i in range(10):
+            g.upsert_doc(
+                _make_gene(f"pr1 built gene body {i}", gene_id=f"pr1-{i}"),
+                apply_gate=False,
+            )
+    finally:
+        g.close()
+
+    expected_bytes = DIM * 4
+    conn = sqlite3.connect(str(db_path))
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+        to_process = conn.execute(
+            "SELECT COUNT(*) FROM genes "
+            "WHERE embedding_dense_v2 IS NULL "
+            "   OR length(embedding_dense_v2) != ?",
+            (expected_bytes,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert total == 10
+    assert to_process == 0, (
+        f"backfill would re-process {to_process}/{total} rows — PR-1 encoding "
+        f"does not satisfy the length(blob)==dim*4 skip-clause"
+    )
+
+
+# ── 8. shared fp32 packing helper ────────────────────────────────────
+
+
+def test_vec_to_blob_shared_helper_length_and_roundtrip():
+    """``vec_to_blob`` packs to exactly dim*4 little-endian fp32 bytes and
+    ``np.frombuffer`` recovers the values within fp32 epsilon.
+    """
+    vec = _hash_vec("shared-helper").tolist()
+    blob = vec_to_blob(vec, DIM)
+    assert isinstance(blob, bytes)
+    assert len(blob) == DIM * 4
+    back = np.frombuffer(blob, dtype="<f4")
+    assert np.allclose(back, np.asarray(vec, dtype=np.float32), atol=1e-7)
+
+
+def test_vec_to_blob_rejects_wrong_dim():
+    """A dim mismatch raises ValueError — guards against a half-written
+    or wrong-dim row reaching the column.
+    """
+    with pytest.raises(ValueError):
+        vec_to_blob(_hash_vec("x", 512).tolist(), DIM)
+
+
+def test_vec_to_blob_matches_backfill_script_helper():
+    """The backfill script's ``_vec_to_blob`` is the shared helper — the
+    inline-ingest write and the offline backfill cannot drift.
+    """
+    import importlib.util
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "backfill_bgem3_v2.py"
+    spec = importlib.util.spec_from_file_location("backfill_bgem3_v2_id", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # Same function object, not merely an equivalent implementation.
+    assert mod._vec_to_blob is vec_to_blob
+
+    vec = _hash_vec("drift-check").tolist()
+    assert mod._vec_to_blob(vec, DIM) == vec_to_blob(vec, DIM)
+
+
+# ── 9. codec batch path parity ───────────────────────────────────────
+
+
+def test_encode_batch_matches_encode():
+    """``BGEM3Codec.encode_batch`` produces the same vectors as repeated
+    ``encode`` for the same texts (same truncation + renormalisation),
+    so the batched ingest path is byte-equivalent to per-strand encode.
+    """
+    codec = BGEM3Codec(dim=64)
+
+    # Deterministic per-text mock: identical to how encode would see it.
+    def fake_single(text, normalize_embeddings=True, show_progress_bar=False):
+        seed = int.from_bytes(
+            hashlib.sha256(str(text).encode()).digest()[:8], "little"
+        )
+        rng = np.random.default_rng(seed)
+        v = rng.standard_normal(128).astype(np.float32)
+        return v
+
+    def fake_batch(texts, normalize_embeddings=True, show_progress_bar=False):
+        return np.stack([fake_single(t) for t in texts])
+
+    texts = ["alpha passage", "beta passage", "gamma passage"]
+
+    # encode path
+    from unittest.mock import MagicMock
+    m1 = MagicMock()
+    m1.encode.side_effect = fake_single
+    codec._model = m1
+    codec._backend = "sentence_transformers"
+    one_by_one = [codec.encode(t, task="passage") for t in texts]
+
+    # encode_batch path
+    m2 = MagicMock()
+    m2.encode.side_effect = fake_batch
+    codec._model = m2
+    batched = codec.encode_batch(texts, task="passage")
+
+    assert len(batched) == len(one_by_one) == 3
+    for a, b in zip(one_by_one, batched):
+        assert np.allclose(
+            np.asarray(a, dtype=np.float32),
+            np.asarray(b, dtype=np.float32),
+            atol=1e-6,
+        ), "encode_batch diverged from encode"
+
+
+def test_encode_batch_empty_returns_empty():
+    codec = BGEM3Codec(dim=64)
+    assert codec.encode_batch([], task="passage") == []
+
+
+# ── 10. live — real BGE-M3 encode + pack ─────────────────────────────
+
+
+@pytest.mark.live
+def test_live_real_codec_encode_and_pack_roundtrip():
+    """Exercise the real BGE-M3 codec: encode a passage, pack it via the
+    shared helper, confirm the BLOB is dim*4 bytes and the vector is
+    unit-norm. Skipped automatically when the model is unavailable.
+    """
+    try:
+        codec = BGEM3Codec(dim=DIM)
+        vec = codec.encode("helix runs an OpenAI-compatible proxy", task="passage")
+    except Exception as exc:  # noqa: BLE001 — model download / import failure
+        pytest.skip(f"BGE-M3 model unavailable: {exc}")
+
+    assert len(vec) == DIM
+    arr = np.asarray(vec, dtype=np.float32)
+    assert abs(float(np.linalg.norm(arr)) - 1.0) < 1e-3
+    blob = vec_to_blob(vec, DIM)
+    assert len(blob) == DIM * 4
+    assert np.allclose(np.frombuffer(blob, dtype="<f4"), arr, atol=1e-7)
+
+
+@pytest.mark.live
+def test_live_upsert_doc_lazy_compute_with_real_codec():
+    """End-to-end: upsert_doc with the real BGE-M3 codec and the
+    dense_embed_on_ingest knob on persists a real dim*4 vector.
+    """
+    g = Genome(path=":memory:", dense_embed_on_ingest=True, dense_embedding_dim=DIM)
+    try:
+        try:
+            g._get_dense_codec()  # force the real load up front
+        except Exception as exc:  # noqa: BLE001
+            pytest.skip(f"BGE-M3 model unavailable: {exc}")
+        g.upsert_doc(
+            _make_gene("a real passage encoded by BGE-M3", gene_id="live-1"),
+            apply_gate=False,
+        )
+        assert _blob_len(g, "live-1") == DIM * 4
+    finally:
+        g.close()

--- a/tests/test_ingest_dense_v2.py
+++ b/tests/test_ingest_dense_v2.py
@@ -37,7 +37,6 @@ runs without BGE-M3 weights (mirrors ``tests/test_dense_recall.py``).
 from __future__ import annotations
 
 import hashlib
-import random
 import sqlite3
 from pathlib import Path
 
@@ -56,47 +55,14 @@ from helix_context.schemas import (
     ChromatinState, EpigeneticMarkers, Gene, PromoterTags,
 )
 
+# The deterministic fake BGE-M3 codec is defined once in tests/conftest.py
+# (the `_stub_dense_codec` autouse fixture installs the same class for every
+# non-live test). `_hash_vec` / `_FakeCodec` stay as local aliases so this
+# file's existing call sites are unchanged.
+from tests.conftest import FakeBGEM3Codec as _FakeCodec
+from tests.conftest import hash_vec as _hash_vec
+
 DIM = 1024
-
-
-# ── Test helpers (mirror tests/test_dense_recall.py) ─────────────────
-
-
-def _hash_vec(text: str, dim: int = DIM) -> np.ndarray:
-    """Deterministic L2-normalised fp32 vector seeded from text."""
-    out = np.zeros(dim, dtype=np.float32)
-    seed = hashlib.sha256(text.encode("utf-8")).digest()
-    rng = random.Random(int.from_bytes(seed[:8], "little"))
-    for i in range(dim):
-        out[i] = rng.gauss(0.0, 1.0)
-    n = np.linalg.norm(out)
-    if n > 0:
-        out /= n
-    return out
-
-
-class _FakeCodec:
-    """Test stand-in for BGEM3Codec; same shape contract.
-
-    Exposes both ``encode`` (used by the lazy upsert_doc path) and
-    ``encode_batch`` (used by context_manager.ingest).
-    """
-
-    def __init__(self, dim: int = DIM):
-        self.dim = dim
-        self.encode_calls = 0
-        self.batch_calls = 0
-
-    def encode(self, text: str, task: str = "passage"):
-        self.encode_calls += 1
-        return _hash_vec(text, self.dim).tolist()
-
-    def encode_batch(self, texts, task: str = "passage"):
-        self.batch_calls += 1
-        return [_hash_vec(t, self.dim).tolist() for t in texts]
-
-    def similarity(self, a, b) -> float:
-        return float(np.dot(np.asarray(a), np.asarray(b)))
 
 
 def _make_gene(content: str, *, gene_id: str | None = None) -> Gene:

--- a/tests/test_sharded_adapter_parity.py
+++ b/tests/test_sharded_adapter_parity.py
@@ -264,18 +264,83 @@ def test_adapter_get_doc_and_get_gene_are_same_callable(adapter):
     assert adapter.get_gene("nonexistent") is None
 
 
-def test_adapter_declares_fusion_mode_rrf(adapter):
-    """Issue #115: ShardRouter unconditionally builds an RRF Fuser
-    (``shard_router.py:236``), so the adapter must declare
-    ``_fusion_mode = "rrf"`` for ``context_manager._build_signals`` to
-    read RRF via ``getattr(self.genome, "_fusion_mode", "additive")``.
-    Without this, the abstain absolute-score floor (2.5, BM25-calibrated)
-    trips on every sharded query because RRF scores compress to ~0.3.
+def test_adapter_declares_fusion_mode_additive(adapter):
+    """Tier-0 PR-3 (2026-05-16), Decision 2 Option (b): the adapter
+    declares ``_fusion_mode = "additive"`` — the honest label.
+
+    The ShardRouter builds an RRF ``Fuser`` but uses its ``all_scores()``
+    only as a secondary sort tiebreaker; the primary sort key and the
+    published ``last_query_scores`` map are the IDF-corrected
+    *additive*-scale ``corrected`` scores. The router never publishes
+    RRF-scale numbers. The previous ``"rrf"`` label (issue #115) made
+    ``tier_logic`` skip its absolute floors on every sharded query —
+    treating a symptom of the mislabel. With ``"additive"`` the gates
+    interpret the BM25-ish sharded scores on the scale they were
+    calibrated for, so ``skip_absolute_floors`` is False and the
+    absolute floors run.
     """
-    assert adapter._fusion_mode == "rrf", (
-        "ShardedGenomeAdapter must declare _fusion_mode='rrf' so the "
-        "TIGHT/FOCUSED and ABSTAIN floor bypass engages for sharded "
-        "reads (issue #115)."
+    assert adapter._fusion_mode == "additive", (
+        "ShardedGenomeAdapter must declare _fusion_mode='additive' so the "
+        "downstream gates interpret the router's IDF-corrected "
+        "additive-scale scores on the correct scale (Tier-0 PR-3, "
+        "Decision 2 Option (b))."
+    )
+
+
+def test_sharded_fusion_mode_runs_absolute_floors_in_tier_logic(adapter):
+    """Tier-0 PR-3, Decision 2 Option (b) — behavioural check.
+
+    The adapter's ``_fusion_mode`` flows into ``pipeline.tier_logic`` via
+    ``context_manager``'s ``getattr(self.genome, "_fusion_mode",
+    "additive")``. With the honest ``"additive"`` label,
+    ``tier_logic.apply_budget_tiers`` sets ``skip_absolute_floors`` to
+    False (it is ``fusion_mode == "rrf"``), so the absolute
+    TIGHT/FOCUSED/ABSTAIN floors RUN on sharded queries — they were
+    skipped under the pre-PR-3 ``"rrf"`` mislabel.
+
+    Proof: a score distribution (top=0.40, gradient to 0.05) whose
+    legacy ``top/mean`` ratio is ~1.78 (< the 1.8 abstain ratio floor)
+    and whose top is far below the 2.5 absolute abstain floor. Fed the
+    adapter's actual ``_fusion_mode``:
+      - "additive" -> absolute floor active, ratio gate trips -> ABSTAIN
+      - "rrf"      -> absolute floor SKIPPED, baseline-normalized ratio
+                      is 2.0 (>= 1.5) -> NO abstain
+    The outcomes diverge, so this pins that the floors actually run for
+    the sharded path under the corrected label.
+    """
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+    from tests.conftest import make_gene
+
+    n = 12
+    top, low = 0.40, 0.05
+    step = (top - low) / (n - 1)
+    candidates = [
+        make_gene(f"shard_{i}", gene_id=f"shard_gene_{i:010d}")
+        for i in range(n)
+    ]
+    scores = {candidates[i].gene_id: top - i * step for i in range(n)}
+
+    # The adapter declares "additive"; feed exactly that to tier_logic.
+    result_sharded = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode=adapter._fusion_mode,
+    )
+    assert result_sharded.abstain is True, (
+        "with the honest 'additive' label the absolute abstain floor runs "
+        "and this weak distribution abstains"
+    )
+
+    # Counterfactual: the pre-PR-3 "rrf" mislabel would have skipped the
+    # floor and NOT abstained on the identical distribution.
+    result_mislabel = apply_budget_tiers(
+        candidates, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert result_mislabel.abstain is False, (
+        "sanity: the same distribution under the old 'rrf' label skips "
+        "the absolute floor and does not abstain — confirms the relabel "
+        "changes gate behaviour, which is the point of Option (b)"
     )
 
 

--- a/tests/test_sharded_adapter_parity.py
+++ b/tests/test_sharded_adapter_parity.py
@@ -139,6 +139,10 @@ ADAPTER_ONLY_DIFFERENCES_WHITELIST = frozenset({
     # internal tables.
     "rebuild_fts", "rebuild_path_kv_index", "rebuild_entity_graph",
     "rebuild_dense_matrix", "_dense_matrix", "_ensure_dense_matrix",
+    # Tier-0 PR-1 (2026-05-16): inline dense-vector encode at ingest.
+    # Write-path helper on the per-shard Genome only — the adapter's
+    # upsert_doc is a no-op, so it never encodes.
+    "_encode_dense_v2_blob",
 
     # Dense recall — per-shard, no cross-shard fan-out in V1.
     "query_docs_dense_recall", "query_genes_dense_recall",

--- a/tests/test_swap_db.py
+++ b/tests/test_swap_db.py
@@ -21,6 +21,8 @@ from helix_context.config import (
     HelixConfig,
     RibosomeConfig,
     ServerConfig,
+    VaultConfig,
+    VaultTracesConfig,
 )
 from helix_context.knowledge_store import KnowledgeStore
 from helix_context.schemas import (
@@ -309,6 +311,77 @@ class TestSwapDbEndpoint:
         except sqlite3.ProgrammingError as exc:  # pragma: no cover
             pytest.fail(f"registry.sweep() hit a closed DB after swap: {exc}")
         assert isinstance(counts, dict)
+
+    def test_swap_db_repoints_vault_genome(self, tmp_path):
+        """The VaultManager is repointed at the new store after a swap.
+
+        Tier-0 follow-up #4 (2026-05-17): the VaultManager — like the
+        session Registry (Bug B, test above) — captures a genome reference
+        at app construction (app.py: ``VaultManager(genome=helix.genome)``).
+        Its pruner thread calls ``refresh_stale_view(genome=self.genome)``
+        on a timer. Before this fix a swap left the VaultManager holding
+        the OLD store, which the swap then closed; the next prune cycle
+        raised ``sqlite3.ProgrammingError: Cannot operate on a closed
+        database``.
+        """
+        import sqlite3
+
+        db_a = str(tmp_path / "vault_a.db")
+        db_b = str(tmp_path / "vault_b.db")
+        _make_db(db_a, genes=1).close()
+        _make_db(db_b, genes=2).close()
+
+        # Build the app with the vault ENABLED so the pruner payload
+        # actually touches the genome (a disabled vault would no-op).
+        config = HelixConfig(
+            ribosome=RibosomeConfig(model="mock", timeout=5),
+            budget=BudgetConfig(max_genes_per_turn=4),
+            genome=GenomeConfig(path=db_a, cold_start_threshold=5),
+            server=ServerConfig(upstream="http://localhost:11434"),
+        )
+        config.vault = VaultConfig(
+            enabled=True, path=str(tmp_path / "vault"),
+            party_id="", fan_out_threshold=5000,
+            redact_body=False, stale_threshold=0.5,
+            traces=VaultTracesConfig(
+                enabled=True, retention_hours=48,
+                max_retention_hours_hard=720, max_count=10000,
+                rollup_enabled=True, rollup_shard="hour",
+                prune_interval_minutes=60, trigger_only=False,
+            ),
+        )
+        app = create_app(config)
+        app.state.helix.ribosome.backend = _MockBackend()
+        client = TestClient(app)
+
+        # TestClient is not used as a context manager here, so the app
+        # lifespan never runs — start the vault by hand.
+        vault = app.state.vault
+        vault.start()
+        try:
+            assert vault._started is True
+            # Pre-swap: vault points at the boot store.
+            assert vault.genome is app.state.helix.genome
+
+            resp = client.post("/admin/swap-db", json={"path": db_b})
+            assert resp.status_code == 200
+
+            # Post-swap: vault tracks the new live store, not the closed one.
+            assert vault.genome is app.state.helix.genome
+            assert vault.genome.path == db_b
+
+            # The pruner's payload runs against the new store without
+            # "Cannot operate on a closed database".
+            try:
+                results = vault.run_prune_cycle()
+            except sqlite3.ProgrammingError as exc:  # pragma: no cover
+                pytest.fail(
+                    f"vault prune cycle hit a closed DB after swap: {exc}"
+                )
+            assert isinstance(results, dict)
+            assert "stale" in results
+        finally:
+            vault.stop()
 
 
 # -- Sharded round-trip via swap-db ----------------------------------------

--- a/tests/test_swap_db.py
+++ b/tests/test_swap_db.py
@@ -272,6 +272,44 @@ class TestSwapDbEndpoint:
         assert resp.json()["read_only"] is False
         assert app.state.helix.genome.read_only is False
 
+    def test_swap_db_repoints_registry_genome(self, tmp_path):
+        """The session Registry is repointed at the new store after a swap.
+
+        Bug B (2026-05-17): the Registry captures a genome reference at
+        app construction and uses ``genome.conn`` directly for every
+        read/write — including the background sweep. Before the fix, a
+        swap left the Registry holding the OLD store, which the swap then
+        closed; the next ``Registry.sweep()`` raised
+        ``sqlite3.ProgrammingError: Cannot operate on a closed database``.
+        """
+        import sqlite3
+
+        db_a = str(tmp_path / "reg_a.db")
+        db_b = str(tmp_path / "reg_b.db")
+        _make_db(db_a, genes=1).close()
+        _make_db(db_b, genes=2).close()
+
+        app, client = _make_app_and_client(db_a)
+        registry = app.state.registry
+
+        # Pre-swap: registry points at the boot store.
+        assert registry.genome is app.state.helix.genome
+
+        resp = client.post("/admin/swap-db", json={"path": db_b})
+        assert resp.status_code == 200
+
+        # Post-swap: registry tracks the new live store, not the closed one.
+        assert registry.genome is app.state.helix.genome
+        assert registry.genome.path == db_b
+
+        # And the sweep — the background task's payload — runs against the
+        # new store without "Cannot operate on a closed database".
+        try:
+            counts = registry.sweep()
+        except sqlite3.ProgrammingError as exc:  # pragma: no cover
+            pytest.fail(f"registry.sweep() hit a closed DB after swap: {exc}")
+        assert isinstance(counts, dict)
+
 
 # -- Sharded round-trip via swap-db ----------------------------------------
 #


### PR DESCRIPTION
## Summary

Lights up **BGE-M3 dense semantic retrieval** end-to-end in the `/context`
pipeline (design path "B+b" from the 2026-05-16 deep review) and fixes a
sharded score-scale mislabel.

Dense recall now fires at retrieval time and materially reshapes results: a
deterministic, `$0`, no-`claude -p` probe showed dense ON vs OFF changed the
delivered document set on **10/10** probed queries, with a live `dense` tier
in `tier_contributions` and a ~+500-doc candidate pool.

## What's in here

**Dense recall — the 5-PR Tier-0 series:**
- **PR-1** `fe1c0e8` — compute `embedding_dense_v2` (BGE-M3) at ingest
  (`upsert_doc` + `context_manager.ingest`); new `dense_embed_on_ingest`
  knob; shared fp32 packing in `bgem3_codec.vec_to_blob`.
- **PR-2** `9136bdd` — `build_fixture_matrix.py` dense-backfills every built
  `.db` via a shared `backfill_dense_db()`; manifest `dense_coverage`.
- **PR-3** `f24f6d2` — decouple dense recall from `fusion_mode` (the gate is
  now `dense_embedding_enabled`); additive-mode dense merge; honest sharded
  `_fusion_mode = "additive"` relabel; default `dense_embedding_enabled=true`.
- **test-infra** `4600528` — autouse fake BGE-M3 codec keeps the non-live
  suite fast (~10 min, not ~3 h).
- **review fixes** `4c806a8` — `dense_additive_min_cosine = 0.15` noise
  floor; SQLite-connection-leak guard; stale comments.
- **CUDA autodetect** `455961c` — the dense backfill auto-selects CUDA.

**`/admin/swap-db` staleness fixes — the swap-staleness bug class, fully closed:**
- `ddf1af0` — forward the dense/ANN/fusion knobs through the swap. Without
  this, every hot-swapped fixture silently reverted to
  `dense_embedding_enabled=False` — which is why the original bench A/B ran
  dense-dark on both arms.
- `316850e` — repoint the session `Registry` at the new store on swap
  (a stale closed-DB handle otherwise crashed the background sweep).
- `9f00951` — repoint the `VaultManager` at the new store on swap (same
  staleness; only bites when the opt-in vault is enabled).

**Merge** `2e5805b` — merges current `master` (#134 / #135 / #136). One
conflict, `scripts/backfill_bgem3_v2.py`: master #134 added a `BGEM3_DEVICE`
env var to `main()`'s inline backfill, which Tier-0 PR-2 had already
refactored into the shared `backfill_dense_db()`. Resolved by keeping the
refactored structure and folding #134's env var into `backfill_dense_db()`'s
device selection — explicit `BGEM3_DEVICE` wins → else autodetect CUDA → else
CPU — which also extends the env var to the fixture builder.

## Verification

- **Dense recall works** — deterministic `/context` A/B probe (real BGE-M3
  codec, no bench): 10/10 queries changed delivered docs; `dense` tier active;
  candidate pool ~90–560 (OFF) → ~1180–1240 (ON).
- **Full non-live suite on the merge commit `2e5805b`:** **2141 passed**,
  4 failed, 15 skipped, 2 xfailed. The 4 failures are pre-existing
  `test_observability_docs.py::test_root_readme_*` cases — they assert
  root-`README.md` content and **fail identically on `master` (`05e48a8`)**.
  Tier-0 touches no docs files; they are unrelated to this branch (see below).

## Known follow-ups — none block "dense recall works"

- #137 — bench `gold_delivered` metric is too coarse to see dense recall.
- #138 — tune `dense_additive_weight` down from 4.0 (plan risk R1 observed).
- #139 — recalibrate `ann_similarity_threshold` for dim-1024 (Issue C).

The 50-needle bench A/B run during Tier-0 was **inconclusive** — not because
dense recall failed, but because `gold_delivered` (a boolean) is too coarse to
see it (#137). A meaningful re-bench needs that metric work first.

## Pre-existing issue surfaced (not fixed here)

The root `README.md` on `master` is a stub — `test_observability_docs.py`'s
4 `test_root_readme_*` checks already fail on `master`. Worth its own fix;
out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
