### PR TITLE
perf(dense): bound CUDA VRAM during batch ingest (periodic empty_cache)

### DIFF
--- a/helix_context/backends/bgem3_codec.py
+++ b/helix_context/backends/bgem3_codec.py
@@ -52,6 +52,25 @@ def vec_to_blob(vec, dim: int) -> bytes:
     return arr.tobytes(order="C")
 
 
+def _vram_release_interval() -> int:
+    """Release torch's CUDA caching-allocator cache every N batched encodes (0 = never).
+
+    torch's CUDA allocator keeps a separate cached block per distinct input shape,
+    so a long-lived process that batch-encodes many differently-sized passages — the
+    daemon ``/ingest`` route, ``scripts/backfill_bgem3_v2.py``, a 100k+-file genome
+    build — climbs to the card's VRAM ceiling and then spills to shared system memory
+    (measured: ~11.7 GB / 95% of a 12 GB 3080 Ti on a single-worker dense ingest of one
+    mid-size repo, vs a ~6 GB plateau once the cache is released periodically). A
+    periodic ``empty_cache()`` returns only *unused* cached blocks, so emitted vectors
+    are byte-identical and only a cheap ``cudaFree`` is paid every N documents. CPU
+    encoding has no CUDA cache and is unaffected. Tune/disable via the env var.
+    """
+    try:
+        return max(0, int(os.environ.get("HELIX_DENSE_VRAM_RELEASE_EVERY", "256")))
+    except ValueError:
+        return 256
+
+
 class BGEM3Codec:
     # Track which non-sanctioned dim values we've already warned for so we
     # don't spam the log on every re-instantiation in long-running processes.
@@ -62,6 +81,9 @@ class BGEM3Codec:
         self.model_name = model_name
         self._device = device
         self._model = None
+        # Number of batched encodes since construction; drives the periodic CUDA-cache
+        # release that bounds VRAM during long ingest runs (see ``_maybe_release_vram``).
+        self._encode_batch_calls = 0
         # Guards the lazy model load. When this codec is shared across
         # concurrent shard-fan-out workers (the A1 singleton), two threads can
         # hit ``_load`` simultaneously on first use; without the lock both
@@ -155,7 +177,28 @@ class BGEM3Codec:
         norms = np.linalg.norm(mat, axis=1, keepdims=True)
         norms[norms == 0.0] = 1.0
         mat = mat / norms
+        self._encode_batch_calls += 1
+        self._maybe_release_vram()
         return mat.tolist()
+
+    def _maybe_release_vram(self) -> None:
+        """Periodically free torch's CUDA caching-allocator cache during batch ingest.
+
+        See ``_vram_release_interval`` for why this is needed. No-op on CPU (no CUDA
+        cache) or when ``HELIX_DENSE_VRAM_RELEASE_EVERY=0``. Best-effort: a failure to
+        free is logged at debug and never interrupts ingest.
+        """
+        if self._device != "cuda":
+            return
+        every = _vram_release_interval()
+        if not every or (self._encode_batch_calls % every):
+            return
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001
+            log.debug("torch.cuda.empty_cache() failed during dense ingest", exc_info=True)
 
     def similarity(self, vec_a: list[float], vec_b: list[float]) -> float:
         a = np.array(vec_a, dtype=np.float32)

--- a/tests/test_bgem3_codec.py
+++ b/tests/test_bgem3_codec.py
@@ -1,8 +1,11 @@
 """BGE-M3 codec tests (Step 4, 2026-05-08)."""
+import sys
+
 import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
 from helix_context.backends.bgem3_codec import BGEM3Codec
+from helix_context.backends import bgem3_codec as _codec_mod
 
 
 def _make_codec_with_mock(dim=256):
@@ -58,3 +61,88 @@ def test_similarity_orthogonal_vectors():
     a = [1.0, 0.0, 0.0, 0.0]
     b = [0.0, 1.0, 0.0, 0.0]
     assert abs(codec.similarity(a, b)) < 1e-5
+
+
+# ── VRAM cache release (bounds CUDA caching-allocator growth during batch ingest) ──
+
+def _make_batch_codec(dim=64, device="cpu", n_rows=3):
+    """A BGEM3Codec wired to a mocked sentence-transformers backend for encode_batch."""
+    codec = BGEM3Codec(dim=dim, device=device)
+    mock_model = MagicMock()
+    mock_model.encode.return_value = np.ones((n_rows, dim * 2), dtype=np.float32) * 0.5
+    codec._model = mock_model
+    codec._backend = "sentence_transformers"
+    return codec
+
+
+def test_vram_release_interval_default(monkeypatch):
+    monkeypatch.delenv("HELIX_DENSE_VRAM_RELEASE_EVERY", raising=False)
+    assert _codec_mod._vram_release_interval() == 256
+
+
+def test_vram_release_interval_custom(monkeypatch):
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "10")
+    assert _codec_mod._vram_release_interval() == 10
+
+
+def test_vram_release_interval_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "not-an-int")
+    assert _codec_mod._vram_release_interval() == 256
+
+
+def test_encode_batch_counts_calls():
+    codec = _make_batch_codec()
+    assert codec._encode_batch_calls == 0
+    codec.encode_batch(["a", "b", "c"])
+    codec.encode_batch(["d"])
+    assert codec._encode_batch_calls == 2
+
+
+def test_cpu_device_never_releases(monkeypatch):
+    """CPU encoding has no CUDA cache: empty_cache must never be reached."""
+    codec = _make_batch_codec(device="cpu")
+    fake_torch = MagicMock()
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "1")
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        codec.encode_batch(["x"])
+    fake_torch.cuda.empty_cache.assert_not_called()
+
+
+def test_cuda_releases_on_interval(monkeypatch):
+    """On CUDA, empty_cache fires exactly every N batched encodes, not per call."""
+    codec = _make_batch_codec(device="cuda")
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = True
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "2")
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        codec.encode_batch(["a"])  # call 1: 1 % 2 != 0 -> no release
+        assert fake_torch.cuda.empty_cache.call_count == 0
+        codec.encode_batch(["b"])  # call 2: 2 % 2 == 0 -> release
+        assert fake_torch.cuda.empty_cache.call_count == 1
+        codec.encode_batch(["c"])  # call 3: no release
+        codec.encode_batch(["d"])  # call 4: release
+        assert fake_torch.cuda.empty_cache.call_count == 2
+
+
+def test_cuda_release_disabled_with_zero(monkeypatch):
+    """HELIX_DENSE_VRAM_RELEASE_EVERY=0 disables the release entirely."""
+    codec = _make_batch_codec(device="cuda")
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = True
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "0")
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        for t in "abcd":
+            codec.encode_batch([t])
+    fake_torch.cuda.empty_cache.assert_not_called()
+
+
+def test_encode_batch_vectors_unchanged_by_release(monkeypatch):
+    """The release is byte-neutral: vectors with release on == vectors with it off."""
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "0")
+    off = _make_batch_codec(device="cpu").encode_batch(["a", "b", "c"])
+    fake_torch = MagicMock()
+    fake_torch.cuda.is_available.return_value = True
+    monkeypatch.setenv("HELIX_DENSE_VRAM_RELEASE_EVERY", "1")
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        on = _make_batch_codec(device="cuda").encode_batch(["a", "b", "c"])
+    assert np.allclose(np.array(off), np.array(on))


### PR DESCRIPTION
## What

Bound CUDA VRAM growth during dense **batch ingest** by releasing torch's caching-allocator cache every N batched encodes.

Closes #176.

## Why

torch's CUDA allocator caches a block per input shape; the ingest path encodes wildly varying passage lengths, so a long-lived GPU process climbs to the card ceiling and then spills to shared system RAM (the slow path that looks like a hang). helix called `empty_cache()` **nowhere**. Surfaced on the ContextBench code-bench at **~11.7 GB / 95%** of a 12 GB 3080 Ti on a **single** dense worker — and `v0.6.3` ships dense ON by default. Full write-up in #176.

## Change

- `BGEM3Codec.encode_batch` → `_maybe_release_vram()` every `HELIX_DENSE_VRAM_RELEASE_EVERY` batched encodes (default **256**, `0` disables). **cuda-only**; the CPU path is untouched.
- **Behavior-neutral:** `empty_cache()` frees only *unused* cached blocks → vectors are byte-identical (covered by `test_encode_batch_vectors_unchanged_by_release`).
- Best-effort: a failed release is logged at debug and never interrupts ingest.
- Pairs with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for fragmentation.

## Measured (1 worker, mid-size repo dense ingest)

| config | peak VRAM |
|---|---|
| before | ~11.7 GB / 95%, climbing → shared-mem spill |
| `expandable_segments` only | ~7.7 GB start, still climbed |
| + periodic `empty_cache` (this mechanism) | **~6 GB plateau** |

## Tests

`tests/test_bgem3_codec.py`: **8 new**, fully mocked (no GPU / model / real torch). `14 passed in 0.08s`. Covers interval parsing (default / custom / invalid-fallback), batch-call counting, CPU no-op, CUDA cadence (every N, not per call), disable-with-`0`, and vector byte-neutrality.

## Scope / ownership

Single source file + tests, branched off `master`. Touches the dense codec (dense-path owner's area) — **flagging for review, not self-merging**. No retrieval/ranking behavior changes; pure VRAM hygiene.
