### PR TITLE
fix(config): wire semantic_dense_additive_weight + semantic_broaden_routing through retrieval

### DIFF
--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -343,6 +343,14 @@ class RetrievalConfig:
     # negligible weight). Consistent with the cold tier's 0.15 min_cosine;
     # deliberately gentle so it removes only noise-grade hits. Unused under RRF.
     dense_additive_min_cosine: float = 0.15
+    # Semantic-wiring arm (2026-06-02; PRD docs/prds/2026-06-02-semantic-wiring-arm.md).
+    # When query_type=="semantic" AND env HELIX_SEMANTIC_ARM=1, the per-shard
+    # dense term is scaled by semantic_dense_additive_weight (instead of
+    # dense_additive_weight) AND routing broadens to all healthy shards. The two
+    # fire together or not at all. Default-off (env unset) => byte-identical
+    # baseline; lexical/tag/SPLADE tiers are never touched (additive KEEP-BOTH).
+    semantic_dense_additive_weight: float = 16.0
+    semantic_broaden_routing: bool = True
     pki_weight: float = 1.0                 # PKI tier, RRF participant
     # Note: filename_anchor_weight, sr_weight reuse their existing knobs above.
 
@@ -757,6 +765,9 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             dense_additive_weight=float(r.get("dense_additive_weight", cfg.retrieval.dense_additive_weight)),
             # Tier-0 review fix (2026-05-16): additive-mode dense merge noise floor.
             dense_additive_min_cosine=float(r.get("dense_additive_min_cosine", cfg.retrieval.dense_additive_min_cosine)),
+            # Semantic-wiring arm (2026-06-02).
+            semantic_dense_additive_weight=float(r.get("semantic_dense_additive_weight", cfg.retrieval.semantic_dense_additive_weight)),
+            semantic_broaden_routing=bool(r.get("semantic_broaden_routing", cfg.retrieval.semantic_broaden_routing)),
             pki_weight=float(r.get("pki_weight", cfg.retrieval.pki_weight)),
         )
 

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -512,6 +512,12 @@ class HelixContextManager:
             dense_additive_weight=config.retrieval.dense_additive_weight,
             # Tier-0 review fix (2026-05-16): additive-mode dense merge noise floor.
             dense_additive_min_cosine=config.retrieval.dense_additive_min_cosine,
+            # Semantic-wiring arm (2026-06-02): scoped dense weight + broaden
+            # routing for query_type=="semantic" under HELIX_SEMANTIC_ARM.
+            # Fanned to the solo Genome AND every per-shard Genome (open_read_source
+            # -> ShardedGenomeAdapter -> ShardRouter -> Genome). Default-off.
+            semantic_dense_additive_weight=config.retrieval.semantic_dense_additive_weight,
+            semantic_broaden_routing=config.retrieval.semantic_broaden_routing,
             pki_weight=config.retrieval.pki_weight,
         )
 
@@ -1028,6 +1034,7 @@ class HelixContextManager:
         read_only: bool = False,
         decoder_override: Optional[str] = None,
         caller_model_class: str = "generic",
+        query_type: Optional[str] = None,
     ) -> ContextWindow:
         """
         Build the active context window for a query.
@@ -1051,6 +1058,14 @@ class HelixContextManager:
                 "implicit THIS project" signal that real users have but
                 synthetic benches lack. None = no session context, which
                 preserves the previous behaviour exactly.
+            query_type: optional per-call retrieval-intent hint (semantic-wiring
+                arm, PRD 2026-06-02). Forwarded to ``_retrieve`` → sharded
+                ``query_docs`` so that ``"semantic"`` + HELIX_SEMANTIC_ARM=1
+                broadens routing and scopes the dense weight. ``None`` (default)
+                or any other value with the arm off is inert / byte-identical —
+                production /context callers omit it; the bench injects the
+                needle's ground-truth type for A/B. Mirrors the /fingerprint
+                ``query_type`` thread.
         """
         self._maybe_compact()
 
@@ -1176,6 +1191,7 @@ class HelixContextManager:
                     domains, entities, max_genes,
                     query_text=_sub_queries[0], include_cold=include_cold,
                     party_id=party_id, read_only=read_only,
+                    query_type=query_type,
                 )
             else:
                 import concurrent.futures
@@ -1186,6 +1202,7 @@ class HelixContextManager:
                         d, e, max_genes,
                         query_text=sq, include_cold=include_cold,
                         party_id=party_id, read_only=read_only,
+                        query_type=query_type,
                     )
                     with self.genome._last_query_scores_lock:
                         scores = dict(self.genome.last_query_scores or {})
@@ -1587,6 +1604,7 @@ class HelixContextManager:
         read_only: bool = False,
         decoder_override: Optional[str] = None,
         caller_model_class: str = "generic",
+        query_type: Optional[str] = None,
     ) -> ContextWindow:
         """Async wrapper -- runs the sync pipeline in thread pool."""
         loop = asyncio.get_event_loop()
@@ -1604,6 +1622,7 @@ class HelixContextManager:
             read_only,
             decoder_override,
             caller_model_class,
+            query_type,
         )
 
     def reset_session_state(self) -> None:
@@ -2042,8 +2061,15 @@ class HelixContextManager:
         use_harmonic: bool = True,
         use_sr: Optional[bool] = None,
         read_only: bool = False,
+        query_type: Optional[str] = None,
     ) -> List[Gene]:
         """Query knowledge store + pending buffer for matching documents.
+
+        ``query_type`` (semantic-wiring arm, PRD 2026-06-02) is forwarded to the
+        sharded ``query_docs`` path so the router can broaden routing and the
+        per-shard merge can scope the dense weight when it is "semantic" and
+        HELIX_SEMANTIC_ARM=1. Defaults to None (arm inert). The dense-ANN solo
+        branch is intentionally NOT threaded — the arm is sharded-only.
 
         Parameters
         ----------
@@ -2097,6 +2123,7 @@ class HelixContextManager:
                     use_sr=use_sr,
                     use_entity_graph=self.genome._entity_graph_retrieval_enabled,
                     read_only=read_only,
+                    query_type=query_type,
                 )
         except PromoterMismatch:
             pass

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -433,6 +433,12 @@ class KnowledgeStore:
         # negligible weight). Consistent with query_cold_tier's 0.15
         # min_cosine. Unused under RRF.
         dense_additive_min_cosine: float = 0.15,
+        # Semantic-wiring arm (PRD 2026-06-02). semantic_dense_additive_weight
+        # is consulted only when query_type=="semantic" AND HELIX_SEMANTIC_ARM=1.
+        # semantic_broaden_routing is read by ShardRouter; accepted here so the
+        # fanned genome_kwargs don't raise (Genome ignores it).
+        semantic_dense_additive_weight: float = 16.0,
+        semantic_broaden_routing: bool = True,
         pki_weight: float = 1.0,
         main_conn: Optional[sqlite3.Connection] = None,
         shard_name: str = "main",
@@ -525,6 +531,10 @@ class KnowledgeStore:
         self._dense_additive_weight: float = float(dense_additive_weight)
         # Tier-0 review fix: additive-mode dense merge noise floor (see ctor param).
         self._dense_additive_min_cosine: float = float(dense_additive_min_cosine)
+        # Semantic-wiring arm (PRD 2026-06-02): scoped dense weight, gated at
+        # query time by query_type=="semantic" + env HELIX_SEMANTIC_ARM=1.
+        self._semantic_dense_additive_weight: float = float(semantic_dense_additive_weight)
+        self._semantic_broaden_routing: bool = bool(semantic_broaden_routing)
         self._pki_weight: float = float(pki_weight)
         self._threshold_dim_warned: bool = False
         # Phase 2 claims layer (2026-04-19). Optional hook — when a main.db
@@ -1492,9 +1502,16 @@ class KnowledgeStore:
         use_sr: Optional[bool] = None,
         use_entity_graph: Optional[bool] = None,
         read_only: bool = False,
+        query_type: Optional[str] = None,
     ) -> List[Gene]:
         """
         Find documents matching the given tags signals.
+
+        ``query_type`` (semantic-wiring arm, PRD 2026-06-02): when "semantic"
+        AND env HELIX_SEMANTIC_ARM=1, the additive-mode dense term is scaled by
+        ``self._semantic_dense_additive_weight`` instead of the default
+        ``self._dense_additive_weight``. All other tiers are untouched. Any
+        other value (or arm off) is byte-identical to the prior behaviour.
 
         Multi-tier retrieval:
             1. Exact tag match (highest confidence)
@@ -2087,9 +2104,16 @@ class KnowledgeStore:
                     # branch above gives dense-only genes); its tier_contrib
                     # is recorded as 0.0 so telemetry stays coherent with
                     # what entered the sum.
+                    # Semantic-wiring arm (PRD 2026-06-02): scale ONLY the dense
+                    # term by the scoped weight for semantic queries when the arm
+                    # is enabled, so dense cosine ordering clears the lexical
+                    # stack into @10. Computed once; lex/tag/SPLADE are untouched.
+                    _dense_w = self._dense_additive_weight
+                    if query_type == "semantic" and os.environ.get("HELIX_SEMANTIC_ARM") == "1":
+                        _dense_w = self._semantic_dense_additive_weight
                     for gid, cosine in dense_hits:
                         if float(cosine) >= self._dense_additive_min_cosine:
-                            contribution = float(cosine) * self._dense_additive_weight
+                            contribution = float(cosine) * _dense_w
                             gene_scores[gid] = gene_scores.get(gid, 0.0) + contribution
                             tier_contrib.setdefault(gid, {})["dense"] = contribution
                         else:

--- a/helix_context/server/routes_context.py
+++ b/helix_context/server/routes_context.py
@@ -260,6 +260,14 @@ def setup_context_routes(app: FastAPI, helix, config, registry, **_kw) -> None:
         # Sprint 2 session working-set
         _ignore_delivered = bool(data.get("ignore_delivered", False))
 
+        # Semantic-wiring arm (PRD 2026-06-02): optional per-call query_type,
+        # mirroring the /fingerprint thread. The bench injects the needle's
+        # ground-truth type so the fixed pipeline can be A/B'd on /context
+        # (delivery), not just /fingerprint (recall). Production callers omit
+        # it; only "semantic" + HELIX_SEMANTIC_ARM=1 changes retrieval — any
+        # other value (or arm off) is inert / byte-identical.
+        query_type = (str(data.get("query_type", "")).strip().lower() or None)
+
         window = await helix.build_context_async(
             query,
             include_cold=include_cold,
@@ -271,6 +279,7 @@ def setup_context_routes(app: FastAPI, helix, config, registry, **_kw) -> None:
             read_only=read_only,
             decoder_override=_decoder_override,
             caller_model_class=caller_model_class,
+            query_type=query_type,
         )
 
         # Stage 5 section 3: echo caller_model_class on response.metadata
@@ -721,6 +730,13 @@ def setup_context_routes(app: FastAPI, helix, config, registry, **_kw) -> None:
         if party_id is None:
             party_id = config.session.default_party_id
 
+        # Semantic-wiring arm (PRD 2026-06-02): optional per-call query_type.
+        # The bench injects the needle's ground-truth type so the arm can be
+        # A/B'd; production callers omit it (a runtime semantic detector is a
+        # separate track). Only "semantic" + HELIX_SEMANTIC_ARM=1 changes
+        # retrieval; any other value (or arm off) is inert/byte-identical.
+        query_type = (str(data.get("query_type", "")).strip().lower() or None)
+
         expand_query = profile in {"balanced", "quality"}
         use_harmonic = profile == "quality"
         use_sr = profile == "quality"
@@ -743,6 +759,7 @@ def setup_context_routes(app: FastAPI, helix, config, registry, **_kw) -> None:
                 party_id=party_id,
                 use_harmonic=use_harmonic,
                 use_sr=use_sr,
+                query_type=query_type,
             )
             candidates, refiner_contrib = helix._apply_candidate_refiners(
                 query,

--- a/helix_context/shard_router.py
+++ b/helix_context/shard_router.py
@@ -330,6 +330,13 @@ class ShardRouter:
             _n = 1
         self._mem_plan = sqlite_memory_budget(max(1, int(_n or 1)))
 
+        # Semantic-wiring arm (PRD 2026-06-02): broaden routing to all healthy
+        # shards for query_type=="semantic" when HELIX_SEMANTIC_ARM=1. Pulled
+        # from the fanned genome_kwargs (config.retrieval.semantic_broaden_routing).
+        self._semantic_broaden_routing: bool = bool(
+            genome_kwargs.get("semantic_broaden_routing", True)
+        )
+
         # Retrieval introspection — mirrors KnowledgeStore's interface so
         # callers can use either interchangeably.
         self.last_query_scores: Dict[str, float] = {}
@@ -377,7 +384,12 @@ class ShardRouter:
 
     # ── Routing ─────────────────────────────────────────────────────
 
-    def route(self, domains: List[str], entities: List[str]) -> List[str]:
+    def route(
+        self,
+        domains: List[str],
+        entities: List[str],
+        query_type: Optional[str] = None,
+    ) -> List[str]:
         """Return shard names likely to contain matches for the query.
 
         V1: LIKE scan against fingerprint_index.domains/entities.
@@ -387,7 +399,20 @@ class ShardRouter:
 
         Empty query → return every healthy shard (preserves the
         fallback path callers rely on for "return something").
+
+        Semantic-wiring arm (PRD 2026-06-02): when ``query_type=="semantic"``
+        AND env ``HELIX_SEMANTIC_ARM=1`` AND ``semantic_broaden_routing``,
+        bypass the LIKE gate and fan out to every healthy shard so dense-top
+        golds whose shard the literal gate would drop still enter the pool.
+        Any other query_type (or arm off) keeps the byte-identical LIKE scan.
         """
+        if (
+            query_type == "semantic"
+            and self._semantic_broaden_routing
+            and os.environ.get("HELIX_SEMANTIC_ARM") == "1"
+        ):
+            return self.known_shards()
+
         terms = [t.lower() for t in (domains + entities) if t]
         if not terms:
             return self.known_shards()
@@ -450,7 +475,14 @@ class ShardRouter:
         correction multiplier collapses to identity and the routing
         behaves as if scores came directly from that shard.
         """
-        shard_names = self.route(domains, entities)
+        # Semantic-wiring arm (PRD 2026-06-02): pop query_type OUT of the
+        # generic kwargs BEFORE fan-out. It must NOT ride in **kwargs — the
+        # per-shard KnowledgeStore.query_docs would TypeError on an unexpected
+        # kwarg and the except-fallback below silently drops ALL kwargs
+        # (use_harmonic, etc.). Pass it explicitly into route() and each
+        # shard.query_docs() instead. None (default / arm off) is inert.
+        query_type = kwargs.pop("query_type", None)
+        shard_names = self.route(domains, entities, query_type)
         if not shard_names:
             with self._last_query_scores_lock:
                 self.last_query_scores = {}
@@ -531,6 +563,7 @@ class ShardRouter:
                     max_genes=per_shard_fetch,
                     party_id=party_id,
                     read_only=read_only,
+                    query_type=query_type,
                     **kwargs,
                 )
             except TypeError:


### PR DESCRIPTION
## Summary

Backports the **semantic-arm hunks only** from upstream commit `9b06ee4` ("feat(retrieval): question-conditioned dense + semantic-scoped arm + query_type thread") onto `origin/master` (v0.6.2 base). Lets downstreams running the v0.6.3 fixed-pipeline TOML compare arm-on vs arm-off on master without their config keys silently vanishing at load.

**Context:** `helix.toml` files used by the v0.6.3 external-validation snapshot set `semantic_dense_additive_weight = 16.0` and `semantic_broaden_routing = true`. On `master` (`3173c47` = v0.6.2) the `RetrievalConfig` dataclass has no such fields, so the loader drops them silently and any benchmark believing it's running the fixed pipeline is actually running stock retrieval. Collaborator-reported on cc-exchange `embedding-upgrade/0017`.

**Default behavior is byte-identical** — everything is gated on `HELIX_SEMANTIC_ARM=1` AND `query_type == "semantic"`. Stock requests get the same path they had on v0.6.2.

## Scope discipline (vs upstream `9b06ee4`)

`9b06ee4` bundles five orthogonal features in one diff. This PR cherry-picks ONLY the semantic-arm hunks (~70 LOC net) and explicitly leaves out:

- `HELIX_SHARD_WORKERS` / parallel shard fanout (already on `master` as of v0.6.2)
- `HELIX_QUESTION_DENSE` / `question_text` plumbing
- `_dense_matrix_dtype()` / fp16 matrix
- `PRAGMA cache_size` + `PRAGMA mmap_size` RAM-cap tweaks
- SQLite IN-clause batching
- `tests/test_shard_router.py` fanout-determinism additions
- `HELIX_SEMANTIC_DENSE_WEIGHT` diagnostic env override

A direct `git cherry-pick 9b06ee4` conflicts in `knowledge_store.py` because of (1) and (3)-(5); manual hunk extraction was the cleanest path.

## Files

| File | Δ | Change |
|---|---|---|
| `helix_context/config.py` | +11 / -1 | Add `semantic_dense_additive_weight: float = 16.0` + `semantic_broaden_routing: bool = True` to `RetrievalConfig`; wire via `load_config()` |
| `helix_context/context_manager.py` | +27 / -1 | Thread `query_type` through `build_context` / `build_context_async` / `_retrieve`; fan the two new fields into `Genome` kwargs |
| `helix_context/knowledge_store.py` | +25 / -1 | Add ctor params + instance state; add `query_type` to `query_docs`; `_dense_w` swap when `query_type == "semantic"` AND `HELIX_SEMANTIC_ARM=1` |
| `helix_context/shard_router.py` | +35 / -2 | Read `_semantic_broaden_routing` from `genome_kwargs`; `route()` learns `query_type` + bypasses LIKE gate under arm; thread `query_type` into per-shard `query_docs` |
| `helix_context/server/routes_context.py` | +17 / -0 | Read `query_type` from POST body in `/context` and `/fingerprint` |

**Total: +115 / -3 lines.**

## Test plan

- [x] 57 tests pass in `tests/test_config.py` + `tests/test_shard_router.py` (focused suite for the touched modules)
- [x] 95 tests pass across `test_config.py` + `test_shard_router.py` + `test_genome.py` (Pytest reports the broader run)
- [x] Syntax check on all 5 modified files
- [x] `HELIX_SEMANTIC_ARM` unset + `query_type` omitted → byte-identical to baseline (smoke verified)
- [ ] No new tests added in this PR — focused scope; happy to add `test_semantic_arm.py` covering the env-gate × query_type matrix in a follow-up

## Refs

- cc-exchange thread `embedding-upgrade/0017` — collaborator confirmed the silent-drop on `7ca260d`
- cc-exchange thread `embedding-upgrade/0018` — announces this PR
- v0.6.3 tag (`1510f12`) — frozen external-validation snapshot where the full pipeline + these fields live

🤖 Generated with [Claude Code](https://claude.com/claude-code)