### PR TITLE
fix(packet): preserve source_id prefix on non-repo-root paths in <GENE src=...> tag (closes #146)

### DIFF
--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -1506,11 +1506,32 @@ class HelixContextManager:
             short = ""
             if src and not src.startswith("_"):
                 parts = src.replace("\\", "/").split("/")
-                try:
-                    j = parts.index("Projects")
-                    short = "/".join(parts[j + 1:])
-                except ValueError:
-                    short = "/".join(parts[-3:]) if len(parts) > 3 else src
+                # Canonical ingest layout is `<root>/sources/<source_type>/...`
+                # (e.g. enterprise_rag_*: `F:/tmp/.../sources/confluence/...`,
+                # or `F:/Projects/EnterpriseRAG-Bench-main/generated_data/sources/...`).
+                # Slice from the segment AFTER `sources/` so the source-type
+                # prefix (`confluence/`, `github/`, etc.) is preserved verbatim
+                # in `<GENE src=...>`. Fixes #146 — the prior `parts[-3:]`
+                # fallback dropped the source-type for any path >3 segments
+                # deep below `sources/<type>/`, which was ~30% of confluence
+                # paths in enterprise_rag_* and propagated as truncated
+                # citations into the answerer prompt and downstream lookups.
+                short = ""
+                # Prefer the last `sources` segment so nested fixtures like
+                # `.../sources/confluence/.../sources_attached/...` still
+                # anchor on the canonical ingest boundary.
+                src_idx = -1
+                for _i, _p in enumerate(parts):
+                    if _p == "sources":
+                        src_idx = _i
+                if src_idx >= 0 and src_idx + 1 < len(parts):
+                    short = "/".join(parts[src_idx + 1:])
+                if not short:
+                    try:
+                        j = parts.index("Projects")
+                        short = "/".join(parts[j + 1:])
+                    except ValueError:
+                        short = "/".join(parts[-3:]) if len(parts) > 3 else src
             # Dense XML document format — structured for small model extraction
             kv_attrs = ""
             if g.key_values:

--- a/tests/test_gene_src_prefix.py
+++ b/tests/test_gene_src_prefix.py
@@ -1,0 +1,238 @@
+"""Regression tests for #146 — `<GENE src=...>` source-prefix preservation.
+
+The renderer in ``HelixContextManager.build_context`` shortens
+``gene.source_id`` into the ``src=...`` attribute of each `<GENE>` block.
+Before the fix, the shortener:
+
+  1. Looked for a ``Projects`` segment and sliced after it, OR
+  2. Fell back to the last 3 path components.
+
+The (2) fallback dropped the canonical ``<source_type>/`` prefix for any
+path layered as ``<root>/sources/<source_type>/<sub>/<file>`` whose
+``<sub>`` was a directory (i.e., > 3 segments below the boundary). That
+hit ~30% of confluence paths in the enterprise_rag_* fixtures and any
+similarly-deep gmail/jira/github tree, and propagated as truncated
+citations into the answerer prompt and downstream lookups.
+
+The fix prefers a ``sources`` marker over both prior branches so the
+source-type prefix (``confluence/``, ``github/``, etc.) is always
+preserved verbatim in `<GENE src=...>`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from helix_context.config import (
+    BudgetConfig,
+    GenomeConfig,
+    HelixConfig,
+    RibosomeConfig,
+)
+from helix_context.context_manager import HelixContextManager
+from tests.conftest import make_gene
+
+
+class _MockRibosomeBackend:
+    """Stand-in ribosome backend. Inlined (not imported from
+    ``tests.test_pipeline``) because that module has a top-level
+    ``pytest.importorskip("sentence_transformers")`` that would skip this
+    file on import in environments without sentence-transformers.
+
+    Returns plausible JSON shapes for each of the four prompt families
+    the ribosome dispatches: ``pack`` (compression engine), ``re-rank``
+    (expression scorer), ``splice`` (context splicer), and ``replicate``
+    (replication engine). Any other system prompt gets an empty object.
+    """
+
+    def complete(self, prompt: str, system: str = "", temperature: float = 0.0) -> str:
+        if "compression engine" in system:
+            return json.dumps({
+                "codons": [
+                    {"meaning": "mock_concept", "weight": 0.9, "is_exon": True},
+                    {"meaning": "mock_detail", "weight": 0.5, "is_exon": True},
+                ],
+                "complement": "Mock compressed summary.",
+                "promoter": {
+                    "domains": ["testing"],
+                    "entities": [],
+                    "intent": "test",
+                    "summary": "Mock gene",
+                },
+            })
+        if "expression scorer" in system:
+            import re
+            gene_ids = re.findall(r"(\w{16}):", prompt)
+            return json.dumps({gid: round(0.9 - i * 0.1, 1)
+                               for i, gid in enumerate(gene_ids)})
+        if "context splicer" in system:
+            import re
+            gene_ids = re.findall(r"Gene (\w+)", prompt)
+            return json.dumps({gid: [0, 1] for gid in gene_ids})
+        if "replication engine" in system:
+            return json.dumps({
+                "codons": [{"meaning": "x", "weight": 1.0, "is_exon": True}],
+                "complement": "Mock replicated.",
+                "promoter": {"domains": [], "entities": [],
+                             "intent": "conversation", "summary": "x"},
+            })
+        return "{}"
+
+
+@pytest.fixture
+def manager():
+    """Manager with mock backend + in-memory genome.
+
+    The ribosome backend is mocked so build_context does not try to call a
+    real LLM; the path-shortening branch we exercise sits in the splice
+    loop, which runs unconditionally once candidates are selected.
+    """
+    cfg = HelixConfig(
+        ribosome=RibosomeConfig(model="mock", timeout=5),
+        budget=BudgetConfig(max_genes_per_turn=4, splice_aggressiveness=0.5),
+        genome=GenomeConfig(path=":memory:", cold_start_threshold=5),
+    )
+    mgr = HelixContextManager(cfg)
+    mgr.ribosome.backend = _MockRibosomeBackend()
+    yield mgr
+    mgr.close()
+
+
+def _seed_with_source(mgr, source_id: str, *, gene_id: str = "src_prefix_test_0001"):
+    """Seed exactly one gene with a controlled ``source_id``.
+
+    The single-gene seeding keeps the splice loop deterministic — the
+    rendered `<GENE>` tag is the only one in the expressed context.
+    """
+    g = make_gene(
+        "Document about confluence audit logging retention",
+        domains=["confluence", "audit"],
+        entities=["confluence", "audit", "retention"],
+        gene_id=gene_id,
+    )
+    g.source_id = source_id
+    mgr.genome.upsert_gene(g)
+    return g
+
+
+def _render_src_for(mgr, source_id: str) -> str:
+    """Drive build_context with a query that matches the seeded gene and
+    return the rendered ``<GENE src=...>`` attribute body (or empty
+    string if no src= was emitted)."""
+    _seed_with_source(mgr, source_id)
+    win = mgr.build_context("confluence audit retention")
+    body = win.expressed_context
+    # Extract the src="..." attribute from the first <GENE ...> tag.
+    import re
+    m = re.search(r'<GENE\b[^>]*\bsrc="([^"]*)"', body)
+    return m.group(1) if m else ""
+
+
+# ── #146 regression cases ────────────────────────────────────────────
+
+
+def test_confluence_path_preserves_source_type_prefix(manager):
+    """A canonical ``F:/tmp/.../sources/confluence/<sub>/<file>`` path
+    must render with ``confluence/`` retained — the prior fallback
+    sliced to ``parts[-3:]`` and stripped it."""
+    src = (
+        r"F:\tmp\enterprise_rag_10k\sources\confluence\architecture-and-standards"
+        r"\decision-records\adr-015-admission-control.json"
+    )
+    out = _render_src_for(manager, src)
+    assert out == (
+        "confluence/architecture-and-standards/decision-records/"
+        "adr-015-admission-control.json"
+    ), out
+
+
+def test_gmail_path_does_not_get_literal_sources_prefix(manager):
+    """The bug also produced ``sources/gmail/...`` (literal ``sources/``
+    prefix on a path that was already only 3 segments deep below
+    ``sources/``). After the fix, the ``sources`` segment itself is
+    stripped while the ``gmail/`` source-type prefix is retained."""
+    src = (
+        r"F:\tmp\enterprise_rag_10k\sources\gmail"
+        r"\20250610-private-upgrade-audit-log-requirements.json"
+    )
+    out = _render_src_for(manager, src)
+    assert out == "gmail/20250610-private-upgrade-audit-log-requirements.json", out
+
+
+def test_eng_private_deployments_path_keeps_source_type(manager):
+    """``eng-private-deployments`` is one of the source-type subdirs
+    listed in the bug report. The deep-path case must keep it."""
+    src = (
+        r"F:\tmp\enterprise_rag_10k\sources\eng-private-deployments"
+        r"\deployment-guides\private-audit-log-export-config.json"
+    )
+    out = _render_src_for(manager, src)
+    assert out == (
+        "eng-private-deployments/deployment-guides/"
+        "private-audit-log-export-config.json"
+    ), out
+
+
+def test_company_misc_path_keeps_source_type(manager):
+    """``company/misc/...`` was reported stripped to just
+    ``company/misc/<file>``; after the fix it is fully preserved."""
+    src = (
+        r"F:\tmp\enterprise_rag_10k\sources\company\misc"
+        r"\coverage-gap-census-lite-oct-2031.json"
+    )
+    out = _render_src_for(manager, src)
+    assert out == "company/misc/coverage-gap-census-lite-oct-2031.json", out
+
+
+# ── Defense-in-depth: existing behaviors must not regress ────────────
+
+
+def test_projects_path_still_short_circuits_to_projects_index(manager):
+    """``F:/Projects/<repo>/<sub>/<file>`` is the dev-laptop layout.
+    Without a ``sources`` segment the shortener still slices after the
+    ``Projects`` segment exactly as before."""
+    src = r"F:\Projects\helix-context\helix_context\context_manager.py"
+    out = _render_src_for(manager, src)
+    assert out == "helix-context/helix_context/context_manager.py", out
+
+
+def test_projects_with_nested_sources_prefers_sources_anchor(manager):
+    """When BOTH ``Projects`` and ``sources`` segments are present (e.g.
+    the upstream ``F:/Projects/EnterpriseRAG-Bench-main/generated_data/
+    sources/...`` layout described in the corpus matrix), the ``sources``
+    anchor takes precedence so the source-type prefix is preserved."""
+    src = (
+        r"F:\Projects\EnterpriseRAG-Bench-main\generated_data\sources\confluence"
+        r"\architecture-and-standards\decision-records\adr-015.json"
+    )
+    out = _render_src_for(manager, src)
+    assert out == (
+        "confluence/architecture-and-standards/decision-records/adr-015.json"
+    ), out
+
+
+def test_short_non_sources_path_falls_back_to_parts3(manager):
+    """A path with neither ``sources`` nor ``Projects`` still falls back
+    to the legacy ``parts[-3:]`` behavior — the fallback is only wrong
+    for the deep-``sources`` case, which the new branch catches first.
+
+    The path is constructed to include the retrieval-side query tokens
+    (``confluence``, ``audit``) so the synthetic gene clears the
+    promoter-match floor and a `<GENE>` tag is actually emitted —
+    otherwise build_context short-circuits to a `<helix:no_match>`
+    token before the shortener ever runs.
+    """
+    src = "/var/log/confluence/audit/output.json"
+    out = _render_src_for(manager, src)
+    assert out == "confluence/audit/output.json", out
+
+
+def test_underscore_prefixed_source_id_emits_no_src_attr(manager):
+    """Sentinel / synthetic source_ids that start with ``_`` (e.g.
+    ``_inline``, ``_replication``) are explicitly excluded from the
+    shortener and must not emit ``src=`` at all."""
+    src = "_inline_synthetic"
+    out = _render_src_for(manager, src)
+    assert out == "", out


### PR DESCRIPTION
## Summary

- Root cause: `HelixContextManager.build_context`'s path-shortener for the `<GENE src=...>` attribute fell back to `parts[-3:]` when no `Projects` segment was present in `gene.source_id`. For canonical enterprise_rag_* ingest paths shaped `<root>/sources/<source_type>/<sub>/<file>`, the fallback over-stripped the `<source_type>/` prefix (~30% of confluence paths).
- Fix: prefer the last `sources/` segment as the slice anchor before the existing `Projects` / `parts[-3:]` branches. The source-type prefix (`confluence/`, `gmail/`, `eng-private-deployments/`, ...) is now preserved verbatim. Legacy behavior for dev-laptop `F:/Projects/<repo>/...` paths is unchanged.
- Closes #146.

## Reproduction (per issue body)

Before:
```
F:\tmp\enterprise_rag_10k\sources\confluence\architecture-and-standards\decision-records\adr-015-...json
→ "architecture-and-standards/decision-records/adr-015-...json"  (source-type stripped)
```

After:
```
→ "confluence/architecture-and-standards/decision-records/adr-015-...json"  (preserved)
```

## Test plan

- [x] `tests/test_gene_src_prefix.py` — 8 cases covering:
  - 4 #146 regressions: confluence (deep), gmail (literal `sources/` prefix), eng-private-deployments, company/misc.
  - 3 defense-in-depth: Projects-only (legacy slice), Projects + nested `sources` (sources wins), short non-`sources` path (legacy `parts[-3:]` fallback intact).
  - 1 underscore-prefix sentinel (`_inline` → no `src=` attr).
- [x] Local `pytest tests/test_gene_src_prefix.py` — 8 passed, 0 failed.
- [x] Adjacent `test_context_packet.py` regression check — 10 passed, no diffs.
- [ ] Bench-side prepend-fallback branch in `bench_enterprise_rag.py::match_delivered_to_gold` should become never-taken on the next `enterprise_rag_*` run (per issue acceptance criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)