### PR TITLE
feat(retrieval): SPLADE pre-filter for dense matmul (Issue #159 Wall-2)

### DIFF
--- a/benchmarks/ablate_dense_prefilter.py
+++ b/benchmarks/ablate_dense_prefilter.py
@@ -203,10 +203,12 @@ def wait_for_ready(
     return 0, last
 
 
-def warmup_daemon(n: int = 2) -> None:
+def warmup_daemon(n: int = 2, timeout_s: float = 300.0) -> None:
     """Fire 2 throwaway /fingerprint calls so subsequent timings exclude
-    first-query model warmup (BGE-M3 + SPLADE GPU load on first hit)."""
-    client = httpx.Client(timeout=60)
+    first-query model warmup (BGE-M3 + SPLADE GPU load on first hit). At
+    105-shard scale the first query also lazy-loads dense matrices across
+    every routed shard, which can take minutes — hence the long timeout."""
+    client = httpx.Client(timeout=timeout_s)
     try:
         for _ in range(n):
             try:
@@ -220,15 +222,21 @@ def warmup_daemon(n: int = 2) -> None:
         client.close()
 
 
-def start_helix(config_path: Path, fixture: Path, boot_log: Path) -> subprocess.Popen:
+def start_helix(
+    config_path: Path, fixture: Path, boot_log: Path, sharded: bool = False,
+) -> subprocess.Popen:
     env = os.environ.copy()
     env["HELIX_CONFIG"] = str(config_path)
     env["HELIX_GENOME_PATH"] = str(fixture)
-    env.pop("HELIX_USE_SHARDS", None)  # single-DB fixture
+    if sharded:
+        env["HELIX_USE_SHARDS"] = "1"
+    else:
+        env.pop("HELIX_USE_SHARDS", None)
     boot_log.parent.mkdir(parents=True, exist_ok=True)
     log_fh = boot_log.open("a", encoding="utf-8")
     log_fh.write(f"\n\n=== boot at {datetime.now(timezone.utc).isoformat()} "
-                 f"config={config_path.name} fixture={fixture.name} ===\n\n")
+                 f"config={config_path.name} fixture={fixture.name} "
+                 f"sharded={sharded} ===\n\n")
     log_fh.flush()
     return subprocess.Popen(
         [sys.executable, "-m", "uvicorn", "helix_context._asgi:app",
@@ -239,12 +247,21 @@ def start_helix(config_path: Path, fixture: Path, boot_log: Path) -> subprocess.
     )
 
 
-def run_recall_bench(needles: list[dict], k: int) -> dict:
-    """Hit /fingerprint per needle, record rank + per-query latency."""
+def run_recall_bench(
+    needles: list[dict], k: int, proc: subprocess.Popen | None = None,
+    query_timeout_s: float = 30,
+) -> dict:
+    """Hit /fingerprint per needle, record rank + per-query latency.
+
+    Aborts cleanly if the daemon process exits mid-bench (OOM, crash). The
+    remaining needles are recorded as None ranks (missed) so the metrics
+    still compute, but a daemon_died flag is set so the caller can report.
+    """
     ranks: list[int | None] = []
     latencies_ms: list[float] = []
     rows = []
-    client = httpx.Client(timeout=30)
+    daemon_died_at: int | None = None
+    client = httpx.Client(timeout=query_timeout_s)
     try:
         for i, n in enumerate(needles, 1):
             gold_rels = {_rel_after_sources(p) for p in n["gold_paths"]}
@@ -261,6 +278,12 @@ def run_recall_bench(needles: list[dict], k: int) -> dict:
                 print(f"    [{i}] {n['id']} ERROR {exc}")
                 ranks.append(None)
                 latencies_ms.append(elapsed_ms)
+                # Did the daemon crash? Check immediately so we abort fast.
+                if proc is not None and proc.poll() is not None:
+                    daemon_died_at = i
+                    print(f"    [{i}] daemon process exited rc={proc.returncode}; "
+                          f"aborting variant after {i}/{len(needles)} queries")
+                    break
                 continue
             hit_rank = None
             for fp in fps:
@@ -306,13 +329,15 @@ def run_recall_bench(needles: list[dict], k: int) -> dict:
         "latency_ms_p95": pct(95),
         "latency_ms_p99": pct(99),
         "latency_ms_mean": statistics.fmean(latencies_ms) if latencies_ms else 0.0,
+        "daemon_died_at": daemon_died_at,
         "rows": rows,
     }
 
 
 def run_variant(
     code: str, label: str, patch: dict, fixture: Path, needles: list[dict],
-    k: int, run_label: str,
+    k: int, run_label: str, sharded: bool, boot_timeout_s: float,
+    query_timeout_s: float,
 ) -> dict:
     print(f"\n{'='*72}\n=== Variant {code}: {label}\n{'='*72}")
     print(f"  patch: {patch}")
@@ -331,11 +356,11 @@ def run_variant(
     time.sleep(3)
 
     boot_log = Path(rf"F:/tmp/helix_ablate_{run_label}_{code}.log")
-    proc = start_helix(tmp_path, fixture, boot_log)
-    print(f"  spawned uvicorn pid={proc.pid}; log={boot_log}")
+    proc = start_helix(tmp_path, fixture, boot_log, sharded=sharded)
+    print(f"  spawned uvicorn pid={proc.pid}; log={boot_log}; sharded={sharded}")
 
-    print(f"  waiting for /health (up to 240s) ...")
-    genes, health = wait_for_ready(proc, timeout_s=240)
+    print(f"  waiting for /health (up to {boot_timeout_s:.0f}s) ...")
+    genes, health = wait_for_ready(proc, timeout_s=boot_timeout_s)
     if genes <= 0:
         print(f"  ERROR: daemon never reached genes>0. last_health={health}")
         try: proc.terminate()
@@ -345,9 +370,15 @@ def run_variant(
 
     print(f"  daemon ready: genes={genes}; warming up (2 throwaway queries) ...")
     warmup_daemon(n=2)
+    if proc.poll() is not None:
+        print(f"  ERROR: daemon died during warmup rc={proc.returncode}")
+        tmp_path.unlink(missing_ok=True)
+        return {"variant": code, "label": label, "error": "daemon-died-during-warmup",
+                "returncode": proc.returncode}
+
     print(f"  running recall bench, n={len(needles)}, k={k} ...")
     t_bench = time.perf_counter()
-    metrics = run_recall_bench(needles, k)
+    metrics = run_recall_bench(needles, k, proc=proc, query_timeout_s=query_timeout_s)
     bench_wall_s = time.perf_counter() - t_bench
     metrics["variant"] = code
     metrics["label"] = label
@@ -355,9 +386,12 @@ def run_variant(
     metrics["bench_wall_s"] = round(bench_wall_s, 1)
     metrics["genes_loaded"] = genes
 
+    died_msg = ""
+    if metrics.get("daemon_died_at") is not None:
+        died_msg = f"  *** DAEMON DIED at query {metrics['daemon_died_at']} ***"
     print(f"  recall@10={metrics['recall@10']:.1f}%  "
           f"p95={metrics['latency_ms_p95']:.0f}ms  "
-          f"bench_wall={bench_wall_s:.1f}s")
+          f"bench_wall={bench_wall_s:.1f}s{died_msg}")
 
     kill_existing_helix()
     wait_for_port_free(11437, timeout_s=30)
@@ -409,6 +443,12 @@ def main() -> int:
                     help="label suffix for result files (e.g., 'smoke', 'full')")
     ap.add_argument("--variants", default="T,A,B,C",
                     help="comma-separated variant codes to run (default all)")
+    ap.add_argument("--sharded", action="store_true",
+                    help="fixture is a sharded main.genome.db (sets HELIX_USE_SHARDS=1)")
+    ap.add_argument("--boot-timeout", type=float, default=240,
+                    help="seconds to wait for /health; bump for sharded fixtures")
+    ap.add_argument("--query-timeout", type=float, default=30,
+                    help="per-/fingerprint timeout in seconds")
     args = ap.parse_args()
 
     if not args.fixture.exists():
@@ -432,7 +472,9 @@ def main() -> int:
     results: list[dict] = []
     for code, label, patch in chosen:
         result = run_variant(code, label, patch, args.fixture, needles,
-                             args.k, run_label)
+                             args.k, run_label, sharded=args.sharded,
+                             boot_timeout_s=args.boot_timeout,
+                             query_timeout_s=args.query_timeout)
         results.append(result)
         # Per-variant artifact (in case full run is interrupted)
         per_path = RESULTS_DIR / f"variant_{code}_{run_label}.json"

--- a/benchmarks/ablate_dense_prefilter.py
+++ b/benchmarks/ablate_dense_prefilter.py
@@ -1,0 +1,457 @@
+r"""Four-run SPLADE pre-filter ablation on EnterpriseRAG-Bench Onyx.
+
+Issue #159 Wall-2 lever, PRD docs/prds/2026-05-26-splade-prefilter-dense-recall.md §5.
+
+Variants:
+  T. Today (baseline)          — splade_enabled=true,  dense_prefilter_enabled=false
+  A. SPLADE off                — splade_enabled=false, dense_prefilter_enabled=false
+  B. Prefilter on, escape=0    — splade_enabled=true,  dense_prefilter_enabled=true, escape=0
+  C. Prefilter on, escape=250  — splade_enabled=true,  dense_prefilter_enabled=true, escape=250
+
+Per variant: patches helix.toml to a temp file, starts the daemon against
+the supplied fixture, runs the EnterpriseRAG questions through /fingerprint
+with per-query wall-clock timing, captures recall@1/3/5/10 + MRR +
+p50/p95/p99 latency. Writes per-variant JSON + a combined comparison table.
+
+Usage:
+  python benchmarks/ablate_dense_prefilter.py --fixture <db_path> --max-questions 100
+  python benchmarks/ablate_dense_prefilter.py --fixture <db_path> --max-questions 10 --label smoke
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+import re
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bench_enterprise_rag import load_needles, _rel_after_sources  # noqa: E402
+
+WORKTREE = Path(__file__).resolve().parent.parent
+BASE_CONFIG = WORKTREE / "helix.toml"
+HEALTH_URL = "http://127.0.0.1:11437/health"
+FINGERPRINT_URL = "http://127.0.0.1:11437/fingerprint"
+NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+RESULTS_DIR = WORKTREE / "benchmarks" / "results" / "ablate_dense_prefilter"
+
+
+VARIANTS: list[tuple[str, str, dict]] = [
+    (
+        "T",
+        "Today (baseline)",
+        {},  # No patch — current helix.toml
+    ),
+    (
+        "A",
+        "SPLADE off",
+        {"ingestion": {"splade_enabled": False}},
+    ),
+    (
+        "B",
+        "Prefilter on, escape=0",
+        {"retrieval": {
+            "dense_prefilter_enabled": True,
+            "dense_prefilter_escape_budget": 0,
+        }},
+    ),
+    (
+        "C",
+        "Prefilter on, escape=250",
+        {"retrieval": {
+            "dense_prefilter_enabled": True,
+            "dense_prefilter_escape_budget": 250,
+        }},
+    ),
+]
+
+
+_SECTION_RE = re.compile(r"^\[([^\]]+)\]\s*$")
+
+
+def _toml_value(v) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    if isinstance(v, str):
+        return f'"{v}"'
+    raise ValueError(f"unsupported TOML value type for ablation patch: {type(v)} {v!r}")
+
+
+def write_patched_toml(patch: dict[str, dict], dest: Path) -> None:
+    """Apply a {section: {key: value}} patch by line-level replacement on the
+    base helix.toml. Keys must already exist in the section (we only flip
+    existing values for the ablation — no append semantics needed).
+    """
+    text = BASE_CONFIG.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+
+    # Group: walk lines, track current section, replace matching keys.
+    current_section: str | None = None
+    out: list[str] = []
+    pending = {sec: dict(kvs) for sec, kvs in patch.items()}
+    for line in lines:
+        m = _SECTION_RE.match(line.strip())
+        if m:
+            current_section = m.group(1)
+            out.append(line)
+            continue
+        if current_section in pending and pending[current_section]:
+            stripped = line.lstrip()
+            for key in list(pending[current_section]):
+                # Match "key = ..." possibly with leading whitespace and a
+                # trailing comment. Be tolerant of spacing variants.
+                kre = re.compile(rf"^(\s*){re.escape(key)}\s*=\s*[^#\n]*(\s*#.*)?$")
+                if kre.match(line):
+                    new_val = _toml_value(pending[current_section][key])
+                    indent_m = re.match(r"^(\s*)", line)
+                    indent = indent_m.group(1) if indent_m else ""
+                    comment_m = re.search(r"(\s*#.*)$", line)
+                    comment = comment_m.group(1) if comment_m else ""
+                    out.append(f"{indent}{key} = {new_val}{comment}\n")
+                    pending[current_section].pop(key)
+                    break
+            else:
+                out.append(line)
+            continue
+        out.append(line)
+
+    leftover = {s: ks for s, ks in pending.items() if ks}
+    if leftover:
+        raise RuntimeError(
+            f"patch keys not found in base helix.toml: {leftover}. "
+            "Add them to helix.toml first or extend the patcher."
+        )
+    dest.write_text("".join(out), encoding="utf-8")
+
+
+def kill_existing_helix() -> None:
+    try:
+        subprocess.run(
+            [
+                "powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+                "Get-CimInstance Win32_Process -Filter \"Name='python.exe'\" | "
+                "Where-Object { $_.CommandLine -match 'uvicorn helix_context._asgi' "
+                "-and $_.ProcessId -ne $PID } | ForEach-Object { "
+                "Stop-Process -Id $_.ProcessId -Force }",
+            ],
+            check=False, capture_output=True, timeout=15,
+            creationflags=NO_WINDOW,
+        )
+    except Exception:
+        pass
+
+
+def wait_for_port_free(port: int = 11437, timeout_s: float = 30) -> bool:
+    """After kill, the OS may take a few seconds to release the listen socket.
+    Poll until nothing is listening on the port, or timeout."""
+    deadline = time.perf_counter() + timeout_s
+    while time.perf_counter() < deadline:
+        try:
+            r = subprocess.run(
+                ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+                 f"(Get-NetTCPConnection -State Listen -LocalPort {port} "
+                 f"-ErrorAction SilentlyContinue | Measure-Object).Count"],
+                capture_output=True, text=True, timeout=5,
+                creationflags=NO_WINDOW,
+            )
+            if r.returncode == 0 and r.stdout.strip() == "0":
+                return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+def wait_for_ready(
+    proc: subprocess.Popen, timeout_s: float = 240,
+) -> tuple[int, dict | None]:
+    """Poll /health via httpx until genes>0. Aborts early if the daemon
+    process exits (poll() not None means dead).
+    """
+    deadline = time.perf_counter() + timeout_s
+    last = None
+    client = httpx.Client(timeout=8)
+    try:
+        while time.perf_counter() < deadline:
+            if proc.poll() is not None:
+                return 0, {"error": f"daemon process exited rc={proc.returncode}"}
+            try:
+                r = client.get(HEALTH_URL)
+                if r.status_code == 200:
+                    data = r.json()
+                    last = data
+                    if data.get("genes", 0) > 0:
+                        return data["genes"], data
+            except Exception:
+                pass
+            time.sleep(2)
+    finally:
+        client.close()
+    return 0, last
+
+
+def warmup_daemon(n: int = 2) -> None:
+    """Fire 2 throwaway /fingerprint calls so subsequent timings exclude
+    first-query model warmup (BGE-M3 + SPLADE GPU load on first hit)."""
+    client = httpx.Client(timeout=60)
+    try:
+        for _ in range(n):
+            try:
+                client.post(FINGERPRINT_URL, json={
+                    "query": "warmup query for the helix daemon",
+                    "max_results": 10, "score_floor": 0.0,
+                })
+            except Exception:
+                pass
+    finally:
+        client.close()
+
+
+def start_helix(config_path: Path, fixture: Path, boot_log: Path) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["HELIX_CONFIG"] = str(config_path)
+    env["HELIX_GENOME_PATH"] = str(fixture)
+    env.pop("HELIX_USE_SHARDS", None)  # single-DB fixture
+    boot_log.parent.mkdir(parents=True, exist_ok=True)
+    log_fh = boot_log.open("a", encoding="utf-8")
+    log_fh.write(f"\n\n=== boot at {datetime.now(timezone.utc).isoformat()} "
+                 f"config={config_path.name} fixture={fixture.name} ===\n\n")
+    log_fh.flush()
+    return subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "helix_context._asgi:app",
+         "--host", "127.0.0.1", "--port", "11437"],
+        cwd=str(WORKTREE), env=env,
+        stdout=log_fh, stderr=subprocess.STDOUT,
+        creationflags=NO_WINDOW,
+    )
+
+
+def run_recall_bench(needles: list[dict], k: int) -> dict:
+    """Hit /fingerprint per needle, record rank + per-query latency."""
+    ranks: list[int | None] = []
+    latencies_ms: list[float] = []
+    rows = []
+    client = httpx.Client(timeout=30)
+    try:
+        for i, n in enumerate(needles, 1):
+            gold_rels = {_rel_after_sources(p) for p in n["gold_paths"]}
+            gold_rels = {r for r in gold_rels if r}
+            t0 = time.perf_counter()
+            try:
+                resp = client.post(FINGERPRINT_URL, json={
+                    "query": n["question"], "max_results": k, "score_floor": 0.0,
+                })
+                elapsed_ms = (time.perf_counter() - t0) * 1000.0
+                fps = resp.json().get("fingerprints", [])
+            except Exception as exc:
+                elapsed_ms = (time.perf_counter() - t0) * 1000.0
+                print(f"    [{i}] {n['id']} ERROR {exc}")
+                ranks.append(None)
+                latencies_ms.append(elapsed_ms)
+                continue
+            hit_rank = None
+            for fp in fps:
+                rel = _rel_after_sources(fp.get("source", "")) or ""
+                if rel in gold_rels:
+                    hit_rank = fp["rank"]
+                    break
+            ranks.append(hit_rank)
+            latencies_ms.append(elapsed_ms)
+            rows.append({"id": n["id"], "type": n["type"],
+                         "hit_rank": hit_rank, "latency_ms": round(elapsed_ms, 1),
+                         "n_returned": len(fps), "n_gold": len(gold_rels)})
+            if i % 25 == 0:
+                print(f"    [{i}/{len(needles)}] ranks={hit_rank} latency_ms={elapsed_ms:.0f}")
+    finally:
+        client.close()
+
+    def recall_at(kk: int) -> float:
+        hits = sum(1 for r in ranks if r is not None and r < kk)
+        return hits / len(ranks) * 100 if ranks else 0.0
+
+    mrr = (sum(1.0 / (r + 1) for r in ranks if r is not None) / len(ranks)
+           if ranks else 0.0)
+    latencies_sorted = sorted(latencies_ms)
+    n_lat = len(latencies_sorted)
+
+    def pct(p: float) -> float:
+        if n_lat == 0:
+            return 0.0
+        idx = max(0, min(n_lat - 1, int(round(p / 100 * (n_lat - 1)))))
+        return latencies_sorted[idx]
+
+    return {
+        "n_questions": len(ranks),
+        "k": k,
+        "recall@1": recall_at(1),
+        "recall@3": recall_at(3),
+        "recall@5": recall_at(5),
+        "recall@10": recall_at(10),
+        "mrr": mrr,
+        "missed": sum(1 for r in ranks if r is None),
+        "latency_ms_p50": pct(50),
+        "latency_ms_p95": pct(95),
+        "latency_ms_p99": pct(99),
+        "latency_ms_mean": statistics.fmean(latencies_ms) if latencies_ms else 0.0,
+        "rows": rows,
+    }
+
+
+def run_variant(
+    code: str, label: str, patch: dict, fixture: Path, needles: list[dict],
+    k: int, run_label: str,
+) -> dict:
+    print(f"\n{'='*72}\n=== Variant {code}: {label}\n{'='*72}")
+    print(f"  patch: {patch}")
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".toml", delete=False, encoding="utf-8",
+    ) as tmp:
+        tmp_path = Path(tmp.name)
+    write_patched_toml(patch, tmp_path)
+
+    print(f"  patched config: {tmp_path}")
+    kill_existing_helix()
+    print(f"  waiting for port 11437 to be released ...")
+    if not wait_for_port_free(11437, timeout_s=30):
+        print(f"  WARN: port 11437 still listening after 30s; continuing anyway")
+    time.sleep(3)
+
+    boot_log = Path(rf"F:/tmp/helix_ablate_{run_label}_{code}.log")
+    proc = start_helix(tmp_path, fixture, boot_log)
+    print(f"  spawned uvicorn pid={proc.pid}; log={boot_log}")
+
+    print(f"  waiting for /health (up to 240s) ...")
+    genes, health = wait_for_ready(proc, timeout_s=240)
+    if genes <= 0:
+        print(f"  ERROR: daemon never reached genes>0. last_health={health}")
+        try: proc.terminate()
+        except Exception: pass
+        tmp_path.unlink(missing_ok=True)
+        return {"variant": code, "label": label, "error": "daemon-not-ready", "health": health}
+
+    print(f"  daemon ready: genes={genes}; warming up (2 throwaway queries) ...")
+    warmup_daemon(n=2)
+    print(f"  running recall bench, n={len(needles)}, k={k} ...")
+    t_bench = time.perf_counter()
+    metrics = run_recall_bench(needles, k)
+    bench_wall_s = time.perf_counter() - t_bench
+    metrics["variant"] = code
+    metrics["label"] = label
+    metrics["patch"] = patch
+    metrics["bench_wall_s"] = round(bench_wall_s, 1)
+    metrics["genes_loaded"] = genes
+
+    print(f"  recall@10={metrics['recall@10']:.1f}%  "
+          f"p95={metrics['latency_ms_p95']:.0f}ms  "
+          f"bench_wall={bench_wall_s:.1f}s")
+
+    kill_existing_helix()
+    wait_for_port_free(11437, timeout_s=30)
+    tmp_path.unlink(missing_ok=True)
+    time.sleep(5)
+    return metrics
+
+
+def print_comparison_table(results: list[dict]) -> None:
+    print(f"\n{'='*88}")
+    print(f"=== ABLATION RESULTS — Issue #159 Wall-2 SPLADE pre-filter")
+    print(f"{'='*88}")
+    print(f"{'Code':<5} {'Label':<28} {'R@1':>6} {'R@3':>6} {'R@5':>6} {'R@10':>6} "
+          f"{'MRR':>6} {'p50ms':>7} {'p95ms':>7}")
+    print("-" * 88)
+    for r in results:
+        if "error" in r:
+            print(f"{r['variant']:<5} {r['label']:<28} ERROR: {r['error']}")
+            continue
+        print(f"{r['variant']:<5} {r['label']:<28} "
+              f"{r['recall@1']:>5.1f}% {r['recall@3']:>5.1f}% "
+              f"{r['recall@5']:>5.1f}% {r['recall@10']:>5.1f}% "
+              f"{r['mrr']:>6.3f} {r['latency_ms_p50']:>7.0f} "
+              f"{r['latency_ms_p95']:>7.0f}")
+
+    # Deltas vs T
+    by_code = {r["variant"]: r for r in results if "error" not in r}
+    if "T" in by_code:
+        T = by_code["T"]
+        print(f"\n=== Deltas vs T (recall@10 / p95 latency) ===")
+        for code in ("A", "B", "C"):
+            if code in by_code:
+                v = by_code[code]
+                d_r10 = v["recall@10"] - T["recall@10"]
+                d_p95 = v["latency_ms_p95"] - T["latency_ms_p95"]
+                print(f"  {code} vs T:  recall@10  {d_r10:+.1f}pp     "
+                      f"p95  {d_p95:+.0f}ms")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--fixture", required=True, type=Path)
+    ap.add_argument("--max-questions", type=int, default=100)
+    ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--types", default="basic,semantic,intra_document_reasoning",
+                    help="comma-separated question types")
+    ap.add_argument("--label", default="full",
+                    help="label suffix for result files (e.g., 'smoke', 'full')")
+    ap.add_argument("--variants", default="T,A,B,C",
+                    help="comma-separated variant codes to run (default all)")
+    args = ap.parse_args()
+
+    if not args.fixture.exists():
+        print(f"ERROR: fixture not found: {args.fixture}", file=sys.stderr)
+        return 2
+
+    types = [t.strip() for t in args.types.split(",")] if args.types else None
+    needles = load_needles(max_questions=args.max_questions, question_types=types)
+    print(f"loaded {len(needles)} needles from EnterpriseRAG-Bench questions.jsonl")
+    print(f"types: {types}")
+    print(f"fixture: {args.fixture}")
+
+    selected = set(args.variants.split(","))
+    chosen = [(c, l, p) for c, l, p in VARIANTS if c in selected]
+    print(f"variants: {[c for c, _, _ in chosen]}")
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = int(time.time())
+    run_label = f"{args.label}_{ts}"
+
+    results: list[dict] = []
+    for code, label, patch in chosen:
+        result = run_variant(code, label, patch, args.fixture, needles,
+                             args.k, run_label)
+        results.append(result)
+        # Per-variant artifact (in case full run is interrupted)
+        per_path = RESULTS_DIR / f"variant_{code}_{run_label}.json"
+        per_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    print_comparison_table(results)
+
+    summary_path = RESULTS_DIR / f"ablation_{run_label}.json"
+    summary_path.write_text(json.dumps({
+        "fixture": str(args.fixture),
+        "max_questions": args.max_questions,
+        "types": types,
+        "k": args.k,
+        "ts": ts,
+        "results": results,
+    }, indent=2), encoding="utf-8")
+    print(f"\nwritten: {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results/ablate_dense_prefilter/ablation_full_1779831899.json
+++ b/benchmarks/results/ablate_dense_prefilter/ablation_full_1779831899.json
@@ -1,0 +1,3311 @@
+{
+  "fixture": "F:\\Projects\\helix-context\\genomes\\bench\\matrix\\enterprise_rag_10k_w16000.db",
+  "max_questions": 100,
+  "types": [
+    "basic",
+    "semantic",
+    "intra_document_reasoning"
+  ],
+  "k": 10,
+  "ts": 1779831899,
+  "results": [
+    {
+      "n_questions": 100,
+      "k": 10,
+      "recall@1": 49.0,
+      "recall@3": 56.99999999999999,
+      "recall@5": 59.0,
+      "recall@10": 60.0,
+      "mrr": 0.5333333333333333,
+      "missed": 40,
+      "latency_ms_p50": 1857.4065000066184,
+      "latency_ms_p95": 2336.929199998849,
+      "latency_ms_p99": 2515.5530999982147,
+      "latency_ms_mean": 1856.6203209993546,
+      "rows": [
+        {
+          "id": "qst_0001",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1567.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0002",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1545.3,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1446.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2144.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1547.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0006",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1836.1,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0007",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2065.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0008",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1520.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0009",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2222.0,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0010",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1735.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0011",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1497.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0012",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1847.1,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0013",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1627.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0014",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1858.1,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0015",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2032.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0016",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1697.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0017",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1651.5,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0018",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1930.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0019",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2119.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0020",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2213.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0021",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2002.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0022",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1319.7,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0023",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1892.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0024",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2115.8,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0025",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1723.8,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0026",
+          "type": "basic",
+          "hit_rank": 5,
+          "latency_ms": 2166.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0027",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1992.1,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0028",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1674.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0029",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1785.4,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0030",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1880.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0031",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1607.2,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0032",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1696.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0033",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2247.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0034",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1516.8,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0035",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2025.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0036",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 1862.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0037",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2076.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0038",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1857.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0039",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1879.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0040",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1803.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0041",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2191.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0042",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1950.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0043",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 2336.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0044",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1922.1,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0045",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1857.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0046",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2407.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0047",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1334.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0048",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1652.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0049",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2359.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0050",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1788.9,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0051",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1900.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0052",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1633.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0053",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1629.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0054",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1693.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0055",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2519.2,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0056",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2156.4,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0057",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1798.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0058",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2178.4,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0059",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1880.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0060",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1676.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0061",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1554.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0062",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1880.0,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0063",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2084.1,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0064",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1673.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0065",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2515.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0066",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2172.7,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0067",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1644.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0068",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1969.8,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0069",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2032.7,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0070",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2006.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0071",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1786.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0072",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1592.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0073",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1641.5,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0074",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1903.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0075",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1438.9,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0076",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1935.0,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0077",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1948.6,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0078",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1595.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0079",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2369.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0080",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2039.3,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0081",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1656.3,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0082",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1696.7,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0083",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1956.3,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0084",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2299.5,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0085",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1653.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0086",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1739.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0087",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1741.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0088",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1604.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0089",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1680.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0090",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1947.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0091",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1669.9,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0092",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2009.6,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0093",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1739.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0094",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1726.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0095",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1628.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0096",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1722.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0097",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1625.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0098",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2239.0,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0099",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1498.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0100",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1941.6,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "T",
+      "label": "Today (baseline)",
+      "patch": {},
+      "bench_wall_s": 185.7,
+      "genes_loaded": 10167
+    },
+    {
+      "n_questions": 100,
+      "k": 10,
+      "recall@1": 49.0,
+      "recall@3": 56.99999999999999,
+      "recall@5": 59.0,
+      "recall@10": 60.0,
+      "mrr": 0.5333333333333333,
+      "missed": 40,
+      "latency_ms_p50": 1208.0592999991495,
+      "latency_ms_p95": 1411.1725999973714,
+      "latency_ms_p99": 1635.394400000223,
+      "latency_ms_mean": 1217.8743989993382,
+      "rows": [
+        {
+          "id": "qst_0001",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1177.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0002",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1150.6,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1146.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1238.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1091.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0006",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1260.3,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0007",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1635.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0008",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1145.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0009",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1307.2,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0010",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1207.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0011",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1003.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0012",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1240.0,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0013",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1167.3,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0014",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1150.2,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0015",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1221.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0016",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1112.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0017",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1128.5,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0018",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1326.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0019",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1334.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0020",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1270.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0021",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1217.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0022",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1042.6,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0023",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1086.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0024",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1251.5,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0025",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1311.9,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0026",
+          "type": "basic",
+          "hit_rank": 5,
+          "latency_ms": 1400.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0027",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1179.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0028",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1067.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0029",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1181.4,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0030",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1245.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0031",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1074.7,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0032",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1183.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0033",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1300.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0034",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1107.2,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0035",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1174.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0036",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 1210.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0037",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1196.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0038",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1170.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0039",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1194.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0040",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1473.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0041",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1311.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0042",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1091.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0043",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 1240.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0044",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1084.9,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0045",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1110.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0046",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1436.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0047",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1038.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0048",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1226.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0049",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1308.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0050",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1119.0,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0051",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1306.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0052",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1197.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0053",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1297.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0054",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1411.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0055",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1471.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0056",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1331.5,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0057",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1352.0,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0058",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1346.0,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0059",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1329.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0060",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1264.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0061",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1152.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0062",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1274.6,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0063",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1062.8,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0064",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1144.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0065",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1227.1,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0066",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1217.9,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0067",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1208.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0068",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1273.3,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0069",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1318.0,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0070",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1256.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0071",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1284.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0072",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1194.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0073",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1214.5,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0074",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1179.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0075",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1043.6,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0076",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1321.0,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0077",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1091.2,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0078",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1157.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0079",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1272.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0080",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1689.9,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0081",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1287.1,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0082",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1087.7,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0083",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1397.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0084",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1295.8,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0085",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1123.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0086",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1192.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0087",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1179.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0088",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1047.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0089",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1008.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0090",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1011.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0091",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1114.3,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0092",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1130.9,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0093",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1094.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0094",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1257.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0095",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1297.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0096",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1126.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0097",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1193.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0098",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1343.2,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0099",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1080.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0100",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1271.6,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "A",
+      "label": "SPLADE off",
+      "patch": {
+        "ingestion": {
+          "splade_enabled": false
+        }
+      },
+      "bench_wall_s": 121.8,
+      "genes_loaded": 10167
+    },
+    {
+      "n_questions": 100,
+      "k": 10,
+      "recall@1": 49.0,
+      "recall@3": 56.99999999999999,
+      "recall@5": 59.0,
+      "recall@10": 60.0,
+      "mrr": 0.5333333333333333,
+      "missed": 40,
+      "latency_ms_p50": 1815.6983999942895,
+      "latency_ms_p95": 2348.267499997746,
+      "latency_ms_p99": 2451.923699998588,
+      "latency_ms_mean": 1859.0385430000606,
+      "rows": [
+        {
+          "id": "qst_0001",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1827.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0002",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1573.4,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1487.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2348.3,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1544.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0006",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1887.1,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0007",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2131.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0008",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1792.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0009",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2493.3,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0010",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1715.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0011",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1378.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0012",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1734.9,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0013",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1710.2,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0014",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1799.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0015",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1840.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0016",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1759.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0017",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1678.5,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0018",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2134.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0019",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2103.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0020",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2036.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0021",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1774.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0022",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1283.9,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0023",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1929.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0024",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2051.9,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0025",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1920.6,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0026",
+          "type": "basic",
+          "hit_rank": 5,
+          "latency_ms": 2173.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0027",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1957.3,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0028",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1504.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0029",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1873.5,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0030",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1995.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0031",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1616.4,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0032",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1665.1,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0033",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2099.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0034",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1631.3,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0035",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1956.6,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0036",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 1768.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0037",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1981.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0038",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2248.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0039",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1625.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0040",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1721.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0041",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2176.0,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0042",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2043.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0043",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 2346.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0044",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1739.8,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0045",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1768.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0046",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2360.2,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0047",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1589.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0048",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1631.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0049",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2235.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0050",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1672.0,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0051",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2067.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0052",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1649.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0053",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1556.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0054",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1839.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0055",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2451.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0056",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2136.1,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0057",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1815.7,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0058",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2287.7,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0059",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1783.7,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0060",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1551.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0061",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1484.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0062",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1934.1,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0063",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1928.1,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0064",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1627.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0065",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2448.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0066",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2301.8,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0067",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1760.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0068",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1826.2,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0069",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1960.9,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0070",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1970.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0071",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1794.6,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0072",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1529.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0073",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1564.5,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0074",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1823.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0075",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1486.7,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0076",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1970.2,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0077",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2099.8,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0078",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1668.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0079",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2370.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0080",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2117.2,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0081",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1603.7,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0082",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1813.9,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0083",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1895.9,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0084",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2241.5,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0085",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1800.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0086",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1814.8,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0087",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1654.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0088",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1640.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0089",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1688.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0090",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1851.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0091",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1833.8,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0092",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2020.6,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0093",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1713.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0094",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1772.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0095",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1625.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0096",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1551.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0097",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1867.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0098",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2152.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0099",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1430.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0100",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1801.0,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "B",
+      "label": "Prefilter on, escape=0",
+      "patch": {
+        "retrieval": {
+          "dense_prefilter_enabled": true,
+          "dense_prefilter_escape_budget": 0
+        }
+      },
+      "bench_wall_s": 185.9,
+      "genes_loaded": 10167
+    },
+    {
+      "n_questions": 100,
+      "k": 10,
+      "recall@1": 49.0,
+      "recall@3": 56.99999999999999,
+      "recall@5": 59.0,
+      "recall@10": 60.0,
+      "mrr": 0.5333333333333333,
+      "missed": 40,
+      "latency_ms_p50": 1824.856200000795,
+      "latency_ms_p95": 2322.5053000060143,
+      "latency_ms_p99": 2458.556400000816,
+      "latency_ms_mean": 1853.3532580001338,
+      "rows": [
+        {
+          "id": "qst_0001",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1636.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0002",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1746.2,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1452.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2262.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1690.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0006",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1770.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0007",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2182.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0008",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1669.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0009",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2458.6,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0010",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1910.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0011",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1398.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0012",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1731.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0013",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1607.5,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0014",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1988.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0015",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2120.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0016",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1667.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0017",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1601.8,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0018",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2135.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0019",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2082.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0020",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2107.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0021",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1898.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0022",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1289.0,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0023",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1883.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0024",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2004.1,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0025",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1929.4,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0026",
+          "type": "basic",
+          "hit_rank": 5,
+          "latency_ms": 2209.0,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0027",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1916.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0028",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1469.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0029",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1867.6,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0030",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1756.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0031",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1695.5,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0032",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1579.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0033",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2128.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0034",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1780.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0035",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1959.4,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0036",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 1832.3,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0037",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2064.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0038",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1915.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0039",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1676.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0040",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1740.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0041",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2243.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0042",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1983.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0043",
+          "type": "basic",
+          "hit_rank": 2,
+          "latency_ms": 2423.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0044",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 1729.5,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0045",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1727.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0046",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2470.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0047",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1450.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0048",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1552.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0049",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2212.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0050",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1680.2,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0051",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1824.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0052",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1723.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0053",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1622.6,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0054",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1780.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0055",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2455.0,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0056",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2162.9,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0057",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1845.9,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0058",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2107.0,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0059",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1997.7,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0060",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1665.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0061",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1493.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0062",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2005.6,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0063",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2011.6,
+          "n_returned": 8,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0064",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1568.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0065",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2414.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0066",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 2299.4,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0067",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1846.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0068",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1968.4,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0069",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2035.9,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0070",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2038.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0071",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1704.7,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0072",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1602.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0073",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1569.9,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0074",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1698.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0075",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1408.7,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0076",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1992.4,
+          "n_returned": 3,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0077",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1980.2,
+          "n_returned": 6,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0078",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1506.7,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0079",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2152.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0080",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2069.1,
+          "n_returned": 5,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0081",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1612.1,
+          "n_returned": 7,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0082",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1629.7,
+          "n_returned": 4,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0083",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1949.0,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0084",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 2120.7,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0085",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1678.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0086",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1858.2,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0087",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1742.9,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0088",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1627.0,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0089",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1627.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0090",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1925.1,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0091",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1708.8,
+          "n_returned": 2,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0092",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1925.4,
+          "n_returned": 9,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0093",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1627.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0094",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1801.3,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0095",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 1788.8,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0096",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1637.2,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0097",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1573.5,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0098",
+          "type": "basic",
+          "hit_rank": 1,
+          "latency_ms": 2322.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0099",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 1545.4,
+          "n_returned": 1,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0100",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 1789.9,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "C",
+      "label": "Prefilter on, escape=250",
+      "patch": {
+        "retrieval": {
+          "dense_prefilter_enabled": true,
+          "dense_prefilter_escape_budget": 250
+        }
+      },
+      "bench_wall_s": 185.4,
+      "genes_loaded": 10167
+    }
+  ]
+}

--- a/benchmarks/results/ablate_dense_prefilter/ablation_onyx_full_smoke3_postreboot_1779837749.json
+++ b/benchmarks/results/ablate_dense_prefilter/ablation_onyx_full_smoke3_postreboot_1779837749.json
@@ -1,0 +1,227 @@
+{
+  "fixture": "F:\\Projects\\helix-context\\genomes\\bench\\matrix-sharded\\enterprise_rag_onyx_full\\main.genome.db",
+  "max_questions": 5,
+  "types": [
+    "basic",
+    "semantic",
+    "intra_document_reasoning"
+  ],
+  "k": 10,
+  "ts": 1779837749,
+  "results": [
+    {
+      "n_questions": 5,
+      "k": 10,
+      "recall@1": 20.0,
+      "recall@3": 20.0,
+      "recall@5": 40.0,
+      "recall@10": 40.0,
+      "mrr": 0.25,
+      "missed": 3,
+      "latency_ms_p50": 477125.6802999999,
+      "latency_ms_p95": 600014.728,
+      "latency_ms_p99": 600014.728,
+      "latency_ms_mean": 499620.26216000004,
+      "daemon_died_at": null,
+      "rows": [
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 477125.7,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 427238.8,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 393710.8,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "T",
+      "label": "Today (baseline)",
+      "patch": {},
+      "bench_wall_s": 2498.1,
+      "genes_loaded": 850500
+    },
+    {
+      "n_questions": 5,
+      "k": 10,
+      "recall@1": 20.0,
+      "recall@3": 20.0,
+      "recall@5": 40.0,
+      "recall@10": 40.0,
+      "mrr": 0.25,
+      "missed": 3,
+      "latency_ms_p50": 290494.4411000006,
+      "latency_ms_p95": 506417.23860000004,
+      "latency_ms_p99": 506417.23860000004,
+      "latency_ms_mean": 331455.1243400003,
+      "daemon_died_at": null,
+      "rows": [
+        {
+          "id": "qst_0001",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 506417.2,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0002",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 290494.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 288639.1,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 301275.4,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 270449.5,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "A",
+      "label": "SPLADE off",
+      "patch": {
+        "ingestion": {
+          "splade_enabled": false
+        }
+      },
+      "bench_wall_s": 1657.3,
+      "genes_loaded": 850500
+    },
+    {
+      "n_questions": 5,
+      "k": 10,
+      "recall@1": 20.0,
+      "recall@3": 20.0,
+      "recall@5": 40.0,
+      "recall@10": 40.0,
+      "mrr": 0.25,
+      "missed": 3,
+      "latency_ms_p50": 426604.4649000005,
+      "latency_ms_p95": 600003.1622000006,
+      "latency_ms_p99": 600003.1622000006,
+      "latency_ms_mean": 488076.10626000026,
+      "daemon_died_at": null,
+      "rows": [
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 426604.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 424827.6,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 388943.9,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "B",
+      "label": "Prefilter on, escape=0",
+      "patch": {
+        "retrieval": {
+          "dense_prefilter_enabled": true,
+          "dense_prefilter_escape_budget": 0
+        }
+      },
+      "bench_wall_s": 2440.4,
+      "genes_loaded": 850500
+    },
+    {
+      "n_questions": 5,
+      "k": 10,
+      "recall@1": 20.0,
+      "recall@3": 20.0,
+      "recall@5": 40.0,
+      "recall@10": 40.0,
+      "mrr": 0.25,
+      "missed": 3,
+      "latency_ms_p50": 433625.9229999996,
+      "latency_ms_p95": 600014.2769000013,
+      "latency_ms_p99": 600014.2769000013,
+      "latency_ms_mean": 491386.85759999976,
+      "daemon_died_at": null,
+      "rows": [
+        {
+          "id": "qst_0003",
+          "type": "basic",
+          "hit_rank": 0,
+          "latency_ms": 433625.9,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0004",
+          "type": "basic",
+          "hit_rank": null,
+          "latency_ms": 429882.5,
+          "n_returned": 10,
+          "n_gold": 1
+        },
+        {
+          "id": "qst_0005",
+          "type": "basic",
+          "hit_rank": 3,
+          "latency_ms": 393405.3,
+          "n_returned": 10,
+          "n_gold": 1
+        }
+      ],
+      "variant": "C",
+      "label": "Prefilter on, escape=250",
+      "patch": {
+        "retrieval": {
+          "dense_prefilter_enabled": true,
+          "dense_prefilter_escape_budget": 250
+        }
+      },
+      "bench_wall_s": 2457.0,
+      "genes_loaded": 850500
+    }
+  ]
+}

--- a/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
+++ b/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
@@ -1,0 +1,161 @@
+# PRD: SPLADE pre-filter for dense recall
+
+**Date:** 2026-05-26
+**Author:** Claude Opus 4.7 (with Max)
+**Status:** Approved — design signed off 2026-05-26. Implementation on `perf/dense-prefilter-via-splade-candidates` reflects the four locked-in decisions (see §6). Ready for commit + PR.
+**Related:** Issue #159, [[project_helix_109_shard_pressure_test]], [[helix_100shard_context_commit_ceiling]]
+
+---
+
+## 1. Problem
+
+At 100+ shards (the 105-shard EnterpriseRAG Onyx fixture is the canonical case), the helix-context daemon hits **Wall 2** — per-query latency from brute-force-no-ANN dense matmul over the full N. The shard router exists but is functionally degenerate as a winnower: SQL probes on 2026-05-26 showed common English query terms hit 90-100% of shards, and a query-level simulation (50 synthetic 3-token queries) showed entities-exact OR-matching alone yields **median 100/105 shards routed-to** — statistically indistinguishable from today.
+
+Adding IDF filtering cuts that to median 26/105 but drops 69% of query tokens as noise and 36% of queries fall back to OR-union. The fingerprint redesign is a real lever but has a structural floor.
+
+**Dense matmul** scales linearly with N_total_genes (~850K on this corpus → ~870M FLOPs per query). At cross-shard fan-out, this dominates query latency. SPLADE already runs per-shard and produces a small candidate set per query, but its hits flow into the score accumulator in parallel with dense — never as a pre-filter.
+
+## 2. Motivation
+
+The 2026-05-26 query-level probe singled out **SPLADE pre-filter** as the unambiguous #1 Wall-2 lever. Sparse term-level discrimination is far sharper than fingerprint JSON LIKE-matching, AND it sidesteps the OR-union saturation that defeats column-swap-only fingerprint fixes.
+
+Stays inside the design pillars:
+
+- No LLM ([[feedback_helix_ribosome_off]])
+- No ANN
+- LLM-free retrieval
+
+FLOP-impact estimate: `O(N_total_genes) → O(|SPLADE candidates|)`. On the onyx_full fixture with ~5K SPLADE hits per typical query, that's ~170× FLOP reduction in the dense tier per query.
+
+## 3. Design
+
+### Public API change
+
+Two new keyword-only kwargs on `query_docs_dense_recall`:
+
+```python
+def query_docs_dense_recall(
+    self,
+    query: str,
+    *,
+    k: int = 500,
+    party_id: Optional[str] = None,
+    read_only: bool = False,
+    candidate_ids: Optional[set[str]] = None,         # NEW
+    dense_prefilter_escape_budget: int = 0,           # NEW
+) -> List[tuple[str, float]]: ...
+```
+
+**Semantics:**
+
+- `candidate_ids=None` (default): full matmul. Byte-identical to current behavior.
+- `candidate_ids={...}`: matmul scoped to the row subset whose gene_id is in the set.
+- `candidate_ids=set()` with `dense_prefilter_escape_budget=0`: returns `[]` (strict empty prefilter).
+- `dense_prefilter_escape_budget>0`: ALSO scan the complement, take top-N from there. Escape valve for genes the prefilter missed (the "needle outside top-12" case from spec §9). **Result budget, NOT a FLOP budget** — the complement scan is a full matmul on the uncovered rows; this knob preserves cold-lex recall at the cost of those FLOPs.
+- Unknown ids in `candidate_ids`: silently filtered (no crash).
+
+### Two new config knobs (KnowledgeStore ctor + helix.toml + config.py)
+
+- `dense_prefilter_enabled: bool = False` — opt-in flag for the wire-up in `_retrieve`.
+- `dense_prefilter_escape_budget: int = 0` — RESULT budget for the recall escape valve.
+
+Both knobs land in `[retrieval]` in `helix.toml` and the `RetrievalConfig` dataclass with the same defaults, plumbed through `context_manager.py` to the `KnowledgeStore` constructor — same pattern as `dense_pool_size` / `dense_additive_weight`.
+
+### Wire-up in `_retrieve`
+
+When `dense_prefilter_enabled=True` AND `gene_scores` is non-empty (lex/SPLADE found something):
+
+```python
+prefilter_ids = set(gene_scores.keys())
+prefilter_budget = self._dense_cold_lex_budget
+```
+
+When `gene_scores` is empty (pure cold-lex query): fall back to full scan so dense-only needles still surface.
+
+### Alternatives considered
+
+**A. SPLADE candidate set only (no `gene_scores.keys()` union)** — would skip lex-tier hits the prefilter, potentially excluding genes lex found but SPLADE missed. Rejected — using the post-lex/SPLADE gene_scores is strictly more inclusive at near-zero extra cost.
+
+**B. Bounded-FLOPs escape scan (random sample of complement)** — would cap FLOPs even with the escape budget on. Rejected — random sampling defeats the recall purpose (needles are by definition rare hits, not random). The caller-owned budget trade-off is the honest API.
+
+**C. Threshold-based fallback (if `|candidate_ids| < N`, full scan)** — adds non-determinism (a query routes differently based on candidate count). Rejected for simplicity; if recall regresses, caller can set `dense_prefilter_escape_budget` instead.
+
+**D. Naming: `splade_prefilter_enabled` instead of `dense_prefilter_enabled`** — closer to the design intent (SPLADE-derived candidates). Rejected because the API accepts ANY candidate_ids, not just SPLADE; the flag governs the dense tier, not SPLADE.
+
+## 4. Test plan
+
+9 new tests in `tests/test_dense_recall.py`:
+
+**Unit (5):**
+
+- `candidate_ids` constrains results — out-of-set gene excluded even when it's the natural top hit
+- empty `candidate_ids` + zero escape budget returns `[]`
+- unknown ids filtered (no crash)
+- `dense_prefilter_escape_budget` recovers a complement-side needle
+- `candidate_ids=None` ≡ omitting the kwarg (regression guard)
+
+**Integration via `query_docs` (4):**
+
+- prefilter OFF preserves needle recall (regression guard for default users)
+- prefilter ON + escape_budget=0 excludes lex-disjoint needle
+- prefilter ON + escape_budget>0 recovers the needle
+- config defaults + plumbing (instance attrs `_dense_prefilter_enabled` and `_dense_prefilter_escape_budget`)
+
+Plus one whitelist entry in `test_sharded_adapter_parity.py` for the new private helper `_dense_recall_with_prefilter` (per-genome internal, like other `_get_dense_codec` siblings).
+
+**Status:** 23/23 pass in `test_dense_recall.py`; 79/79 pass across the broader regression sweep (dense_recall + sharded_adapter_parity + calibration + ingest_dense_v2 + fixture_dense_backfill).
+
+## 5. Rollout & risks
+
+**Ship dark.** `dense_prefilter_enabled` defaults to False. No production callers exercise the new path until `helix.toml` is updated. The candidate_ids API surface is available immediately for ad-hoc testing.
+
+### Validation path
+
+**Step 1.** Land this PR (API + config knobs, all tests green, no behavior change in prod).
+
+**Step 2 — Pre-flip gate: four-run tier-ablation table on EnterpriseRAG-Bench.**
+
+Before flipping `dense_prefilter_enabled=True` as the default, run all four configs on the same fixture (target: the 109-shard onyx_full corpus once Wall-1 is also resolved per Issue #159 Path A; otherwise on the leak-free 10K/50K Onyx corpus). Same query set, same model, same seed.
+
+| Run | Config | Diagnostic purpose |
+| --- | --- | --- |
+| **T. Today (baseline)** | `splade_enabled=True`, `dense_prefilter_enabled=False` | Reference point — current shipped behavior. |
+| **A. SPLADE off** | `splade_enabled=False`, `dense_prefilter_enabled=False` | What does SPLADE alone contribute to recall@K? Defines the upper bound on what the prefilter could over-prune. |
+| **B. Prefilter on, no escape valve** | `dense_prefilter_enabled=true`, `dense_prefilter_escape_budget=0` | Worst-case prefilter recall — does it regress vs T? Measures the cost of strict prefiltering. |
+| **C. Prefilter on, with escape valve** | `dense_prefilter_enabled=true`, `dense_prefilter_escape_budget=250` | Does the escape budget close the recall gap from B? Trades FLOPs back for recall. |
+
+**Metrics per run:** recall@1 / recall@5 / recall@10 / MRR, plus p50 / p95 / p99 `/context` latency.
+
+**Diagnostic reads:**
+
+- **T → A** (delta): SPLADE's standalone contribution to recall. If small (< 2pp at recall@10), the prefilter has lots of headroom and `dense_prefilter_escape_budget=0` is likely safe. If large (> 5pp), the escape valve matters and B will probably regress.
+- **T → B** (delta): the recall cost of the strict prefilter. Acceptable if within ±1pp at recall@10.
+- **B → C** (delta): the escape valve's recall recovery. Confirms the budget knob actually works.
+- **T → C** (delta): the net recall change from shipping prefilter ON. This is the headline number for the flip decision.
+- **Latency T → B → C**: confirms the FLOP-savings story actually materializes in wall-clock.
+
+**Flip criteria:**
+
+- T → C recall@10 within −1pp: flip default to True with `dense_prefilter_escape_budget=250` (or whichever budget the runs land on).
+- T → C recall@10 within −1pp AND T → B already passes: flip default to True with `dense_prefilter_escape_budget=0` (max FLOP savings).
+- T → C recall@10 worse than −1pp: do NOT flip. Either tune budget higher and re-bench, or document the recall/latency trade-off and let the deployment decide.
+
+**Why all four runs (not just T vs C):** the SPLADE-off run (A) is the only way to *understand* the result. Without it, a flat C ≈ T number is ambiguous — it could mean the prefilter is perfect, OR that SPLADE was never doing much. The four-run table resolves that ambiguity and the diagnostic data has lasting value beyond this PR (first tier-ablation on the leak-free EnterpriseRAG corpus).
+
+**Cost.** Each run is hours of wall-clock on the 109-shard fixture (per [[project_helix_109_shard_pressure_test]]). Total ~half a day across the four. Wall-1 (memory ceiling) must be resolved first per Issue #159 Path A — otherwise the daemon OOMs before the bench completes. As a fallback, the 10K/50K Onyx corpus is also leak-free and reproduces the recall numbers in the existing memory ([[project_helix_bench_investigation_2026-05]]) — runs faster, less load-bearing but still diagnostic.
+
+**Risks:**
+
+- **Recall regression on cold-lex queries.** A query whose terms aren't in any SPLADE candidate's sparse vector AND aren't lex-matched will see an empty `gene_scores`, fall back to full scan — same as today. The risk surface is queries with *some* lex match but the actual needle is dense-only. `dense_prefilter_escape_budget` is the lever; the bench in step 2 measures it.
+- **FLOP savings smaller than estimated** if typical queries have larger SPLADE candidate sets than the ~5K assumption. Bench will measure actual.
+- **Adapter surface drift.** The new private helper is whitelisted; any future structural change to `ShardedGenomeAdapter` should mirror the whitelist convention.
+- **Behavioral coupling with #158 (parallel fan-out + SPLADE liftout).** Both PRs touch the dense tier indirectly. This PR doesn't depend on #158 — but if both land, the SPLADE encoding is hoisted once per query (from #158) AND the dense matmul is scoped per shard (from this PR). The combined effect is the actual Wall-2 fix.
+
+## 6. Resolved decisions (signed off 2026-05-26)
+
+1. **Flag name** — `dense_prefilter_enabled`. It governs dense behavior, not SPLADE itself. SPLADE-derived candidates are the *typical* source for `candidate_ids`, but the API accepts any caller-supplied set.
+2. **Default state** — `False` for this PR. TOML plumbing, dataclass field, and `helix.toml` entry land now so the knob is wireable from config without a code change. The flip to `True` happens in a follow-up PR, after the four-run ablation in §5 lands a decisive result.
+3. **Escape-valve abstraction** — `dense_prefilter_escape_budget` (renamed from `cold_lex_budget`). Documented prominently as a **result budget, not a FLOP budget** — the complement scan is a full matmul on uncovered rows. Caller owns the trade between recall preservation and the cost of that scan.
+4. **Empty-`gene_scores` semantic** — fall back to full scan. Skipping dense entirely would erase dense-only needles for any query whose lex/SPLADE tiers happened to return nothing — too aggressive a tradeoff for the FLOP win in that edge case.
+
+These four decisions are reflected in the code on `perf/dense-prefilter-via-splade-candidates`.

--- a/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
+++ b/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
@@ -212,6 +212,54 @@ python benchmarks/ablate_dense_prefilter.py \
 
 Result artifact: `benchmarks/results/ablate_dense_prefilter/ablation_onyx_full_smoke3_postreboot_1779837749.json`.
 
+### v2 100-shard scale-up (2026-05-27)
+
+Following the 105-shard analysis we rebuilt the corpus on the Path-A profile (`enterprise_rag_onyx_full_2`) with the default `--auto-subshard-threshold-files=100000` — expecting ~12 fewer-larger shards. The auto-subsharder still split `slack` and `gmail` into ~50+ per-channel / per-user shards, so the v2 fixture landed at **100 shards, 850,500 genes, 45.16 GB on disk, 18-hour wall-clock build**. Roughly the same shard count as v1, but distinct shard composition (fewer micro-shards from confluence/jira/linear/etc., more from the chatty sources). Daemon private commit on v2 is ~240 GB (vs v1's 247 GB) — still well into pagefile territory on 48 GB RAM, but the per-shard page-fault topology differs.
+
+#### Results (n=5, k=10, fixture: `enterprise_rag_onyx_full_2/main.genome.db`)
+
+| Variant | R@1 | R@3 | R@5 | R@10 | MRR | p50 (s) | p95 (s) | Δ p95 vs T | timed out at 10 min? |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **T. Today (baseline)** | 20% | 20% | 40% | 40% | 0.250 | 593 | 600 | — | 2 queries (q1, q2) |
+| **A. SPLADE off** | 20% | 20% | 40% | 40% | 0.250 | **306** | **447** | **−153 s** | **none** |
+| **B. Prefilter on, escape=0** | 20% | 20% | 40% | 40% | 0.250 | **289** | 600 | −0.0 s | 2 queries (q1, q2) |
+| **C. Prefilter on, escape=250** | 20% | 20% | 40% | 40% | 0.250 | **276** | 600 | −0.0 s | 1 query (q1) |
+
+#### Diagnostic findings at v2 100-shard scale
+
+**The prefilter's CPU-FLOP win finally surfaces on p50.** Variants B and C both beat T's p50 by ~300 s (~50%). This is the structural FLOP-reduction the prefilter was designed to deliver, visible now that v2's per-shard page-fault topology is less catastrophic than v1's. Variant C edges B by ~13 s at p50 — the 250-row escape budget pays for itself when it actually gets to run.
+
+**But the prefilter doesn't help on the worst-case queries.** B and C both still hit the 600 s cap on q1 (and B also on q2), the same queries where T times out. The prefilter scopes the matmul *inside* shards it does touch, but on these queries those shards are already so paged-out that the constant-factor matmul savings disappear into the page-fault storm. **Same Wall-1-dominates-Wall-2 pattern as v1** — Wall-2 just gets to win on the queries where Wall-1 happens not to dominate.
+
+**SPLADE-off wins p95 by a wider margin than v1.** Variant A is now the **only configuration with zero timeouts** on the 850 K corpus at any sample size we've measured. The p95 win grows from 94 s (v1) to 153 s (v2), and crosses a meaningful operational threshold: under-8-min response on every query at n=5. The "all pain, no gain" pattern for SPLADE on this corpus is now 3-for-3 across fixtures (10 K → v1 105-shard → v2 100-shard).
+
+**Cross-verified architectural finding (2026-05-27).** The dense matmul at `knowledge_store.py:2709` runs as plain NumPy CPU (`sims = matrix @ query_vec` on an `np.stack(...)` heap-resident fp32 array; no `np.memmap`, no torch, no GPU). BGEM3Codec defaults to `device="cpu"`. Live diagnostics on three hosts (Max-Windows + Joe's two DGX Sparks) all show single-threaded CPU pegging with GPU ~16% (SPLADE-only spikes). The prefilter's FLOP savings are **CPU NumPy FLOPs**, not GPU FLOPs — which explains why even on Spark's ARM cores the prefilter's value tracks with the same per-shard page-fault story. Native CUDA BGE-M3 + a torch-on-GPU matmul are queued as future work (post-bench engineering, not gating any PR).
+
+#### Flip recommendation is REVISED
+
+The two-fixture trend (v1 → v2) clarifies the flip story:
+
+1. **Prefilter is still recall-neutral.** Three fixtures, identical recall@K. The hard gate is satisfied at every scale.
+2. **Prefilter delivers measurable p50 latency savings on v2** — first such measurement after the 10 K result. This is the real architectural answer to Wall-2.
+3. **SPLADE-off delivers measurable p95 latency savings on every fixture, every time.** It's the only configuration with zero timeouts on the 850 K corpus, and the win grows with shard count.
+4. **The two levers are independent and stack.** `splade_enabled=false` + `dense_prefilter_enabled=true` would in principle deliver both wins (A's p95 + B/C's p50). v2 smoke didn't include that combined variant — that's the next data point worth gathering.
+
+**Standing flip for THIS PR:** `dense_prefilter_enabled=true, dense_prefilter_escape_budget=0`. Recall-neutral, no latency regression on any fixture, measurable p50 win at 100-shard scale. The SPLADE-off decision is being handled separately under the 2026-05-26-splade-on-by-default-investigation PRD.
+
+#### Reproducibility (v2 100-shard)
+
+```bash
+python benchmarks/ablate_dense_prefilter.py \
+  --fixture F:/Projects/helix-context/genomes/bench/matrix-sharded/enterprise_rag_onyx_full_2/main.genome.db \
+  --sharded \
+  --max-questions 5 \
+  --boot-timeout 300 \
+  --query-timeout 600 \
+  --label v2_smoke
+```
+
+Result artifact: `benchmarks/results/ablate_dense_prefilter/ablation_v2_smoke_1779917068.json`.
+
 ### Follow-up: flip PR
 
 The flip PR is a one-line change:

--- a/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
+++ b/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
@@ -147,6 +147,71 @@ Per PRD flip criteria, when T → B already passes, ship with `dense_prefilter_e
 
 The combined `(SPLADE off + prefilter on)` configuration would deliver the latency win of A with the structural FLOP savings of B — but the SPLADE decision deserves its own PRD and bench coverage (other corpora, additional question types) before flipping it. The prefilter PR ships independently.
 
+### 105-shard scale-up (2026-05-26 evening)
+
+The 10K results above don't exercise Wall-2 (the cross-shard fan-out latency wall the prefilter was designed for). To get the real measurement, we re-ran the same four variants against the full Onyx EnterpriseRAG fixture: **105 shards, 850,500 genes, 42.6 GB on disk** at `genomes/bench/matrix-sharded/enterprise_rag_onyx_full/`.
+
+This required two operational changes:
+
+1. **Per-query timeout raised to 10 min** to match Onyx-paper precedent for cross-shard searches.
+2. **Pagefile resize: fixed 240 GB on C:** (Samsung 980 Pro NVMe, separate from F: where the data lives). First attempt at the full fixture OOM-killed the daemon during warmup when private commit hit 143 GB on the default 56 GB pagefile. With 240 GB fixed, total commit ceiling is 288 GB and the daemon's worst-case 247 GB private commit fits cleanly. Pre-allocated to avoid Windows' 1-2 GB auto-grow chunks lagging behind the daemon's ~10 GB / 45s allocation rate.
+
+#### Results (n=5, k=10, fixture: `enterprise_rag_onyx_full/main.genome.db`)
+
+Smaller n because per-query wall-clock is 5-10 min at this scale; 5 queries × 4 variants is already a ~3-hour run.
+
+| Variant | R@1 | R@3 | R@5 | R@10 | MRR | p50 (s) | p95 (s) | Δ p95 vs T | timed out at 10 min? |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **T. Today (baseline)** | 20% | 20% | 40% | 40% | 0.250 | **477** | 600 | — | 1 query |
+| **A. SPLADE off** | 20% | 20% | 40% | 40% | 0.250 | **291** | **506** | **−94 s** | none |
+| **B. Prefilter on, escape=0** | 20% | 20% | 40% | 40% | 0.250 | 427 | 600 | −0.0 s | 1 query |
+| **C. Prefilter on, escape=250** | 20% | 20% | 40% | 40% | 0.250 | 434 | 600 | −0.0 s | 1 query |
+
+#### Diagnostic findings at 105-shard scale
+
+**Recall stays identical across all 4 variants.** The same pattern as 10K — prefilter is recall-neutral, SPLADE contributes 0pp at K=1/3/5/10. Sample is small (n=5, granular at 20pp) but consistent with 10K.
+
+**Prefilter latency savings vanish into pagefile thrashing.** B and C are statistically indistinguishable from T (Δ p95 ≈ 0). On this rig:
+
+- Daemon's working state is 247 GB private commit on 48 GB physical RAM → ~200 GB lives in pagefile
+- Per-query cost decomposes as `(shards_routed × per-shard-page-fault-storm) + dense_matmul`
+- The page-fault storm dominates by an order of magnitude — every dense matrix touched during fan-out is mostly paged out and has to be brought back from NVMe
+- The prefilter scopes the matmul *inside* each touched shard but doesn't change *which* shards are touched, so the page-fault cost is unchanged
+- **Wall-1 (mmap + heap pressure → pagefile I/O) dominates Wall-2 (dense matmul FLOPs)** on a 48 GB RAM box at full-Onyx scale
+
+**SPLADE-off scales linearly.** The 10K result's ~926 ms p95 win for SPLADE-off scales to **~94 s p95 at 105-shard** (about 100×). At full corpus scale this becomes structurally significant. Still 0pp recall change. The "all pain, no gain" finding from 10K is even more pronounced — and warrants its own PRD with broader question-type coverage.
+
+**Escape budget cost is statistically zero** at this scale too. C - B = +7s p50 / 0s p95. The recall-preservation knob is essentially free; the FLOP-savings hypothesis just doesn't pay off here because page-fault cost dominates.
+
+**Daemons survived cleanly.** Zero crashes across all 4 variants with the 240 GB pagefile. Confirms Wall-1 is a *resource-budget* problem, not a runtime-correctness problem.
+
+#### Flip recommendation is unchanged
+
+Still: **`dense_prefilter_enabled=true`, `dense_prefilter_escape_budget=0`**. Reasoning:
+
+- Recall preserved at every K on both corpora (the only hard gate)
+- Latency cost is zero (B ≡ T) at 105-shard; mild noise at 10K
+- On future rigs where Wall-1 is *not* in the way — more physical RAM, or the memory-entry's Path-A "fewer-larger-shards" rebuild — the FLOP-savings story is expected to materialize. The prefilter is correct by construction (unit tests on synthetic data prove the matmul scopes); we just can't measure its benefit on this rig until Wall-1 is also addressed.
+
+#### Side findings worth flagging
+
+1. **Path-A rebuild becomes more urgent.** Until the fixture is re-ingested at ~12 fewer-larger shards (or this dev rig gets more RAM), the 105-shard fixture is a pagefile-thrashing benchmark. The prefilter alone won't fix it.
+2. **`splade_enabled = false` is the cheapest measurable latency win on Onyx** at any scale tested so far. 94 s p95 savings at 105-shard with 0pp recall cost. Deserves a separate PRD — and a broader question set to confirm SPLADE doesn't shine on rare-term-expansion queries the bench doesn't include.
+
+#### Reproducibility (105-shard)
+
+```bash
+python benchmarks/ablate_dense_prefilter.py \
+  --fixture F:/Projects/helix-context/genomes/bench/matrix-sharded/enterprise_rag_onyx_full/main.genome.db \
+  --sharded \
+  --max-questions 5 \
+  --boot-timeout 600 \
+  --query-timeout 600 \
+  --label onyx_full_smoke3_postreboot
+```
+
+Result artifact: `benchmarks/results/ablate_dense_prefilter/ablation_onyx_full_smoke3_postreboot_1779837749.json`.
+
 ### Follow-up: flip PR
 
 The flip PR is a one-line change:

--- a/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
+++ b/docs/prds/2026-05-26-splade-prefilter-dense-recall.md
@@ -111,9 +111,68 @@ Plus one whitelist entry in `test_sharded_adapter_parity.py` for the new private
 
 ### Validation path
 
-**Step 1.** Land this PR (API + config knobs, all tests green, no behavior change in prod).
+**Step 1.** Land this PR (API + config knobs, all tests green, no behavior change in prod). **DONE — landed as PR #160 on `bench/int-5fixture` at commit 9328111.**
 
-**Step 2 — Pre-flip gate: four-run tier-ablation table on EnterpriseRAG-Bench.**
+**Step 2 — Pre-flip gate: four-run tier-ablation table on EnterpriseRAG-Bench. ✓ COMPLETED 2026-05-26.**
+
+### Results (n=100, k=10, fixture: `enterprise_rag_10k_w16000.db`)
+
+| Variant | R@1 | R@3 | R@5 | R@10 | MRR | p50 ms | p95 ms | p99 ms |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **T. Today (baseline)** | 49.0% | 57.0% | 59.0% | 60.0% | 0.533 | 1857 | 2337 | 2516 |
+| **A. SPLADE off** | 49.0% | 57.0% | 59.0% | 60.0% | 0.533 | 1208 | **1411** | 1635 |
+| **B. Prefilter on, escape=0** | 49.0% | 57.0% | 59.0% | 60.0% | 0.533 | 1816 | 2348 | 2452 |
+| **C. Prefilter on, escape=250** | 49.0% | 57.0% | 59.0% | 60.0% | 0.533 | 1825 | 2323 | 2459 |
+
+### Decision: FLIP with `dense_prefilter_escape_budget=0`
+
+Both flip criteria pass:
+
+- **T → B recall@10:** +0.0pp (within ±1pp threshold) → max-FLOP-savings config is safe
+- **T → C recall@10:** +0.0pp (within ±1pp threshold)
+
+Per PRD flip criteria, when T → B already passes, ship with `dense_prefilter_escape_budget=0` (cold-lex escape valve is not needed on this corpus).
+
+### Notable diagnostic findings
+
+**1. The prefilter is recall-neutral.** At every K (1/3/5/10) and on MRR, B/C are byte-identical to T. The design hypothesis holds: the post-lex/SPLADE `gene_scores.keys()` is a sufficient candidate set for the dense matmul on this corpus.
+
+**2. On 10K, prefilter latency is noise.** B/C differ from T by ≤25 ms at p95 — within run-to-run variance. The dense matmul on ~10K rows is already cheap (~10M FLOPs). The prefilter's structural FLOP-reduction story is **valid by construction** (unit tests prove the matmul is scoped) and should materialize at 100+ shard scale where cross-shard dense fan-out is ~500K+ rows per query — but this corpus doesn't exercise it.
+
+**3. SPLADE contributes 0pp to recall on this fixture.** `T → A` is +0.0pp at every K, while p95 latency drops 926 ms (~40%). This is "all pain, no gain" for SPLADE on the Onyx 10K basic/semantic/intra_document_reasoning question set. **This is a separate concern** — it does not gate the prefilter flip — but warrants a follow-up investigation:
+
+- Is SPLADE redundant with FTS5 + dense on this corpus?
+- Does it shine on rare-term-expansion question types the bench doesn't include?
+- Is its current tier weight (3.5) over-allocated?
+
+The combined `(SPLADE off + prefilter on)` configuration would deliver the latency win of A with the structural FLOP savings of B — but the SPLADE decision deserves its own PRD and bench coverage (other corpora, additional question types) before flipping it. The prefilter PR ships independently.
+
+### Follow-up: flip PR
+
+The flip PR is a one-line change:
+
+```toml
+# helix.toml [retrieval]
+dense_prefilter_enabled = true
+# dense_prefilter_escape_budget stays at 0 (the default)
+```
+
+That PR should:
+
+1. Update `helix.toml` to flip the flag.
+2. Update the dataclass default in `helix_context/config.py` to match (so downstream callers see the right default).
+3. Reference this PRD's §5 results as the gate.
+4. Note the artifact: `benchmarks/results/ablate_dense_prefilter/ablation_full_1779831899.json`.
+
+### Reproducibility
+
+```bash
+python benchmarks/ablate_dense_prefilter.py \
+  --fixture F:/Projects/helix-context/genomes/bench/matrix/enterprise_rag_10k_w16000.db \
+  --max-questions 100 --label full
+```
+
+The orchestrator (`benchmarks/ablate_dense_prefilter.py`) is committed with this PR. It patches `helix.toml` per variant, spawns a fresh daemon, warms it, runs the recall bench with per-query latency timing, and aggregates the comparison table.
 
 Before flipping `dense_prefilter_enabled=True` as the default, run all four configs on the same fixture (target: the 109-shard onyx_full corpus once Wall-1 is also resolved per Issue #159 Path A; otherwise on the leak-free 10K/50K Onyx corpus). Same query set, same model, same seed.
 

--- a/helix.toml
+++ b/helix.toml
@@ -336,6 +336,19 @@ ann_threshold_max_genes = 12
 ann_threshold_mode = "absolute"           # "absolute" | "margin_over_random"
 ann_threshold_sigma_multiplier = 3.0      # mu + N*sigma over random pairs
 dense_pool_size = 500
+# Issue #159 Wall-2 lever (2026-05-26): SPLADE pre-filter for dense matmul.
+# When true, _retrieve scopes the dense matmul to the post-SPLADE/lex
+# candidate set — drops dense FLOPs from O(N_total_genes) to O(|candidates|)
+# at 100+ shard scale. Default false; flip after the four-run ablation
+# documented in docs/prds/2026-05-26-splade-prefilter-dense-recall.md.
+dense_prefilter_enabled = false
+# Escape-valve RESULT budget for the prefilter (NOT a FLOP budget). When >0
+# and the prefilter is enabled, dense recall also scans the complement of
+# the candidate set and surfaces up to N additional hits SPLADE/lex missed.
+# The complement scan is a full matmul on uncovered rows — this preserves
+# cold-lex recall at the cost of those FLOPs. Default 0 (strict prefilter,
+# max FLOP savings).
+dense_prefilter_escape_budget = 0
 # Stage 3 (2026-05-08): Reciprocal Rank Fusion. Spec
 # docs/specs/2026-05-08-stage-3-rrf-fusion.md replaces the additive
 # gene_scores += tier_score accumulator with rank-level RRF (Cormack 2009).

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -346,6 +346,19 @@ class RetrievalConfig:
     # ann_threshold_max_genes (the final cut). 500 hits ~3% of an 18.9k
     # corpus per spec §4.
     dense_pool_size: int = 500
+    # Issue #159 Wall-2 lever (2026-05-26): SPLADE pre-filter for dense matmul.
+    # When True, _retrieve scopes the dense matmul to post-SPLADE/lex
+    # gene_scores — drops dense FLOPs from O(N_total_genes) to O(|candidates|)
+    # at 100+ shard scale. Default False; flip after the four-run ablation
+    # documented in docs/prds/2026-05-26-splade-prefilter-dense-recall.md.
+    dense_prefilter_enabled: bool = False
+    # Escape-valve RESULT budget for the prefilter (NOT a FLOP budget). When
+    # >0 and the prefilter is enabled, dense recall also scans the complement
+    # of candidate_ids and surfaces up to N additional hits SPLADE/lex missed.
+    # The complement scan is a full matmul on uncovered rows — this preserves
+    # cold-lex recall at the cost of those FLOPs. Default 0 (strict prefilter,
+    # max FLOP savings).
+    dense_prefilter_escape_budget: int = 0
     # Stage 3 (2026-05-08): Reciprocal Rank Fusion accumulator.
     # Spec: docs/specs/2026-05-08-stage-3-rrf-fusion.md.
     # When ``fusion_mode == "additive"`` (default for one release), the
@@ -775,6 +788,14 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             )),
             # Stage 2 (2026-05-08): dense recall pool size, decoupled from final cut.
             dense_pool_size=int(r.get("dense_pool_size", cfg.retrieval.dense_pool_size)),
+            # Issue #159 Wall-2 lever (2026-05-26): SPLADE pre-filter for dense.
+            dense_prefilter_enabled=bool(r.get(
+                "dense_prefilter_enabled", cfg.retrieval.dense_prefilter_enabled,
+            )),
+            dense_prefilter_escape_budget=int(r.get(
+                "dense_prefilter_escape_budget",
+                cfg.retrieval.dense_prefilter_escape_budget,
+            )),
             # Stage 3 (2026-05-08): RRF fusion. Default "additive" preserves
             # pre-Stage-3 behavior byte-for-byte. Flip to "rrf" for the new
             # rank-fusion path. Spec §7 deprecation timeline keeps both

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -497,6 +497,9 @@ class HelixContextManager:
             ann_threshold_mode=config.retrieval.ann_threshold_mode,
             ann_threshold_sigma_multiplier=config.retrieval.ann_threshold_sigma_multiplier,
             dense_pool_size=config.retrieval.dense_pool_size,
+            # Issue #159 Wall-2 lever (2026-05-26): SPLADE pre-filter for dense.
+            dense_prefilter_enabled=config.retrieval.dense_prefilter_enabled,
+            dense_prefilter_escape_budget=config.retrieval.dense_prefilter_escape_budget,
             # Stage 3 (2026-05-08): RRF fusion + per-tier weights.
             fusion_mode=config.retrieval.fusion_mode,
             rrf_k=config.retrieval.rrf_k,

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -358,6 +358,20 @@ class KnowledgeStore:
         ann_threshold_sigma_multiplier: float = 3.0,
         # Stage 2: dense recall pool size, decoupled from ann_threshold_max_genes.
         dense_pool_size: int = 500,
+        # Issue #159 Wall-2 lever (2026-05-26): SPLADE pre-filter for dense matmul.
+        # When True, _retrieve passes the post-SPLADE/lex gene_scores.keys() as
+        # candidate_ids to query_docs_dense_recall, scoping the matmul from
+        # O(N_total_genes) to O(|candidates|). Default False — opt-in until
+        # validated end-to-end (see project_helix_109_shard_pressure_test).
+        dense_prefilter_enabled: bool = False,
+        # Escape-valve RESULT budget (not a FLOP budget) for the prefilter.
+        # When >0 and prefilter is enabled, query_docs_dense_recall ALSO scans
+        # the complement of candidate_ids and surfaces up to N additional hits
+        # that SPLADE/lex missed. The complement scan does full matmul on the
+        # uncovered rows — this is a recall-preservation knob, NOT a way to
+        # cap dense FLOPs. Default 0 (strict prefilter, max FLOP savings). Set
+        # to a small fraction of dense_pool_size if recall regresses.
+        dense_prefilter_escape_budget: int = 0,
         # Stage 3 (2026-05-08): Reciprocal Rank Fusion (spec
         # docs/specs/2026-05-08-stage-3-rrf-fusion.md). Default
         # "additive" preserves pre-Stage-3 ranking byte-for-byte; flip
@@ -439,6 +453,9 @@ class KnowledgeStore:
         # Stage 2 (2026-05-08): pool size for dense + lex recall, decoupled
         # from max_genes (the post-ranking final cut).
         self._dense_pool_size: int = int(dense_pool_size)
+        # Issue #159 Wall-2 prefilter knobs (see ctor params).
+        self._dense_prefilter_enabled: bool = bool(dense_prefilter_enabled)
+        self._dense_prefilter_escape_budget: int = int(dense_prefilter_escape_budget)
         self._dense_codec: "BGEM3Codec | None" = None  # lazy-loaded
         # Stage 2: in-memory hot-tier dense matrix cache. Populated lazily by
         # _ensure_dense_matrix() on first dense recall query; invalidated by
@@ -1980,11 +1997,22 @@ class KnowledgeStore:
         if self._dense_embedding_enabled:
             try:
                 _dense_t0 = time.monotonic()
+                # Issue #159 Wall-2 prefilter: scope the dense matmul to the
+                # post-SPLADE/lex candidate set when enabled. Falls back to a
+                # full scan when gene_scores is empty so dense-only needles
+                # still surface in pure-cold-lex queries.
+                prefilter_ids: Optional[set[str]] = None
+                escape_budget = 0
+                if self._dense_prefilter_enabled and gene_scores:
+                    prefilter_ids = set(gene_scores.keys())
+                    escape_budget = self._dense_prefilter_escape_budget
                 dense_hits = self.query_docs_dense_recall(
                     " ".join(query_terms),
                     k=min(self._dense_pool_size, limit * 4),
                     party_id=party_id,
                     read_only=read_only,
+                    candidate_ids=prefilter_ids,
+                    dense_prefilter_escape_budget=escape_budget,
                 )
                 if self._fusion_mode == "rrf":
                     # Stage 3: feed Fuser. raw_score = cosine.
@@ -2599,6 +2627,8 @@ class KnowledgeStore:
         k: int = 500,
         party_id: Optional[str] = None,
         read_only: bool = False,
+        candidate_ids: Optional[set[str]] = None,
+        dense_prefilter_escape_budget: int = 0,
     ) -> List[tuple[str, float]]:
         """Stage 2 first-class dense recall.
 
@@ -2612,6 +2642,33 @@ class KnowledgeStore:
         ``party_id`` and ``read_only`` are accepted for API symmetry with
         ``query_genes_ann``; party-aware sharding is out of scope for Stage 2
         (spec §13 punts it to a later release).
+
+        SPLADE pre-filter (Issue #159 Wall-2 lever, 2026-05-26):
+
+        ``candidate_ids`` (default ``None``) scopes the dense matmul to a
+        caller-supplied subset of gene ids. ``None`` preserves the full-N
+        scan (current behavior). A non-None value drops dense FLOPs from
+        ``O(N_total_genes)`` to ``O(|candidate_ids|)``.
+
+        ``dense_prefilter_escape_budget`` (default ``0``) is a RESULT budget,
+        NOT a FLOP budget. When >0, an extra scan over ``ids \\ candidate_ids``
+        reserves up to N slots for genes SPLADE/lex missed (the "needle outside
+        top-12" case from spec §9). The complement scan is a full matmul on the
+        uncovered rows — this knob preserves recall, it does NOT cap dense
+        FLOPs. Set to 0 for max FLOP savings; set to a small fraction of
+        ``dense_pool_size`` to recover cold-lex needles at the cost of the
+        complement matmul.
+
+        Semantics:
+
+        - ``candidate_ids=None``: full matmul (unchanged).
+        - ``candidate_ids=set()`` with ``dense_prefilter_escape_budget=0``:
+          returns ``[]`` (strict empty prefilter).
+        - ``candidate_ids=set()`` with ``dense_prefilter_escape_budget>0``:
+          degenerates to a top-``dense_prefilter_escape_budget`` unconstrained
+          scan.
+        - ``candidate_ids`` containing ids absent from the matrix: missing
+          ids are silently filtered (no crash).
         """
         del party_id, read_only  # reserved; spec §13 explicitly defers sharding
         if not self._dense_embedding_enabled:
@@ -2642,6 +2699,13 @@ class KnowledgeStore:
 
         # All vectors are L2-normalized at encode/backfill time (codec
         # contract). matmul == cosine.
+
+        if candidate_ids is not None:
+            return self._dense_recall_with_prefilter(
+                matrix, ids, query_vec, int(k),
+                candidate_ids, int(dense_prefilter_escape_budget),
+            )
+
         sims = matrix @ query_vec
         n = sims.shape[0]
         k_eff = min(int(k), n)
@@ -2652,6 +2716,53 @@ class KnowledgeStore:
         # Sort the partition descending by similarity.
         idx_sorted = idx_part[np.argsort(-sims[idx_part])]
         return [(ids[int(i)], float(sims[int(i)])) for i in idx_sorted]
+
+    def _dense_recall_with_prefilter(
+        self,
+        matrix,
+        ids: list[str],
+        query_vec,
+        k: int,
+        candidate_ids: set[str],
+        escape_budget: int,
+    ) -> List[tuple[str, float]]:
+        """SPLADE-pre-filtered dense recall — see ``query_docs_dense_recall``."""
+        import numpy as np
+
+        if not candidate_ids and escape_budget <= 0:
+            return []
+
+        candidate_mask = np.fromiter(
+            (gid in candidate_ids for gid in ids), dtype=bool, count=len(ids),
+        )
+        constrained_rows = np.where(candidate_mask)[0]
+
+        scored: list[tuple[int, float]] = []
+        if constrained_rows.size:
+            constrained_sims = matrix[constrained_rows] @ query_vec
+            scored.extend(
+                (int(constrained_rows[i]), float(constrained_sims[i]))
+                for i in range(constrained_rows.size)
+            )
+
+        if escape_budget > 0:
+            escape_rows = np.where(~candidate_mask)[0]
+            if escape_rows.size:
+                escape_sims = matrix[escape_rows] @ query_vec
+                n_escape = min(escape_budget, escape_sims.shape[0])
+                if n_escape > 0:
+                    escape_part = np.argpartition(-escape_sims, n_escape - 1)[:n_escape]
+                    escape_sorted = escape_part[np.argsort(-escape_sims[escape_part])]
+                    scored.extend(
+                        (int(escape_rows[i]), float(escape_sims[i]))
+                        for i in escape_sorted
+                    )
+
+        if not scored:
+            return []
+        scored.sort(key=lambda x: x[1], reverse=True)
+        k_eff = min(k, len(scored))
+        return [(ids[idx], score) for idx, score in scored[:k_eff]]
 
     def query_docs_ann(
         self,

--- a/tests/test_dense_recall.py
+++ b/tests/test_dense_recall.py
@@ -787,3 +787,257 @@ def test_live_additive_dense_recall_through_query_docs():
         )
     finally:
         g.close()
+
+
+# ── SPLADE pre-filter: candidate_ids prunes matmul rows ──────────────
+#
+# Issue #159 Wall-2 lever. Threads an optional ``candidate_ids: set[str]``
+# through ``query_docs_dense_recall`` so callers (the hybrid retriever in
+# ``_retrieve``) can scope the dense matmul to the SPLADE/lex hit set.
+# Cuts dense FLOPs from O(N_total_genes) to O(|candidate_ids|).
+# ``dense_prefilter_escape_budget`` is the recall escape valve: a small top-k
+# is ALSO included so terms SPLADE missed (cold lexicon) still surface.
+
+
+def test_dense_recall_candidate_ids_constrains_results(dense_genome):
+    """With candidate_ids set, dense recall returns ONLY genes in that set —
+    even when an out-of-set gene would otherwise rank #1.
+    """
+    g = dense_genome
+
+    for i in range(10):
+        gid = f"g-{i:03d}"
+        g.upsert_gene(_make_gene(f"body {i}", gene_id=gid))
+        _populate_v2(g, gid, _hash_vec(f"vec-{gid}", 1024))
+
+    # Query encoder maps to g-005's vector — unconstrained top hit is g-005.
+    g._dense_codec = _FakeCodec(dim=1024, query_target="vec-g-005")
+
+    baseline = g.query_genes_dense_recall("query", k=3)
+    assert baseline[0][0] == "g-005", (
+        f"sanity: g-005 should top unconstrained baseline; got {baseline}"
+    )
+
+    constrained = g.query_genes_dense_recall(
+        "query", k=3, candidate_ids={"g-002", "g-003"},
+    )
+    ids = {gid for gid, _ in constrained}
+    assert ids.issubset({"g-002", "g-003"}), (
+        f"candidate_ids must constrain matmul output; got {ids}"
+    )
+    assert ids == {"g-002", "g-003"}, (
+        f"both candidates should appear with k=3; got {ids}"
+    )
+
+
+def test_dense_recall_empty_candidate_ids_returns_empty(dense_genome):
+    """Empty set is distinct from None: empty = strict "no candidates allowed"."""
+    g = dense_genome
+    for i in range(3):
+        gid = f"g-{i:03d}"
+        g.upsert_gene(_make_gene(f"body {i}", gene_id=gid))
+        _populate_v2(g, gid, _hash_vec(f"vec-{gid}", 1024))
+    g._dense_codec = _FakeCodec(dim=1024)
+
+    out = g.query_genes_dense_recall("query", k=5, candidate_ids=set())
+    assert out == [], f"empty candidate_ids should yield empty result; got {out}"
+
+
+def test_dense_recall_unknown_candidate_ids_no_crash(dense_genome):
+    """candidate_ids that don't exist in the matrix don't crash — just no rows."""
+    g = dense_genome
+    for i in range(3):
+        gid = f"g-{i:03d}"
+        g.upsert_gene(_make_gene(f"body {i}", gene_id=gid))
+        _populate_v2(g, gid, _hash_vec(f"vec-{gid}", 1024))
+    g._dense_codec = _FakeCodec(dim=1024)
+
+    out = g.query_genes_dense_recall(
+        "query", k=5, candidate_ids={"nonexistent-1", "nonexistent-2"},
+    )
+    assert out == [], (
+        f"unknown candidate_ids should yield empty result, no crash; got {out}"
+    )
+
+    # Mixed known + unknown returns only the known.
+    out2 = g.query_genes_dense_recall(
+        "query", k=5, candidate_ids={"nonexistent-1", "g-001"},
+    )
+    ids = {gid for gid, _ in out2}
+    assert ids == {"g-001"}, f"unknown ids filtered, known kept; got {ids}"
+
+
+def test_dense_recall_escape_budget_recovers_cold_lex_needle(dense_genome):
+    """dense_prefilter_escape_budget reserves N slots for an unconstrained
+    dense scan — preserves needle-finding for terms SPLADE missed (cold lex).
+    Result budget, NOT a FLOP budget.
+    """
+    g = dense_genome
+
+    # 20 distractor genes with random vectors + 1 needle with the query-matched vector.
+    for i in range(20):
+        gid = f"g-{i:03d}"
+        g.upsert_gene(_make_gene(f"body {i}", gene_id=gid))
+        _populate_v2(g, gid, _hash_vec(f"vec-{gid}", 1024))
+    g.upsert_gene(_make_gene("needle body", gene_id="needle"))
+    _populate_v2(g, "needle", _hash_vec("query target", 1024))
+
+    g._dense_codec = _FakeCodec(dim=1024, query_target="query target")
+
+    # candidate_ids covers ONE constrained gene (g-002), NOT the needle.
+    # Without an escape budget, the needle would be invisible to dense.
+    # With dense_prefilter_escape_budget=5, the complement scan must surface it.
+    hits = g.query_genes_dense_recall(
+        "query", k=10,
+        candidate_ids={"g-002"},
+        dense_prefilter_escape_budget=5,
+    )
+    ids = [gid for gid, _ in hits]
+    assert "needle" in ids, (
+        f"escape budget should surface the cold-lex needle outside candidate_ids; "
+        f"got {ids}"
+    )
+    assert "g-002" in ids, (
+        f"the constrained candidate should also appear; got {ids}"
+    )
+    # Needle has cosine=1.0 (query_target match); g-002 has cosine~0.
+    # The cold-lex hit should outrank the constrained hit on score.
+    score_by_id = dict(hits)
+    assert score_by_id["needle"] > score_by_id["g-002"], (
+        f"needle cosine should beat g-002; got needle={score_by_id['needle']} "
+        f"g-002={score_by_id['g-002']}"
+    )
+
+
+def test_dense_recall_candidate_ids_none_preserves_full_scan(dense_genome):
+    """Regression guard: candidate_ids=None (the default) preserves
+    today's behavior — full matmul over all rows.
+    """
+    g = dense_genome
+    for i in range(10):
+        gid = f"g-{i:03d}"
+        g.upsert_gene(_make_gene(f"body {i}", gene_id=gid))
+        _populate_v2(g, gid, _hash_vec(f"vec-{gid}", 1024))
+    g._dense_codec = _FakeCodec(dim=1024, query_target="vec-g-007")
+
+    # Without the new kwarg: existing call shape, behavior unchanged.
+    out_default = g.query_genes_dense_recall("query", k=3)
+    # With candidate_ids=None explicitly: same behavior.
+    out_none = g.query_genes_dense_recall("query", k=3, candidate_ids=None)
+
+    assert out_default == out_none, (
+        "candidate_ids=None must be identical to omitting the kwarg"
+    )
+    assert out_default[0][0] == "g-007", (
+        f"full scan should find g-007 at top; got {out_default}"
+    )
+
+
+# ── End-to-end: prefilter wire-up through query_docs ─────────────────
+
+
+def _prefilter_genome(*, prefilter_enabled: bool, escape_budget: int) -> Genome:
+    g = Genome(
+        path=":memory:",
+        dense_embedding_enabled=True,
+        dense_embedding_dim=1024,
+        dense_pool_size=500,
+        fusion_mode="additive",
+        dense_prefilter_enabled=prefilter_enabled,
+        dense_prefilter_escape_budget=escape_budget,
+    )
+    _orig = g.upsert_doc
+    def _ungated(gene, apply_gate=False):
+        return _orig(gene, apply_gate=apply_gate)
+    g.upsert_doc = _ungated
+    g.upsert_gene = _ungated
+    return g
+
+
+def _seed_anchor_and_dense_only_needle(g: Genome, target: str) -> None:
+    # Lex anchor — populates gene_scores so the prefilter has candidates.
+    g.upsert_gene(_make_gene(
+        "alpha lexical anchor body", domains=["alpha"], gene_id="anchor",
+    ))
+    # Needle — token-disjoint from the query, reachable only via dense.
+    g.upsert_gene(_make_gene(
+        "wholly disjoint surface tokens for the dense-only needle",
+        domains=["needle"], gene_id="needle",
+    ))
+    _populate_v2(g, "anchor", _hash_vec("anchor-noise", 1024))
+    _populate_v2(g, "needle", _hash_vec(target, 1024))
+    g._dense_codec = _FakeCodec(dim=1024, query_target=target)
+
+
+def test_dense_prefilter_off_preserves_needle_recall():
+    """Regression guard: with the prefilter OFF (the default), a dense-only
+    needle still surfaces through query_docs — today's behavior unchanged.
+    """
+    g = _prefilter_genome(prefilter_enabled=False, escape_budget=0)
+    try:
+        _seed_anchor_and_dense_only_needle(g, target="prefilter-off-target")
+        docs = g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        ids = {d.gene_id for d in docs}
+        assert "needle" in ids, (
+            f"prefilter off: dense should still find the lex-disjoint needle; "
+            f"got {ids}"
+        )
+    finally:
+        g.close()
+
+
+def test_dense_prefilter_on_with_zero_escape_budget_excludes_needle():
+    """Wire-up: with prefilter ON and escape_budget=0, a dense-only needle
+    is excluded — dense matmul is scoped to lex/SPLADE candidates.
+    """
+    g = _prefilter_genome(prefilter_enabled=True, escape_budget=0)
+    try:
+        _seed_anchor_and_dense_only_needle(g, target="prefilter-on-target")
+        docs = g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        ids = {d.gene_id for d in docs}
+        assert "needle" not in ids, (
+            f"prefilter on + escape_budget=0: lex-disjoint needle must be "
+            f"excluded from dense; got {ids}"
+        )
+        # The lex anchor is unchanged — prefilter does not drop lex hits.
+        assert "anchor" in ids, (
+            f"the lex anchor must still be returned; got {ids}"
+        )
+    finally:
+        g.close()
+
+
+def test_dense_prefilter_on_with_escape_budget_recovers_needle():
+    """Escape valve: with prefilter ON and escape_budget > 0, the needle is
+    recovered via the complement scan (recall preservation knob).
+    """
+    g = _prefilter_genome(prefilter_enabled=True, escape_budget=5)
+    try:
+        _seed_anchor_and_dense_only_needle(g, target="prefilter-escape-target")
+        docs = g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        ids = {d.gene_id for d in docs}
+        assert "needle" in ids, (
+            f"escape_budget should recover the needle; got {ids}"
+        )
+    finally:
+        g.close()
+
+
+def test_dense_prefilter_config_defaults_and_plumbing():
+    """Constructor defaults: prefilter OFF, escape_budget=0; both are
+    stored on the instance and accept overrides.
+    """
+    g_default = Genome(path=":memory:")
+    g_custom = Genome(
+        path=":memory:",
+        dense_prefilter_enabled=True,
+        dense_prefilter_escape_budget=250,
+    )
+    try:
+        assert g_default._dense_prefilter_enabled is False
+        assert g_default._dense_prefilter_escape_budget == 0
+        assert g_custom._dense_prefilter_enabled is True
+        assert g_custom._dense_prefilter_escape_budget == 250
+    finally:
+        g_default.close()
+        g_custom.close()

--- a/tests/test_sharded_adapter_parity.py
+++ b/tests/test_sharded_adapter_parity.py
@@ -133,6 +133,9 @@ ADAPTER_ONLY_DIFFERENCES_WHITELIST = frozenset({
     "_auto_link_by_entity", "_bm25_candidate_set", "_compact_row_to_gene",
     "_expand_by_entity_graph", "_expand_coactivated", "_expand_terms",
     "_get_dense_codec", "_get_effective_ann_threshold",
+    # SPLADE pre-filter helper — operates on the per-genome dense matrix
+    # (each shard has its own; the adapter does not). Issue #159.
+    "_dense_recall_with_prefilter",
     "_init_db", "_refresh_snapshot", "_row_to_gene",
 
     # FTS / KV / indexing helpers that operate on a single .db file's


### PR DESCRIPTION
## Summary

Issue #159 Wall-2 lever — SPLADE pre-filter for dense matmul. At 100+ shard scale, dense recall scales linearly with N_total_genes (~850K on the onyx_full corpus → ~870M FLOPs/query). The 2026-05-26 router probe (see PRD §1) showed neither the shard router nor entities-exact fingerprint OR-matching can winnow at the query level — SPLADE pre-filter is the unambiguous #1 Wall-2 lever per the per-query simulation.

This PR ships the lever **dark** — API + config + wire-up, default off. A follow-up PR will flip the default after the four-run ablation gate in PRD §5 passes.

## Design

Full design rationale, alternatives considered, and sign-off decisions in [docs/prds/2026-05-26-splade-prefilter-dense-recall.md](docs/prds/2026-05-26-splade-prefilter-dense-recall.md). This is the inaugural use of the PRD-first workflow (write design doc → sign off → implement); PRD §6 records the four resolved decisions.

**API additions** (keyword-only kwargs on `query_docs_dense_recall`):
- `candidate_ids: Optional[set[str]] = None` — scopes matmul to provided subset
- `dense_prefilter_escape_budget: int = 0` — **result budget, NOT a FLOP budget**; reserves N slots for an unconstrained complement scan that recovers cold-lex needles

**Config knobs** (helix.toml + `RetrievalConfig` + `KnowledgeStore` ctor):
- `dense_prefilter_enabled` (bool, default false)
- `dense_prefilter_escape_budget` (int, default 0)

**Wire-up** in `_retrieve` behind the feature flag; empty `gene_scores` falls back to full scan to preserve dense-only needle recall on pure cold-lex queries.

## Test plan

- [x] 5 unit tests on `candidate_ids` / `dense_prefilter_escape_budget` (constraints, empty set, unknown ids, escape recovery, `None`-default regression)
- [x] 4 integration tests via `query_docs` (prefilter off / on×budget=0 / on×budget>0 / config plumbing)
- [x] Sharded adapter parity whitelist entry for new private helper `_dense_recall_with_prefilter`
- [x] 79/79 pass across `test_dense_recall`, `test_sharded_adapter_parity`, `test_calibration`, `test_ingest_dense_v2`, `test_fixture_dense_backfill`
- [ ] Four-run ablation on EnterpriseRAG-Bench (T baseline / A SPLADE-off / B prefilter-on+escape=0 / C prefilter-on+escape=250) — gates the follow-up default-flip PR per PRD §5

## Notes

- No behavior change in production until `dense_prefilter_enabled = true` lands in `helix.toml` via a follow-up PR.
- Stacks alongside (does not depend on) #155, #156, #157, #158 — all targeting the same `bench/int-5fixture` base.
- Combined with #158 (parallel fan-out + SPLADE lift-out), the SPLADE encoding is hoisted once per query AND the dense matmul is scoped per shard — the combined effect is the actual Wall-2 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)