### PR TITLE
fix(bench): exclude untrusted xl-sharded from the default run

### DIFF
--- a/benchmarks/bench_claude_matrix.py
+++ b/benchmarks/bench_claude_matrix.py
@@ -1,4 +1,8 @@
-r"""Run the 10-needle bench against all 6 frozen fixtures via ``claude -p``.
+r"""Run the 50-needle bench against the frozen fixture matrix via ``claude -p``.
+
+A default run covers the trusted fixtures only; xl-sharded is excluded
+because its `projects` shard fixture is corrupt (see issue #133). Pass
+``--include-untrusted`` to run it anyway.
 
 Per fixture:
   1. POST /admin/swap-db pointing at the fixture's primary .db
@@ -30,14 +34,15 @@ Output (no overwrite — per-run subdir):
     large.jsonl
     xl.jsonl
     medium-sharded.jsonl
-    xl-sharded.jsonl
+    xl-sharded.jsonl     (only with --include-untrusted; see #133)
     run.log
     uvicorn.log         (when managing the server)
 
 Usage:
   python benchmarks/bench_claude_matrix.py
   python benchmarks/bench_claude_matrix.py --only small,medium
-  python benchmarks/bench_claude_matrix.py --skip xl-sharded
+  python benchmarks/bench_claude_matrix.py --skip large
+  python benchmarks/bench_claude_matrix.py --include-untrusted
   python benchmarks/bench_claude_matrix.py --model sonnet --max-usd 0.20
   python benchmarks/bench_claude_matrix.py --external-server
 """
@@ -75,6 +80,16 @@ RESULTS_ROOT = Path(r"F:\Projects\helix-context\benchmarks\results")
 CLAUDE_TIMEOUT_S = 300        # 5 min per question — generous for MCP + reasoning
 SWAP_TIMEOUT_S = 60           # SPLADE rebuild on swap can take a moment
 CONTEXT_TIMEOUT_S = 30        # /context retrieval-only call
+
+# Profiles whose fixture is known-untrustworthy and excluded from a
+# default run. xl-sharded's `projects` shard was built from a polluted
+# source tree — F:\Projects\_worktrees\helix-context\* PR-branch
+# worktrees plus a helix-retrieval-upgrade clone, with no canonical
+# helix-context/ checkout — so the needles' gold_source labels resolve
+# to nothing there and retr_hit / MRR on it are meaningless (correctness
+# decoupled from retrieval). See issue #133. Re-include once the projects
+# shard is rebuilt clean; --include-untrusted forces it in meanwhile.
+UNTRUSTED_PROFILES = frozenset({"xl-sharded"})
 
 
 # ── Needles (copied from benchmarks/bench_needle.py so this script is
@@ -794,6 +809,22 @@ def parse_filter(spec: str | None, all_keys: list[str]) -> set[str]:
     return set(parts)
 
 
+def resolve_profiles(all_keys: list[str], only: set[str], skip: set[str],
+                     include_untrusted: bool = False) -> list[str]:
+    """Ordered list of profiles to run.
+
+    Applies --only / --skip, then drops UNTRUSTED_PROFILES unless
+    ``include_untrusted`` is set or the profile was explicitly named in
+    ``only`` (an explicit by-name request wins). Order follows ``all_keys``.
+    """
+    keys = [k for k in all_keys
+            if (not only or k in only) and k not in skip]
+    if not include_untrusted:
+        keys = [k for k in keys
+                if k not in UNTRUSTED_PROFILES or k in only]
+    return keys
+
+
 def summarize_profile(per_needle: list[dict], n_needles: int) -> dict:
     n_correct = sum(1 for r in per_needle if r["score"] == 1)
     n_abstain = sum(1 for r in per_needle if r["score"] == 0)
@@ -822,6 +853,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--only", help="Comma-separated profiles to run")
     parser.add_argument("--skip", help="Comma-separated profiles to skip")
+    parser.add_argument("--include-untrusted", action="store_true",
+                        help="Include UNTRUSTED_PROFILES (xl-sharded; corrupt "
+                             "fixture, see issue #133). Excluded by default.")
     parser.add_argument("--model", default="haiku",
                         help="claude -p --model arg (haiku/sonnet/opus/full id). "
                              "Default: haiku — cloud speed prioritized over model "
@@ -852,8 +886,7 @@ def main() -> int:
     all_keys = list(manifest["targets"].keys())
     only = parse_filter(args.only, all_keys)
     skip = parse_filter(args.skip, all_keys)
-    keys = [k for k in all_keys
-            if (not only or k in only) and k not in skip]
+    keys = resolve_profiles(all_keys, only, skip, args.include_untrusted)
 
     run_dir = make_run_dir()
     log = setup_logger(run_dir)
@@ -861,6 +894,17 @@ def main() -> int:
     log.info("model=%s max_usd_per_question=%.2f external_server=%s",
              args.model, args.max_usd, args.external_server)
     log.info("profiles in run: %s", keys)
+    for k in all_keys:
+        if k not in UNTRUSTED_PROFILES:
+            continue
+        if k in keys:
+            log.warning("profile %r is UNTRUSTED: fixture corrupt, its "
+                        "retr_hit / MRR are not meaningful (see issue #133)", k)
+        else:
+            log.info("untrusted profile %r excluded from this run "
+                     "(see issue #133; --include-untrusted to force)", k)
+    untrusted_excluded = [k for k in all_keys
+                          if k in UNTRUSTED_PROFILES and k not in keys]
 
     overall: dict = {
         "run_dir": str(run_dir),
@@ -868,6 +912,7 @@ def main() -> int:
         "model": args.model,
         "max_usd_per_question": args.max_usd,
         "external_server": args.external_server,
+        "untrusted_excluded": untrusted_excluded,
         "profiles": {},
     }
 

--- a/tests/test_bench_profiles.py
+++ b/tests/test_bench_profiles.py
@@ -1,0 +1,67 @@
+"""Untrusted-fixture exclusion for the claude-matrix bench (issue #133).
+
+The xl-sharded fixture's `projects` shard was built from a polluted
+source tree -- F:/Projects/_worktrees/helix-context/* PR-branch worktrees
+plus a helix-retrieval-upgrade clone, with no canonical helix-context/
+checkout. The needles' gold_source labels cannot resolve there, so
+retr_hit / MRR on xl-sharded are not meaningful (correctness decoupled
+from retrieval -- the 4-correct-with-gold / 17-correct-without inversion).
+
+`resolve_profiles` drops UNTRUSTED_PROFILES from a default run;
+`--include-untrusted`, or naming the profile explicitly in `--only`,
+forces it back in.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+sys.path.insert(0, str(BENCH_DIR))
+
+from bench_claude_matrix import UNTRUSTED_PROFILES, resolve_profiles  # noqa: E402
+
+ALL = ["small", "medium", "large", "xl", "medium-sharded", "xl-sharded"]
+
+
+def test_xl_sharded_is_marked_untrusted():
+    assert "xl-sharded" in UNTRUSTED_PROFILES
+
+
+def test_default_run_drops_untrusted_profiles():
+    keys = resolve_profiles(ALL, only=set(), skip=set(),
+                            include_untrusted=False)
+    assert "xl-sharded" not in keys
+    assert keys == ["small", "medium", "large", "xl", "medium-sharded"]
+
+
+def test_include_untrusted_flag_keeps_them():
+    keys = resolve_profiles(ALL, only=set(), skip=set(),
+                            include_untrusted=True)
+    assert keys == ALL
+
+
+def test_explicit_only_overrides_untrusted_exclusion():
+    """Naming an untrusted profile in --only is an explicit operator request."""
+    keys = resolve_profiles(ALL, only={"xl-sharded"}, skip=set(),
+                            include_untrusted=False)
+    assert keys == ["xl-sharded"]
+
+
+def test_only_without_untrusted_is_unaffected():
+    keys = resolve_profiles(ALL, only={"small", "medium"}, skip=set(),
+                            include_untrusted=False)
+    assert keys == ["small", "medium"]
+
+
+def test_skip_still_applies_and_does_not_resurrect_untrusted():
+    keys = resolve_profiles(ALL, only=set(), skip={"small"},
+                            include_untrusted=False)
+    assert keys == ["medium", "large", "xl", "medium-sharded"]
+
+
+def test_profile_order_is_preserved():
+    keys = resolve_profiles(ALL, only=set(), skip=set(),
+                            include_untrusted=True)
+    assert keys == ALL


### PR DESCRIPTION
## Summary

On the xl-sharded fixture the bench's `retr_hit` is decoupled from answer correctness — the 2026-05-15 run scored **4** needles correct-with-gold-delivered vs **17** correct-with-gold-*missed*, a clear inversion (#133).

**Root cause is a corrupt fixture, not stale labels.** Querying the xl-sharded `projects` shard (`projects.genome.db`, 28,085 genes):

- **Zero** genes under the canonical `helix-context/` path.
- helix-context content exists only as PR-branch *worktree copies* under `F:\Projects\_worktrees\helix-context\{goofy-merkle-pr, tier0-integration, tier0-pr2-…, tier0-pr3-…, track-freeze-manifest}\`, plus a `helix-retrieval-upgrade/` clone.
- The shard also swept in `.obsidian/`, `.vscode/`, `agentome/` — a broad junk-crawl of `F:\Projects\`.

So all 50 needles' gold labels (`helix-context/helix.toml`, …) point at canonical paths that don't exist in this fixture; the agent answers correctly off a worktree *copy* the labels don't name.

Re-curating 50 needles to the `_worktrees/...` paths would be brittle (those dirs are transient) and would bless a corrupt fixture. This PR takes the **exclude-now / rebuild-later** path:

- `UNTRUSTED_PROFILES` + `resolve_profiles()` — xl-sharded is dropped from a default run. `--include-untrusted`, or naming it explicitly in `--only`, forces it back in.
- Run logs warn when an untrusted profile runs or is skipped; `summary.json` records `untrusted_excluded`.
- Docstring: stale "10-needle" → 50; documents the exclusion.

The trusted 5 fixtures (small / medium / large / xl-blob / medium-sharded) are unaffected — this unblocks the dense re-bench now.

**`Refs #133`, not `Closes`** — #133 stays open to track the real fix: a clean rebuild of the xl-sharded `projects` shard (excluding `_worktrees/`, clones, dotdirs).

## Test plan

- [x] `tests/test_bench_profiles.py` — 7 new tests: default run drops xl-sharded; `--include-untrusted` keeps it; explicit `--only xl-sharded` overrides; `--skip` unaffected; order preserved.
- [x] `python -m pytest tests/ -m "not live" -k bench` → 94 passed.
- [x] `--help` renders and `--include-untrusted` is registered.
- [ ] Not run: the paid `claude -p` matrix bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)