### PR TITLE
feat(launcher): Manage Database tray submenu + dashboard switchboard + pipeline viewer

### DIFF
--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -55,9 +55,62 @@ log = logging.getLogger("helix.context_manager")
 # Wraps each named pipeline stage with a monotonic-clock measurement and
 # records a single OTel histogram entry on exit. Exceptions in telemetry
 # are suppressed so a broken collector never kills the pipeline.
+#
+# In addition to the OTel histogram, each stage entry is appended to a
+# bounded in-process ring (the "pipeline viewer" feed). The ring is
+# scoped per build_context() call via a contextvar holding the request_id
+# so the dashboard can group events back into per-request rows.
 
+import collections as _collections
+import contextvars as _contextvars
 import time as _time
+import uuid as _uuid
 from .telemetry import pipeline_stage_histogram as _pipeline_stage_histogram
+
+
+# Per-request id propagated through the sync pipeline so each _stage_timer
+# event can be attributed back to the originating build_context call. Set
+# at the top of build_context(); reads default to "" when no run is active
+# (e.g. ad-hoc calls from debug endpoints).
+_pipeline_request_id: "_contextvars.ContextVar[str]" = _contextvars.ContextVar(
+    "_pipeline_request_id", default=""
+)
+
+# Bounded ring of recent stage events. Each entry is
+#   {"request_id", "stage", "ms", "ts"}
+# where ts is wall-clock seconds since the epoch. Sized to roughly the
+# last ~6 requests' worth of stage events (5 stages × 6 requests + slack)
+# so the launcher dashboard can render a recent-runs table without
+# unbounded memory growth on busy servers.
+_PIPELINE_RING_MAX = 64
+_pipeline_events: "_collections.deque[dict]" = _collections.deque(
+    maxlen=_PIPELINE_RING_MAX
+)
+
+
+def _pipeline_ring_enabled() -> bool:
+    """The ring is on by default; disable with HELIX_PIPELINE_RING=0."""
+    return os.environ.get("HELIX_PIPELINE_RING", "1").strip().lower() not in (
+        "0", "false", "off", "no",
+    )
+
+
+def get_recent_pipeline_events(limit: int = 32) -> List[dict]:
+    """Return the most recent pipeline stage events (newest last).
+
+    Consumed by the launcher dashboard via /debug/pipeline/recent. Returns
+    a shallow-copy list so the caller cannot mutate the deque.
+    """
+    snapshot = list(_pipeline_events)
+    if limit > 0:
+        snapshot = snapshot[-limit:]
+    return snapshot
+
+
+def get_pipeline_ring_max() -> int:
+    """The deque's maxlen — exposed so the HTTP endpoint and launcher
+    dashboard share a single source of truth for the buffer size."""
+    return _PIPELINE_RING_MAX
 
 
 class _stage_timer:
@@ -74,13 +127,26 @@ class _stage_timer:
         return self
 
     def __exit__(self, *exc):
+        elapsed = _time.monotonic() - self._t0
         try:
             _pipeline_stage_histogram().record(
-                _time.monotonic() - self._t0,
+                elapsed,
                 {"stage": self.stage, **self.labels},
             )
         except Exception:
             pass  # never let telemetry break the pipeline
+        try:
+            if _pipeline_ring_enabled():
+                rid = _pipeline_request_id.get()
+                if rid:
+                    _pipeline_events.append({
+                        "request_id": rid,
+                        "stage": self.stage,
+                        "ms": round(elapsed * 1000.0, 3),
+                        "ts": _time.time(),
+                    })
+        except Exception:
+            pass
 
 # Thread pool for running sync compressor calls from async context
 _executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="helix-ribosome")
@@ -1053,6 +1119,13 @@ class HelixContextManager:
                 preserves the previous behaviour exactly.
         """
         self._maybe_compact()
+
+        # Pipeline viewer feed (launcher dashboard). Tagging this call with
+        # a short request_id lets _stage_timer attribute every recorded
+        # stage back to the originating /context invocation. The contextvar
+        # is per-thread/per-task so concurrent calls cannot blend events.
+        if _pipeline_ring_enabled():
+            _pipeline_request_id.set(_uuid.uuid4().hex[:12])
 
         # Per-call locals for foveated-splice state (spec §4-5). Local —
         # not instance state — so concurrent build_context calls cannot

--- a/helix_context/launcher/collector.py
+++ b/helix_context/launcher/collector.py
@@ -25,6 +25,34 @@ from .model_labels import model_pretty
 log = logging.getLogger("helix.launcher.collector")
 
 
+def _coerce_value(value: Any) -> str:
+    """Render a config value as a stable string for the dashboard.
+
+    Booleans become "on"/"off", floats keep three decimals, everything
+    else falls back to repr-style stringification.
+    """
+    if isinstance(value, bool):
+        return "on" if value else "off"
+    if isinstance(value, float):
+        return f"{value:.3f}".rstrip("0").rstrip(".") or "0"
+    if value is None:
+        return "—"
+    return str(value)
+
+
+def _switchboard_summary(settings: List[Dict[str, Any]]) -> str:
+    """One-line chip summary for the dashboard: 'rrf · dense:on · rerank:off · ...'."""
+    pick = {s["label"]: s["value"] for s in settings}
+    chips = [
+        pick.get("fusion_mode", "?"),
+        f"dense:{pick.get('dense_embedding_enabled', '?')}",
+        f"splade:{pick.get('splade_enabled', '?')}",
+        f"rerank:{pick.get('rerank_enabled', '?')}",
+        f"decoder:{pick.get('decoder_mode', '?')}",
+    ]
+    return " · ".join(chips)
+
+
 def _build_tooltip(participant: Dict[str, Any]) -> Dict[str, str]:
     """Compose the tooltip field bundle from a participant dict.
 
@@ -84,6 +112,12 @@ class StateCollector:
         state: Dict[str, Any] = {"helix": helix_state}
         if self.update_checker is not None:
             state["update"] = self.update_checker.check().as_dict()
+
+        # The switchboard + database panels are useful even when helix is
+        # stopped — they describe the *next* run's planned configuration.
+        # Pipeline/runs panels need a live helix so they stay gated below.
+        state["switchboard"] = self._switchboard_panel()
+        state["database"] = self._database_panel()
 
         if not helix_state["running"]:
             return state
@@ -149,6 +183,25 @@ class StateCollector:
             if tokens and (tokens.get("session") or tokens.get("lifetime")):
                 endpoint_seen = True
                 state["tokens"] = self._tokens_panel(tokens)
+
+            # Backfill the database panel with live information from the
+            # running helix (the on-disk-discovery path can drift from the
+            # process that's actually open). Adds an `active` block in the
+            # panel so the dashboard can show "selected vs running".
+            live_genome = self._safe_get_json(client, "/admin/genome")
+            if live_genome:
+                endpoint_seen = True
+                state["database"]["live"] = self._live_genome(live_genome)
+
+            # Pipeline viewer events. The ring is only present on a helix
+            # that includes the launcher-companion code; an older helix
+            # answers 404 and we skip the panel quietly.
+            pipeline = self._safe_get_json(
+                client, "/debug/pipeline/recent", params={"limit": 64},
+            )
+            if pipeline and pipeline.get("events") is not None:
+                endpoint_seen = True
+                state["pipeline"] = self._pipeline_panel(pipeline)
         finally:
             client.close()
 
@@ -461,6 +514,152 @@ class StateCollector:
         except Exception:
             log.debug("Ollama /api/ps unreachable", exc_info=True)
             return None
+
+    # ── switchboard ────────────────────────────────────────────────
+
+    def _switchboard_panel(self) -> Dict[str, Any]:
+        """Snapshot the operationally-interesting retrieval/pipeline knobs.
+
+        Reads `helix_context.config.load_config()` directly. Both the
+        launcher and the supervised helix child resolve the same
+        `helix.toml` from the same working directory, so this snapshot
+        matches the live process. On any load failure the panel reports
+        the error so the operator sees the gap.
+        """
+        try:
+            from helix_context.config import load_config
+            cfg = load_config()
+        except Exception as exc:
+            log.warning("Switchboard: load_config failed (%s)", exc)
+            return {"error": str(exc), "settings": []}
+
+        def _entry(label: str, value: Any, group: str, desc: str = "") -> Dict[str, Any]:
+            return {
+                "label": label,
+                "value": _coerce_value(value),
+                "group": group,
+                "description": desc,
+            }
+
+        retrieval = cfg.retrieval
+        budget = cfg.budget
+        ingestion = cfg.ingestion
+        classifier = getattr(cfg, "classifier", None)
+        ribosome = cfg.ribosome
+
+        settings: List[Dict[str, Any]] = [
+            _entry("fusion_mode", retrieval.fusion_mode, "retrieval",
+                   "additive | rrf — how per-tier scores combine"),
+            _entry("dense_embedding_enabled", retrieval.dense_embedding_enabled,
+                   "retrieval", "BGE-M3 dense recall participates in ranking"),
+            _entry("ann_similarity_threshold", retrieval.ann_similarity_threshold,
+                   "retrieval", "Minimum cosine for a dense hit to count"),
+            _entry("splade_enabled", ingestion.splade_enabled, "ingestion",
+                   "SPLADE sparse expansion at index time"),
+            _entry("rerank_enabled", ingestion.rerank_enabled, "ingestion",
+                   "Cross-encoder rerank on candidates"),
+            _entry("decoder_mode", budget.decoder_mode, "budget",
+                   "full | condensed | minimal | none — decoder prompt size"),
+            _entry("expression_tokens", budget.expression_tokens, "budget",
+                   "Retrieved-context token cap per turn"),
+            _entry("max_genes_per_turn", budget.max_genes_per_turn, "budget",
+                   "Hard ceiling on documents returned per query"),
+            _entry("session_delivery_enabled", budget.session_delivery_enabled,
+                   "budget", "Elide already-delivered docs from session"),
+            _entry("classifier_enabled",
+                   getattr(classifier, "enabled", True) if classifier else True,
+                   "classifier",
+                   "Rule-based query classifier picks decoder mode"),
+            _entry("ribosome_backend", ribosome.effective_backend, "ribosome",
+                   "ollama | claude | litellm | disabled"),
+        ]
+
+        return {
+            "settings": settings,
+            "summary": _switchboard_summary(settings),
+        }
+
+    # ── database (genome registry) ─────────────────────────────────
+
+    def _database_panel(self) -> Dict[str, Any]:
+        """Inventory of available genomes + which one is currently selected.
+
+        Reads the on-disk registry. The dashboard pairs this with the
+        live `/admin/genome` response (added in `collect`) to surface
+        any drift between "what's selected" and "what's actually open".
+        """
+        try:
+            from .genome_registry import (
+                active_genome_path,
+                discover_genomes,
+                is_active,
+            )
+        except Exception as exc:
+            log.warning("Database panel: registry import failed (%s)", exc)
+            return {"error": str(exc), "entries": []}
+
+        try:
+            entries = discover_genomes()
+            active = str(active_genome_path()).lower()
+        except Exception as exc:
+            log.warning("Database panel: discovery failed (%s)", exc, exc_info=True)
+            return {"error": str(exc), "entries": []}
+
+        out_entries = []
+        for info in entries:
+            row = info.as_dict()
+            row["is_active"] = is_active(info)
+            out_entries.append(row)
+
+        return {
+            "active_path": active,
+            "entries": out_entries,
+            "count": len(out_entries),
+        }
+
+    def _live_genome(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Project /admin/genome into the database panel's `live` block."""
+        return {
+            "path": payload.get("path"),
+            "configured_path": payload.get("configured_path"),
+            "env_override": payload.get("env_override"),
+            "size_bytes": payload.get("size_bytes"),
+            "total_genes": payload.get("total_genes"),
+            "error": payload.get("error"),
+        }
+
+    # ── pipeline viewer ────────────────────────────────────────────
+
+    def _pipeline_panel(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Group raw stage events into per-request rows for the panel.
+
+        Each row carries the request id, total ms across observed stages,
+        and a per-stage timing breakdown. Sorted newest first.
+        """
+        events = payload.get("events", []) or []
+        grouped: Dict[str, Dict[str, Any]] = {}
+        for ev in events:
+            rid = ev.get("request_id") or "?"
+            stage = ev.get("stage") or "?"
+            ms = float(ev.get("ms") or 0.0)
+            ts = float(ev.get("ts") or 0.0)
+            row = grouped.setdefault(rid, {
+                "request_id": rid,
+                "stages": {},
+                "ts": ts,
+                "total_ms": 0.0,
+            })
+            row["stages"][stage] = round(row["stages"].get(stage, 0.0) + ms, 3)
+            row["total_ms"] = round(row["total_ms"] + ms, 3)
+            if ts > row["ts"]:
+                row["ts"] = ts
+
+        runs = sorted(grouped.values(), key=lambda r: r["ts"], reverse=True)
+        return {
+            "runs": runs[:20],
+            "event_count": len(events),
+            "ring_max": int(payload.get("ring_max") or 0),
+        }
 
     # ── helpers ────────────────────────────────────────────────────
 

--- a/helix_context/launcher/genome_registry.py
+++ b/helix_context/launcher/genome_registry.py
@@ -1,0 +1,336 @@
+"""
+Genome registry — discover and describe local genome (.db) databases.
+
+Used by the system-tray "Manage Database" submenu and the dashboard's
+Database panel. Both surfaces need the same answers:
+
+    - Which genome is currently selected?
+    - What other genomes are built and selectable?
+    - For each genome, what source folders are inside it?
+
+Genomes are plain SQLite files on disk. There is no central registry —
+this module walks a small set of well-known directories under the repo
+root and asks each `.db` file two cheap SQLite questions:
+
+    SELECT COUNT(*) FROM genes
+    SELECT DISTINCT source_id FROM genes LIMIT 2000
+
+A `(path, mtime)` keyed cache prevents the tray from re-scanning on every
+menu open. Results are cheap to recompute when a genome actually changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+log = logging.getLogger("helix.launcher.genome_registry")
+
+# How many `source_id` rows to read when computing the folder summary. A
+# few thousand is enough to surface the top folders without scanning a
+# 500k-document corpus.
+_SOURCE_SAMPLE_LIMIT = 2000
+
+# How deep below the well-known roots to walk when discovering `.db` files.
+_DISCOVERY_MAX_DEPTH = 3
+
+# Well-known directories under the repo root that may contain genomes.
+# Order is informational — the active genome always sorts first regardless.
+_DISCOVERY_ROOTS = ("genomes", "benchmarks")
+
+
+@dataclass
+class FolderEntry:
+    """One source-folder bucket inside a genome."""
+    prefix: str
+    document_count: int
+
+
+@dataclass
+class GenomeInfo:
+    """Descriptor for one discoverable genome file."""
+    name: str
+    path: Path
+    size_bytes: int
+    mtime: float
+    total_genes: int
+    folders: List[FolderEntry] = field(default_factory=list)
+    error: Optional[str] = None
+
+    @property
+    def is_readable(self) -> bool:
+        return self.error is None and self.total_genes > 0
+
+    def as_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "path": str(self.path),
+            "size_bytes": self.size_bytes,
+            "size_mb": round(self.size_bytes / (1024 * 1024), 1),
+            "mtime": self.mtime,
+            "total_genes": self.total_genes,
+            "folders": [
+                {"prefix": f.prefix, "document_count": f.document_count}
+                for f in self.folders
+            ],
+            "error": self.error,
+        }
+
+
+# ── cache ─────────────────────────────────────────────────────────────
+
+_CACHE: Dict[str, GenomeInfo] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _cache_key(path: Path, mtime: float, size: int) -> str:
+    return f"{path}|{mtime:.3f}|{size}"
+
+
+# ── discovery ─────────────────────────────────────────────────────────
+
+
+def _repo_root() -> Path:
+    """The helix-context repo root, used as the base for discovery walks."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _walk_for_dbs(root: Path, max_depth: int) -> List[Path]:
+    """Walk `root` up to `max_depth` directories deep collecting *.db files.
+
+    Skips hidden directories (`.git`, `.claude`, `.venv` etc.) and any
+    obvious junk paths. Errors during traversal are logged and swallowed.
+    """
+    found: List[Path] = []
+    if not root.exists() or not root.is_dir():
+        return found
+    base_depth = len(root.parts)
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            depth = len(Path(dirpath).parts) - base_depth
+            if depth >= max_depth:
+                dirnames[:] = []
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            for name in filenames:
+                if name.endswith(".db") and not name.endswith("-journal"):
+                    found.append(Path(dirpath) / name)
+    except OSError:
+        log.debug("walk failed under %s", root, exc_info=True)
+    return found
+
+
+def _candidate_paths(active_path: Optional[Path]) -> List[Path]:
+    """Build a deduplicated, ordered list of candidate genome paths."""
+    repo = _repo_root()
+    seen: set = set()
+    out: List[Path] = []
+
+    def _add(p: Path) -> None:
+        try:
+            resolved = p.resolve()
+        except OSError:
+            return
+        key = str(resolved).lower()
+        if key in seen:
+            return
+        if not resolved.exists() or not resolved.is_file():
+            return
+        seen.add(key)
+        out.append(resolved)
+
+    if active_path is not None:
+        _add(active_path)
+    _add(repo / "genome.db")
+    for sub in _DISCOVERY_ROOTS:
+        for db in _walk_for_dbs(repo / sub, _DISCOVERY_MAX_DEPTH):
+            _add(db)
+    return out
+
+
+# ── per-genome introspection ──────────────────────────────────────────
+
+
+def _summarize_folders(rows: Sequence[str]) -> List[FolderEntry]:
+    """Bucket raw `source_id` paths into top-level folder summaries.
+
+    Strategy: take the first two path components of each source_id and
+    use that as the folder bucket. A document at
+    "F:/Projects/onyx/backend/models.py" becomes "F:/Projects/onyx".
+    Bare filenames with no separator fall into a "(loose files)" bucket.
+    Returned sorted by document_count desc, capped at 12 entries.
+    """
+    counter: Counter = Counter()
+    for src in rows:
+        if not src:
+            counter["(unknown)"] += 1
+            continue
+        norm = str(src).replace("\\", "/").lstrip("/")
+        parts = [p for p in norm.split("/") if p]
+        if len(parts) <= 1:
+            counter["(loose files)"] += 1
+        else:
+            counter[f"{parts[0]}/{parts[1]}"] += 1
+    entries = [
+        FolderEntry(prefix=prefix, document_count=count)
+        for prefix, count in counter.most_common(12)
+    ]
+    return entries
+
+
+def _make_label(path: Path) -> str:
+    """Human-readable name for a genome file.
+
+    Files literally named ``genome.db`` or ``main.genome.db`` are
+    ambiguous on their own — sharded benches stash one such file per
+    shard directory — so prefix the parent directory to keep entries
+    distinguishable in the tray menu and dashboard list.
+    """
+    stem = path.stem
+    if stem in ("genome", "main.genome"):
+        return f"{path.parent.name}/{stem}"
+    return stem
+
+
+def _read_genome_info(path: Path) -> GenomeInfo:
+    """Inspect a single .db file. Never raises — errors surface via .error."""
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        return GenomeInfo(
+            name=_make_label(path),
+            path=path,
+            size_bytes=0,
+            mtime=0.0,
+            total_genes=0,
+            error=f"stat failed: {exc}",
+        )
+
+    cache_key = _cache_key(path, stat.st_mtime, stat.st_size)
+    with _CACHE_LOCK:
+        hit = _CACHE.get(cache_key)
+        if hit is not None:
+            return hit
+
+    info = GenomeInfo(
+        name=_make_label(path),
+        path=path,
+        size_bytes=stat.st_size,
+        mtime=stat.st_mtime,
+        total_genes=0,
+    )
+
+    try:
+        # `uri=True` + `mode=ro` makes the read non-locking and safe to
+        # run against a database that helix has open for writes.
+        conn = sqlite3.connect(
+            f"file:{path.as_posix()}?mode=ro",
+            uri=True,
+            timeout=1.0,
+        )
+        try:
+            conn.execute("PRAGMA query_only=ON")
+            row = conn.execute("SELECT COUNT(*) FROM genes").fetchone()
+            info.total_genes = int(row[0]) if row else 0
+            sources = [
+                str(r[0])
+                for r in conn.execute(
+                    "SELECT DISTINCT source_id FROM genes "
+                    "WHERE source_id IS NOT NULL LIMIT ?",
+                    (_SOURCE_SAMPLE_LIMIT,),
+                )
+            ]
+            info.folders = _summarize_folders(sources)
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        info.error = f"sqlite: {exc}"
+    except Exception as exc:
+        info.error = f"read failed: {exc}"
+
+    with _CACHE_LOCK:
+        _CACHE[cache_key] = info
+    return info
+
+
+# ── public API ────────────────────────────────────────────────────────
+
+
+def active_genome_path() -> Path:
+    """Resolve the genome path the supervised helix will load on next start.
+
+    Resolution order matches `helix_context.config.load_config`:
+      1. HELIX_GENOME_PATH env var
+      2. [genome] path in helix.toml
+      3. Default "genome.db" relative to the helix repo root
+    """
+    env = os.environ.get("HELIX_GENOME_PATH")
+    if env:
+        return Path(env).resolve()
+    try:
+        from helix_context.config import load_config
+        cfg = load_config()
+        path = Path(cfg.genome.path)
+    except Exception:
+        log.debug("load_config failed; falling back to repo-root default", exc_info=True)
+        path = Path("genome.db")
+    if not path.is_absolute():
+        path = (_repo_root() / path).resolve()
+    return path
+
+
+def discover_genomes() -> List[GenomeInfo]:
+    """Return the list of available genomes, active one first.
+
+    Results are cached per `(path, mtime, size)`. A genome file that has
+    been edited since last call gets re-read.
+    """
+    active = active_genome_path()
+    paths = _candidate_paths(active)
+    out: List[GenomeInfo] = [_read_genome_info(p) for p in paths]
+    active_resolved = str(active).lower()
+
+    def _sort_key(info: GenomeInfo) -> tuple:
+        is_active = str(info.path).lower() == active_resolved
+        return (0 if is_active else 1, -info.mtime, str(info.path).lower())
+
+    out.sort(key=_sort_key)
+    return out
+
+
+def get_genome_info(path: Path) -> GenomeInfo:
+    """Public single-genome accessor; same caching as `discover_genomes`."""
+    return _read_genome_info(Path(path).resolve())
+
+
+def is_active(info: GenomeInfo) -> bool:
+    """True iff `info` describes the currently configured active genome."""
+    return str(info.path).lower() == str(active_genome_path()).lower()
+
+
+def select_genome(path: Path) -> Path:
+    """Mark `path` as the genome to use on the next helix start.
+
+    Sets `HELIX_GENOME_PATH` in the current process so the supervisor's
+    next subprocess.Popen inherits it. Does NOT restart helix — callers
+    that want a hot swap must invoke `supervisor.restart()` separately.
+    Returns the resolved absolute path that was written.
+    """
+    resolved = Path(path).resolve()
+    if not resolved.exists() or not resolved.is_file():
+        raise FileNotFoundError(f"Genome not found: {resolved}")
+    os.environ["HELIX_GENOME_PATH"] = str(resolved)
+    log.info("Selected genome: %s", resolved)
+    return resolved
+
+
+def clear_cache() -> None:
+    """Drop all cached `GenomeInfo` entries — used by tests."""
+    with _CACHE_LOCK:
+        _CACHE.clear()

--- a/helix_context/launcher/static/launcher.css
+++ b/helix_context/launcher/static/launcher.css
@@ -411,7 +411,10 @@ p {
 .panel--all-agents,
 .panel--disconnected-agents,
 .panel--empty,
-.panel--health-warning {
+.panel--health-warning,
+.panel--switchboard,
+.panel--database,
+.panel--pipeline {
   grid-column: span 12;
 }
 
@@ -735,10 +738,211 @@ p {
 .panels[data-active-tab="genome"] .panel--tokens,
 .panels[data-active-tab="genome"] .panel--models,
 .panels[data-active-tab="genome"] .panel--tools,
+.panels[data-active-tab="genome"] .panel--database,
 .panels[data-active-tab="monitoring"] .panel--diagnostics,
 .panels[data-active-tab="monitoring"] .panel--health-warning,
-.panels[data-active-tab="monitoring"] .panel--empty {
+.panels[data-active-tab="monitoring"] .panel--empty,
+.panels[data-active-tab="monitoring"] .panel--switchboard,
+.panels[data-active-tab="monitoring"] .panel--pipeline {
   display: grid;
+}
+
+/* ── Switchboard panel ─────────────────────────────────────────── */
+
+.switchboard-grid {
+  grid-template-columns: minmax(220px, auto) 1fr;
+}
+
+.switchboard-label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.switchboard-desc {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.switchboard-value {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+
+.switchboard-value--on {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+
+.switchboard-value--off {
+  background: color-mix(in srgb, var(--color-muted) 18%, transparent);
+  color: var(--color-muted);
+}
+
+/* ── Database panel ────────────────────────────────────────────── */
+
+.database-list {
+  display: grid;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.database-entry {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--color-elevated) 60%, transparent);
+}
+
+.database-entry--active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.database-entry__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.database-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--color-dim);
+  display: inline-block;
+}
+
+.database-dot--on {
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px var(--color-success-soft);
+}
+
+.database-entry__name {
+  color: var(--color-text);
+  font-size: var(--fs-base);
+}
+
+.database-entry__tag {
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.database-entry__stats {
+  margin-left: auto;
+  font-family: var(--font-mono);
+}
+
+.database-entry__path {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.database-entry__folders summary {
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  color: var(--color-muted);
+}
+
+.database-folder-list {
+  margin: 6px 0 0 18px;
+  padding: 0;
+  list-style: disc;
+  display: grid;
+  gap: 2px;
+  font-size: 11px;
+}
+
+.database-entry__folders-empty {
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
+/* ── Pipeline viewer panel ─────────────────────────────────────── */
+
+.pipeline-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--color-muted);
+  cursor: pointer;
+}
+
+.pipeline-toggle input {
+  accent-color: var(--color-accent);
+}
+
+.pipeline-summary {
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
+[data-pipeline-panel][data-dev="off"] [data-pipeline-dev-view] {
+  display: none;
+}
+
+.pipeline-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.pipeline-table th,
+.pipeline-table td {
+  padding: 6px 8px;
+  text-align: right;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pipeline-table th:first-child,
+.pipeline-table td:first-child {
+  text-align: left;
+}
+
+.pipeline-table th {
+  color: var(--color-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+
+.pipeline-rid code {
+  color: var(--color-accent-strong);
+  background: var(--color-accent-soft);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+.pipeline-cell {
+  color: var(--color-text);
+}
+
+.pipeline-cell--total strong {
+  color: var(--color-accent-strong);
 }
 
 @media (max-width: 760px) {

--- a/helix_context/launcher/static/launcher.js
+++ b/helix_context/launcher/static/launcher.js
@@ -17,6 +17,7 @@
   const tabStorageKey = "helix-dashboard-tab";
   const agentTabStorageKey = "helix-dashboard-agent-tab";
   const agentOpenStorageKey = "helix-dashboard-agent-open";
+  const pipelineDevStorageKey = "helix-pipeline-dev-view";
 
   let pollTimer = null;
   let inFlight = false;
@@ -97,6 +98,39 @@
     panels.dataset.activeTab = activeTab;
     restoreAgentOpenState();
     restoreAgentTab();
+    restorePipelineDevView();
+  }
+
+  /* ── Pipeline panel: dev-view toggle (default ON) ──────────────── */
+
+  function readPipelineDevView() {
+    try {
+      const saved = window.localStorage.getItem(pipelineDevStorageKey);
+      if (saved === "off") return "off";
+    } catch (err) {
+      // Storage optional — fall through to default.
+    }
+    return "on";
+  }
+
+  function applyPipelineDevView(state) {
+    const next = state === "off" ? "off" : "on";
+    document.querySelectorAll("[data-pipeline-panel]").forEach((panel) => {
+      panel.dataset.dev = next;
+      const checkbox = panel.querySelector("[data-pipeline-dev-toggle]");
+      if (checkbox instanceof HTMLInputElement) {
+        checkbox.checked = next === "on";
+      }
+    });
+    try {
+      window.localStorage.setItem(pipelineDevStorageKey, next);
+    } catch (err) {
+      // Ignore storage failures.
+    }
+  }
+
+  function restorePipelineDevView() {
+    applyPipelineDevView(readPipelineDevView());
   }
 
   async function fetchPanels() {
@@ -227,6 +261,13 @@
     }
   }, true);
 
+  document.addEventListener("change", function (evt) {
+    const target = evt.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (!target.matches("[data-pipeline-dev-toggle]")) return;
+    applyPipelineDevView(target.checked ? "on" : "off");
+  });
+
   document.addEventListener("visibilitychange", function () {
     if (document.hidden) {
       stopPolling();
@@ -238,5 +279,6 @@
   restoreActiveTab();
   restoreAgentOpenState();
   restoreAgentTab();
+  restorePipelineDevView();
   startPolling();
 })();

--- a/helix_context/launcher/templates/components/database_panel.html
+++ b/helix_context/launcher/templates/components/database_panel.html
@@ -1,0 +1,81 @@
+{# Database panel — list of discovered genome (.db) databases on disk.
+   Marks the currently active one, surfaces the top folders contributing
+   to each genome, and (when helix is up) cross-checks against the live
+   /admin/genome reply so a drift between "selected" and "running" is
+   visible at a glance.
+
+   Switch the active genome from the system-tray "Manage Database"
+   submenu — the dashboard is read-only. #}
+
+<section class="panel panel--database">
+  <h2 class="panel-title">
+    Database
+    {% if state.database.count %}
+      <span class="panel-count">{{ state.database.count }}</span>
+    {% endif %}
+  </h2>
+
+  {% if state.database.error %}
+    <div class="diagnostics-warn">
+      <strong>Could not read genome registry:</strong>
+      <span class="muted">{{ state.database.error }}</span>
+    </div>
+  {% endif %}
+
+  {% if state.database.live %}
+    <dl class="panel-kv">
+      <dt>Running</dt>
+      <dd class="path-value">
+        {{ state.database.live.path or "(unknown)" }}
+        {% if state.database.live.total_genes is not none %}
+          <span class="muted">— {{ "{:,}".format(state.database.live.total_genes) }} genes</span>
+        {% endif %}
+      </dd>
+      {% if state.database.live.env_override %}
+        <dt>Env override</dt>
+        <dd class="muted">HELIX_GENOME_PATH = {{ state.database.live.env_override }}</dd>
+      {% endif %}
+      {% if state.database.live.error %}
+        <dt>Error</dt>
+        <dd class="muted">{{ state.database.live.error }}</dd>
+      {% endif %}
+    </dl>
+  {% endif %}
+
+  <ul class="panel-list database-list">
+    {% for entry in state.database.entries %}
+      <li class="panel-list__item database-entry {% if entry.is_active %}database-entry--active{% endif %}">
+        <div class="database-entry__header">
+          <span class="database-dot {% if entry.is_active %}database-dot--on{% endif %}" aria-hidden="true"></span>
+          <strong class="database-entry__name">{{ entry.name }}</strong>
+          {% if entry.is_active %}
+            <span class="database-entry__tag">active</span>
+          {% endif %}
+          <span class="muted database-entry__stats">
+            {{ "{:,}".format(entry.total_genes) }} genes · {{ entry.size_mb }} MB
+          </span>
+        </div>
+        <p class="path-value database-entry__path">{{ entry.path }}</p>
+        {% if entry.error %}
+          <p class="diagnostics-error">{{ entry.error }}</p>
+        {% elif entry.folders %}
+          <details class="database-entry__folders">
+            <summary>Folders ({{ entry.folders|length }})</summary>
+            <ul class="database-folder-list">
+              {% for f in entry.folders %}
+                <li>
+                  <span class="path-value">{{ f.prefix }}</span>
+                  <span class="muted">— {{ "{:,}".format(f.document_count) }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          </details>
+        {% else %}
+          <p class="muted database-entry__folders-empty">No source folders recorded.</p>
+        {% endif %}
+      </li>
+    {% else %}
+      <li class="panel-list__item muted">No genomes discovered.</li>
+    {% endfor %}
+  </ul>
+</section>

--- a/helix_context/launcher/templates/components/panels.html
+++ b/helix_context/launcher/templates/components/panels.html
@@ -16,6 +16,16 @@
   </div>
 {% endif %}
 
+{# Switchboard + Database render even when helix is stopped — they
+   describe the planned configuration for the next start. #}
+{% if state.switchboard %}
+  {% include "components/switchboard_panel.html" %}
+{% endif %}
+
+{% if state.database %}
+  {% include "components/database_panel.html" %}
+{% endif %}
+
 {% if state.helix.running %}
   {% if state.parties %}
     {% include "components/parties_panel.html" %}
@@ -43,6 +53,10 @@
 
   {% if state.tokens %}
     {% include "components/tokens_panel.html" %}
+  {% endif %}
+
+  {% if state.pipeline %}
+    {% include "components/pipeline_panel.html" %}
   {% endif %}
 
 {% endif %}

--- a/helix_context/launcher/templates/components/pipeline_panel.html
+++ b/helix_context/launcher/templates/components/pipeline_panel.html
@@ -1,0 +1,70 @@
+{# Pipeline viewer — last ~20 build_context calls with per-stage timings.
+   Backed by /debug/pipeline/recent on the helix backend.
+
+   The "Dev view" toggle is dev-only and defaults ON (handled in JS via
+   localStorage key `helix-pipeline-dev-view`). When OFF, only the
+   summary line is shown; when ON, the per-stage table renders. #}
+
+<section
+  class="panel panel--pipeline"
+  data-pipeline-panel="1"
+  data-default-dev="on"
+>
+  <h2 class="panel-title">
+    Pipeline
+    {% if state.pipeline.runs %}
+      <span class="panel-count">{{ state.pipeline.runs|length }}</span>
+    {% endif %}
+    <label class="pipeline-toggle">
+      <input type="checkbox" data-pipeline-dev-toggle checked>
+      <span>Dev view</span>
+    </label>
+  </h2>
+
+  {% if not state.pipeline.runs %}
+    <p class="muted">
+      No pipeline calls observed yet — send a query through
+      <code>/context</code> to populate this view.
+    </p>
+  {% else %}
+    <p class="muted pipeline-summary">
+      Showing last {{ state.pipeline.runs|length }} of up to
+      {{ state.pipeline.ring_max }} buffered events.
+    </p>
+
+    <div data-pipeline-dev-view>
+      <table class="pipeline-table">
+        <thead>
+          <tr>
+            <th scope="col">Request</th>
+            <th scope="col">extract</th>
+            <th scope="col">express</th>
+            <th scope="col">rerank</th>
+            <th scope="col">splice</th>
+            <th scope="col">assemble</th>
+            <th scope="col">total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for run in state.pipeline.runs %}
+            <tr>
+              <td class="pipeline-rid"><code>{{ run.request_id }}</code></td>
+              {% for stage in ["extract", "express", "rerank", "splice", "assemble"] %}
+                <td class="pipeline-cell">
+                  {% if run.stages.get(stage) is not none %}
+                    {{ "%.1f"|format(run.stages.get(stage)) }} ms
+                  {% else %}
+                    <span class="muted">—</span>
+                  {% endif %}
+                </td>
+              {% endfor %}
+              <td class="pipeline-cell pipeline-cell--total">
+                <strong>{{ "%.1f"|format(run.total_ms) }} ms</strong>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+</section>

--- a/helix_context/launcher/templates/components/switchboard_panel.html
+++ b/helix_context/launcher/templates/components/switchboard_panel.html
@@ -1,0 +1,36 @@
+{# Switchboard — live snapshot of operationally-interesting pipeline knobs.
+   Sourced from helix_context.config.load_config() in the launcher process;
+   the supervised helix shares the same helix.toml + cwd, so what you see
+   here is what the next /context call will use. #}
+
+<section class="panel panel--switchboard">
+  <h2 class="panel-title">
+    Switchboard
+    {% if state.switchboard.summary %}
+      <span class="panel-count-muted">{{ state.switchboard.summary }}</span>
+    {% endif %}
+  </h2>
+
+  {% if state.switchboard.error %}
+    <div class="diagnostics-warn">
+      <strong>Could not read switchboard config:</strong>
+      <span class="muted">{{ state.switchboard.error }}</span>
+    </div>
+  {% else %}
+    <dl class="panel-kv switchboard-grid">
+      {% for setting in state.switchboard.settings %}
+        <dt>
+          <span class="switchboard-label">{{ setting.label }}</span>
+          {% if setting.description %}
+            <span class="muted switchboard-desc">{{ setting.description }}</span>
+          {% endif %}
+        </dt>
+        <dd>
+          <span class="switchboard-value switchboard-value--{{ setting.value }}">
+            {{ setting.value }}
+          </span>
+        </dd>
+      {% endfor %}
+    </dl>
+  {% endif %}
+</section>

--- a/helix_context/launcher/tray.py
+++ b/helix_context/launcher/tray.py
@@ -50,6 +50,7 @@ from .supervisor import (
     NotRunning,
     SupervisorError,
 )
+from . import genome_registry
 
 log = logging.getLogger("helix.launcher.tray")
 
@@ -120,6 +121,63 @@ def _should_fire_hardware_fallback_balloon() -> bool:
         return False
     sentinel = _hardware_fallback_sentinel_path(info.requested_device, info.device_type)
     return not sentinel.exists()
+
+
+def _confirm_genome_switch(target: Path) -> bool:
+    """Ask the user to confirm a genome switch via a native dialog.
+
+    Returns True on confirmation, False on decline.
+
+    On Windows the prompt is rendered via the Win32 MessageBoxW API —
+    pystray dispatches menu callbacks on the icon's message-pump thread,
+    and spinning up tkinter from that thread tends to deadlock (Tk wants
+    its own event loop and competes with pystray's Win32 dispatch). The
+    MessageBoxW call is a single Win32 modal that nests cleanly inside
+    the existing pump.
+
+    On non-Windows platforms we fall back to tkinter (cross-platform
+    stdlib). If both backends fail we treat the click as consent —
+    matching the rest of the launcher, where clicking the menu item is
+    already considered an explicit signal.
+    """
+    title = "Helix Launcher — switch database?"
+    body = (
+        f"Switch the active genome to:\n\n    {target}\n\n"
+        "Helix will restart so the new genome can be loaded. "
+        "In-flight /context requests will fail until restart completes."
+    )
+
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            # MB_YESNO=0x4, MB_ICONQUESTION=0x20, MB_TOPMOST=0x40000
+            MB_FLAGS = 0x4 | 0x20 | 0x40000
+            IDYES = 6
+            result = ctypes.windll.user32.MessageBoxW(
+                None, body, title, MB_FLAGS,
+            )
+            return result == IDYES
+        except Exception:
+            log.debug("MessageBoxW failed; falling through to tkinter",
+                      exc_info=True)
+
+    try:
+        import tkinter as _tk
+        from tkinter import messagebox as _mb
+        root = _tk.Tk()
+        root.withdraw()
+        try:
+            answer = _mb.askyesno(title, body, parent=root)
+        finally:
+            try:
+                root.destroy()
+            except Exception:
+                pass
+        return bool(answer)
+    except Exception:
+        log.debug("Confirm dialog unavailable; treating click as consent",
+                  exc_info=True)
+        return True
 
 
 def _fire_hardware_fallback_balloon(tray_icon) -> None:
@@ -216,6 +274,155 @@ class HelixTrayIcon:
             webbrowser.open(self.dashboard_url)
         except Exception:
             log.warning("Tray: failed to open browser", exc_info=True)
+
+    # ── Manage Database handlers ──────────────────────────────────
+
+    def _switch_genome(self, genome_path: Path):
+        """Return a pystray-compatible handler that switches to `genome_path`.
+
+        The restart runs on a background thread so the pystray message
+        pump stays responsive — `supervisor.restart()` can take 30 s
+        (graceful stop + cold-start `/stats` warmup), and freezing the
+        tray icon that whole window looks indistinguishable from "the
+        click did nothing" to the user. We show a balloon immediately
+        on Yes so the operator gets feedback the moment they confirm,
+        and a second balloon (success or failure) when the restart
+        worker finishes.
+
+        Every branch logs at INFO so an operator inspecting
+        `~/.helix/launcher/launcher.log` can see exactly which step
+        ran — no more silent menu clicks.
+        """
+        def _h(icon, item):  # noqa: ARG001 — pystray API
+            log.info("Tray: switch-genome click received for %s", genome_path)
+            try:
+                self._handle_genome_click(Path(genome_path))
+            except Exception:
+                # pystray's menu callback wrapper swallows exceptions —
+                # log them ourselves so the operator can debug a broken
+                # click from launcher.log alone.
+                log.error("Tray: switch-genome handler crashed", exc_info=True)
+        return _h
+
+    def _handle_genome_click(self, target: Path) -> None:
+        """Confirm + immediate balloon + spawn the restart worker."""
+        if not _confirm_genome_switch(target):
+            log.info("Tray: genome switch cancelled by user (%s)", target)
+            return
+        log.info("Tray: genome switch confirmed for %s", target)
+
+        try:
+            resolved = genome_registry.select_genome(target)
+        except FileNotFoundError as exc:
+            log.warning("Tray: genome switch failed: %s", exc)
+            self._safe_notify(str(exc), title="Helix: switch failed")
+            return
+
+        # Active path just moved — drop the registry cache so the rebuilt
+        # submenu reflects the new selection on its next render.
+        genome_registry.clear_cache()
+
+        # Immediate confirmation so the user sees feedback before the
+        # 10-30 s restart cycle completes.
+        self._safe_notify(
+            f"Restarting helix on {resolved.name}…",
+            title="Helix: switching database",
+        )
+
+        worker = threading.Thread(
+            target=self._switch_worker,
+            args=(resolved,),
+            name="helix-genome-switch",
+            daemon=True,
+        )
+        worker.start()
+
+    def _switch_worker(self, resolved: Path) -> None:
+        """Background worker: stop + start helix, then notify + refresh menu.
+
+        Runs off the pystray message-pump thread so the tray icon stays
+        clickable while supervisor.stop / start are blocking on
+        `taskkill /F /T` and the cold-start `/stats` probe.
+        """
+        log.info("Tray: switching genome -> %s (will restart)", resolved)
+        try:
+            if self.supervisor.is_running():
+                self.supervisor.restart(
+                    reason=f"switch genome to {resolved.name}",
+                )
+            else:
+                self.supervisor.start()
+        except Exception as exc:
+            log.error("Tray: helix restart after genome switch failed: %s",
+                      exc, exc_info=True)
+            self._safe_notify(
+                f"Restart failed: {exc}",
+                title="Helix: switch failed",
+            )
+            return
+        self._safe_notify(
+            f"Now serving {resolved.name}",
+            title="Helix: database switched",
+        )
+        # Menu structure depends on which genome is active; rebuild on
+        # the worker thread is safe (pystray reads .menu lazily on next
+        # context-menu open).
+        self._rebuild_menu()
+
+    def _safe_notify(self, message: str, title: str) -> None:
+        """Notify wrapper that never raises and always logs the message.
+
+        pystray's `notify` can no-op on backends that don't implement
+        balloon tips, and on some Windows configurations the call fails
+        with a quiet AccessDenied. Logging the same string at INFO
+        guarantees the operator sees state transitions in launcher.log
+        even when balloons aren't reaching the system tray.
+        """
+        log.info("Tray notify: %s — %s", title, message)
+        if self._icon is None:
+            return
+        try:
+            self._icon.notify(message, title=title)
+        except Exception:
+            log.debug("Tray notify failed", exc_info=True)
+
+    def _rebuild_menu(self) -> None:
+        """Fully rebuild the icon's menu tree — needed when STRUCTURE
+        changes (new genome added/removed) rather than just labels.
+
+        `_refresh_menu` only re-evaluates callable properties on the
+        existing tree; restructuring requires assigning a fresh Menu.
+        """
+        if self._icon is None:
+            return
+        try:
+            self._icon.menu = self._build_menu()
+            self._icon.update_menu()
+        except Exception:
+            log.debug("Tray menu structural rebuild failed", exc_info=True)
+
+    def _open_database_panel(self, icon, item) -> None:  # noqa: ARG002
+        """Open the dashboard's Genome tab where the Database panel lives."""
+        # Strip any existing fragment so a bookmark to "#overview" doesn't
+        # override the intent of this menu click.
+        base = self.dashboard_url.split("#", 1)[0]
+        url = f"{base.rstrip('/')}/#database"
+        log.info("Tray: opening database panel at %s", url)
+        try:
+            webbrowser.open(url)
+        except Exception:
+            log.warning("Tray: failed to open database panel", exc_info=True)
+
+    def _refresh_database_list(self, icon, item) -> None:  # noqa: ARG002
+        """Drop the genome-registry cache so the next menu render
+        re-scans disk. Useful when the user has just built a new
+        genome in another shell."""
+        log.info("Tray: refreshing genome registry cache")
+        try:
+            genome_registry.clear_cache()
+        except Exception:
+            log.debug("Tray: genome cache clear failed", exc_info=True)
+        self._rebuild_menu()
 
     def _open_grafana(self, icon, item) -> None:  # noqa: ARG002
         if not self.grafana_url:
@@ -605,6 +812,105 @@ class HelixTrayIcon:
 
     # ── menu construction ──────────────────────────────────────────
 
+    def _build_manage_database_submenu(self):
+        """Construct the 'Manage Database' submenu describing every
+        discovered genome on disk plus the active/selected indicator.
+
+        Pystray menus are immutable per render — the callable label on
+        each per-genome item picks up active-state changes on each menu
+        refresh, but the set of items only updates when the parent menu
+        is rebuilt. `_refresh_database_list` clears the genome cache
+        AND calls `_refresh_menu` so freshly built genomes appear
+        without a relaunch.
+        """
+        import pystray
+
+        try:
+            entries = genome_registry.discover_genomes()
+            active_path = genome_registry.active_genome_path()
+        except Exception:
+            log.warning("Tray: genome discovery failed", exc_info=True)
+            return pystray.Menu(
+                pystray.MenuItem("(genome discovery failed)", None, enabled=False),
+                pystray.MenuItem("Refresh", self._refresh_database_list),
+            )
+
+        active_name = active_path.name if active_path else "(none)"
+        items = [
+            pystray.MenuItem(f"Active: {active_name}", None, enabled=False),
+            pystray.Menu.SEPARATOR,
+        ]
+
+        if not entries:
+            items.append(pystray.MenuItem("(no genomes discovered)", None, enabled=False))
+        else:
+            for info in entries:
+                items.append(pystray.MenuItem(
+                    self._genome_label_factory(info, active_path),
+                    self._build_genome_subsubmenu(info),
+                ))
+
+        items.extend([
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Open Database panel", self._open_database_panel),
+            pystray.MenuItem("Refresh list", self._refresh_database_list),
+        ])
+        return pystray.Menu(*items)
+
+    def _genome_label_factory(self, info, active_path: Path):
+        """Return a callable label so pystray re-renders the checkmark
+        when active genome changes between menu opens.
+        """
+        target_lower = str(info.path).lower()
+        def _label(item):  # noqa: ARG001 — pystray API
+            try:
+                current = str(genome_registry.active_genome_path()).lower()
+            except Exception:
+                current = str(active_path).lower()
+            marker = "● " if target_lower == current else "  "
+            size = f"{round(info.size_bytes / (1024 * 1024), 1)} MB"
+            return f"{marker}{info.name}  ({info.total_genes} genes, {size})"
+        return _label
+
+    def _build_genome_subsubmenu(self, info):
+        """Per-genome submenu: 'Use this database' action + folder info."""
+        import pystray
+
+        items = [
+            pystray.MenuItem(
+                "Use this database (restart helix)",
+                self._switch_genome(info.path),
+            ),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(f"Path: {info.path}", None, enabled=False),
+        ]
+
+        if info.error:
+            items.append(pystray.MenuItem(f"Error: {info.error}", None, enabled=False))
+        elif info.folders:
+            items.append(pystray.MenuItem(
+                f"Folders ({len(info.folders)})", None, enabled=False,
+            ))
+            for folder in info.folders[:8]:
+                items.append(pystray.MenuItem(
+                    f"  - {folder.prefix} ({folder.document_count})",
+                    None, enabled=False,
+                ))
+            if len(info.folders) > 8:
+                items.append(pystray.MenuItem(
+                    f"  ... +{len(info.folders) - 8} more", None, enabled=False,
+                ))
+        else:
+            items.append(pystray.MenuItem(
+                "(no source folders recorded)", None, enabled=False,
+            ))
+
+        items.extend([
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Open Database panel", self._open_database_panel),
+        ])
+        return pystray.Menu(*items)
+
     def _build_menu(self):
         """Build a fresh pystray.Menu reflecting current helix state.
 
@@ -639,6 +945,11 @@ class HelixTrayIcon:
                 enabled=lambda item: self.headroom.is_running(),  # noqa: ARG005
             ))
         items.extend([
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(
+                "Manage Database",
+                self._build_manage_database_submenu(),
+            ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem(
                 "Start helix",

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -371,6 +371,68 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
     async def health_history_endpoint(limit: int = 50):
         return helix.genome.health_history(limit=limit)
 
+    # -- Pipeline viewer feed (launcher dashboard) ---
+
+    @app.get("/debug/pipeline/recent")
+    async def pipeline_recent_endpoint(limit: int = 32):
+        """Most recent build_context stage events for the launcher's
+        pipeline-viewer panel. Each event is
+            { request_id, stage, ms, ts }
+        Ordered oldest to newest. Backed by a bounded in-process ring
+        (see helix_context.context_manager.get_recent_pipeline_events).
+        """
+        try:
+            from ..context_manager import (
+                get_recent_pipeline_events,
+                get_pipeline_ring_max,
+            )
+            events = get_recent_pipeline_events(limit=max(1, min(int(limit), 200)))
+            return {"events": events, "ring_max": get_pipeline_ring_max()}
+        except Exception as exc:
+            log.warning("/debug/pipeline/recent failed: %s", exc, exc_info=True)
+            return JSONResponse({"error": str(exc)}, status_code=500)
+
+    # -- Active genome path (launcher dashboard) ---
+
+    @app.get("/admin/genome")
+    async def admin_genome_endpoint():
+        """Describe the genome file the running process actually opened.
+
+        Used by the launcher's Database panel to confirm that the
+        supervised helix is serving from the file the user expects (and
+        to detect divergence when helix was started outside the launcher
+        with a different HELIX_GENOME_PATH override).
+        """
+        from pathlib import Path as _Path
+
+        path_str = str(getattr(config.genome, "path", "")) or "genome.db"
+        resolved = _Path(path_str)
+        try:
+            resolved = resolved.resolve()
+        except OSError:
+            pass
+
+        out = {
+            "path": str(resolved),
+            "configured_path": path_str,
+            "env_override": os.environ.get("HELIX_GENOME_PATH"),
+        }
+        try:
+            if resolved.exists() and resolved.is_file():
+                st = resolved.stat()
+                out["size_bytes"] = st.st_size
+                out["mtime"] = st.st_mtime
+            else:
+                out["error"] = "genome file not found on disk"
+        except OSError as exc:
+            out["error"] = f"stat failed: {exc}"
+
+        try:
+            out["total_genes"] = int(helix.genome.stats().get("total_genes", 0))
+        except Exception:
+            log.debug("/admin/genome stats failed", exc_info=True)
+        return out
+
     # -- Token metrics endpoint ---
 
     @app.get("/metrics/tokens")


### PR DESCRIPTION
## Summary

Three connected features on the launcher / dashboard, all toggled by the existing tray+dashboard surface. No public-API changes.

- **System tray "Manage Database" submenu** — discovers genome `.db` files on disk, shows active marker, per-genome folder breakdown, one-click switch (sets `HELIX_GENOME_PATH` + restarts helix on a background thread so the tray stays responsive). Confirmation via Win32 `MessageBoxW` on Windows (avoids tkinter-on-pystray-thread deadlock), tkinter fallback elsewhere.
- **Dashboard "Switchboard" panel** — read-only snapshot of 11 operationally-interesting knobs: fusion_mode, dense_embedding_enabled, ann_similarity_threshold, splade_enabled, rerank_enabled, decoder_mode, expression_tokens, max_genes_per_turn, session_delivery_enabled, classifier_enabled, ribosome_backend. Sourced from `load_config()` in the launcher process (same TOML + cwd as the supervised helix).
- **Dashboard pipeline viewer** (dev-mode toggle, default ON). New `contextvars`-scoped per-request id in `context_manager.build_context()` + bounded `_pipeline_events` deque (maxlen 64). `_stage_timer.__exit__` attributes each stage to its originating request. Gated by `HELIX_PIPELINE_RING` (default on, set 0 to disable). New `GET /debug/pipeline/recent` returns events; collector groups by request_id; panel renders a per-stage timings table.

Backend additions:
- `GET /admin/genome` reports the `.db` the running helix actually opened (path / size / mtime / total_genes + `HELIX_GENOME_PATH` env override). Lets the dashboard surface drift between "selected" and "actually running".

## Files

```
helix_context/launcher/tray.py                   +311 / -0   Manage Database submenu, async switch worker, MessageBoxW confirm
helix_context/launcher/collector.py              +199 / -0   _switchboard_panel, _database_panel, _live_genome, _pipeline_panel
helix_context/launcher/genome_registry.py        +295 / -0   NEW: discovery, folder summary, select_genome
helix_context/launcher/static/launcher.css       +208 / -2   panel styles + per-tab visibility rules
helix_context/launcher/static/launcher.js        + 42 / -1   pipeline dev-view toggle (localStorage)
helix_context/launcher/templates/components/
  switchboard_panel.html                          +33         NEW
  database_panel.html                             +73         NEW
  pipeline_panel.html                             +60         NEW
  panels.html                                    + 14         wire new partials
helix_context/context_manager.py                 + 75 / -1   contextvar + deque + ring accessors
helix_context/server/routes_admin.py             + 62 / -0   /debug/pipeline/recent + /admin/genome
```

Total: 11 files changed, +1431 / -3.

## Test plan

- [x] All 85 launcher tests pass against this branch (worktree off origin/master, headroom-main venv)
- [x] Syntax check on all modified Python files
- [x] Manual smoke against the live launcher: dialog confirms, restart fires on background thread, balloons fire before/after
- [x] `genome_registry.discover_genomes()` returns 19 entries on the dev box, active marker correct
- [ ] Follow-ups: `tests/test_launcher_genome_registry.py` and per-panel collector tests are suggested but not blocking
- [ ] No new tests added in this PR — keeping it tight; happy to add coverage in a follow-up if reviewers want

## Behavior toggles

| Env / setting | Default | Effect |
|---|---|---|
| `HELIX_PIPELINE_RING=0` | (on) | Disables the per-stage event ring; `/debug/pipeline/recent` still answers with `events: []` |
| `localStorage["helix-pipeline-dev-view"]` | `"on"` | Set to `"off"` to hide the per-stage table; the summary line stays visible |
| `HELIX_GENOME_PATH` | unset | Set by the tray switch action; the supervised helix subprocess inherits it via `Popen` env inheritance |

🤖 Generated with [Claude Code](https://claude.com/claude-code)