### PR TITLE
fix(tagger,ddl) + feat(build): cherry-pick + port PR #161 fixes onto master

### DIFF
--- a/helix_context/storage/ddl.py
+++ b/helix_context/storage/ddl.py
@@ -344,12 +344,34 @@ def _create_fts5(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> bool:
             conn.commit()
             log.info("FTS5 incremental sync: +%d genes (total: %d)", delta, gene_count)
         elif delta < 0:
-            cur.execute(
-                "DELETE FROM genes_fts "
-                "WHERE gene_id NOT IN (SELECT gene_id FROM genes)"
-            )
-            conn.commit()
-            log.info("FTS5 cleanup: removed %d orphan entries", -delta)
+            # Orphan FTS5 entries are HARMLESS at query time: downstream
+            # ``gene_id`` joins return NULL for missing rows and the orphan
+            # is filtered out before delivery. The previous cleanup used
+            # ``WHERE gene_id NOT IN (SELECT gene_id FROM genes)`` which is
+            # an O(N*M) correlated subquery — on a 850K-gene sharded fixture
+            # (105 shards averaged ~8K genes each, ~40 orphans per shard) it
+            # pegged a single core for 5-10 minutes PER SHARD on cold-cache,
+            # blocking the daemon's first /fingerprint response for hours.
+            # Skip cleanup entirely when orphans are <5% of gene_count
+            # (statistical noise); use an indexed NOT EXISTS for the rare
+            # significant-drift case.
+            orphan_ratio = -delta / max(gene_count, 1)
+            if orphan_ratio < 0.05:
+                log.info(
+                    "FTS5 has %d orphan entries (%.2f%% of %d genes); "
+                    "leaving as-is (harmless at query time)",
+                    -delta, orphan_ratio * 100, gene_count,
+                )
+            else:
+                cur.execute(
+                    "DELETE FROM genes_fts "
+                    "WHERE NOT EXISTS ("
+                    "  SELECT 1 FROM genes "
+                    "  WHERE genes.gene_id = genes_fts.gene_id"
+                    ")"
+                )
+                conn.commit()
+                log.info("FTS5 cleanup: removed %d orphan entries", -delta)
         return True
     except Exception:
         log.warning(

--- a/helix_context/tagger.py
+++ b/helix_context/tagger.py
@@ -143,9 +143,18 @@ _KV_PATTERNS = [
     (re.compile(r'(?:host|address|bind)\s*[=:]\s*["\']?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|localhost)', re.IGNORECASE), "host"),
 ]
 
-# Patterns that extract key=value pairs
+# Patterns that extract key=value pairs.
+#
+# NB: the key group used to be ``(\w+(?:_\w+)*)`` but ``\w`` already includes
+# ``_``, so the inner alternation ``(?:_\w+)*`` was redundant ambiguity that
+# triggered catastrophic backtracking on underscore-heavy content (e.g.
+# EnterpriseRAG-Bench JSON with keys like ``expected_doc_ids``,
+# ``data_source_id``). A single worker spinning on `tagger.py:439`'s
+# ``finditer(content[:5000])`` hung the build for 60+ minutes on one google-
+# drive shared-drives file. ``(\w+)`` is functionally identical (same match
+# set, since ``\w`` includes ``_``) but has no nested quantifier.
 _KV_PAIR_PATTERN = re.compile(
-    r'(\w+(?:_\w+)*)\s*[=:]\s*["\']?(\d+(?:\.\d+)?(?:s|ms|m|h|mb|gb|kb)?|true|false|[a-zA-Z0-9._:/-]+)["\']?',
+    r'(\w+)\s*[=:]\s*["\']?(\d+(?:\.\d+)?(?:s|ms|m|h|mb|gb|kb)?|true|false|[a-zA-Z0-9._:/-]+)["\']?',
     re.IGNORECASE,
 )
 

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -72,7 +72,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 # Also put this ``scripts/`` dir on the path so the sibling-module import of
@@ -743,6 +743,124 @@ def _slug_for_root(root: str) -> str:
     return slug or "root"
 
 
+def _try_salvage_complete_shard(
+    p: Path, label: str, root: str,
+) -> Optional[dict]:
+    """Return a result dict for an already-complete shard on disk, or None.
+
+    Used by ``_build_one_shard`` to skip a rebuild when a prior run already
+    produced a fully-ingested + fully-dense-backfilled shard ``.db``. A shard
+    is considered complete iff (a) the file exists with no live WAL sidecar,
+    (b) the ``genes`` table has rows, AND (c) every row has a populated
+    ``embedding_dense_v2`` column (dense_coverage == 100%). Anything else
+    falls back to a full rebuild.
+
+    Returns the same result-dict shape that the build path constructs, so
+    the parent's ``_commit_shard_result`` can register the shard idempotently
+    (main.db uses ``INSERT OR REPLACE`` on both fingerprint_index and
+    source_index — duplicate registrations are safe).
+    """
+    import sqlite3 as _sqlite3
+    # WAL sidecar with non-zero size means an uncommitted transaction; treat
+    # as incomplete and rebuild to avoid resurrecting partial state.
+    wal_path = Path(str(p) + "-wal")
+    if wal_path.exists() and wal_path.stat().st_size > 0:
+        return None
+    try:
+        conn = _sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+        conn.row_factory = _sqlite3.Row
+        try:
+            tables = {
+                r[0] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            if "genes" not in tables:
+                return None
+            cur = conn.execute("SELECT COUNT(*) FROM genes")
+            gene_count = cur.fetchone()[0]
+            if gene_count == 0:
+                return None
+            cols = {
+                r[1] for r in conn.execute(
+                    "PRAGMA table_info(genes)"
+                ).fetchall()
+            }
+            if "embedding_dense_v2" not in cols:
+                return None
+            populated = conn.execute(
+                "SELECT COUNT(*) FROM genes "
+                "WHERE embedding_dense_v2 IS NOT NULL"
+            ).fetchone()[0]
+            if populated != gene_count:
+                return None
+            fp_rows = conn.execute(
+                "SELECT gene_id, source_id, repo_root, source_kind, "
+                "observed_at, mtime, content_hash, volatility_class, "
+                "authority_class, support_span, last_verified_at, "
+                "promoter, key_values, is_fragment "
+                "FROM genes"
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+    now = time.time()
+    fp_payload = []
+    si_payload = []
+    for r in fp_rows:
+        promoter_blob = r["promoter"]
+        domains_json = None
+        entities_json = None
+        if promoter_blob:
+            try:
+                pm = json.loads(promoter_blob)
+                domains_json = json.dumps(pm.get("domains") or [])
+                entities_json = json.dumps(pm.get("entities") or [])
+            except Exception:
+                pass
+        fp_payload.append((
+            r["gene_id"], label, r["source_id"],
+            domains_json, entities_json, r["key_values"],
+            0 if r["is_fragment"] else 1, None, now,
+        ))
+        observed_at = r["observed_at"] if r["observed_at"] is not None else now
+        last_verified_at = (
+            r["last_verified_at"] if r["last_verified_at"] is not None else now
+        )
+        si_payload.append((
+            r["gene_id"], label, r["source_id"], r["repo_root"],
+            r["source_kind"], observed_at, r["mtime"], r["content_hash"],
+            r["volatility_class"] or "medium",
+            r["authority_class"] or "primary",
+            r["support_span"], last_verified_at,
+            None, now,
+        ))
+    try:
+        byte_size = p.stat().st_size if p.is_file() else 0
+    except OSError:
+        byte_size = 0
+    return {
+        "label": label,
+        "root": root,
+        "shard_db_path": str(p),
+        "gene_count": gene_count,
+        "byte_size": byte_size,
+        "elapsed_s": 0.0,
+        "files": 0,
+        "genes": gene_count,
+        "skipped": 0,
+        "errors": 0,
+        "missing_roots": [],
+        "fingerprint_payload": fp_payload,
+        "source_index_payload": si_payload,
+        "dense_coverage": 100.0,
+        "dense_genes_populated": gene_count,
+        "salvaged": True,
+    }
+
+
 def _build_one_shard(
     label: str,
     root: str,
@@ -764,7 +882,14 @@ def _build_one_shard(
     :func:`_shard_worker_entry`).
     """
     p = Path(shard_db_path)
+    # Resume support: if a prior run left a complete shard on disk
+    # (genes ingested + 100% dense coverage), skip rebuild. Returning early
+    # here lets ``_commit_shard_result`` re-register via INSERT OR REPLACE.
     if p.exists():
+        salvaged = _try_salvage_complete_shard(p, label, root)
+        if salvaged is not None:
+            return salvaged
+        # Incomplete: nuke and rebuild.
         p.unlink()
         for s in (str(p) + "-wal", str(p) + "-shm"):
             if os.path.exists(s):


### PR DESCRIPTION
## Summary

Cherry-picks (and one manual port) of the **master-mergeable** commits from open PR #161, so anyone deploying from `origin/master` — including remote contributors building the EnterpriseRAG-Onyx corpus — picks up the catastrophic-backtracking fix, the FTS5-cleanup-perf fix, and the shard-resume-on-rebuild helper that have been gating Linux/DGX-Spark deploys.

### Commits

1. **`fix(tagger): eliminate catastrophic backtracking in _KV_PAIR_PATTERN`** (`05195887` from #161, clean cherry-pick)
   - `(\w+(?:_\w+)*)` → `(\w+)` in `helix_context/tagger.py:156`
   - `\w` already includes `_`, so the inner alternation was redundant nested-quantifier ambiguity
   - **60+ minute hang → 0.5–2ms** on underscore-heavy JSON content (verified on the EnterpriseRAG-Onyx `gmail/jonas_weber` shard that originally triggered the bug)
   - Convergent forensic evidence: two independent py-spy investigations on different hardware (Windows + DGX Spark) on different days both fingered the same line + same root cause

2. **`perf(ddl): skip FTS5 orphan cleanup when delta is <5% of gene count`** (`40608870` from #161, clean cherry-pick)
   - Replaces an O(N·M) `NOT IN` correlated subquery with an indexed `NOT EXISTS` for the significant-drift path
   - Skips cleanup entirely for the typical case (trivial orphan delta) — orphan FTS5 entries are harmless at query time (downstream `gene_id` joins filter them out)
   - **Daemon `/health` first-response: \"hangs forever\" → milliseconds** on the 850K-gene EnterpriseRAG-Onyx fixture

3. **`feat(build): salvage already-complete shards on rebuild (resume support)`** (manual port of `a6934da1` from #161)
   - Adds `_try_salvage_complete_shard()` to `scripts/build_fixture_matrix.py` + hooks it into `_build_one_shard`'s entry
   - On rebuild, opens each existing shard `.db` read-only, verifies 100% dense backfill + no live WAL, and short-circuits the rebuild by returning a result-dict that `_commit_shard_result` can re-register via INSERT OR REPLACE
   - **Verified at scale**: 21 of 22 already-complete shards re-registered in 2min 19sec into a fresh main.genome.db (vs ~13 hours to rebuild from scratch) during a kill+restart of the EnterpriseRAG-Onyx 850K-gene build
   - **Why a manual port instead of cherry-pick**: the original commit's textual diff included the `enterprise_rag_onyx_full` profile entry and sat next to PR #149's `_decompose_oversized_root` (auto-subsharding, only on `bench/int-5fixture`). Neither is a runtime dependency of the salvage helper. This commit ports only the helper + the `_build_one_shard` hook, and confirms master's existing `_build_one_shard` / `_commit_shard_result` / `genes` schema match the helper's expectations exactly.

### What's still NOT on master after this PR

- `enterprise_rag_onyx_full_2` profile entry — depends on PR #149's profile machinery from `bench/int-5fixture`. Anyone needing v2 profile builds still has to base from PR #161's branch.
- Other bench-branch additions (per-gene budget allocator, auto-subshard threshold flags, etc.) — same reason.

### Verification

- All three commits land on a clean checkout of `origin/master` with no conflicts (commits 1 + 2 via cherry-pick, commit 3 via manual port + `ast.parse` + smoke tests)
- Tagger regex re-tested post-cherry-pick: 200-underscore chain = 1.9ms, 5000-char JSON = 0.5ms
- DDL fix verified at scale during the 850K-gene EnterpriseRAG-Onyx build (all 105 shards skip cleanup, daemon boots in seconds)
- Salvage helper smoke-tested on master: empty file → None, missing `genes` table → None, missing `embedding_dense_v2` column → None, non-empty WAL sidecar → None
- Companion regression tests live on PR #155's branch but were not consolidated into #161 — that's a known follow-up

## Test plan

- [x] All three commits apply cleanly to `origin/master` (no conflicts)
- [x] `_KV_PAIR_PATTERN` smoke test: <10ms on ReDoS pathological inputs
- [x] `_try_salvage_complete_shard` early-return paths smoke-tested on master
- [x] `python -m ast` parses the modified `build_fixture_matrix.py` cleanly
- [ ] CI green (no CI currently configured on this repo — local `pytest tests/test_tagger_kv.py` passes)
- [ ] Reviewer sanity-check: confirm the salvage helper's `fp_payload` / `si_payload` column tuples match `_commit_shard_result`'s INSERT signatures on master (they do as of HEAD, but worth eyeballing the SQL one more time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)