### PR TITLE
fix(bench): ASCII-only argparse --help text (no cp1252 crash)

### DIFF
--- a/benchmarks/bench_babilong.py
+++ b/benchmarks/bench_babilong.py
@@ -10,9 +10,9 @@ problems and ingests them into a scratch corpus, then queries with
 multi-hop questions.
 
 Supported tasks:
-  - task_1  — single supporting fact  (sanity check, same as needle)
-  - task_2  — two supporting facts    (two-hop reasoning)
-  - task_3  — three supporting facts  (three-hop reasoning)
+  - task_1  - single supporting fact  (sanity check, same as needle)
+  - task_2  - two supporting facts    (two-hop reasoning)
+  - task_3  - three supporting facts  (three-hop reasoning)
 
 Each task generates N=10 problems with distractor text padding,
 ingests them as genes, and measures:

--- a/benchmarks/bench_cache_hitrate.py
+++ b/benchmarks/bench_cache_hitrate.py
@@ -1,10 +1,10 @@
-"""Cache hit-rate benchmark — simulates a multi-agent workload where
+"""Cache hit-rate benchmark - simulates a multi-agent workload where
 overlapping queries hit overlapping source_ids.
 
 Design:
     - N "agents" (distinct session_ids) run a shared pool of queries.
     - Queries are drawn with replacement so overlap is explicit.
-    - Each query → Helix packet → DAL fetch for every source_id.
+    - Each query -> Helix packet -> DAL fetch for every source_id.
     - Two runs: cold (fresh cache per call) and warm (shared cache).
     - Reports: per-agent + aggregate hit-rate + latency savings.
 

--- a/benchmarks/bench_claude_matrix.py
+++ b/benchmarks/bench_claude_matrix.py
@@ -3,13 +3,13 @@ r"""Run the 10-needle bench against all 6 frozen fixtures via ``claude -p``.
 Per fixture:
   1. POST /admin/swap-db pointing at the fixture's primary .db
      (or restart uvicorn with HELIX_USE_SHARDS=1 when crossing
-     blob<->sharded mode boundaries — handled by BenchServer)
+     blob<->sharded mode boundaries - handled by BenchServer)
   2. For each needle, invoke ``claude -p --output-format json`` so the
      model answers via helix-context MCP (which now hits the swapped db)
   3. Also call /context directly per needle for retrieval-only metrics
      (citation-grounded gold-source check, with legacy <GENE src> regex
      fallback for older response shapes / archived JSONL)
-  4. Score answer ∈ {-1, 0, +1} via word-boundary accept-match
+  4. Score answer in {-1, 0, +1} via word-boundary accept-match
   5. Write per-fixture JSONL into a timestamped results dir
 
 Pre-conditions:
@@ -22,7 +22,7 @@ Pre-conditions:
     ``--external-server`` to use a server you've started manually
     (legacy behavior).
 
-Output (no overwrite — per-run subdir):
+Output (no overwrite - per-run subdir):
   benchmarks/results/claude_matrix_<UTC-timestamp>/
     summary.json
     small.jsonl
@@ -824,7 +824,7 @@ def main() -> int:
     parser.add_argument("--skip", help="Comma-separated profiles to skip")
     parser.add_argument("--model", default="haiku",
                         help="claude -p --model arg (haiku/sonnet/opus/full id). "
-                             "Default: haiku — cloud speed prioritized over model "
+                             "Default: haiku - cloud speed prioritized over model "
                              "quality for retrieval-quality bench. See "
                              "memory/bench_default_haiku.md.")
     parser.add_argument("--max-usd", type=float, default=0.30,

--- a/benchmarks/bench_dal_http_s3.py
+++ b/benchmarks/bench_dal_http_s3.py
@@ -4,14 +4,14 @@ The companion bench `bench_cache_hitrate.py` measured 41.67% hit rate
 but only 4.5% wall savings because the underlying DAL fetches local
 files (<1ms). For HTTP/S3/remote backends, each miss costs real wall
 time (tens-to-hundreds of ms), and the same 41% hit rate converts into
-10× or more savings.
+10x or more savings.
 
 This bench isolates that relationship: we register a synthetic "slow://"
 scheme with a configurable per-fetch sleep, replay a deterministic
-multi-agent workload, and sweep latency from 1ms → 200ms.
+multi-agent workload, and sweep latency from 1ms -> 200ms.
 
 The point is not to prove the cache works (bench_cache_hitrate does
-that) — it's to show the *per-backend* wall-savings curve so operators
+that) - it's to show the *per-backend* wall-savings curve so operators
 can estimate cache value without deploying it.
 
 Usage:

--- a/benchmarks/bench_headroom_latency.py
+++ b/benchmarks/bench_headroom_latency.py
@@ -1,4 +1,4 @@
-"""Headroom E2E latency — measure the compress_text() seam with headroom
+"""Headroom E2E latency - measure the compress_text() seam with headroom
 enabled vs disabled (HELIX_DISABLE_HEADROOM=1 fallback).
 
 Samples real gene content from the running genome across content types
@@ -8,7 +8,7 @@ in each mode, and reports:
     - compression ratio per call (output_chars / input_chars)
     - per-content-type breakdown
 
-Runs in-process via the library — no HTTP, no separate server. The
+Runs in-process via the library - no HTTP, no separate server. The
 headroom_bridge ``_disabled()`` check reads env on every call, so we
 can toggle between trials without restarting anything.
 
@@ -136,7 +136,7 @@ def _format_table(rows: list[dict]) -> str:
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--trials", type=int, default=10,
-                        help="Trials per (sample × budget × mode)")
+                        help="Trials per (sample x budget x mode)")
     parser.add_argument("--samples-per-kind", type=int, default=3)
     parser.add_argument("--out", type=str,
                         default=f"benchmarks/results/headroom_latency_"

--- a/benchmarks/bench_orchestrator.py
+++ b/benchmarks/bench_orchestrator.py
@@ -1,12 +1,12 @@
-"""Bench orchestrator — manage uvicorn lifecycle + hot-swap across the
+"""Bench orchestrator - manage uvicorn lifecycle + hot-swap across the
 6-fixture matrix (4 monolithic blobs + 2 sharded) without manual server
 restarts between runs.
 
 Two transition shapes:
 
-- **Same-mode (blob→blob, sharded→sharded)**: POST /admin/swap-db.
+- **Same-mode (blob->blob, sharded->sharded)**: POST /admin/swap-db.
   Atomic, ~milliseconds, no process restart. Available since PR #91.
-- **Cross-mode (blob↔sharded)**: full uvicorn restart with the
+- **Cross-mode (blob<->sharded)**: full uvicorn restart with the
   ``HELIX_USE_SHARDS`` env var set/unset. ``open_read_source()`` in
   ``helix_context/sharding.py`` reads that env at store-construction time;
   it can't be flipped mid-process.

--- a/benchmarks/bench_packet.py
+++ b/benchmarks/bench_packet.py
@@ -1,8 +1,8 @@
-"""Phase 5 packet benchmark — does freshness + coord confidence
+"""Phase 5 packet benchmark - does freshness + coord confidence
 actually change agent behavior on controlled scenarios?
 
 Per ``docs/specs/2026-04-17-agent-context-index-build-spec.md``
-§"Phase 5 — Benchmarks" the question is whether the packet's
+section "Phase 5 - Benchmarks" the question is whether the packet's
 ``verified / stale_risk / needs_refresh`` labeling catches scenarios
 a naive relevance-only retriever would happily return. This bench
 builds N controlled in-memory genomes, runs ``build_context_packet``
@@ -10,22 +10,22 @@ against each, and reports precision/recall against the expected
 status.
 
 Scenario families covered in v1:
-    1. stale_by_age           — verified long ago vs volatility half-life
-    2. invalidated            — ``invalidated_at`` is set
-    3. coordinate_mismatch    — content relevant, path off-target
-    4. task_sensitivity       — same gene, different task_type → different verdict
-    5. clean_verified         — fresh + aligned + high-authority (negative control)
+    1. stale_by_age           - verified long ago vs volatility half-life
+    2. invalidated            - ``invalidated_at`` is set
+    3. coordinate_mismatch    - content relevant, path off-target
+    4. task_sensitivity       - same gene, different task_type -> different verdict
+    5. clean_verified         - fresh + aligned + high-authority (negative control)
 
 Families deferred to later passes:
-    - conflicting_config_values — gated on Phase 2 claims layer
-    - duplicate_fact_across_shards — gated on real multi-shard setup
-    - generated_log_contamination — partially covered by stale_by_age +
+    - conflicting_config_values - gated on Phase 2 claims layer
+    - duplicate_fact_across_shards - gated on real multi-shard setup
+    - generated_log_contamination - partially covered by stale_by_age +
       hot volatility; full version needs ingest-time log-folder rules
 
 Metrics per family:
-    - correct_flag_rate  — of "should flag" cases, how many did flag
-    - false_flag_rate    — of "should verify" cases, how many were flagged
-    - avg_build_ms       — time to produce a labeled packet
+    - correct_flag_rate  - of "should flag" cases, how many did flag
+    - false_flag_rate    - of "should verify" cases, how many were flagged
+    - avg_build_ms       - time to produce a labeled packet
 
 Usage::
 

--- a/benchmarks/bench_plr_smoke.py
+++ b/benchmarks/bench_plr_smoke.py
@@ -1,9 +1,9 @@
-"""PLR smoke bench — does [plr] enabled=true add plr_confidence to
+"""PLR smoke bench - does [plr] enabled=true add plr_confidence to
 /context/packet responses without degrading p95 latency?
 
 Hits /context/packet with N harvested-needle queries, captures
 (latency_ms, has_plr_field, plr_confidence_value_if_present). Run
-twice — once at PLR off, once at PLR on — then compare p50/p95 latency
+twice - once at PLR off, once at PLR on - then compare p50/p95 latency
 plus presence rate.
 
 Acceptance gate (#74):

--- a/benchmarks/bench_skill_activation.py
+++ b/benchmarks/bench_skill_activation.py
@@ -3,11 +3,11 @@ Skill / tool activation profiler.
 
 For a curated set of distinct prompt SHAPES, probe the /context endpoint
 and capture WHICH retrieval signals fire (and how strongly). Output is
-a 2D activation matrix: prompt-shape × retrieval-tier → contribution.
+a 2D activation matrix: prompt-shape x retrieval-tier -> contribution.
 
 This makes the lane graph from docs/PIPELINE_LANES.md MEASURABLE rather
 than asserted. We can verify that the engine actually picks the tools
-we think it picks for each query type — and detect drift if a refactor
+we think it picks for each query type - and detect drift if a refactor
 silently changes the routing.
 
 Requires server-side per-tier breakdown surfaced via /context's
@@ -20,9 +20,9 @@ Usage:
     HELIX_MODEL=qwen3:8b python benchmarks/bench_skill_activation.py
 
 Output:
-    benchmarks/skill_activation_results.json — per-shape activation
+    benchmarks/skill_activation_results.json - per-shape activation
         matrix with raw contributions + heatmap-friendly aggregates
-    Console — ASCII heatmap (10 shapes × N tiers)
+    Console - ASCII heatmap (10 shapes x N tiers)
 
 Companion: benchmarks/bench_dimensional_lock.py (precision curve);
 this bench is the ingredient profile.
@@ -286,7 +286,7 @@ def main() -> int:
         choices=("additive", "rrf"),
         default=os.environ.get("HELIX_FUSION_MODE_LABEL", "additive"),
         help=(
-            "Annotation only — the bench reads server output as-is. "
+            "Annotation only - the bench reads server output as-is. "
             "Restart the helix server with [retrieval] fusion_mode=<this> "
             "before running the bench to actually exercise the path."
         ),

--- a/tests/test_bench_help_ascii.py
+++ b/tests/test_bench_help_ascii.py
@@ -1,0 +1,73 @@
+"""`--help` text in bench scripts must be ASCII so it cannot crash.
+
+`python benchmarks/bench_*.py --help` makes argparse encode the module
+docstring (the parser ``description``) and every ``help=`` string to the
+console encoding. On a Windows cp1252 console a non-cp1252 character
+(e.g. U+2192 RIGHTWARDS ARROW, U+2208 ELEMENT OF) raises
+UnicodeEncodeError before help is shown. Keeping that text pure ASCII
+keeps ``--help`` working on every locale.
+
+Scope is exactly what argparse encodes: the module docstring and
+``add_argument(help=...)`` strings of bench scripts that use argparse.
+Comments, function docstrings, and runtime output (e.g. heatmap glyphs)
+are intentionally out of scope -- argparse never encodes them.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+
+
+def _argparse_bench_files() -> list[Path]:
+    """Bench scripts that build an argparse parser (so they have --help)."""
+    return [
+        p for p in sorted(BENCH_DIR.glob("bench_*.py"))
+        if "argparse" in p.read_text(encoding="utf-8")
+    ]
+
+
+def _help_strings(tree: ast.Module) -> list[str]:
+    """Every constant `help=` string passed to an add_argument-style call."""
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if (kw.arg == "help"
+                        and isinstance(kw.value, ast.Constant)
+                        and isinstance(kw.value.value, str)):
+                    out.append(kw.value.value)
+    return out
+
+
+def _non_ascii(text: str) -> list[str]:
+    return sorted({c for c in text if ord(c) > 127})
+
+
+def test_argparse_bench_files_are_discovered():
+    """Guard against the glob silently matching nothing (vacuous pass)."""
+    files = _argparse_bench_files()
+    assert files, "no argparse bench scripts found under benchmarks/"
+    assert any(p.name == "bench_claude_matrix.py" for p in files)
+
+
+def test_argparse_help_text_is_ascii():
+    """Module docstring + every `help=` string of every argparse bench
+    script must be ASCII, so `--help` cannot raise UnicodeEncodeError on a
+    non-UTF-8 console."""
+    offenders: list[str] = []
+    for path in _argparse_bench_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        doc_bad = _non_ascii(ast.get_docstring(tree) or "")
+        if doc_bad:
+            offenders.append(f"{path.name}: docstring -> {doc_bad}")
+        for help_text in _help_strings(tree):
+            help_bad = _non_ascii(help_text)
+            if help_bad:
+                offenders.append(f"{path.name}: help= -> {help_bad}")
+    assert not offenders, (
+        "non-ASCII in argparse --help text (crashes --help on cp1252):\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

`python benchmarks/bench_*.py --help` crashes with `UnicodeEncodeError` on a Windows cp1252 console. argparse encodes the module docstring (the parser `description`) and every `help=` string to the console encoding; a non-cp1252 character aborts `--help` before it prints — e.g. `bench_claude_matrix.py`'s docstring has a `∈` (U+2208), `bench_orchestrator.py` has `→`/`↔`.

This ASCII-cleans exactly the text argparse encodes:

- **9 argparse bench scripts** — module docstring + `help=` strings only — with ASCII equivalents: `—`→`-`, `→`→`->`, `↔`→`<->`, `∈`→`in`, `×`→`x`, `§`→`section`.
- **Deliberately left alone:** comments (incl. the `─` section dividers), function docstrings, and runtime output such as the `█▓░` heatmap glyphs in `bench_skill_activation.py` — argparse never encodes those, so they are not a `--help` crash vector.
- `tests/test_bench_help_ascii.py` — a regression guard that scans every argparse bench script and asserts the module docstring + `help=` strings are ASCII. Auto-covers any new bench script.

## Test plan

- [x] `tests/test_bench_help_ascii.py` — 2 tests (argparse files discovered; their `--help` text is ASCII).
- [x] `python -m pytest tests/ -m "not live" -k bench` → 89 passed.
- [x] `python benchmarks/{bench_claude_matrix,bench_packet,bench_orchestrator,bench_dal_http_s3,bench_cache_hitrate}.py --help` → exit 0 on a cp1252 stdout (previously crashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)