### PR TITLE
feat(bench): consolidated build bundle + enterprise_rag_onyx_full_2 (supersedes #155, #156, #157)

### DIFF
--- a/helix_context/storage/ddl.py
+++ b/helix_context/storage/ddl.py
@@ -344,12 +344,34 @@ def _create_fts5(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> bool:
             conn.commit()
             log.info("FTS5 incremental sync: +%d genes (total: %d)", delta, gene_count)
         elif delta < 0:
-            cur.execute(
-                "DELETE FROM genes_fts "
-                "WHERE gene_id NOT IN (SELECT gene_id FROM genes)"
-            )
-            conn.commit()
-            log.info("FTS5 cleanup: removed %d orphan entries", -delta)
+            # Orphan FTS5 entries are HARMLESS at query time: downstream
+            # ``gene_id`` joins return NULL for missing rows and the orphan
+            # is filtered out before delivery. The previous cleanup used
+            # ``WHERE gene_id NOT IN (SELECT gene_id FROM genes)`` which is
+            # an O(N*M) correlated subquery — on a 850K-gene sharded fixture
+            # (105 shards averaged ~8K genes each, ~40 orphans per shard) it
+            # pegged a single core for 5-10 minutes PER SHARD on cold-cache,
+            # blocking the daemon's first /fingerprint response for hours.
+            # Skip cleanup entirely when orphans are <5% of gene_count
+            # (statistical noise); use an indexed NOT EXISTS for the rare
+            # significant-drift case.
+            orphan_ratio = -delta / max(gene_count, 1)
+            if orphan_ratio < 0.05:
+                log.info(
+                    "FTS5 has %d orphan entries (%.2f%% of %d genes); "
+                    "leaving as-is (harmless at query time)",
+                    -delta, orphan_ratio * 100, gene_count,
+                )
+            else:
+                cur.execute(
+                    "DELETE FROM genes_fts "
+                    "WHERE NOT EXISTS ("
+                    "  SELECT 1 FROM genes "
+                    "  WHERE genes.gene_id = genes_fts.gene_id"
+                    ")"
+                )
+                conn.commit()
+                log.info("FTS5 cleanup: removed %d orphan entries", -delta)
         return True
     except Exception:
         log.warning(

--- a/helix_context/tagger.py
+++ b/helix_context/tagger.py
@@ -143,9 +143,18 @@ _KV_PATTERNS = [
     (re.compile(r'(?:host|address|bind)\s*[=:]\s*["\']?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|localhost)', re.IGNORECASE), "host"),
 ]
 
-# Patterns that extract key=value pairs
+# Patterns that extract key=value pairs.
+#
+# NB: the key group used to be ``(\w+(?:_\w+)*)`` but ``\w`` already includes
+# ``_``, so the inner alternation ``(?:_\w+)*`` was redundant ambiguity that
+# triggered catastrophic backtracking on underscore-heavy content (e.g.
+# EnterpriseRAG-Bench JSON with keys like ``expected_doc_ids``,
+# ``data_source_id``). A single worker spinning on `tagger.py:439`'s
+# ``finditer(content[:5000])`` hung the build for 60+ minutes on one google-
+# drive shared-drives file. ``(\w+)`` is functionally identical (same match
+# set, since ``\w`` includes ``_``) but has no nested quantifier.
 _KV_PAIR_PATTERN = re.compile(
-    r'(\w+(?:_\w+)*)\s*[=:]\s*["\']?(\d+(?:\.\d+)?(?:s|ms|m|h|mb|gb|kb)?|true|false|[a-zA-Z0-9._:/-]+)["\']?',
+    r'(\w+)\s*[=:]\s*["\']?(\d+(?:\.\d+)?(?:s|ms|m|h|mb|gb|kb)?|true|false|[a-zA-Z0-9._:/-]+)["\']?',
     re.IGNORECASE,
 )
 

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -615,6 +615,37 @@ PROFILES: dict[str, dict] = {
         "extra_skip_dirs": set(),
         "extra_filename_filters": [],
     },
+    # Indexes EnterpriseRAG-Bench's official 500K-doc corpus directly from the
+    # upstream repo layout (no prep-copy subset). Roots are scoped to the 9
+    # source-type subdirs under ``generated_data/sources/`` exactly; everything
+    # outside that subtree is EXCLUDED:
+    #   - ``questions.jsonl`` / ``extra_questions.jsonl`` (benchmark Q&A)
+    #   - ``answer_evaluation/`` (eval infrastructure)
+    #   - ``uuid_index.json`` (dsid→file answer-key map; lives in
+    #     ``generated_data/`` ROOT, not under sources/)
+    #   - ``src/`` (benchmark generation code)
+    #   - ``company_overview.md`` / ``employee_directory.yaml`` / etc.
+    #     (top-level metadata, also outside sources/)
+    # Gold-path audit (2026-05-25): all 742 ``expected_doc_ids`` across 500
+    # questions resolve INTO ``sources/`` subdirs — zero outside, zero missing —
+    # so this scope is the canonical Onyx leaderboard-comparable corpus.
+    "enterprise_rag_onyx_full": {
+        "label": "EnterpriseRAG-Bench Onyx official 500K corpus (leaderboard-comparable)",
+        "active_roots": 9,
+        "roots": [
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\confluence",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\fireflies",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\github",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\gmail",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\google_drive",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\hubspot",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\jira",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\linear",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\slack",
+        ],
+        "extra_skip_dirs": set(),
+        "extra_filename_filters": [],
+    },
     "xl": {
         "label": "Projects plus external Steam/game code corpus",
         "active_roots": 13,
@@ -1040,6 +1071,130 @@ def _decompose_oversized_root(
     return parts or [(parent_slug, root)]
 
 
+def _try_salvage_complete_shard(
+    p: Path, label: str, root: str,
+) -> Optional[dict]:
+    """Return a result dict for an already-complete shard on disk, or None.
+
+    Used by ``_build_one_shard`` to skip a rebuild when a prior run already
+    produced a fully-ingested + fully-dense-backfilled shard ``.db``. A shard
+    is considered complete iff (a) the file exists with no live WAL sidecar,
+    (b) the ``genes`` table has rows, AND (c) every row has a populated
+    ``embedding_dense_v2`` column (dense_coverage == 100%). Anything else
+    falls back to a full rebuild.
+
+    Returns the same result-dict shape that the build path constructs, so
+    the parent's ``_commit_shard_result`` can register the shard idempotently
+    (main.db uses ``INSERT OR REPLACE`` on both fingerprint_index and
+    source_index — duplicate registrations are safe).
+    """
+    import sqlite3 as _sqlite3
+    # WAL sidecar with non-zero size means an uncommitted transaction; treat
+    # as incomplete and rebuild to avoid resurrecting partial state.
+    wal_path = Path(str(p) + "-wal")
+    if wal_path.exists() and wal_path.stat().st_size > 0:
+        return None
+    try:
+        conn = _sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+        conn.row_factory = _sqlite3.Row
+        try:
+            # Required tables exist + has rows
+            tables = {
+                r[0] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            if "genes" not in tables:
+                return None
+            cur = conn.execute("SELECT COUNT(*) FROM genes")
+            gene_count = cur.fetchone()[0]
+            if gene_count == 0:
+                return None
+            # Schema check: embedding_dense_v2 column present
+            cols = {
+                r[1] for r in conn.execute(
+                    "PRAGMA table_info(genes)"
+                ).fetchall()
+            }
+            if "embedding_dense_v2" not in cols:
+                return None
+            # 100% dense coverage required
+            populated = conn.execute(
+                "SELECT COUNT(*) FROM genes "
+                "WHERE embedding_dense_v2 IS NOT NULL"
+            ).fetchone()[0]
+            if populated != gene_count:
+                return None
+            # Rebuild the same fingerprint_payload + source_index_payload
+            # that the normal build path produces (lines below mirror the
+            # construction in ``_build_one_shard``).
+            fp_rows = conn.execute(
+                "SELECT gene_id, source_id, repo_root, source_kind, "
+                "observed_at, mtime, content_hash, volatility_class, "
+                "authority_class, support_span, last_verified_at, "
+                "promoter, key_values, is_fragment "
+                "FROM genes"
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+    now = time.time()
+    fp_payload = []
+    si_payload = []
+    for r in fp_rows:
+        promoter_blob = r["promoter"]
+        domains_json = None
+        entities_json = None
+        if promoter_blob:
+            try:
+                pm = json.loads(promoter_blob)
+                domains_json = json.dumps(pm.get("domains") or [])
+                entities_json = json.dumps(pm.get("entities") or [])
+            except Exception:
+                pass
+        fp_payload.append((
+            r["gene_id"], label, r["source_id"],
+            domains_json, entities_json, r["key_values"],
+            0 if r["is_fragment"] else 1, None, now,
+        ))
+        observed_at = r["observed_at"] if r["observed_at"] is not None else now
+        last_verified_at = (
+            r["last_verified_at"] if r["last_verified_at"] is not None else now
+        )
+        si_payload.append((
+            r["gene_id"], label, r["source_id"], r["repo_root"],
+            r["source_kind"], observed_at, r["mtime"], r["content_hash"],
+            r["volatility_class"] or "medium",
+            r["authority_class"] or "primary",
+            r["support_span"], last_verified_at,
+            None, now,
+        ))
+    try:
+        byte_size = p.stat().st_size if p.is_file() else 0
+    except OSError:
+        byte_size = 0
+    return {
+        "label": label,
+        "root": root,
+        "shard_db_path": str(p),
+        "gene_count": gene_count,
+        "byte_size": byte_size,
+        "elapsed_s": 0.0,
+        "files": 0,
+        "genes": gene_count,
+        "skipped": 0,
+        "errors": 0,
+        "missing_roots": [],
+        "fingerprint_payload": fp_payload,
+        "source_index_payload": si_payload,
+        "dense_coverage": 100.0,
+        "dense_genes_populated": gene_count,
+        "salvaged": True,
+    }
+
+
 def _build_one_shard(
     label: str,
     root: str,
@@ -1061,7 +1216,14 @@ def _build_one_shard(
     :func:`_shard_worker_entry`).
     """
     p = Path(shard_db_path)
+    # Resume support: if a prior run left a complete shard on disk
+    # (genes ingested + 100% dense coverage), skip rebuild. Returning early
+    # here lets ``_commit_shard_result`` re-register via INSERT OR REPLACE.
     if p.exists():
+        salvaged = _try_salvage_complete_shard(p, label, root)
+        if salvaged is not None:
+            return salvaged
+        # Incomplete: nuke and rebuild.
         p.unlink()
         for s in (str(p) + "-wal", str(p) + "-shm"):
             if os.path.exists(s):

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -646,6 +646,32 @@ PROFILES: dict[str, dict] = {
         "extra_skip_dirs": set(),
         "extra_filename_filters": [],
     },
+    # Path-A rebuild of the Onyx-full corpus (Issue #159 Wall-1 fix): same 9
+    # source roots, but built WITHOUT the v1 session's
+    # ``--auto-subshard-threshold-files 20000`` override. With the builder's
+    # default 100K threshold the slack/gmail/google_drive sources stay as
+    # single shards instead of being decomposed into ~50 micro-shards each,
+    # yielding ~12 fewer-larger shards (~3-5 GB each) instead of 105.
+    # Target: daemon mmap fits in ~50 GB committed (vs 247 GB on v1's 105
+    # shards), eliminating pagefile-thrashing observed in the 2026-05-26
+    # ablation (see [[project_helix_109_shard_pressure_test]]).
+    "enterprise_rag_onyx_full_2": {
+        "label": "EnterpriseRAG-Bench Onyx 500K corpus, Path-A rebuild (~12 shards)",
+        "active_roots": 9,
+        "roots": [
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\confluence",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\fireflies",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\github",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\gmail",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\google_drive",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\hubspot",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\jira",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\linear",
+            r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\slack",
+        ],
+        "extra_skip_dirs": set(),
+        "extra_filename_filters": [],
+    },
     "xl": {
         "label": "Projects plus external Steam/game code corpus",
         "active_roots": 13,


### PR DESCRIPTION
## Summary

Consolidated bundle of all build-pipeline fixes needed to rebuild the Onyx EnterpriseRAG corpus in a Wall-1-friendly shape, plus the new profile that points to that rebuild. Supersedes three open PRs that have been sitting independently for a week.

## What's in here

| Commit | Origin | Purpose |
| --- | --- | --- |
| `fix(tagger): eliminate catastrophic backtracking in _KV_PAIR_PATTERN` | from #155 | Prevents the v1 build's 60+ min hangs on underscore-heavy enterprise JSON (slack/google_drive). Without this, the build hangs at the slack-mega-shard. |
| `perf(ddl): skip FTS5 orphan cleanup when delta is <5% of gene count` | from #157 | O(N²) → no-op for small drift. Unblocks daemon `/health` and shard-open path at scale. |
| `feat(build): salvage already-complete shards on rebuild (resume support)` | from #156 | Allows kill+restart of long builds without losing completed shards. Saved 13h during prior session's restart cycle. |
| `feat(bench): add enterprise_rag_onyx_full_2 profile for Path-A rebuild` | **net-new** | Same 9 source roots as `enterprise_rag_onyx_full`, but intended to be built with the builder's DEFAULT `--auto-subshard-threshold-files 100000` instead of the prior session's `20000` override. Yields ~12 fewer-larger shards (~3-5 GB each) instead of 105 micro-shards. |

## Why consolidate

PR #160's 2026-05-26 ablation on the v1 fixture (105 shards) showed **Wall-1 (mmap + heap thrashing through pagefile) dominates Wall-2 (matmul FLOPs)** on a 48 GB RAM box, masking the SPLADE prefilter's actual FLOP-savings story. The Path-A rebuild's ~50 GB mmap footprint fits in commit budget without paging, restoring the conditions under which prefilter savings (and SPLADE's standalone value) can be measured cleanly.

The three superseded PRs are **inseparable** in practice — the v2 fixture build hangs without #155's regex fix, and #156's salvage feature is needed for safe iteration on multi-hour builds. Shipping them together makes the narrative tractable.

## Test plan

- [x] Cherry-picked commits apply cleanly on top of `bench/int-5fixture` (no conflicts)
- [x] `enterprise_rag_onyx_full_2` profile is currently building on Max's box using exactly the bundle in this PR — build is alive and progressing at ~16 genes/sec
- [ ] Build completion + verification that the fixture has 100% dense + SPLADE coverage (in progress, ~7-10h remaining)
- [ ] Re-run the PR #160 4-variant ablation on the new fixture to confirm Wall-1 relief (queued behind build completion)

## References

- Issue #159 (Wall-1 + Wall-2 in helix-context)
- PR #160 (SPLADE prefilter, including the §5 ablation that motivated this rebuild)
- `docs/prds/2026-05-26-splade-prefilter-dense-recall.md` §5 (the Wall-1-dominates finding)

## Supersedes

Closing on merge: #155, #156, #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)