### PR TITLE
fix(tagger): eliminate catastrophic backtracking in _KV_PAIR_PATTERN

### DIFF
--- a/helix_context/tagger.py
+++ b/helix_context/tagger.py
@@ -143,9 +143,18 @@ _KV_PATTERNS = [
     (re.compile(r'(?:host|address|bind)\s*[=:]\s*["\']?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|localhost)', re.IGNORECASE), "host"),
 ]
 
-# Patterns that extract key=value pairs
+# Patterns that extract key=value pairs.
+#
+# NB: the key group used to be ``(\w+(?:_\w+)*)`` but ``\w`` already includes
+# ``_``, so the inner alternation ``(?:_\w+)*`` was redundant ambiguity that
+# triggered catastrophic backtracking on underscore-heavy content (e.g.
+# EnterpriseRAG-Bench JSON with keys like ``expected_doc_ids``,
+# ``data_source_id``). A single worker spinning on `tagger.py:439`'s
+# ``finditer(content[:5000])`` hung the build for 60+ minutes on one google-
+# drive shared-drives file. ``(\w+)`` is functionally identical (same match
+# set, since ``\w`` includes ``_``) but has no nested quantifier.
 _KV_PAIR_PATTERN = re.compile(
-    r'(\w+(?:_\w+)*)\s*[=:]\s*["\']?(\d+(?:\.\d+)?(?:s|ms|m|h|mb|gb|kb)?|true|false|[a-zA-Z0-9._:/-]+)["\']?',
+    r'(\w+)\s*[=:]\s*["\']?(\d+(?:\.\d+)?(?:s|ms|m|h|mb|gb|kb)?|true|false|[a-zA-Z0-9._:/-]+)["\']?',
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary

- The KV-pair extractor's key group `(\w+(?:_\w+)*)` is a textbook nested-quantifier regex: since `\w` already includes `_`, the inner alternation creates exponential backtracking on underscore-heavy text.
- Simplified to `(\w+)` — functionally identical match set, no backtracking.

## Why it matters

Discovered during the EnterpriseRAG-Bench-Onyx-full corpus build (511,970 files, 105 shards). A single file worker spun for 60+ minutes on one google_drive shared-drives JSON file with `expected_doc_ids`, `data_source_id`-style keys before py-spy pinpointed the regex. Killed the build twice (v1 hung 5h, v2 hung 25 min on the same shard transition).

## Smoke test

```
upgrade-plan-json-schema-draft.json           26,167B  ->  20 matches in 0.40ms
meter-sanity-checks-sql-queries-v1.json       24,778B  ->  20 matches in 0.52ms
edge-cases-and-failure-modes-autoscaling.json 20,870B  ->  33 matches in 0.41ms
STRESS underscore-chain (1,430B)                       ->   1 match  in 0.02ms
```

All sub-millisecond. Previously hung indefinitely on these inputs.

## Impact

- xl-sharded code-corpus build was unaffected (no underscore-heavy JSON content triggered the pathology)
- 105-shard EnterpriseRAG-Bench build went from "hangs at first shard" to completing in 7h 27min after this fix landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)