### PR TITLE
docs(benchmarks): add Layer 3 (EnterpriseRAG-Bench) + EnterpriseRAG fixtures

### DIFF
--- a/docs/benchmarks/BENCHMARKS.md
+++ b/docs/benchmarks/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Helix Context Benchmarks
 
-**Last updated:** 2026-04-10
+**Last updated:** 2026-05-28 *(Layer 3 / EnterpriseRAG-Bench added; Layer 1+2 figures unchanged since 2026-04-10)*
 
 Helix solves a specific problem: **agents drowning in RAG search context.** A typical RAG
 pipeline dumps 15-50 kilobytes of candidate chunks into the prompt per turn and hopes the
@@ -509,6 +509,122 @@ OLLAMA_KV_CACHE_TYPE=q4_0    (INT4 KV cache — q8_0 tested, regressed accuracy)
 HELIX_CONFIG=F:/Projects/helix-context/helix.toml
 GENOME_DB=F:/Projects/helix-context/genome-bench-2026-04-10.db
 ```
+
+---
+
+## Layer 3 — EnterpriseRAG-Bench (leak-free retrieval at corpus scale)
+
+**Scripts:** `benchmarks/build_enterprise_rag_batched.py`, `benchmarks/score_enterprise_rag_onyx.py`, `benchmarks/ablate_dense_prefilter.py`
+**Methodology:** Index Onyx-dot-app's [EnterpriseRAG-Bench](https://github.com/onyx-dot-app/EnterpriseRAG-Bench) synthetic enterprise corpus (confluence + fireflies + github + gmail + google_drive + hubspot + jira + linear + slack) as a sharded genome, then run the production retrieval pipeline against the author-supplied questions + gold-path map.
+**Purpose:** Establish helix's behavior on a corpus where (a) the bench owner is not the system owner — no own-code leak surface, (b) each question has explicit gold paths — no telepathy required, and (c) corpus size sweeps across orders of magnitude (10K → 850K genes).
+
+### Why this layer was needed
+
+The Layer 2 KV-Harvest results bottomed at ~16-20% retrieval — a fair noise-floor measurement, but uninformative for "is retrieval working well at scale on real-shape questions?" because:
+
+1. **Source corpus = helix's own dev tree.** Filesystem-grep + CLAUDE.md leaks inflated earlier matrix-bench numbers (the system was finding answers by reading its own developer documentation, not by retrieving through the pipeline). The 2026-05-21 bench investigation report at `docs/benchmarks/2026-05-21_bench_investigation_report.md` lays out the leak audit.
+2. **Synthetic single-axis KV queries** measure the leftmost point on the dimensional-lock curve (see [`BENCHMARK_RATIONALE.md`](BENCHMARK_RATIONALE.md)) and tell you nothing about composition.
+3. **No corpus-scale gradient.** Layer 2 cannot answer "does recall scale with N?" — it's pinned to one 7,313-gene snapshot.
+
+EnterpriseRAG-Bench solves all three: external corpus, multi-token natural-language questions with gold paths, and four built fixture sizes spanning 10K → 850K genes.
+
+### Bench investigation rebuild (2026-05-20 → 2026-05-21)
+
+A wave of investigation work landed in mid-May 2026 that rebuilt the matrix bench with leak-check discipline:
+
+- **Filesystem-grep + CLAUDE.md leak elimination** — `bench_claude_matrix.retrieval_probe` now supports an `isolated=True` mode that launches the downstream sub-agent with `--tools ""` + `--strict-mcp-config` + empty MCP config + sterile CWD. Sub-agents can only see what helix's `/context` endpoint delivers.
+- **3 MCP TDD-fixes shipped** (Windows stdio handshake, identity guard, etc.) that unblocked `claude -p` agent dispatch.
+- **5-fixture grid** (small / medium / medium-sharded / xl / xl-sharded) re-baselined under isolation.
+- Headline measurement: **+32.4 pp helix lift, 65% hallucination reduction** under sterile conditions vs. raw-context baseline.
+- Cross-model finding: **local Gemma 4 e4b ($0, 9.6 GB VRAM) and Claude Haiku 4.5 (API) both landed at exactly 11/250 wrong = 4.4% under M2** — grounding precision is `retrieval × anchor`, not model strength.
+
+Full report: `docs/benchmarks/2026-05-21_bench_investigation_report.md`.
+
+### Cross-corpus results across fixture sizes
+
+| Fixture | Genes | Shards | Disk | Recall@10 | Sonnet-judged correctness | Hallucination |
+|---|---:|---:|---:|---:|---:|---:|
+| `enterprise_rag_10k` (subset) | ~10 K | 1 (monolithic) | ~600 MB | **60%** *(variant A, n=100)* | 19% *(depth-16 d1)* | 1-12% *(depth-dependent)* |
+| `enterprise_rag_50k` (subset) | ~50 K | 1 | ~3 GB | **71%** | 4% *(depth-1)* | 1-2% |
+| `enterprise_rag_onyx_full` (v1) | ~850 K | 105 *(auto-subsharded)* | 42.6 GB | n/a *(Wall-1 dominated; pre PR #163 SQL fix)* | — | — |
+| **`enterprise_rag_onyx_full_2`** (v2) | **850,501** | **100** *(Path-A)* | **47.24 GB** | **28%** *(variant A, n=100, 2026-05-28)* | pending Sonnet judge | pending |
+
+**Corpus-scale recall erosion is real:** 60% @ 10K → 28% @ 850K under SPLADE-off / no-prefilter. This finding is the dominant Wall-2 latency-cost-of-recall input to PR #160's SPLADE pre-filter design and [Issue #164](https://github.com/mbachaud/helix-context/issues/164)'s SPLADE-as-corpus-regime-feature hypothesis.
+
+### The expression-budget clamp fix (2026-05-22)
+
+A separate finding during Layer 3 work that dramatically improved per-gene answer correctness without changing retrieval at all.
+
+The `recall@10 → correctness` gap was being created by a hard-coded per-gene DELIVERY clamp at `context_manager.py:1449` (`target=1000`) — the compression step was head-truncating long genes before they reached the answer model, even when retrieval surfaced them correctly.
+
+**Fix:** `per_gene_budget = "dynamic"` (floor-then-greedy allocator, TDD'd). Effect on 16K-depth-1 fixture:
+
+| Metric | Pre-fix | Post-fix |
+|---|---:|---:|
+| Correctness | 4% | **43%** |
+| Correct given gold-delivered | 10% | **97.5%** |
+| Hallucination | 2% | 1% |
+| Cost | baseline | +17% |
+| Retrieval | 40/100 | **identical 40/100** |
+
+**Default flipped to dynamic on 2026-05-22** after passing flip-gate at depth-8/n=100: 0 gold dropped, 752 = 752 genes preserved, /context p95 −0.34s, 22 tests green.
+
+This finding **reframed the earlier "56 ranker" claim**: retrieval recall@10 on the 10K corpus was actually 83%; only 17 questions were TRUE retrieval misses. The "56 missed" number was a delivery@1 artifact from the clamp, not a ranker deficiency.
+
+### Issue #159 — 850K-gene corpus exposes two scaling walls
+
+Building the 850K-gene `enterprise_rag_onyx_full` fixture (105 shards in v1, 100 in v2) surfaced a clean architectural pressure-test framing for retrieval at scale. See [Issue #159](https://github.com/mbachaud/helix-context/issues/159) and the [SPLADE pre-filter PRD](../prds/2026-05-26-splade-prefilter-dense-recall.md):
+
+- **Wall-1 (memory commit ceiling).** Daemon at 105+ shard scale needs ~247 GB private commit (~50 GB mmap'd shard data × the multi-connection SQLite footprint, plus heap). Default Windows 56 GB pagefile crashes the daemon during warmup at ~143 GB. **Mitigations:** 240 GB fixed pagefile on C: NVMe (288 GB total commit ceiling) AND Path-A rebuild → fewer larger shards.
+- **Wall-2 (brute-force-no-ANN latency wall).** ~870M FLOPs per query for the dense matmul at 850K genes. The pipeline does not use ANN indexes (a design pillar — see `feedback-helix-ribosome-off`); the brute-force matmul IS the cost. Levers within the no-ANN/no-LLM constraint: SPLADE pre-filter ([PR #160](https://github.com/mbachaud/helix-context/pull/160)), inverted term→shard hashmap, cymatics as N-reducer, Matryoshka dim=256.
+
+**Important architectural finding (2026-05-27, cross-verified on three hosts):** the dense matmul at `knowledge_store.py:2709` is **plain NumPy CPU** — `sims = matrix @ query_vec` on an `np.stack(...)` heap-resident fp32 array, no `np.memmap`, no torch, no GPU. BGEM3Codec defaults to `device="cpu"`. Both my x86 + RTX 3080 Ti and Joe's ARM64 Grace + GB10 saw CPU-pegged single-thread + GPU ~16% (SPLADE-only spikes). The prefilter's "FLOP savings" are CPU NumPy FLOPs, not GPU FLOPs. Native CUDA BGE-M3 + a torch-on-GPU matmul are queued as post-bench engineering.
+
+### v2 100q variant-A result (2026-05-28, first leaderboard-grade datapoint)
+
+| Metric | Value |
+|---|---|
+| Fixture | `enterprise_rag_onyx_full_2` (100 shards, 850,501 genes, 47.24 GB) |
+| Variant | A — SPLADE disabled, no prefilter |
+| n | 100 questions (basic type) |
+| recall@1 | 4.0% |
+| recall@3 | 11.0% |
+| recall@5 | 18.0% |
+| **recall@10** | **28.0%** |
+| MRR | 0.100 |
+| p50 latency | 98.4 s |
+| **p95 latency** | **154.5 s** (~2.5 min) |
+| p99 latency | 311.5 s |
+| Timeouts (10-min cap) | **0 / 100** |
+| Wall-clock | 3.08 h |
+| Daemon survived | yes |
+
+**Variants T (baseline), B (prefilter on, escape=0), and C (prefilter on, escape=250)** were swept at the smoke level (n=5) on the same fixture — see PR #160 §5. Cross-variant smoke result: identical 40% recall@10 / MRR 0.25 across all four; only variant A had zero timeouts. Variant A locked as the bench candidate on (recall-tied) + (zero-timeout) + (lowest config complexity).
+
+The 500q variant-A is in flight at the time of writing.
+
+### Engineering fixes that landed during Layer 3
+
+Three master-mergeable PRs were ported off the Layer 3 work:
+
+| PR | Title | Status | Headline impact |
+|---|---|---|---|
+| [#162](https://github.com/mbachaud/helix-context/pull/162) | `fix(tagger,ddl) + feat(build): cherry-pick + port PR #161 fixes onto master` | **merged 2026-05-28** at `478e893` | Tagger ReDoS regex fix (60+min hang → 0.5-2ms on underscore-heavy JSON); FTS5 cleanup O(N²) → O(N log N); shard salvage helper for kill+restart cycle |
+| [#163](https://github.com/mbachaud/helix-context/pull/163) | `fix(knowledge_store): batch IN-clause queries to stay under SQLite cap` | merged 2026-05-28 *(pending CI confirmation at time of writing)* | Eliminates silent shard-skipping on variant-A retrieval; 4 hot sites batched + helper + TDD'd regression test |
+| [#160](https://github.com/mbachaud/helix-context/pull/160) | `feat(retrieval): SPLADE pre-filter for dense matmul (Issue #159 Wall-2)` | open | Recall-neutral by construction; latency win conditional on corpus regime |
+
+**Cross-host validation of the tagger fix:** the same `_KV_PAIR_PATTERN` ReDoS was independently reproduced and fixed by py-spy investigation on x86 Ryzen + RTX 3080 Ti (2026-05-19) and ARM64 Grace + GB10 (2026-05-27), 8 days apart, on different agents. Same line (`tagger.py:439`), same root cause (`(\w+(?:_\w+)*)` nested-quantifier ambiguity on underscore-heavy content), same fix (`(\w+)`). Two independent reproductions on different hardware classes — the strongest possible regression-fix validation footnote.
+
+### Open issues filed from Layer 3 storage audit
+
+- [Issue #164](https://github.com/mbachaud/helix-context/issues/164) — **Storage breakdown of v2 EnterpriseRAG-Onyx corpus**: 17.6× expansion from 2.6 GB raw → 47.24 GB built; SPLADE = 21.1% / 9.96 GB; proposed `splade_enabled = "auto"` with two-threshold size-aware default (`splade_auto_disable_above_genes`, `splade_auto_enable_below_genes`); full scale-curve follow-up (1K, 5K, 25K, 47K, 100K, 850K) defines the SPLADE-as-corpus-regime-feature curve.
+- [Issue #165](https://github.com/mbachaud/helix-context/issues/165) — **Audit fingerprint routing index (path_key_index) storage: 34.1% of v2 corpus** (~19 KB of index per gene); hypothesizes the index was sized for a router design that's currently degenerate (per the 2026-05-26 router discrimination probe finding that broad query terms hit 90-100% of shards). Larger single storage lever than SPLADE; separate workstream.
+
+### Cross-host comparison (in progress)
+
+Joe's spark-e92c completed its v2 build at 16:12Z on 2026-05-28 (15h 6min wall — ~16% faster than the Ryzen baseline on encode + tagger CPU-bound steps). **Topology identical** to the Max-rig build: 100 shards, 850,503 genes, 47.6 GB on disk, 100% dense. The earlier "12-shard" framing was wrong — `enterprise_rag_onyx_full_2` is *labelled* Path-A but auto-subsharding lands at 100 on both hosts.
+
+Cross-host comparison therefore isolates a single variable: hardware. Ryzen + 48 GB + RTX 3080 Ti + 240 GB pagefile (heavy paging) vs ARM64 Grace + 118 GB + GB10 (mmap fits in physical RAM). Recall@K is expected to be near-identical across hosts (same code, data, questions); latency delta will be a pure RAM-headroom / pagefile-pressure story. Joe's variant-A 100q is queued behind a WAL checkpoint + rsync; cross-host writeup pending its completion.
 
 ---
 

--- a/docs/benchmarks/BENCHMARK_RATIONALE.md
+++ b/docs/benchmarks/BENCHMARK_RATIONALE.md
@@ -214,6 +214,76 @@ the second one is the question that matches the architecture.
 
 ---
 
+## Addendum (2026-05-28): how Layer 3 / EnterpriseRAG-Bench answered the rationale's questions
+
+The 2026-05-20 → 2026-05-21 bench investigation rebuilt the matrix harness
+with [EnterpriseRAG-Bench](https://github.com/onyx-dot-app/EnterpriseRAG-Bench)
+(Onyx-dot-app's external corpus) as the test substrate. This was a direct
+response to two of the three NIAH-doesn't-fit-helix problems above, and a
+partial answer to the third:
+
+1. **"There is rarely *one* correct answer"** → EnterpriseRAG-Bench
+   questions ship with explicit `expected_doc_ids` gold-path lists per
+   question. The bench grades a hit when ANY entry in the list appears in
+   the delivered citations (multi-valid-gold — see
+   [`MULTI_VALID_GOLD.md`](MULTI_VALID_GOLD.md)). Telepathy is no longer
+   required to score.
+2. **"Queries are dimensional descriptors, not single vectors"** →
+   EnterpriseRAG-Bench questions are real natural-language enterprise-RAG
+   queries with multiple narrowing signals built in. The single-axis
+   *"What is the value of `port`?"* pathology is gone — questions look
+   like *"What is the deployment process for the new authentication
+   service?"* with project, component, and target-attribute axes all
+   present.
+3. **"Recall@1 ignores the multi-axis index"** → reported metric is
+   recall@K (K=10 is the headline), with the gold path tested against
+   the full delivered citation list. Multi-axis composition is allowed
+   to contribute — though strict recall@1 is still reported alongside
+   for legibility (recall@1 = 4% vs recall@10 = 28% on the v2 850K
+   fixture shows the multi-axis lift directly).
+
+### What this layer adds beyond dimensional-lock
+
+The dimensional-lock 4-variant grid (`bench_dimensional_lock.py`, this
+rationale's companion bench) remains the right diagnostic for *"is the
+multi-axis index composing correctly under controlled axis-count
+gradients?"* — a synthetic question that needs a synthetic harness.
+
+EnterpriseRAG-Bench answers a different question: *"is the system
+working at scale on real-shape queries on a leak-free corpus?"* It
+trades the controlled axis gradient for natural-question variety and
+corpus-size sweep (10K → 850K genes). The two benches are complementary;
+both stay maintained.
+
+### What the leak-free corpus revealed
+
+Three findings that the own-corpus harness couldn't have shown:
+
+- **Corpus-scale recall erosion is real**: 60% recall@10 at 10K genes,
+  28% at 850K genes (same variant, same model, same code). This is the
+  Wall-2 latency-cost-of-recall trade-off that motivated PR #160's
+  SPLADE pre-filter design.
+- **The 4%→43% correctness lift from the per-gene-budget clamp fix**
+  (2026-05-22) was found because retrieval recall@10 on the 10K fixture
+  was 83% but answer correctness was 4%. That gap pointed at delivery,
+  not retrieval — a diagnostic the prior single-snapshot harness
+  couldn't have produced.
+- **SPLADE as corpus-regime feature**: SPLADE-on contributes 0 pp to
+  recall on the EnterpriseRAG question set across 10K / v1 850K / v2 850K
+  fixtures, while costing measurable p95 latency and 21.1% / 9.96 GB of
+  disk. The 3-fixture "all pain, no gain" pattern motivated
+  [Issue #164](https://github.com/mbachaud/helix-context/issues/164)'s
+  hypothesis that SPLADE is useful below ~50K genes and net-negative
+  above ~100K. The dimensional-lock harness couldn't have surfaced this
+  — it doesn't sweep corpus size.
+
+The 850K-gene v2 corpus + variant-A 100q result of **recall@10 = 28%**
+(2026-05-28) is the first leaderboard-grade datapoint from this layer.
+See [`BENCHMARKS.md`](BENCHMARKS.md) §"Layer 3 — EnterpriseRAG-Bench"
+for the full results table.
+
+---
+
 ## Companion docs
 
 - [`MUSIC_OF_RETRIEVAL.md`](MUSIC_OF_RETRIEVAL.md) — the 12-signal +
@@ -222,6 +292,8 @@ the second one is the question that matches the architecture.
   axes (org / device / user / agent / tz)
 - [`PIPELINE_LANES.md`](PIPELINE_LANES.md) — full ingest + query data flow
 - [`BENCHMARKS.md`](BENCHMARKS.md) — practical bench harness reference
+- [`GENOME_FIXTURE_MATRIX.md`](GENOME_FIXTURE_MATRIX.md) — fixture roots,
+  including the EnterpriseRAG-Bench family that backs Layer 3
 
 ## Companion bench
 

--- a/docs/benchmarks/GENOME_FIXTURE_MATRIX.md
+++ b/docs/benchmarks/GENOME_FIXTURE_MATRIX.md
@@ -1,6 +1,6 @@
 # Genome Fixture Matrix
 
-**Status:** working operator matrix, 2026-05-13.
+**Status:** working operator matrix, 2026-05-28 *(EnterpriseRAG-Bench fixtures added; original four-profile matrix unchanged since 2026-05-13)*.
 
 This document records the four current monolithic Helix test-genome size
 profiles. It is intentionally limited to source-root selection: it does not
@@ -130,3 +130,110 @@ shard build didn't observe yet:
 These defaults are conservative on purpose: a bench fixture exercises
 freshness logic without forcing every classifier to run during the build.
 A real ingest path will overwrite the row on its next observation cycle.
+
+---
+
+## EnterpriseRAG-Bench fixtures (added 2026-05-20 onwards)
+
+A separate fixture family that backs Layer 3 of [`BENCHMARKS.md`](BENCHMARKS.md)
+— the leak-free cross-corpus retrieval benchmark. Distinct from the four
+monolithic profiles above in that they index an **external** corpus
+(Onyx-dot-app's [EnterpriseRAG-Bench](https://github.com/onyx-dot-app/EnterpriseRAG-Bench)
+upstream repo) rather than `F:/Projects` — eliminating the own-code +
+CLAUDE.md leak surface that the rebuilt matrix bench's `isolated=True`
+mode also addresses.
+
+### Fixture table
+
+| Profile | Genes | Shards | Disk | Status | Source root |
+|---|---:|---:|---:|---|---|
+| `enterprise_rag_10k` | ~10 K | 1 (monolithic) | ~600 MB | active | `F:/tmp/enterprise_rag_10k/sources/...` (9 source subdirs) |
+| `enterprise_rag_50k` | ~50 K | 1 | ~3 GB | active | `F:/tmp/enterprise_rag_50k/sources/...` |
+| `enterprise_rag_500k` | (subset prep) | 1 | — | deprecated | `F:/tmp/enterprise_rag_500k/sources/...` — replaced by Onyx-full |
+| `enterprise_rag_onyx_full` | ~850 K | 105 (auto-subsharded) | 42.6 GB | superseded by v2 | `F:/Projects/EnterpriseRAG-Bench-main/generated_data/sources/...` |
+| **`enterprise_rag_onyx_full_2`** | **850,501** | **100 (Path-A)** | **47.24 GB** | **canonical** | same upstream as v1; Path-A profile with default `--auto-subshard-threshold-files=100000` |
+
+### Source-root scope (all five fixtures)
+
+All five share the same 9-source-root pattern under the bench's
+`generated_data/sources/` subtree:
+
+```text
+{ERB_ROOT}/generated_data/sources/confluence
+{ERB_ROOT}/generated_data/sources/fireflies
+{ERB_ROOT}/generated_data/sources/github
+{ERB_ROOT}/generated_data/sources/gmail
+{ERB_ROOT}/generated_data/sources/google_drive
+{ERB_ROOT}/generated_data/sources/hubspot
+{ERB_ROOT}/generated_data/sources/jira
+{ERB_ROOT}/generated_data/sources/linear
+{ERB_ROOT}/generated_data/sources/slack
+```
+
+### Excluded from `sources/` ingest
+
+The following live elsewhere in the upstream repo and must NOT be indexed
+(they would either inflate retrieval with bench infrastructure or leak gold
+into the corpus):
+
+- `questions.jsonl` / `extra_questions.jsonl` — benchmark Q&A
+- `answer_evaluation/` — evaluation infrastructure
+- `uuid_index.json` — gold-path map (lives in `generated_data/` ROOT, not under `sources/`)
+- `src/` — benchmark generation code
+- `company_overview.md`, `employee_directory.yaml`, etc. — top-level metadata
+
+A 2026-05-25 gold-path audit confirmed all 742 `expected_doc_ids` across
+500 EnterpriseRAG-Bench questions resolve INTO `sources/` subdirs — zero
+outside, zero missing — so this scope is the canonical Onyx
+leaderboard-comparable corpus.
+
+### Build profile + auto-subsharding behavior
+
+The `enterprise_rag_onyx_full_2` profile is *labelled* as a Path-A
+"fewer-larger-shards" rebuild, but the builder's default
+`--auto-subshard-threshold-files=100000` decomposes `slack` and `gmail`
+into per-channel / per-user subshards. **Both Max-rig (Windows + Ryzen +
+48 GB) and Joe's spark-e92c (Linux + ARM64 + 118 GB) land at 100 shards
+on this profile** — the topology is identical across hosts. Earlier
+documentation that referenced "~12 shards" was wrong (aspirational design,
+not actual partitioning).
+
+To get true Path-A behavior (single shard per root, ~9 shards total) the
+operator must pass `--auto-subshard-threshold-files=0` explicitly.
+
+### Path-portability gotcha (Joe's Spark deploy, 2026-05-28)
+
+The `enterprise_rag_onyx_full_2` profile entry in
+`scripts/build_fixture_matrix.py` currently hardcodes Windows
+`F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\…` paths in
+its `roots` list, AND the builder checks those paths via raw
+`os.path.exists()` which bypasses pathlib-only monkey-patching. On Linux
+deploys without a shim, the build silently completes with **0 shards
+ingested** because none of the Windows paths exist.
+
+Joe's working shim on spark-e92c also patches
+`os.path.{exists,isdir,isfile}` + `os.walk`/`os.scandir`/`os.listdir` and
+overrides `bfm.PROFILES['enterprise_rag_onyx_full_2']['roots']` to Linux
+paths (mirroring the existing `enterprise_rag_500k` override pattern).
+
+The cleanest upstream fix when the profile folds into master is to make
+roots derive from `os.environ.get("ERB_ROOT", DEFAULT)` so the profile is
+OS-agnostic out of the box. <30 LOC change. Should land BEFORE the
+`bench/int-5fixture` integration branch's eventual master merge, OR as
+part of whatever PR folds in the v2 profile entry. See PR #161's
+close-as-superseded note for the recovery recipe.
+
+### Branch / PR routing
+
+The fixture profiles + their build machinery live across several open or
+recently-closed PRs. As of 2026-05-28:
+
+| Component | Branch / PR | Notes |
+|---|---|---|
+| `enterprise_rag_10k` / `_50k` / `_500k` profiles | `bench/int-5fixture` integration branch | Not yet merged to master |
+| `enterprise_rag_onyx_full` profile (v1) | `bench/int-5fixture` | Superseded; v1 fixture exists on disk but produces Wall-1 OOM at 105-shard scale |
+| `enterprise_rag_onyx_full_2` profile (v2) | originally PR #161 (closed-as-superseded by #162) | Profile entry not on master; only on `feat/onyx-full-v2-build-bundle` |
+| Shard salvage helper | merged to master via [PR #162](https://github.com/mbachaud/helix-context/pull/162) @ `478e893` | Re-registers already-complete shards on rebuild (kill+restart cycle) |
+| Tagger ReDoS fix | merged to master via PR #162 @ `32a74ef` | Critical for ingest — prevents 60+min hangs on underscore-heavy JSON |
+| FTS5 cleanup perf fix | merged to master via PR #162 @ `ec74434` | Daemon /health first-response from "hangs forever" → ms |
+| Batched-IN SQL fix | [PR #163](https://github.com/mbachaud/helix-context/pull/163) | Required to get above n=5 on variant A retrieval — eliminates silent shard skips at 850K-gene scale |

--- a/docs/benchmarks/MULTI_VALID_GOLD.md
+++ b/docs/benchmarks/MULTI_VALID_GOLD.md
@@ -1,13 +1,15 @@
 # Multi-Valid-Gold Needle Matching
 
 **Status:** shipped 2026-05-14 in `feat/bench-multi-valid-gold` (PR forthcoming).
+**Last updated:** 2026-05-28 — added §"EnterpriseRAG-Bench gold-path matching" for the Layer 3 multi-gold pattern.
 **Scope:** `benchmarks/bench_claude_matrix.py` (the 10-needle matrix
 runner) + `benchmarks/bench_needle.py` (the legacy 10-needle bench).
 **Out of scope:** the 1000-needle bench (`bench_needle_1000.py` uses a
 different per-needle schema with a single `source` string), the
 multi-needle group benches (`bench_multi_needle*.py` use
 `gold_source_groups` with stricter all-of semantics), and any retrieval
-code.
+code. **The Layer 3 EnterpriseRAG-Bench harness uses a different multi-gold
+mechanism with the same spirit — see §"EnterpriseRAG-Bench gold-path matching" below.**
 
 ## Why
 
@@ -212,6 +214,102 @@ The 1000-needle bench (`bench_needle_1000.py`) uses a separate per-needle
 schema (`source` as a single string) and is **unaffected** by this
 change. The same is true for the multi-needle group benches.
 
+## EnterpriseRAG-Bench gold-path matching (added 2026-05-28)
+
+Layer 3 of [`BENCHMARKS.md`](BENCHMARKS.md) uses a separate harness
+(`benchmarks/score_enterprise_rag_onyx.py`,
+`benchmarks/ablate_dense_prefilter.py`) with a different per-question
+schema, but the **same "ANY-match against a gold list" spirit** as the
+matrix bench.
+
+### Schema
+
+Each EnterpriseRAG-Bench question (from upstream `questions.jsonl` +
+`uuid_index.json`) ships with:
+
+```jsonc
+{
+  "id": "qst_0001",
+  "question": "What is the deployment process for the new auth service?",
+  "type": "basic",                              // or "semantic" / "intra_document_reasoning"
+  "expected_doc_ids": [                         // gold-path list — ANY-match
+    "9f3c1b...",                                // dsid → resolved to a path under sources/
+    "a4d822..."
+  ]
+}
+```
+
+The dsid → relative-path resolution happens via
+`generated_data/uuid_index.json` (the upstream's dsid → file map). At
+score time, `expected_doc_ids` becomes a list of relative paths under
+`generated_data/sources/`.
+
+### Match rule
+
+The orchestrator computes a hit when ANY entry in `expected_doc_ids`
+matches a delivered citation's source path, using
+`benchmarks/ablate_dense_prefilter._rel_after_sources` to normalize both
+sides before comparison:
+
+```python
+gold_rels = {_rel_after_sources(p) for p in n["gold_paths"]}
+gold_rels = {r for r in gold_rels if r}
+# ...
+for fp in fps:                                      # /fingerprint response
+    rel = _rel_after_sources(fp.get("source", "")) or ""
+    if rel in gold_rels:
+        hit_rank = fp["rank"]
+        break
+```
+
+Same ANY-match short-circuit as the matrix bench, just with **path
+normalization that strips the variable prefix above `sources/`** rather
+than substring containment. This handles the case where Helix delivers a
+citation with an absolute Windows path (`F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\slack\incidents\msg-123.md`)
+but the gold list ships relative paths (`slack/incidents/msg-123.md`) —
+both normalize to `slack/incidents/msg-123.md` for the match.
+
+### Prefix-tolerant gold matching (PR #148, 2026-05-26)
+
+A subtle gold-match bug was found and fixed in this layer's first pass
+(closes `#137 partial`): when a citation source lacks the `sources/`
+segment in its path (e.g., a synthetic test fixture or a hand-built
+shard), `_rel_after_sources` returned `None` rather than the path
+as-given. Downstream this caused false `gold=False` at delivery time
+even when the file content was correct.
+
+**Fix:** `_rel_after_sources` now falls back to the raw normalized path
+when no `sources/` segment is found, so prefix-mismatched citations
+still get matched against the gold list when the trailing path
+components agree.
+
+Audit verification: d1 untainted, 0 flips on the existing fixtures,
+recall sweep clean after the fix. See PR #148 commit message for the
+exact diff.
+
+### Why the EnterpriseRAG-Bench harness can't reuse the matrix-bench code
+
+Two structural differences:
+
+1. **List-of-dsids vs list-of-substrings.** EnterpriseRAG-Bench gold is
+   a list of opaque document IDs that must be resolved through
+   `uuid_index.json` to relative paths — there's no natural substring
+   match (`gmail/jonas_weber/msg-9024.md` is not a substring of itself
+   under absolute paths). The matrix bench's substring-containment rule
+   wouldn't work without further normalization.
+2. **No author curation on which gold paths are "best".** The
+   matrix-bench curation policy (above) emphasized hand-picking one
+   canonical path per needle. EnterpriseRAG-Bench's gold lists come from
+   the upstream benchmark generator — every listed dsid is by definition
+   a valid answer, and the helix orchestrator treats them as equal.
+
+The end result is the same retrieval-quality signal — *"did the system
+surface a document that actually answers the question?"* — but
+mechanically implemented in different code with different schemas. Tests
+on both harnesses pin the ANY-match contract independently.
+
+---
+
 ## Related tests
 
 * `tests/test_bench_needles.py` — 13 regression tests covering
@@ -221,3 +319,7 @@ change. The same is true for the multi-needle group benches.
 * `tests/test_bench_citations.py` — the citation parser tests (not
   affected by this change, but exercised together as the bench-data
   test suite).
+* `tests/test_bench_path_match_prefix_stripped.py` — added with PR #148;
+  pins the prefix-tolerant `_rel_after_sources` behavior so a citation
+  with a non-`sources/` path still matches a gold entry whose trailing
+  components agree.


### PR DESCRIPTION
## Summary

Documents the last ~13 days of bench work that landed off the EnterpriseRAG-Bench rebuild and the 850K-gene v2 corpus build. Docs-only PR — no code changes. Reflects results that have already shipped via PR #148 / #155 / #156 / #157 (consolidated into closed PR #161 → merged to master via PR #162), [PR #163](https://github.com/mbachaud/helix-context/pull/163) (batched-IN SQL fix), open [PR #160](https://github.com/mbachaud/helix-context/pull/160) (SPLADE pre-filter), and Issues [#159](https://github.com/mbachaud/helix-context/issues/159), [#164](https://github.com/mbachaud/helix-context/issues/164), [#165](https://github.com/mbachaud/helix-context/issues/165).

## What lands

| File | Change | Headline addition |
|---|---|---|
| `docs/benchmarks/BENCHMARKS.md` | +118 / −3 | New **Layer 3 — EnterpriseRAG-Bench** section between Layer 2 and "The injection budget thesis" |
| `docs/benchmarks/GENOME_FIXTURE_MATRIX.md` | +109 | New **EnterpriseRAG-Bench fixtures** section + branch/PR routing table |
| `docs/benchmarks/BENCHMARK_RATIONALE.md` | +72 | **Addendum (2026-05-28)** on how Layer 3 answered the rationale's NIAH-doesn't-fit problems |
| `docs/benchmarks/MULTI_VALID_GOLD.md` | +104 / −1 | New **EnterpriseRAG-Bench gold-path matching** section + PR #148 prefix-tolerant fix note |

Total: **+400 / −3** across four files.

## Per-file detail

### `BENCHMARKS.md` — new Layer 3 section

- **Why this layer was needed** — own-corpus + CLAUDE.md leak surface; single-snapshot can't sweep corpus size
- **2026-05-20→21 bench investigation rebuild** — `isolated=True` mode, +32.4 pp helix lift, 65% hallucination reduction, Gemma 4 e4b == Haiku 4.5 at 4.4% under M2
- **Cross-corpus results table**: 60% recall@10 @ 10K → 71% @ 50K → 28% @ 850K (variant A, n=100 on v2)
- **Expression-budget clamp fix (2026-05-22)** — 4%→43% correctness with identical retrieval; default flipped to `per_gene_budget = "dynamic"` after flip-gate passed
- **Issue #159 Wall-1 / Wall-2 framing** — commit-ceiling memory wall + brute-force-no-ANN latency wall; cross-verified CPU NumPy matmul finding on three hosts
- **v2 100q variant-A result table** — recall@10=28%, p95=154.5 s, 0 timeouts, 3.08 h wall-clock
- **PR #162 / #163 / #160 engineering fixes** — tagger ReDoS, FTS5 cleanup perf, salvage helper, batched-IN SQL cap, SPLADE pre-filter
- **Cross-host tagger-fix validation** — x86 Ryzen + ARM64 Grace, two independent py-spy reproductions 8 days apart, same line / cause / fix
- **Issues #164 / #165 storage findings** — corpus 47.24 GB / SPLADE 21.1% / path_key_index 34.1%
- **Cross-host comparison status** — Joe's spark-e92c topology-identical (100 shards / 850 K genes / 47.6 GB); recall expected near-identical, latency delta is pure RAM-headroom story

### `GENOME_FIXTURE_MATRIX.md` — new EnterpriseRAG-Bench fixtures section

- 5-row fixture table: `enterprise_rag_{10k, 50k, 500k[deprecated], onyx_full[v1], onyx_full_2[canonical]}`
- Shared 9-source-root scope under `generated_data/sources/` (confluence, fireflies, github, gmail, google_drive, hubspot, jira, linear, slack)
- Excluded-from-ingest list (`questions.jsonl`, `uuid_index.json`, `src/`, top-level metadata) — needed to prevent gold leaks
- **Auto-subsharding correction**: both hosts land at 100 shards on the v2 profile, not the earlier "~12" (the profile is *labelled* Path-A but the auto-subsharder decomposes slack/gmail into per-channel/per-user subshards by default)
- Path-portability gotcha (Windows hardcoded paths + raw `os.path.exists()` bypassing pathlib monkey-patching) + Joe's spark-e92c shim recipe + recommended `os.environ.get("ERB_ROOT", ...)` upstream fix
- Branch/PR routing table covering where each component currently lives

### `BENCHMARK_RATIONALE.md` — addendum

Three NIAH-doesn't-fit problems from the original 2026-04-13 rationale and how Layer 3 answered each:

1. **"There is rarely *one* correct answer"** → `expected_doc_ids` gold lists + ANY-match scoring
2. **"Queries are dimensional descriptors, not single vectors"** → natural enterprise-RAG questions with multiple narrowing axes already present
3. **"Recall@1 ignores the multi-axis index"** → recall@K=10 reported alongside strict recall@1; the multi-axis lift is visible directly (4% → 28% on v2)

Plus three findings the leak-free corpus revealed that the prior harness could not have surfaced:

- Corpus-scale recall erosion (60% → 28%)
- The clamp-fix diagnostic (retrieval 83% / correctness 4% — that gap pointed at delivery, not ranker)
- SPLADE-as-corpus-regime feature

### `MULTI_VALID_GOLD.md` — new EnterpriseRAG-Bench section

- **Schema diff** vs the matrix bench: `expected_doc_ids` (list of dsids) vs `gold_source` (list of substrings)
- `_rel_after_sources` path normalization for matching absolute-path citations against relative gold paths
- **Prefix-tolerant gold-match fix (PR #148, closes #137 partial)** — `_rel_after_sources` falls back to raw normalized path when no `sources/` segment is found, so prefix-mismatched citations still match
- Why the EnterpriseRAG harness can't reuse matrix-bench code (opaque dsid vs substring, no author-curation of "best" gold)
- Adds `tests/test_bench_path_match_prefix_stripped.py` to the related-tests list

## Test plan

- [x] All four files render correctly as markdown (visually verified, tables OK, internal links resolve)
- [x] No code changes — no tests to run
- [ ] CI green on Linux + macOS-MPS + Windows
- [ ] Reviewer sanity-check: confirm the corpus-scale recall numbers (60% / 71% / 28%) and the v2 result-table values match what's actually in `benchmarks/results/ablate_dense_prefilter/`

## Lint note

The new tables use the same spaced-pipe style (`| col |`) as the rest of these docs. The project's markdownlint config wants MD060 compact style (`|col|`), so every table in this file family (including the pre-existing ones) currently warns. Bringing the docs into lint compliance would be a separate doc-wide pass; this PR only adds content in the existing style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
