### PR TITLE
fix(knowledge_store): batch IN-clause queries to stay under SQLite cap

### DIFF
--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -308,6 +308,37 @@ _DENSITY_RATE_MIN_HITS = 3      # ≥3 accesses in the window → override
 # every retrieval call.
 _CORPUS_SIZE_TTL = 60.0
 
+# SQLite caps `WHERE col IN (?, ?, ...)` placeholders at
+# SQLITE_LIMIT_VARIABLE_NUMBER. The historical default is 999; modern builds
+# raise it (2000 on the Python 3.12 / SQLite 3.50 ARM64+x86 wheels we ship to,
+# 32766 in some compile defaults). Batch size 500 stays under every cap we
+# care about while keeping the loop overhead negligible for typical retrievals
+# (gene_scores cardinality is usually well below 500 with SPLADE-on; this only
+# loops when callers pass huge candidate sets).
+_IN_BATCH_SIZE = 500
+
+
+def _iter_in_batches(items, batch_size: int = _IN_BATCH_SIZE):
+    """Yield (placeholder_string, batch_list) pairs for an IN-clause query.
+
+    Used by call sites that build `WHERE col IN (?, ?, ...)` from a
+    caller-determined candidate set. Splits the set into chunks small enough
+    that the placeholder count stays under SQLite's
+    `SQLITE_LIMIT_VARIABLE_NUMBER` cap on every supported build.
+
+    Example::
+
+        rows = []
+        for ph, batch in _iter_in_batches(ids):
+            rows.extend(cur.execute(
+                f"SELECT * FROM t WHERE id IN ({ph})", batch,
+            ).fetchall())
+    """
+    items = list(items)
+    for i in range(0, len(items), batch_size):
+        batch = items[i:i + batch_size]
+        yield ",".join("?" * len(batch)), batch
+
 
 class KnowledgeStore:
     """SQLite-backed document storage with tags-tag retrieval."""
@@ -1283,15 +1314,17 @@ class KnowledgeStore:
         recency_window = 48 * 3600  # 48 hours in seconds
 
         gene_ids = list(gene_scores.keys())
-        id_ph = ",".join("?" * len(gene_ids))
         lower_terms = [t.lower() for t in query_terms]
 
-        # Fetch source_id, tags, signals for all candidates in one query
-        rows = cur.execute(
-            f"SELECT gene_id, source_id, promoter, epigenetics "
-            f"FROM genes WHERE gene_id IN ({id_ph})",
-            gene_ids,
-        ).fetchall()
+        # Fetch source_id, tags, signals for all candidates. Batched to stay
+        # under SQLite's IN-clause placeholder cap — see _iter_in_batches.
+        rows = []
+        for _ph, _batch in _iter_in_batches(gene_ids):
+            rows.extend(cur.execute(
+                f"SELECT gene_id, source_id, promoter, epigenetics "
+                f"FROM genes WHERE gene_id IN ({_ph})",
+                _batch,
+            ).fetchall())
 
         for r in rows:
             gid = r["gene_id"]
@@ -1866,12 +1899,14 @@ class KnowledgeStore:
                 _sema_boost_t0 = time.monotonic()
                 if gene_scores and top_score < 20.0:
                     existing_ids = list(gene_scores.keys())
-                    id_ph = ",".join("?" * len(existing_ids))
-                    sema_rows = cur.execute(
-                        f"SELECT gene_id, embedding FROM genes "
-                        f"WHERE gene_id IN ({id_ph}) AND embedding IS NOT NULL",
-                        existing_ids,
-                    ).fetchall()
+                    # Batched IN-clause — see _iter_in_batches.
+                    sema_rows = []
+                    for _ph, _batch in _iter_in_batches(existing_ids):
+                        sema_rows.extend(cur.execute(
+                            f"SELECT gene_id, embedding FROM genes "
+                            f"WHERE gene_id IN ({_ph}) AND embedding IS NOT NULL",
+                            _batch,
+                        ).fetchall())
 
                     if sema_rows:
                         candidates_sema = []
@@ -2203,12 +2238,15 @@ class KnowledgeStore:
         # ── Party attribution bonus (+0.5) ────────────────────────
         if party_id is not None and _party_filter and gene_scores:
             try:
-                attr_ids_ph = ",".join("?" * len(gene_scores))
-                attr_rows = cur.execute(
-                    f"SELECT gene_id FROM gene_attribution "
-                    f"WHERE party_id = ? AND gene_id IN ({attr_ids_ph})",
-                    (party_id, *list(gene_scores.keys())),
-                ).fetchall()
+                # Batched IN-clause — see _iter_in_batches.
+                _attr_ids = list(gene_scores.keys())
+                attr_rows = []
+                for _ph, _batch in _iter_in_batches(_attr_ids):
+                    attr_rows.extend(cur.execute(
+                        f"SELECT gene_id FROM gene_attribution "
+                        f"WHERE party_id = ? AND gene_id IN ({_ph})",
+                        (party_id, *_batch),
+                    ).fetchall())
                 for ar in attr_rows:
                     gid = ar["gene_id"]
                     gene_scores[gid] += 0.5
@@ -2224,12 +2262,14 @@ class KnowledgeStore:
         if gene_scores:
             try:
                 rate_ids = list(gene_scores.keys())
-                rate_ph = ",".join("?" * len(rate_ids))
-                epi_rows = cur.execute(
-                    f"SELECT gene_id, epigenetics FROM genes "
-                    f"WHERE gene_id IN ({rate_ph}) AND epigenetics IS NOT NULL",
-                    rate_ids,
-                ).fetchall()
+                # Batched IN-clause — see _iter_in_batches.
+                epi_rows = []
+                for _ph, _batch in _iter_in_batches(rate_ids):
+                    epi_rows.extend(cur.execute(
+                        f"SELECT gene_id, epigenetics FROM genes "
+                        f"WHERE gene_id IN ({_ph}) AND epigenetics IS NOT NULL",
+                        _batch,
+                    ).fetchall())
                 for er in epi_rows:
                     try:
                         epi = parse_epigenetics(er["epigenetics"])

--- a/tests/test_knowledge_store_batched_in.py
+++ b/tests/test_knowledge_store_batched_in.py
@@ -1,0 +1,177 @@
+"""Regression tests for SQLite IN-clause batching in knowledge_store.py.
+
+SQLite caps `WHERE col IN (?, ?, ...)` placeholders at `SQLITE_LIMIT_VARIABLE_NUMBER`
+(historically 999; 2000 on the Python 3.12 / SQLite 3.50 ARM64+x86 builds we ship
+to; 32766 on newer compile-defaulted SQLite). Several `KnowledgeStore` methods
+build the IN clause from candidate sets whose size is caller-determined and can
+exceed that cap in production:
+
+  - `_apply_authority_boosts`: scoped over `gene_scores`, which on
+    SPLADE-disabled retrieval contains the full dense fan-out (no SPLADE/
+    prefilter narrowing). Observed in the 2026-05-28 v2-fixture 100q bench:
+    3 of 29 queries had a per-shard `_apply_authority_boosts` raise
+    `sqlite3.OperationalError: too many SQL variables`, which the daemon's
+    per-shard try/except swallowed as "shard X query failed; skipping" — biasing
+    recall@K by silently dropping any gold doc that lived in the skipped shard.
+
+  - Sema-boost embedding lookup (~line 1869), party-attribution lookup
+    (~line 2206), access-rate epigenetics lookup (~line 2227): all scoped over
+    `gene_scores` inside the same `query_docs` call. Same failure mode,
+    different code paths.
+
+These tests pin the contract: each of those four call sites must accept a
+candidate set whose size exceeds SQLite's runtime placeholder cap without
+raising. The fix batches the IN clause; the tests don't care HOW (helper vs
+inlined) — only that it doesn't blow up.
+
+Test scale (3000 candidates) is chosen to exceed the empirical 2000 cap on
+the Python 3.12.13 + SQLite 3.50.4 builds in use, while staying well below
+the 32766 cap of newer SQLite builds — meaning the test will RED on every
+build that has the bug and GREEN on every build that has the fix.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from helix_context.knowledge_store import KnowledgeStore
+
+
+# ── Fixture: a KnowledgeStore on a fresh tmp DB ──────────────────────
+
+
+@pytest.fixture
+def store(tmp_path):
+    """A KnowledgeStore backed by an on-disk SQLite file with the full
+    schema initialized (tables created by KnowledgeStore.__init__).
+
+    The genes table is empty — the regression tests below trigger the
+    SQL-variable cap at BIND time (before any rows are returned), so an
+    empty table is sufficient to expose the bug.
+    """
+    s = KnowledgeStore(path=str(tmp_path / "kv-batched-in.db"))
+    yield s
+    try:
+        s.conn.close()
+    except Exception:
+        pass
+
+
+# ── _apply_authority_boosts: the site that fired in production ──────
+
+
+def test_apply_authority_boosts_does_not_blow_up_past_sqlite_cap(store):
+    """Regression: candidate sets above SQLite's `?` cap must not raise.
+
+    Pre-fix: passing 3000 gene_ids into the `WHERE gene_id IN (?, ?, ...)`
+    clause raises `sqlite3.OperationalError: too many SQL variables` at
+    execute-bind time on any SQLite build with `SQLITE_LIMIT_VARIABLE_NUMBER`
+    below 3000 (covers the 999 legacy cap, the 2000 cap on our current
+    Python 3.12 / SQLite 3.50 builds, and anything else short of the modern
+    32766 default).
+
+    Post-fix: the call site batches into chunks below the cap and returns
+    silently.
+    """
+    cur = store.conn.cursor()
+    gene_scores = {f"gene_{i:05d}": 1.0 for i in range(3000)}
+    query_terms = ["test"]
+
+    # Should not raise. (No rows match — genes table is empty — but the bug
+    # fires before the result set matters.)
+    store._apply_authority_boosts(cur, gene_scores, query_terms)
+
+
+def test_apply_authority_boosts_at_runtime_cap_boundary(store):
+    """Edge case: at, just-above, and well-above the runtime variable cap.
+
+    Probes the SQLite limit with `conn.getlimit` (Python 3.11+) and exercises
+    the call site at:
+      - cap     (highest legal single-batch size; pre-fix passes; post-fix passes)
+      - cap+1   (first illegal size; pre-fix raises; post-fix passes)
+      - 4*cap+7 (off-boundary multiple to catch batch-slicing off-by-ones)
+    """
+    cap = store.conn.getlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)
+    assert cap > 0, f"unexpected SQLite variable cap: {cap}"
+    cur = store.conn.cursor()
+    query_terms = ["test"]
+
+    # At the cap: single batch, always legal.
+    store._apply_authority_boosts(
+        cur, {f"gene_{i:05d}": 1.0 for i in range(cap)}, query_terms,
+    )
+
+    # One past the cap: pre-fix raises, post-fix batches.
+    store._apply_authority_boosts(
+        cur, {f"gene_{i:05d}": 1.0 for i in range(cap + 1)}, query_terms,
+    )
+
+    # Off-boundary multiple: catches off-by-ones in batch slicing.
+    store._apply_authority_boosts(
+        cur, {f"gene_{i:05d}": 1.0 for i in range(4 * cap + 7)}, query_terms,
+    )
+
+
+# ── Empty-input guard (must still return cleanly) ───────────────────
+
+
+def test_apply_authority_boosts_empty_gene_scores_is_a_noop(store):
+    """Empty gene_scores returns silently — does not invoke the SQL path
+    at all, so it cannot raise. Pins existing behavior so the batching
+    refactor doesn't regress the early-return guard.
+    """
+    cur = store.conn.cursor()
+    store._apply_authority_boosts(cur, {}, ["test"])
+
+
+# ── Correctness: the batched query must still return the right rows ─
+
+
+def test_apply_authority_boosts_batched_query_finds_all_matching_genes(store):
+    """When some of the >cap candidates DO exist in the genes table, the
+    batched IN clause must still match them (catch off-by-one in batch
+    slicing) and the boost must still be applied.
+
+    This is the only test that actually inserts rows — the others probe
+    only the cap. We insert N genes spanning a 4-batch range and verify the
+    authority boost is applied to ALL of them — including the ones that
+    straddle batch boundaries — when their gene_ids appear in gene_scores.
+    """
+    cap = store.conn.getlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)
+    # Span >3 batches to expose off-by-one at every internal boundary
+    n_genes = 3 * cap + 17
+
+    cur = store.conn.cursor()
+    # Insert genes with a source_id that contains "test" so the authority-
+    # boost source-match path fires. Promoter / epigenetics blobs are
+    # valid-but-empty JSON to avoid parse warnings.
+    rows = []
+    for i in range(n_genes):
+        rows.append((
+            f"gene_{i:05d}", f"path/to/test_file_{i}.md", "doc",
+            "{}", "{}", None, None,
+        ))
+    cur.executemany(
+        "INSERT INTO genes (gene_id, source_id, source_kind, promoter, "
+        "epigenetics, key_values, content_hash) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    store.conn.commit()
+
+    gene_scores = {f"gene_{i:05d}": 1.0 for i in range(n_genes)}
+    base = dict(gene_scores)
+    store._apply_authority_boosts(cur, gene_scores, ["test"])
+
+    # Every gene should have received the +2.0 source-authority bonus
+    # (source_id contains "test"). Pin that every entry — including those
+    # that straddle internal batch boundaries — got the boost.
+    missed = [
+        gid for gid in base
+        if gene_scores[gid] != pytest.approx(base[gid] + 2.0)
+    ]
+    assert not missed, (
+        f"{len(missed)} genes missing source-authority boost; first 5: "
+        f"{missed[:5]}"
+    )


### PR DESCRIPTION
## Summary

SQLite caps `WHERE col IN (?, ?, ...)` placeholders at `SQLITE_LIMIT_VARIABLE_NUMBER` (historically 999; **2000** on the Python 3.12 / SQLite 3.50 builds we ship to; 32766 on newer compile defaults). Four call sites on the `gene_scores` fan-out path in `query_docs` build the IN clause from caller-determined candidate sets that can exceed the cap in production.

### Reproduction (2026-05-28 v2-fixture 100q bench)

Running the SPLADE-off variant on the v2 EnterpriseRAG-Onyx fixture (100 shards, 850K genes), **3 of 29 queries** had a per-shard `_apply_authority_boosts` raise `sqlite3.OperationalError: too many SQL variables`. The daemon's per-shard try/except swallowed the error as `"shard X query failed; skipping"` in the logs — so the orchestrator saw "successful" queries but with silently-dropped shards (`linear` 1×, `slack__incidents` 2×). Any gold doc that lived in a dropped shard became a false miss, biasing recall@K.

Variants where SPLADE or the prefilter narrows `gene_scores` (T, B, C) don't hit this because the candidate set is bounded by SPLADE/prefilter output. Only the no-filter SPLADE-off path produces sets large enough to blow up — and only on shards where the dense fan-out happens to produce >cap candidates for a given query.

### Change

Adds `_iter_in_batches(items, batch_size=500)` — a small generator that yields `(placeholder_string, batch_list)` pairs — and refactors the four hot sites to use it:

| Site (pre-fix line) | Function context |
|---|---|
| `knowledge_store.py:1286` | `_apply_authority_boosts` — source/domain/recency boosts |
| `knowledge_store.py:1869` | sema-boost embedding lookup (when top_score < 20.0) |
| `knowledge_store.py:2206` | party-attribution lookup (when party_id filter active) |
| `knowledge_store.py:2227` | access-rate epigenetics lookup (tiebreaker) |

Batch size 500 stays under every SQLite cap we care about while keeping the loop overhead negligible for typical retrievals (`gene_scores` is usually well below 500 with SPLADE-on; this only loops when callers pass huge candidate sets, exactly when we need it to).

## Scope: why not all 19 IN-clause sites?

There are 15 other IN-clause sites in `knowledge_store.py` with the same latent pattern. They're **not on the reproduced failure path** — variant A's no-SPLADE candidate fan-out reaches the 4 above. Refactoring the others without per-site tests would be high-risk:
- Some are `UPDATE` statements (different return semantics)
- Some have leading params (`party_id`, `chromatin_floor`, etc.)
- Some run on `read_conn` vs `conn`
- Some are downstream of capped result sets (top-K rankings — already bounded)

Each deserves its own test for correctness under batching. **Filing as a follow-up issue** so each can be addressed incrementally with confidence rather than as a blind sweep.

## Tests

New test file: `tests/test_knowledge_store_batched_in.py` (4 tests, ~140 LOC)

- **`test_apply_authority_boosts_does_not_blow_up_past_sqlite_cap`** — 3000 candidates, asserts no `OperationalError`. RED pre-fix on any build with cap < 3000, GREEN post-fix.
- **`test_apply_authority_boosts_at_runtime_cap_boundary`** — uses `conn.getlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)` to probe the runtime cap, then exercises at `cap`, `cap + 1`, and `4*cap + 7`. RED pre-fix on every build (boundary test is build-agnostic), GREEN post-fix.
- **`test_apply_authority_boosts_empty_gene_scores_is_a_noop`** — pins the early-return guard so the batching refactor doesn't regress it.
- **`test_apply_authority_boosts_batched_query_finds_all_matching_genes`** — inserts `3*cap + 17` real genes, verifies every one (including those straddling batch boundaries) receives the +2.0 source-authority boost. Catches off-by-one in batch slicing.

### Local pytest results

```
tests/test_knowledge_store_batched_in.py + tests/test_dense_recall.py +
tests/test_sharded_adapter_parity.py + tests/test_health.py +
tests/test_admin_refresh.py + tests/test_epigenetic_markers.py +
tests/test_bm25_prefilter.py + tests/test_ann_threshold.py
→ 58 passed, 2 xfailed, 0 regressions in 27.78s
```

## Test plan

- [x] Failing tests written first; verified RED on un-fixed master at `cap + 1` boundary
- [x] Helper + 4 call-site refactors; verified GREEN
- [x] Off-by-one correctness test pinned (every gene across multi-batch span gets the boost)
- [x] Adjacent test files pass: dense_recall, sharded_adapter_parity, health, admin_refresh, epigenetic_markers, bm25_prefilter, ann_threshold
- [ ] CI green on Linux + macOS-MPS + Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)