### PR TITLE
fix(retrieval): recalibrate ann_similarity_threshold for dim-1024 BGE-M3 vectors

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -276,15 +276,22 @@ entity_graph_retrieval_enabled = false
 # BGE-M3 dense vectors + ANN threshold (Step 4, 2026-05-08).
 # Stage 2 (2026-05-08): dim raised to 1024 (full BGE-M3 Matryoshka). The
 # dim=256 truncation collapsed random-pair cosine to ~0.6, sabotaging the
-# threshold. Stage 4 will recalibrate ann_similarity_threshold at 1024-dim.
-# dense_pool_size decouples recall breadth from the final cut (max_genes).
+# threshold. dense_pool_size decouples recall breadth from the final cut
+# (max_genes).
 # Tier-0 PR-3 (2026-05-16): flipped to true. PR-1 computes
 # embedding_dense_v2 at ingest and PR-3 decoupled dense recall from
 # fusion_mode (knowledge_store.query_docs), so dense recall now fires as a
 # retrieval signal under the shipped additive default — not only under RRF.
 dense_embedding_enabled = true
 dense_embedding_dim = 1024
-ann_similarity_threshold = 0.35           # legacy / fallback when calibration row missing
+# Stage 4 / Issue #139 (2026-05-18): recalibrated 0.35 -> 0.58 for dim=1024.
+# 0.35 was a dim-256 value. Measured over the dim-1024 BGE-M3 v2 vectors in
+# the bench fixtures (17.5k docs, 200k random unrelated doc pairs): unrelated-
+# pair cosine mean ~0.50, std ~0.066, p50 ~0.49, p90 ~0.58, p95 ~0.61. So 0.35
+# sat below the p1 noise floor (~0.36) and never cut. 0.58 sits just above the
+# p90 of unrelated pairs — rejects ~90% of pure-noise pairs while staying
+# conservative enough to keep moderately-related hits.
+ann_similarity_threshold = 0.58           # legacy / fallback when calibration row missing
 ann_threshold_min_genes = 1
 ann_threshold_max_genes = 12
 # Stage 4 (2026-05-08): margin-over-random ANN threshold. Spec

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -291,10 +291,15 @@ class RetrievalConfig:
     dense_embedding_enabled: bool = True
     # Stage 2 (2026-05-08): default dim raised from 256 -> 1024. Full BGE-M3
     # Matryoshka. dim=256 collapsed random-pair cosine to ~0.6, sabotaging
-    # threshold semantics. Stage 4 will recalibrate ann_similarity_threshold
-    # at the new dim.
+    # threshold semantics.
     dense_embedding_dim: int = 1024
-    ann_similarity_threshold: float = 0.35
+    # Stage 4 / Issue #139 (2026-05-18): recalibrated 0.35 -> 0.58 for dim=1024.
+    # 0.35 was a dim-256 value. Measured over the dim-1024 BGE-M3 v2 vectors in
+    # the bench fixtures (17.5k docs, 200k random unrelated doc pairs):
+    # unrelated-pair cosine mean ~0.50, std ~0.066, p90 ~0.58. So 0.35 sat
+    # below the p1 noise floor (~0.36) and never cut; 0.58 sits just above the
+    # p90 of unrelated pairs.
+    ann_similarity_threshold: float = 0.58
     ann_threshold_min_genes: int = 1
     ann_threshold_max_genes: int = 12
     # Stage 4 (2026-05-08): margin-over-random ANN calibration. Spec

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -341,7 +341,11 @@ class KnowledgeStore:
         # a precomputed vector). This is the WRITE path only and is
         # independent of dense_embedding_enabled, which gates RETRIEVAL.
         dense_embed_on_ingest: bool = False,
-        ann_similarity_threshold: float = 0.35,
+        # Issue #139 (2026-05-18): default recalibrated 0.35 -> 0.58 for the
+        # dim-1024 BGE-M3 v2 vectors. Callers normally pass the configured
+        # value (config.retrieval.ann_similarity_threshold); this default is
+        # the fallback for direct construction.
+        ann_similarity_threshold: float = 0.58,
         ann_threshold_min_genes: int = 1,
         ann_threshold_max_genes: int = 12,
         # Stage 4 (2026-05-08): margin-over-random ANN calibration. When
@@ -2441,10 +2445,15 @@ class KnowledgeStore:
         if self._dense_codec is None:
             from .backends.bgem3_codec import BGEM3Codec
             self._dense_codec = BGEM3Codec(dim=self._dense_embedding_dim)
-            # One-time threshold-staleness warn: if v2 coverage is non-empty
-            # AND the threshold was calibrated at a different dim, surface it.
-            # Threshold recalibration is Stage 4; we just want it loud.
-            if self._dense_embedding_enabled and not self._threshold_dim_warned:
+            # One-time threshold-staleness warn: ann_similarity_threshold is
+            # calibrated for dim=1024 (Issue #139 / Stage 4, 2026-05-18). If
+            # this knowledge store runs at a different dense_embedding_dim, the
+            # absolute threshold no longer matches the geometry — surface it.
+            if (
+                self._dense_embedding_enabled
+                and not self._threshold_dim_warned
+                and self._dense_embedding_dim != 1024
+            ):
                 try:
                     coverage = self._reader.execute(
                         "SELECT COUNT(*) AS c FROM genes WHERE embedding_dense_v2 IS NOT NULL"
@@ -2454,9 +2463,10 @@ class KnowledgeStore:
                     has_v2 = False
                 if has_v2:
                     log.warning(
-                        "ann_similarity_threshold=%.3f is calibrated for dim=256; "
-                        "v2 vectors are dim=%d. Threshold recalibration is Stage 4. "
-                        "Recall pool is independent of threshold.",
+                        "ann_similarity_threshold=%.3f is calibrated for dim=1024; "
+                        "v2 vectors are dim=%d. The absolute threshold will not "
+                        "transfer — re-measure for this dim. Recall pool is "
+                        "independent of threshold.",
                         self._ann_threshold, self._dense_embedding_dim,
                     )
                     self._threshold_dim_warned = True
@@ -2671,10 +2681,11 @@ class KnowledgeStore:
         4. Body-fetch once via ``_load_genes_by_ids``.
         5. Apply threshold + ``min_genes`` floor; cap at ``max_genes``.
 
-        Stage 2 is **threshold-stale**: ``ann_similarity_threshold`` was
-        calibrated at dim=256; v2 vectors are dim=1024. Stage 4 recalibrates.
-        ``max_genes`` is the hard cap, so blast radius is bounded even if the
-        threshold over-includes.
+        ``ann_similarity_threshold`` was recalibrated for dim=1024 v2 vectors
+        in Issue #139 / Stage 4 (2026-05-18): measured unrelated-pair cosine
+        mean ~0.50 over the bench fixtures, so the default was raised 0.35 ->
+        0.58 (just above the p90 of unrelated pairs). ``max_genes`` remains the
+        hard cap, so blast radius is bounded regardless of the threshold.
 
         Back-compat: callers that pass only positional/keyword args still
         work; ``pool_size`` is keyword-only and optional.


### PR DESCRIPTION
## Summary

`ann_similarity_threshold` (`[retrieval]` in `helix.toml`) was `0.35` — a value calibrated for **dim-256** dense vectors. The v2 BGE-M3 dense embeddings (`embedding_dense_v2`) are **dim-1024**. In the anisotropic dim-1024 BGE-M3 space, unrelated passage pairs sit far above `0.35`, so the cut was **below the noise floor**: it admitted everything and never actually cut, leaving the latent `query_docs_ann` ranking quirk described in Issue #139 (Issue C / Stage-4 deferral). Severity is low — this never blocked dense recall.

This is the long-deferred "Stage-4" recalibration, **measured** against the real dim-1024 distribution rather than guessed.

## Measured evidence (the dim-1024 unrelated-pair noise floor)

Throwaway script: decoded `embedding_dense_v2` BLOBs (raw little-endian fp32, pure numpy — no model download) from the bench fixtures and computed cosine over 200k random unrelated doc pairs.

**`genomes/bench/matrix/medium.db` — 17,477 docs, 199,992 random unrelated pairs:**

| stat | value |
|---|---|
| mean | **0.4971** |
| std  | 0.0672 |
| min  | 0.2057 |
| p1   | 0.3594 |
| p5   | 0.3982 |
| p25  | 0.4525 |
| p50  | **0.4917** |
| p75  | 0.5350 |
| p90  | **0.5817** |
| p95  | 0.6155 |
| p99  | 0.6891 |

`small.db` (1,238 docs) agrees within ~0.004 (mean 0.5009, p50 0.4972, p90 0.5778) — the distribution is corpus-stable.

The old `0.35` cut sat **below the p1** of unrelated pairs (~0.36): it cut nothing.

## Chosen threshold

`0.35` → **`0.58`** — just above the **p90** of unrelated pairs. Rejects ~90% of pure-noise pairs while staying conservative enough to keep moderately-related hits. Lands inside the issue's estimated 0.55–0.60 range, now backed by measurement.

## Changes

- `helix.toml` — `ann_similarity_threshold = 0.58`; stale comment rewritten to past tense citing the measured basis.
- `helix_context/config.py` — `RetrievalConfig.ann_similarity_threshold` code-side default `0.35` → `0.58`.
- `helix_context/knowledge_store.py` — constructor fallback default `0.35` → `0.58`; the now-incorrect dim-256 staleness `WARN` in `_get_dense_codec` (claimed the threshold was dim-256 and recalibration was pending Stage 4) now fires only when `dense_embedding_dim != 1024` — a genuine mismatch against the recalibrated value; stale `query_docs` docstring updated.

## Test plan

- [x] `python -m pytest tests/ -m "not live" -k "config or retriev or ann" -q` — **140 passed**
- [x] `python -m pytest tests/test_calibration.py tests/test_dense_recall.py tests/test_sharded_adapter_parity.py -m "not live" -q` — **45 passed, 1 skipped**
- [x] `load_config()` and `RetrievalConfig()` both resolve `ann_similarity_threshold = 0.58`
- No test asserted the old `0.35` default (`test_calibration.py` passes `0.35` explicitly as a constructor arg — unaffected).

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)