### PR TITLE
fix(bench): dense-backfill CUDA hygiene + xl-sharded skip-dirs cleanup

### DIFF
--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -72,6 +72,9 @@ def _ensure_v2_schema(conn: sqlite3.Connection) -> None:
 _vec_to_blob = vec_to_blob
 
 
+_DEFAULT_CUDA_EMPTY_CACHE_EVERY = 16
+
+
 def backfill_dense_db(
     db_path: str,
     *,
@@ -80,6 +83,7 @@ def backfill_dense_db(
     limit: int | None = None,
     codec=None,
     log_fn=print,
+    cuda_empty_cache_every: int = _DEFAULT_CUDA_EMPTY_CACHE_EVERY,
 ) -> dict:
     """Backfill ``genes.embedding_dense_v2`` on the SQLite DB at ``db_path``.
 
@@ -186,6 +190,13 @@ def backfill_dense_db(
         t0 = time.monotonic()
         processed = 0
         skipped = 0
+        # Track whether we've successfully imported torch and CUDA is
+        # available — once-per-loop check, then per-batch we just check
+        # this flag (avoids re-importing every batch).
+        # Set on first try; subsequent failures (e.g. transient driver
+        # hiccup) gracefully fall back to "no empty_cache" for this run.
+        _cuda_ok: bool | None = None  # None = not probed yet
+        _batches_done = 0
         for start in range(0, len(rows), max(1, batch)):
             chunk = rows[start:start + max(1, batch)]
             encodable = [
@@ -224,6 +235,31 @@ def backfill_dense_db(
                 )
                 processed += len(updates)
             conn.commit()
+
+            # Per-batch GPU-allocator hygiene (#147 follow-up).
+            # PyTorch's caching allocator accumulates freed-but-cached
+            # memory across encode_batch calls. By batch ~60 on a 12 GB
+            # GPU the cache fills to 99 % VRAM and per-call latency
+            # explodes (Factorio shard 2026-05-24: 22 g/s → 1.2 g/s
+            # over ~60 batches). Calling ``torch.cuda.empty_cache()``
+            # every ``cuda_empty_cache_every`` batches returns cached
+            # memory to the global pool, preventing the fragmentation
+            # buildup. No-op on CPU-only / torch-missing hosts.
+            _batches_done += 1
+            if (
+                cuda_empty_cache_every > 0
+                and _batches_done % cuda_empty_cache_every == 0
+                and _cuda_ok is not False
+            ):
+                try:
+                    import torch  # noqa: PLC0415 — lazy, may be missing
+                    if _cuda_ok is None:
+                        _cuda_ok = bool(torch.cuda.is_available())
+                    if _cuda_ok:
+                        torch.cuda.empty_cache()
+                except Exception:  # noqa: BLE001 — torch absent or CUDA error
+                    _cuda_ok = False
+
             elapsed = time.monotonic() - t0
             rate = processed / elapsed if elapsed > 0 else 0.0
             log_fn(

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -96,6 +96,67 @@ from helix_context.shard_schema import (
 from backfill_bgem3_v2 import backfill_dense_db
 
 
+# Module-level codec cache (#147 follow-up, 2026-05-24).
+#
+# Each shard's `_backfill_dense` call used to construct a fresh
+# `BGEM3Codec`, which loaded the BGE-M3 model from scratch onto the GPU.
+# Per-load that's ~2-3 GB of fresh CUDA tensors; over ~5 sequential
+# shards in xl --mode sharded, GPU VRAM saturated (11.9 / 12.0 GB) and
+# the dense backfill rate collapsed to ~0.03 g/s on the 5th shard
+# (dyson-sphere-program, 379 genes). Caching one codec at module level
+# means BGE-M3 is loaded exactly once per build process; the
+# per-batch empty_cache call in `backfill_dense_db` (see #147
+# follow-up in backfill_bgem3_v2.py) handles within-shard hygiene; the
+# `_release_gpu_state` call below handles between-shard hygiene.
+_cached_codec = None
+
+
+def _get_or_create_codec(dim: int, _factory=None):
+    """Lazy module-level codec cache.
+
+    Returns a singleton ``BGEM3Codec(dim=...)`` instance reused across
+    every shard's dense-backfill call. ``_factory`` is a test-only seam
+    that lets the unit test inject a sentinel without loading the real
+    BGE-M3 model.
+    """
+    global _cached_codec
+    if _cached_codec is None or getattr(_cached_codec, "dim", None) != dim:
+        if _factory is not None:
+            _cached_codec = _factory(dim, "cpu")
+            return _cached_codec
+        # Real path: pick device the same way ``backfill_bgem3_v2.main``
+        # does so we stay consistent with the operator script.
+        device = os.environ.get("BGEM3_DEVICE", "").strip()
+        if not device or device.lower() == "auto":
+            try:
+                import torch  # noqa: PLC0415 — optional dep, may be absent
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            except Exception:  # noqa: BLE001
+                device = "cpu"
+        from helix_context.backends.bgem3_codec import BGEM3Codec  # noqa: PLC0415
+        _cached_codec = BGEM3Codec(dim=dim, device=device)
+        log.info("cached codec loaded (dim=%d, device=%s) for cross-shard reuse", dim, device)
+    return _cached_codec
+
+
+def _release_gpu_state() -> None:
+    """Force-release PyTorch CUDA cached memory + run a GC pass.
+
+    Called between shards so PyTorch's caching allocator doesn't
+    accumulate freed-but-cached memory across the shard boundary. No-op
+    on torch-missing / CPU-only hosts (the import is guarded). See
+    tests/test_backfill_cuda_empty_cache.py for the contract pin.
+    """
+    import gc  # noqa: PLC0415
+    gc.collect()
+    try:
+        import torch  # noqa: PLC0415 — optional dep, may be absent
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)-7s %(message)s",
@@ -123,6 +184,15 @@ SKIP_DIRS_COMMON = {
     ".git", "node_modules", "Mono", "MonoBleedingEdge", ".venv", "venv",
     "dist", "build", ".pytest_cache", "target", ".claude", ".serena",
     ".next", ".turbo", ".cache", ".ruff_cache",
+    # Editor / AI tool / vault metadata — never useful for retrieval and
+    # historically polluted xl-sharded (see issue #133 / PR #144).
+    ".vscode", ".codex", ".claude-plugin", ".obsidian",
+    # Git worktree copies — duplicate canonical project content under a
+    # PR-branch path; were the root cause of xl-sharded's gold-label
+    # mismatch (#133 / PR #144). ``_worktrees`` is the top-level
+    # convention; ``.clone`` covers the nested ``.clone/worktrees/...``
+    # variant found under projects like Education on 2026-05-24.
+    "_worktrees", ".clone",
     # Windows system
     "$RECYCLE.BIN", "System Volume Information", "WpSystem",
     "WUDownloadCache", "WindowsApps",
@@ -486,12 +556,20 @@ PROFILES: dict[str, dict] = {
             r"C:\Program Files (x86)\Steam\steamapps\common\The Farmer Was Replaced",
             r"C:\Program Files (x86)\Steam\steamapps\common\Stationeers",
         ],
-        # Game asset / save / cache directories that may sneak through.
+        # Game asset / save / cache directories that may sneak through,
+        # plus the helix-retrieval-upgrade clone (a duplicate of
+        # helix-context that polluted the xl-sharded `projects` shard;
+        # see issue #133 / PR #144), plus EnterpriseRAG-Bench-main
+        # which is the dedicated bench source corpus covered by the
+        # enterprise_rag_{10k,50k,500k} profiles — including it in xl
+        # would double-count and produce a 500K-file long-pole subshard.
         "extra_skip_dirs": {
             "saves", "Saves", "SaveGame", "SaveGames",
             "screenshots", "Screenshots",
             "crashdump", "CrashDump", "Crashes",
             "PlayerData", "Recordings",
+            "helix-retrieval-upgrade",
+            "EnterpriseRAG-Bench-main",
         },
         "extra_filename_filters": [_is_sqlite_sidecar],
     },
@@ -612,8 +690,30 @@ def _backfill_dense(db_path: str) -> dict:
     in the manifest rather than silently producing a dense-dark fixture.
     """
     log.info("dense backfill: %s", db_path)
+    # Cross-shard CUDA-allocator hygiene (#147 follow-up, 2026-05-24):
+    # release any cached GPU memory + Python GC roots from the prior
+    # shard's encode loop before we hand over the cached codec to the
+    # next shard's batch loop. Without this, VRAM creeps up across
+    # ~4-5 shards until the allocator is full and per-call latency
+    # collapses. See tests/test_backfill_cuda_empty_cache.py.
+    _release_gpu_state()
+    # Reuse a single BGE-M3 codec across every shard's backfill instead
+    # of letting backfill_dense_db construct (and load) one per call.
+    # `dim` resolves the same way backfill_dense_db would when codec is
+    # None — through helix.toml's retrieval.dense_embedding_dim — so the
+    # cached-codec path is byte-equivalent.
     try:
-        report = backfill_dense_db(db_path, log_fn=lambda msg: log.info("%s", msg))
+        from helix_context.config import load_config  # noqa: PLC0415
+        dim = int(load_config().retrieval.dense_embedding_dim)
+    except Exception:  # noqa: BLE001
+        dim = 1024
+    codec = _get_or_create_codec(dim=dim)
+    try:
+        report = backfill_dense_db(
+            db_path,
+            codec=codec,
+            log_fn=lambda msg: log.info("%s", msg),
+        )
     except Exception as exc:  # noqa: BLE001 — model load / encode failure
         log.error("dense backfill FAILED for %s: %s", db_path, exc)
         return {

--- a/tests/test_backfill_cuda_empty_cache.py
+++ b/tests/test_backfill_cuda_empty_cache.py
@@ -1,0 +1,244 @@
+"""Regression for the CUDA-allocator rate-decay pathology observed
+during the 500K and xl-sharded build attempts on 2026-05-23/24.
+
+Symptom (Factorio shard at xl --mode sharded, 2026-05-24 12:00-13:04):
+- ingest at 22-30 g/s (healthy)
+- dense backfill starts at 22 g/s
+- after ~3,500 rows: 3.8 g/s
+- after ~4,000 rows: 1.2 g/s (and dropping)
+- GPU: 12,048 / 12,288 MiB used (99 %) — PyTorch's caching allocator
+  has accumulated fragmented memory across ~60 `encode_batch` calls
+
+Same pattern at 500K scale (slack shard): 27 g/s → 0.3 g/s over 11 h.
+
+Fix: periodically call ``torch.cuda.empty_cache()`` inside the batch
+loop so the allocator's freed-but-cached memory is returned to the
+GPU's global pool, preventing fragmentation buildup.
+
+These tests pin:
+
+1. ``empty_cache`` is called at the expected cadence (every
+   ``cuda_empty_cache_every`` batches, default once per ~1 K rows).
+2. The cadence is configurable (parameter + env-var-friendly default).
+3. The call is no-op-safe on a CPU-only or torch-missing environment
+   (i.e., the backfill does not crash without CUDA).
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+
+# --- helpers ------------------------------------------------------------
+
+
+def _make_seeded_db(tmp_path, n_genes: int, content_each: str = "alpha beta gamma"):
+    """Build a tiny SQLite genome with `n_genes` rows of NULL
+    embedding_dense_v2 ready to be backfilled."""
+    p = tmp_path / "seed.db"
+    conn = sqlite3.connect(str(p))
+    # Minimal genes-table shape that satisfies _ensure_v2_schema's
+    # partial-index DDL (needs `chromatin` column) and the backfill
+    # SELECT/UPDATE. embedding_dense_v2 starts NULL so all rows are
+    # eligible.
+    conn.execute(
+        "CREATE TABLE genes ("
+        "gene_id TEXT PRIMARY KEY, content TEXT, "
+        "chromatin INTEGER DEFAULT 0, "
+        "embedding_dense_v2 BLOB"
+        ")"
+    )
+    for i in range(n_genes):
+        conn.execute(
+            "INSERT INTO genes (gene_id, content, chromatin) VALUES (?, ?, ?)",
+            (f"g{i:04d}", content_each, 0),
+        )
+    conn.commit()
+    conn.close()
+    return p
+
+
+class _FakeCodec:
+    """Bytes-correct fake codec — returns deterministic dim-length vectors
+    so the backfill's per-row UPDATE path runs to completion."""
+
+    def __init__(self, dim: int = 1024):
+        self.dim = dim
+        self.encode_batch_calls = 0
+
+    def encode_batch(self, texts, task="passage"):
+        self.encode_batch_calls += 1
+        # Each row gets the same unit vector — exact value doesn't matter,
+        # only that vec_to_blob accepts it.
+        return [[1.0 / self.dim**0.5] * self.dim for _ in texts]
+
+
+# --- tests --------------------------------------------------------------
+
+
+def test_backfill_calls_cuda_empty_cache_at_expected_cadence(tmp_path):
+    """When CUDA is available, ``backfill_dense_db`` should call
+    ``torch.cuda.empty_cache()`` once per ``cuda_empty_cache_every``
+    batches. With default cadence 16 batches and batch=4 (64 rows in
+    real default but 4 makes the test tight), processing 16 batches
+    triggers exactly one empty_cache call."""
+    import backfill_bgem3_v2 as bb
+
+    db = _make_seeded_db(tmp_path, n_genes=64)  # 64 rows / batch=4 = 16 batches
+    codec = _FakeCodec(dim=1024)
+
+    fake_cuda = MagicMock()
+    fake_cuda.is_available.return_value = True
+
+    fake_torch = MagicMock()
+    fake_torch.cuda = fake_cuda
+
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        bb.backfill_dense_db(
+            str(db),
+            dim=1024,
+            batch=4,
+            codec=codec,
+            log_fn=lambda _: None,
+            cuda_empty_cache_every=16,
+        )
+
+    # 64 rows / 4 batch = 16 encode_batch calls
+    assert codec.encode_batch_calls == 16
+    # one empty_cache trigger per 16 batches
+    assert fake_cuda.empty_cache.call_count == 1, (
+        f"expected empty_cache called once per 16 batches, "
+        f"got {fake_cuda.empty_cache.call_count}"
+    )
+
+
+def test_backfill_empty_cache_skipped_when_cuda_unavailable(tmp_path):
+    """If ``torch.cuda.is_available()`` is False (or torch is missing),
+    the backfill must not call ``empty_cache`` — but it also must not
+    crash."""
+    import backfill_bgem3_v2 as bb
+
+    db = _make_seeded_db(tmp_path, n_genes=32)
+    codec = _FakeCodec(dim=1024)
+
+    fake_cuda = MagicMock()
+    fake_cuda.is_available.return_value = False
+
+    fake_torch = MagicMock()
+    fake_torch.cuda = fake_cuda
+
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        bb.backfill_dense_db(
+            str(db), dim=1024, batch=4, codec=codec,
+            log_fn=lambda _: None,
+            cuda_empty_cache_every=4,
+        )
+
+    fake_cuda.empty_cache.assert_not_called()
+
+
+def test_backfill_empty_cache_cadence_configurable(tmp_path):
+    """The cadence is a user-tunable knob: every-N-batches. With cadence=4
+    and 16 batches, empty_cache fires 4 times."""
+    import backfill_bgem3_v2 as bb
+
+    db = _make_seeded_db(tmp_path, n_genes=64)  # 64 / 4 = 16 batches
+    codec = _FakeCodec(dim=1024)
+
+    fake_cuda = MagicMock()
+    fake_cuda.is_available.return_value = True
+
+    fake_torch = MagicMock()
+    fake_torch.cuda = fake_cuda
+
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        bb.backfill_dense_db(
+            str(db), dim=1024, batch=4, codec=codec,
+            log_fn=lambda _: None,
+            cuda_empty_cache_every=4,
+        )
+
+    assert fake_cuda.empty_cache.call_count == 4
+
+
+def test_get_or_create_codec_caches_across_calls():
+    """Cross-shard codec caching — second sharded call must reuse the
+    first call's codec instance, not create a new BGE-M3 model.
+
+    Story (2026-05-24): xl --mode sharded ran factorio + projects +
+    beamng-drive + spaceengineers2 cleanly with the per-batch
+    empty_cache fix above, then dyson-sphere-program (379 genes only)
+    stalled at 0.03 g/s. Diagnosis: each shard called `_backfill_dense`
+    which built a fresh BGE-M3 codec → each model load added ~2-3 GB to
+    GPU; by shard 5 the allocator was 11.9 / 12.0 GB. Old codecs were
+    GC-eligible but the freed memory wasn't returned to GPU pool.
+
+    Fix: cache one codec at module level, reuse across shards.
+    """
+    import build_fixture_matrix as bfm
+
+    # Reset cache so the test starts clean.
+    bfm._cached_codec = None
+
+    sentinel = object()
+
+    def _factory(dim, device):
+        return sentinel
+
+    c1 = bfm._get_or_create_codec(dim=1024, _factory=_factory)
+    c2 = bfm._get_or_create_codec(dim=1024, _factory=_factory)
+    assert c1 is sentinel
+    assert c1 is c2, "second call must reuse the first call's codec"
+
+
+def test_release_gpu_state_no_throw_when_torch_missing():
+    """The cross-shard cleanup helper must be safe on a torch-missing /
+    CPU-only host — must not raise."""
+    import build_fixture_matrix as bfm
+    import builtins
+    real_import = builtins.__import__
+
+    def boom(name, *args, **kwargs):
+        if name == "torch":
+            raise ImportError("simulated torch missing")
+        return real_import(name, *args, **kwargs)
+
+    from unittest.mock import patch
+    with patch("builtins.__import__", side_effect=boom):
+        # Must not raise.
+        bfm._release_gpu_state()
+
+
+def test_backfill_does_not_crash_when_torch_import_fails(tmp_path):
+    """If ``import torch`` raises (e.g., torch missing entirely), the
+    backfill must continue without empty_cache — this preserves the
+    'graceful CPU fallback' posture documented in the codec init."""
+    import backfill_bgem3_v2 as bb
+
+    db = _make_seeded_db(tmp_path, n_genes=16)
+    codec = _FakeCodec(dim=1024)
+
+    # Force `import torch` inside the backfill to raise.
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def boom_import(name, *args, **kwargs):
+        if name == "torch":
+            raise ImportError("simulated torch missing")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=boom_import):
+        # Must complete without raising.
+        result = bb.backfill_dense_db(
+            str(db), dim=1024, batch=4, codec=codec,
+            log_fn=lambda _: None,
+            cuda_empty_cache_every=2,
+        )
+
+    # Should have produced a valid coverage report; the backfill finished.
+    assert result["rows_processed"] == 16


### PR DESCRIPTION
## Summary

Two distinct but related fixes discovered during the 500K EnterpriseRAG and xl-sharded rebuild attempts on 2026-05-23/24, both of which were blocking the fixture builder from completing on a single 12 GB-VRAM host.

1. **Dense-backfill CUDA allocator hygiene** (within-shard + cross-shard).
2. **xl skip-dirs cleanup** — the directory exclusions needed to make the rebuilt xl-sharded fixture clean enough to close #133.

Why one PR: the skip-dirs cleanup was what made the xl rebuild possible *as a validation harness for the CUDA fix*; together they're the empirical case for both. Three commits would feel artificial.

---

## Part 1: Dense-backfill CUDA allocator hygiene

### Problem (validated empirically on Factorio + Slack shards)

PyTorch's CUDA caching allocator accumulates freed-but-cached memory across `encode_batch` calls. Two pathologies surfaced:

**Within a single shard:** after ~60 `encode_batch` calls (~4K rows at batch=64) the allocator fills to ~99 % VRAM and per-call latency explodes.

- Factorio shard (2026-05-24): **22 g/s → 1.2 g/s** over ~60 batches.
- Slack shard (500K, 2026-05-23/24): **27 g/s → 0.3 g/s** over 11 h.
- GPU at 11,932 / 12,288 MiB used, 100 % util, but per-batch latency 90+ s instead of 3 s.

**Across shards:** each shard's `_backfill_dense` constructed a **fresh `BGEM3Codec`**, which loaded a NEW BGE-M3 model onto the GPU. Old codecs were GC-eligible but the freed CUDA memory was never returned to the global pool.

- After 4 sequential shards: VRAM saturated.
- 5th shard (dyson-sphere-program, 379 genes) stalled at **0.03 g/s**, processing 128 rows in 1 h 8 min.

### Fix

Two complementary additions:

| location | fix | knob |
|---|---|---|
| `scripts/backfill_bgem3_v2.py` | New `cuda_empty_cache_every` parameter (default 16 batches ≈ 1 K rows). The drain loop calls `torch.cuda.empty_cache()` at that cadence to return cached memory to the GPU's global pool before fragmentation builds up. | Per-batch within shard |
| `scripts/build_fixture_matrix.py` | Module-level codec cache via `_get_or_create_codec` so BGE-M3 is loaded **exactly once per build process**. Each `_backfill_dense` call invokes `_release_gpu_state` (`gc.collect` + `torch.cuda.empty_cache`) BEFORE handing the cached codec to the next shard, so shard-boundary memory pressure resets. | Cross-shard boundary |

Both fixes are no-op-safe on torch-missing / CPU-only hosts (guarded `import torch` inside try/except).

### Empirical evidence: post-fix xl-sharded full build

12 shards, ~46,000 genes total, 100 % coverage on every shard, **65 min 18 s total wall-clock**.

Per-shard timing:

| shard | genes | backfill | rate sustained |
|---|---:|---:|---:|
| factorio | 5,863 | 207.8 s | 22-30 g/s ✓ (was decaying to 1.2 g/s pre-fix) |
| **projects** (#133 critical) | 27,121 | 947.9 s | 21-28 g/s ✓ |
| beamng-drive | 9,619 | 401.7 s | 22 g/s ✓ |
| spaceengineers2 | 158 | 6.2 s | — |
| **dyson-sphere-program** (5th — the stall-test) | 379 | **35.5 s** | **10.7 g/s** ✓ *(was stuck at 0.03 g/s = 1+ h)* |
| kerbal | 1,016 | 29.2 s | — |
| farmer | 1,020 | 34.0 s | — |
| turing | 254 | 11.3 s | — |
| cities | 82 | 4.5 s | — |
| stationeers | 20 | 1.4 s | — |
| universe-sandbox | 6 | 0.6 s | — |
| satisfactory | 1 | 0.0 s | — |

No crashes, no stalls, no decay.

---

## Part 2: xl skip-dirs cleanup

PR #144 diagnosed the corrupt xl-sharded `projects` shard:
- **Zero genes under canonical `helix-context/`** path
- Content only under `_worktrees/helix-context/*` (PR-branch worktree copies)
- Junk-crawled `.obsidian/`, `.vscode/`, `helix-retrieval-upgrade/` clone, etc.

This commit adds directory exclusions that block all of these at the discovery walk:

```python
SKIP_DIRS_COMMON += {
    ".vscode", ".codex", ".claude-plugin", ".obsidian",
    "_worktrees", ".clone",
}

# xl extra_skip_dirs +=
{"helix-retrieval-upgrade", "EnterpriseRAG-Bench-main"}
```

The `.clone` addition covers a nested `.clone/worktrees/...` variant found under Education on 2026-05-24 — discovered after a first xl rebuild attempt left 1 leak gene.

### Validation against the rebuilt `projects.genome.db`

| check | before (per PR #144) | after this rebuild |
|---|---|---|
| helix-context canonical genes | **0** | **12,387** ✓ |
| `_worktrees/...` (the F:\Projects\_worktrees variety) | full shard | **0** ✓ |
| `.clone/worktrees/...` (Education's nested variant) | (not in PR #144 scope) | **0** ✓ |
| `helix-retrieval-upgrade` clone | present | **0** ✓ |
| `EnterpriseRAG-Bench-main` (~500K-file bench corpus) | present | **0** ✓ |
| `.obsidian` | present | **0** ✓ |
| `.vscode` | present | **0** ✓ |

Top contributors by gene count: helix-context 12,387 / archestra 5,104 / Education 3,885 / headroom-main 3,805 — a realistic "Projects code corpus" shape matching the xl profile's docstring.

---

## Tests

**6 new** in `tests/test_backfill_cuda_empty_cache.py` (all green):

- `test_backfill_calls_cuda_empty_cache_at_expected_cadence`
- `test_backfill_empty_cache_skipped_when_cuda_unavailable`
- `test_backfill_empty_cache_cadence_configurable`
- `test_get_or_create_codec_caches_across_calls` (sentinel via `_factory` seam)
- `test_release_gpu_state_no_throw_when_torch_missing`
- `test_backfill_does_not_crash_when_torch_import_fails`

Existing tests untouched and still green (`test_bench_enterprise_rag.py`, `test_build_fixture_matrix_*` via PR #149).

---

## Cross-references

- **Refs #133** — this rebuilds xl-sharded with canonical `helix-context/` content present and worktree-copy content absent. After this lands + xl-sharded fixture is regenerated on disk, the gold-label-misalignment in #133 should resolve; PR #144's "exclude from default" workaround can be revisited.
- **Refs #147** — empirical follow-up to auto-subshard. Auto-subshard alone wouldn't have fixed the CUDA pathology because even tiny single shards exhibit the rate decay. The two fixes compose: subsharding shrinks per-shard SQLite size; CUDA hygiene fixes encode-rate stability across the full build lifetime.
- Companion to PR #149 (auto-subshard + silent-fail + 500k profile) and PR #148 (bench gold-match path-shape) from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
