### PR TITLE
fix(bench): BenchServer spawn pins cwd + PYTHONPATH + startup table probe (closes #153)

### DIFF
--- a/benchmarks/bench_orchestrator.py
+++ b/benchmarks/bench_orchestrator.py
@@ -51,6 +51,7 @@ import logging
 import os
 import signal
 import socket
+import sqlite3
 import subprocess
 import sys
 import time
@@ -62,6 +63,135 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 log = logging.getLogger("bench.orchestrator")
+
+
+def _repo_root() -> Optional[Path]:
+    """Return the helix-context repo root, derived from this file's location.
+
+    ``bench_orchestrator.py`` lives at ``<repo>/benchmarks/``, so the repo
+    root is ``parents[1]``. We confirm by checking for ``pyproject.toml``
+    AND ``helix_context/__init__.py`` (both required to call this a
+    helix-context source checkout) — defends against the orchestrator
+    being copied/symlinked into an unrelated tree.
+
+    Returns ``None`` if neither marker is present so callers can fall
+    back to the inherited cwd / sys.path without crashing.
+    """
+    try:
+        candidate = Path(__file__).resolve().parents[1]
+    except (IndexError, OSError):
+        return None
+    if (candidate / "pyproject.toml").exists() and (
+        candidate / "helix_context" / "__init__.py"
+    ).exists():
+        return candidate
+    return None
+
+
+# Tables the spawned helix server must find in the fixture DB before we
+# accept it as "the right helix talking to the right fixture". Issue #153:
+# a stale worktree's code path queried tables the fixture's schema didn't
+# include (``cwola_log``, ``session_delivery_log``, ``genes``) and the
+# whole bench logged ``retr=err`` × 50 instead of failing fast. We probe
+# the fixture DB from the orchestrator side so the mismatch surfaces in
+# milliseconds, before the first /context call.
+#
+# ``genes`` is REQUIRED — every non-empty fixture must have it, the issue
+# trace was triggered by its absence. ``cwola_log`` and
+# ``session_delivery_log`` are RECOMMENDED — we warn rather than fail on
+# their absence, because a deliberately-stripped fixture (e.g. a
+# routing-only sharded DB) may legitimately omit them but the loaded
+# helix code path may still try to write to them. The warning gives the
+# operator a heads-up without aborting valid benches.
+REQUIRED_FIXTURE_TABLES: tuple[str, ...] = ("genes",)
+RECOMMENDED_FIXTURE_TABLES: tuple[str, ...] = (
+    "cwola_log",
+    "session_delivery_log",
+)
+
+
+def _resolve_helix_context_file(repo_root: Optional[Path]) -> str:
+    """Best-effort: report ``helix_context.__file__`` for ``repo_root``.
+
+    Used in the RUN START log line so the operator sees which checkout
+    the spawned uvicorn will load. We don't import from a subprocess (too
+    slow / pollutes our own sys.modules); we just check the on-disk path
+    that PYTHONPATH+cwd will resolve to. If ``repo_root`` is None we fall
+    back to whatever the current process already imported.
+    """
+    if repo_root is not None:
+        candidate = repo_root / "helix_context" / "__init__.py"
+        if candidate.exists():
+            return str(candidate)
+    try:
+        import helix_context  # noqa: PLC0415 — lazy by design
+        return getattr(helix_context, "__file__", "<unknown>") or "<unknown>"
+    except Exception:
+        return "<unresolvable>"
+
+
+def _probe_fixture_schema(
+    db_path: str,
+    *,
+    required: Iterable[str] = REQUIRED_FIXTURE_TABLES,
+    recommended: Iterable[str] = RECOMMENDED_FIXTURE_TABLES,
+) -> None:
+    """Open ``db_path`` read-only and assert the required tables exist.
+
+    Issue #153 surfaced as ``sqlite3.OperationalError: no such table: ...``
+    50 times per bench because a stale-worktree helix_context queried
+    tables the fixture's schema didn't include. Probing from the
+    orchestrator side catches the mismatch in milliseconds — and produces
+    a single clear error pointing at the wrong-helix root cause instead
+    of N "retr=err" log lines.
+
+    Required tables raise ``BenchServerError``. Recommended tables only
+    log a warning — the spawn proceeds because some fixtures legitimately
+    omit them (e.g. a stripped routing DB) and the operator may still
+    want to bench retrieval against them.
+
+    The probe is a no-op for a non-file path (defensive: ``:memory:`` or
+    a remote URI just gets skipped rather than crashing the bench
+    launcher).
+    """
+    p = Path(db_path)
+    if not p.is_file():
+        log.debug("schema probe skipped: %s is not a file", db_path)
+        return
+    uri = f"file:{p.as_posix()}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=5.0)
+    except sqlite3.Error as exc:
+        raise BenchServerError(
+            f"fixture {db_path} could not be opened for schema probe: {exc}"
+        ) from exc
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+
+    missing_required = [t for t in required if t not in names]
+    if missing_required:
+        raise BenchServerError(
+            f"fixture {db_path} is missing required table(s) "
+            f"{missing_required}: the spawned helix server would raise "
+            "sqlite3.OperationalError on first /context call. Likely "
+            "causes: wrong helix_context source on PYTHONPATH (issue "
+            "#153), or a fixture built with a stripped schema."
+        )
+    missing_recommended = [t for t in recommended if t not in names]
+    if missing_recommended:
+        log.warning(
+            "fixture %s missing recommended table(s) %s — some helix "
+            "code paths will log OperationalError but the bench will "
+            "proceed",
+            db_path, missing_recommended,
+        )
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 11437
@@ -155,6 +285,7 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         health_timeout_s: float = DEFAULT_HEALTH_TIMEOUT_S,
         shutdown_timeout_s: float = DEFAULT_SHUTDOWN_TIMEOUT_S,
         log_to: Optional[Path] = None,
+        repo_root: Optional[Path] = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -163,6 +294,13 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         self.health_timeout_s = health_timeout_s
         self.shutdown_timeout_s = shutdown_timeout_s
         self.log_to = Path(log_to) if log_to else None
+        # Issue #153: pin the spawned uvicorn's working directory and
+        # PYTHONPATH to a single helix-context source tree. Default to the
+        # repo this orchestrator lives in; callers can override (e.g. to
+        # bench a different worktree) by passing ``repo_root=``.
+        self.repo_root: Optional[Path] = (
+            Path(repo_root).resolve() if repo_root is not None else _repo_root()
+        )
 
         self._proc: Optional[subprocess.Popen] = None
         self._current: Optional[Fixture] = None
@@ -345,6 +483,28 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         env.setdefault("PYTHONHASHSEED", "0")
         env.update(fixture.extra_env)
 
+        # Issue #153: pin the spawned uvicorn to a single helix-context
+        # source tree, otherwise an editable-install / .pth shim / sibling
+        # worktree can win the import race and answer with stale code that
+        # doesn't match the fixture's schema (the canonical failure: a
+        # vibrant-easley worktree on bench/int-5fixture took the
+        # ``helix_context._asgi:app`` import and raised
+        # ``no such table: cwola_log`` × 50 against the xl-sharded
+        # fixture).  Prepend repo_root to PYTHONPATH (preserving any
+        # caller-supplied value) and run the subprocess from there.
+        spawn_cwd: Optional[str] = None
+        if self.repo_root is not None:
+            root_str = str(self.repo_root)
+            existing = env.get("PYTHONPATH", "")
+            if existing:
+                # Avoid an obvious double-prepend on restart.
+                head = existing.split(os.pathsep, 1)[0]
+                if head != root_str:
+                    env["PYTHONPATH"] = root_str + os.pathsep + existing
+            else:
+                env["PYTHONPATH"] = root_str
+            spawn_cwd = root_str
+
         if self.log_to:
             self.log_to.parent.mkdir(parents=True, exist_ok=True)
             self._log_fh = self.log_to.open("ab")
@@ -352,9 +512,24 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         else:
             stdout = stderr = subprocess.DEVNULL
 
+        # RUN START line: log which helix_context source the spawned
+        # process will resolve, so the operator can confirm the right
+        # checkout is answering instead of debugging "retr=err × 50".
+        log.info(
+            "RUN START fixture=%s sharded=%s db=%s "
+            "repo_root=%s helix_context=%s python=%s",
+            fixture.name,
+            fixture.sharded,
+            fixture.db,
+            self.repo_root,
+            _resolve_helix_context_file(self.repo_root),
+            self.python,
+        )
+
         self._proc = subprocess.Popen(
             cmd, env=env, stdout=stdout, stderr=stderr,
             stdin=subprocess.DEVNULL,
+            cwd=spawn_cwd,
             creationflags=_NO_WINDOW,
             close_fds=(os.name != "nt"),
         )
@@ -461,6 +636,11 @@ class BenchServer(AbstractContextManager["BenchServer"]):
         )
 
     def _post_swap(self, fixture: Fixture) -> dict[str, Any]:
+        # Issue #153: schema probe BEFORE the swap. A missing required
+        # table here means the running helix code will raise
+        # OperationalError on every /context call — better to abort now
+        # than to log retr=err × 50 and produce an unactionable summary.
+        _probe_fixture_schema(fixture.db)
         payload = {"path": fixture.db, "read_only": fixture.read_only}
         try:
             return self._http(

--- a/tests/test_bench_orchestrator.py
+++ b/tests/test_bench_orchestrator.py
@@ -1,4 +1,4 @@
-"""Unit tests for bench_orchestrator.py — the issue #127 fixes.
+"""Unit tests for bench_orchestrator.py — the issue #127 + #153 fixes.
 
 Issue #127: a cross-mode bench restart (blob -> sharded) could fail to
 free port 11437 before spawning the replacement uvicorn. The new process
@@ -6,9 +6,15 @@ lost the bind race (Errno 10048), exited, and ``_wait_healthy()`` then
 talked to the *stale* blob-mode server still holding the port. Every
 sharded query returned ``genes=0``.
 
-These tests pin the four hardening fixes — they are pure unit tests:
-the socket / subprocess / HTTP boundaries are mocked, no real uvicorn is
-spawned.
+Issue #153: ``BenchServer._spawn`` set neither ``cwd`` nor ``PYTHONPATH``
+on the uvicorn subprocess, so whichever ``helix_context`` package the
+Python import system resolved first won — including stale sibling
+worktrees with mismatched schemas. The whole bench then logged
+``retr=err`` × 50 from ``OperationalError: no such table: ...``.
+
+These tests pin the hardening fixes — they are pure unit tests:
+the socket / subprocess / HTTP / sqlite boundaries are mocked or
+isolated to ``tmp_path``, no real uvicorn is spawned.
 
   1. ``stop()`` kills the whole process tree and confirms teardown
      (raises if the process is somehow still alive).
@@ -18,11 +24,18 @@ spawned.
      not match the process just spawned.
   4. ``_guard_genes()`` raises when a non-empty fixture reports
      ``genes=0`` after a swap.
+  5. (#153) ``_spawn`` pins ``cwd`` + ``PYTHONPATH`` to the repo root so
+     the spawned uvicorn always loads the orchestrator's own
+     ``helix_context`` checkout.
+  6. (#153) ``_probe_fixture_schema`` aborts on a fixture missing the
+     ``genes`` table — the canonical wrong-helix failure mode — and
+     warns rather than fails on missing aux tables.
 """
 
 from __future__ import annotations
 
 import socket
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -40,6 +53,10 @@ from bench_orchestrator import (  # noqa: E402
     BenchServer,
     BenchServerError,
     Fixture,
+    RECOMMENDED_FIXTURE_TABLES,
+    REQUIRED_FIXTURE_TABLES,
+    _probe_fixture_schema,
+    _repo_root,
     load_manifest,
 )
 
@@ -379,3 +396,195 @@ def test_restart_fails_loudly_when_sharded_fixture_yields_zero_genes() -> None:
             patch.object(srv, "_post_swap", return_value={"genes": 0}):
         with pytest.raises(BenchServerError, match="genes=0"):
             srv._restart_for_fixture(sharded, blob)
+
+
+# ── Issue #153: spawn pins cwd + PYTHONPATH, schema probe ─────────────
+
+
+def _make_fixture_db(path: Path, tables: tuple[str, ...]) -> Path:
+    """Create a sqlite DB at ``path`` with one row in sqlite_master per
+    name in ``tables`` (tables with a single ``id INTEGER`` column).
+
+    Helper for the schema-probe tests so each case can declare exactly
+    which tables exist — including the "wrong helix" case where ``genes``
+    is missing.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        for name in tables:
+            conn.execute(f"CREATE TABLE {name} (id INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def test_repo_root_resolves_to_this_checkout() -> None:
+    """``_repo_root`` must find the helix-context repo this orchestrator
+    lives in (the test runs from one of its checkouts)."""
+    root = _repo_root()
+    assert root is not None, "expected to resolve a repo root from __file__"
+    assert (root / "pyproject.toml").exists()
+    assert (root / "helix_context" / "__init__.py").exists()
+
+
+def test_bench_server_defaults_repo_root_to_this_checkout() -> None:
+    """A no-arg BenchServer picks up the orchestrator's own repo root so
+    the spawned uvicorn loads *this* helix_context, not a sibling."""
+    srv = BenchServer()
+    assert srv.repo_root is not None
+    assert (srv.repo_root / "helix_context" / "__init__.py").exists()
+
+
+def test_bench_server_honors_explicit_repo_root(tmp_path: Path) -> None:
+    """An explicit ``repo_root=`` overrides the auto-derived path so a
+    caller can bench against a specific worktree."""
+    srv = BenchServer(repo_root=tmp_path)
+    assert srv.repo_root == tmp_path.resolve()
+
+
+def test_spawn_passes_cwd_and_pythonpath_to_subprocess(tmp_path: Path) -> None:
+    """``_spawn`` must call ``subprocess.Popen`` with ``cwd=<repo_root>``
+    and ``PYTHONPATH`` starting with the repo root. Without this, an
+    editable install / .pth shim in the inherited environment can win the
+    ``helix_context`` import race and load stale schema code (issue #153)."""
+    # Use a stub repo so we don't depend on the real checkout layout for
+    # this assertion — Popen is patched out either way.
+    (tmp_path / "pyproject.toml").write_text("")
+    (tmp_path / "helix_context").mkdir()
+    (tmp_path / "helix_context" / "__init__.py").write_text("")
+
+    srv = BenchServer(repo_root=tmp_path)
+    fx = Fixture(name="small", db=str(tmp_path / "small.db"), sharded=False)
+    _make_fixture_db(tmp_path / "small.db", tables=("genes",))
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock(pid=4242, poll=MagicMock(return_value=None))
+
+    with patch("bench_orchestrator.subprocess.Popen", side_effect=fake_popen):
+        srv._spawn(fx)
+
+    kwargs = captured["kwargs"]
+    assert kwargs["cwd"] == str(tmp_path.resolve()), \
+        "spawn must pin cwd to repo_root so uvicorn resolves the right helix_context"
+    pythonpath = kwargs["env"].get("PYTHONPATH", "")
+    assert pythonpath.startswith(str(tmp_path.resolve())), \
+        f"PYTHONPATH must lead with repo_root, got {pythonpath!r}"
+
+
+def test_spawn_preserves_existing_pythonpath(tmp_path: Path) -> None:
+    """A pre-existing PYTHONPATH must be preserved as a suffix, not
+    clobbered — the operator may legitimately need extra entries (e.g. a
+    sibling tooling repo on the path) and only the *order* matters for
+    fixing the import race."""
+    (tmp_path / "pyproject.toml").write_text("")
+    (tmp_path / "helix_context").mkdir()
+    (tmp_path / "helix_context" / "__init__.py").write_text("")
+    _make_fixture_db(tmp_path / "small.db", tables=("genes",))
+
+    srv = BenchServer(repo_root=tmp_path)
+    fx = Fixture(name="small", db=str(tmp_path / "small.db"), sharded=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["kwargs"] = kwargs
+        return MagicMock(pid=4242, poll=MagicMock(return_value=None))
+
+    import os as _os
+    with patch.dict(_os.environ, {"PYTHONPATH": "/already/here"}, clear=False), \
+            patch("bench_orchestrator.subprocess.Popen", side_effect=fake_popen):
+        srv._spawn(fx)
+
+    pythonpath = captured["kwargs"]["env"]["PYTHONPATH"]
+    parts = pythonpath.split(_os.pathsep)
+    assert parts[0] == str(tmp_path.resolve())
+    assert "/already/here" in parts, \
+        f"existing PYTHONPATH entries must be preserved, got {parts!r}"
+
+
+def test_spawn_does_not_double_prepend_repo_root(tmp_path: Path) -> None:
+    """On a restart the env already contains repo_root at the head;
+    ``_spawn`` must not stack a duplicate entry every call."""
+    (tmp_path / "pyproject.toml").write_text("")
+    (tmp_path / "helix_context").mkdir()
+    (tmp_path / "helix_context" / "__init__.py").write_text("")
+    _make_fixture_db(tmp_path / "small.db", tables=("genes",))
+
+    srv = BenchServer(repo_root=tmp_path)
+    fx = Fixture(name="small", db=str(tmp_path / "small.db"), sharded=False)
+    root_str = str(tmp_path.resolve())
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["kwargs"] = kwargs
+        return MagicMock(pid=4242, poll=MagicMock(return_value=None))
+
+    import os as _os
+    seeded = root_str + _os.pathsep + "/already/here"
+    with patch.dict(_os.environ, {"PYTHONPATH": seeded}, clear=False), \
+            patch("bench_orchestrator.subprocess.Popen", side_effect=fake_popen):
+        srv._spawn(fx)
+
+    pythonpath = captured["kwargs"]["env"]["PYTHONPATH"]
+    assert pythonpath == seeded, \
+        f"PYTHONPATH should be unchanged when repo_root is already at head: {pythonpath!r}"
+
+
+def test_probe_fixture_schema_passes_when_required_tables_present(tmp_path: Path) -> None:
+    """A fixture DB with every required+recommended table passes silently."""
+    db = _make_fixture_db(
+        tmp_path / "ok.db",
+        tables=REQUIRED_FIXTURE_TABLES + RECOMMENDED_FIXTURE_TABLES,
+    )
+    _probe_fixture_schema(str(db))  # must not raise
+
+
+def test_probe_fixture_schema_raises_when_required_table_missing(tmp_path: Path) -> None:
+    """The canonical #153 failure: ``genes`` is missing because a stale
+    worktree's schema doesn't include it. Probe must abort with a clear
+    pointer to the wrong-helix root cause."""
+    db = _make_fixture_db(tmp_path / "bad.db", tables=("not_genes",))
+    with pytest.raises(BenchServerError, match=r"missing required table"):
+        _probe_fixture_schema(str(db))
+
+
+def test_probe_fixture_schema_warns_on_missing_recommended(tmp_path: Path, caplog) -> None:
+    """Recommended tables (cwola_log / session_delivery_log) only warn;
+    the bench proceeds because some fixtures legitimately strip them."""
+    db = _make_fixture_db(tmp_path / "partial.db", tables=("genes",))
+    with caplog.at_level("WARNING", logger="bench.orchestrator"):
+        _probe_fixture_schema(str(db))
+    assert any(
+        "missing recommended table" in rec.message
+        for rec in caplog.records
+    ), f"expected warning in caplog, got {[r.message for r in caplog.records]}"
+
+
+def test_probe_fixture_schema_skips_nonfile_path(tmp_path: Path) -> None:
+    """A non-file path (e.g. ``:memory:`` or a missing fixture) is a
+    no-op rather than a crash — the bench launcher should report the
+    real issue downstream, not crash on the probe."""
+    _probe_fixture_schema(str(tmp_path / "does_not_exist.db"))  # must not raise
+
+
+def test_post_swap_aborts_when_fixture_missing_required_table(tmp_path: Path) -> None:
+    """``_post_swap`` runs the schema probe before the HTTP call; a bad
+    fixture must abort before we ever hit /admin/swap-db. Otherwise the
+    bench logs ``retr=err`` × N when the live helix code hits the same
+    OperationalError."""
+    db = _make_fixture_db(tmp_path / "bad.db", tables=("not_genes",))
+    srv = BenchServer()
+    fx = Fixture(name="bad", db=str(db), sharded=False)
+
+    fake_http = MagicMock()
+    with patch.object(srv, "_http", fake_http):
+        with pytest.raises(BenchServerError, match=r"missing required table"):
+            srv._post_swap(fx)
+    fake_http.assert_not_called(), \
+        "the probe must short-circuit before we hit /admin/swap-db"


### PR DESCRIPTION
## Summary

Closes #153. The managed ``BenchServer`` spawned uvicorn without pinning ``cwd`` or ``PYTHONPATH``, so the import system would load whichever ``helix_context`` it resolved first — including stale sibling worktrees from editable installs / .pth shims. The 2026-05-24 ``bench_claude_matrix.py`` run on the xl-sharded fixture loaded code from a ``vibrant-easley-73d68a`` worktree and raised ``OperationalError: no such table: cwola_log`` / ``session_delivery_log`` / ``genes`` on every ``/context`` call; the bench logged ``retr=err`` × 50 instead of failing fast, producing an unactionable summary.

## Changes

- ``benchmarks/bench_orchestrator.py``
  - ``_repo_root()`` helper: derives repo root from ``Path(__file__).resolve().parents[1]``, validated by ``pyproject.toml`` + ``helix_context/__init__.py`` markers.
  - ``BenchServer.__init__`` takes ``repo_root=`` (defaults to ``_repo_root()``).
  - ``_spawn`` now sets ``cwd=<repo_root>``, prepends repo root to ``PYTHONPATH`` (preserves existing entries, idempotent on restart), and logs a ``RUN START`` line with the resolved ``helix_context`` file path + python interpreter.
  - ``_probe_fixture_schema`` opens the fixture DB read-only before swap; raises ``BenchServerError`` if ``genes`` is missing (the canonical wrong-helix symptom), warns on missing ``cwola_log`` / ``session_delivery_log`` (some fixtures legitimately strip them).
  - ``_post_swap`` calls the probe before ``/admin/swap-db`` so the mismatch surfaces in milliseconds rather than as N ``retr=err`` lines.

- ``tests/test_bench_orchestrator.py`` — 11 new tests covering repo_root resolution, cwd/PYTHONPATH plumbing (incl. preserve-existing and don't-double-prepend), schema-probe pass/fail/warn/no-op branches, and the ``_post_swap`` short-circuit. 116 bench tests pass.

## Relationship to other fixes

This is the **import-source identity guard**. The pid-ancestry fix on branch ``0393ac8`` (issue #127) is the **port-binding identity guard** — disjoint concerns, no conflict.

## Test plan

- [x] ``python -m pytest tests/test_bench_orchestrator.py -x -q`` → 31 passed
- [x] ``python -m pytest tests/test_bench*.py -x -q`` → 116 passed
- [ ] Re-run ``bench_claude_matrix.py --only xl-sharded`` against the orchestrator to confirm ``RUN START`` logs the right ``helix_context`` and the schema probe fires on a synthetic bad fixture.