### PR TITLE
fix(mcp): registry handshake is best-effort, don't kill subprocess on failure (closes #167)

### DIFF
--- a/helix_context/mcp/mcp_server.py
+++ b/helix_context/mcp/mcp_server.py
@@ -1093,7 +1093,23 @@ def main() -> None:
     log.info("helix-mcp starting — proxying to %s (timeout=%.1fs)",
              HELIX_URL, TIMEOUT_S)
 
-    _register_with_registry()
+    # Registry handshake is best-effort: if helix is unreachable or the
+    # bridge raises during register_participant() (auto-heartbeat thread
+    # init, etc.), we must NOT propagate the failure — it kills the MCP
+    # subprocess before mcp.run() enters the stdio handshake, which the
+    # MCP host then reports as "Connection closed" after ~2s. See the
+    # 2026-05-20 bench-debug session: every claude -p MCP attempt crashed
+    # this way on Windows even with helix alive, because AgentBridge's
+    # auto-heartbeat startup raised at registration time. Tool calls
+    # themselves still proxy to the HTTP API independently — registry is
+    # only used by helix_announce + dashboards.
+    try:
+        _register_with_registry()
+    except Exception:
+        log.exception(
+            "Registry handshake failed — continuing without registration. "
+            "Tool calls will still proxy to %s.", HELIX_URL,
+        )
 
     mcp.run()
 


### PR DESCRIPTION
## Summary

Closes #167.

On Windows, `claude -p` MCP attempts were failing with `"Connection closed"` after ~2s even when helix was alive on `http://127.0.0.1:11437`. Root cause: `_register_with_registry()` was called synchronously before `mcp.run()` entered the stdio handshake; an exception from `register_participant()` (auto-heartbeat thread init, etc.) propagated out of `main()` and killed the MCP subprocess before the host could complete its handshake.

The registry is not load-bearing for tool calls — tool calls proxy directly to the helix HTTP API. Registry is only used by `helix_announce` + dashboards (presence visibility, agent inventory). A failed registration should not block the MCP transport.

## Change

Wraps `_register_with_registry()` in a try/except inside `main()`:
- **Happy path**: registry registers as before, no behavior change
- **Failure path**: log the exception, continue to `mcp.run()` rather than exiting

```python
# Registry handshake is best-effort: if helix is unreachable or the
# bridge raises during register_participant() (auto-heartbeat thread
# init, etc.), we must NOT propagate the failure — it kills the MCP
# subprocess before mcp.run() enters the stdio handshake.
try:
    _register_with_registry()
except Exception:
    log.exception(
        "Registry handshake failed — continuing without registration. "
        "Tool calls will still proxy to %s.", HELIX_URL,
    )
```

## Discovery

2026-05-20 bench-debug session. Every `claude -p` MCP attempt on Windows crashed with `"Connection closed"` even with helix alive and reachable. py-spy stack on the dying subprocess confirmed the exception was unwinding from `register_participant` → `_register_with_registry` → `main` during AgentBridge's auto-heartbeat startup.

## Test plan

- [x] Code change is +17 / -1 in `helix_context/mcp/mcp_server.py`, narrowly scoped to the `main()` registry handshake call
- [x] AST parse clean
- [x] Happy path unchanged (registry registers normally when reachable)
- [ ] CI green on Linux + macOS-MPS + Windows
- [ ] Reviewer sanity-check: confirm `log.exception` is the right severity (vs `log.warning`) for the documented failure modes

## Why this is safe

- Tool calls already use a separate HTTP proxy path; they don't depend on registry state
- The MCP host (Claude Code/Desktop) does not require the registry to be registered for tools to work
- The `log.exception` output preserves the original failure stack for debugging
- No new dependencies, no new config knobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)