### PR TITLE
feat(bench): dense_additive_weight sweep harness + zero-arm support (#138)

### DIFF
--- a/benchmarks/sweep_dense_additive_weight.py
+++ b/benchmarks/sweep_dense_additive_weight.py
@@ -1,0 +1,239 @@
+"""Sweep `dense_additive_weight` across {0.0, 1.0, 2.0, 3.0, 4.0, 6.0} on a
+pre-built genome and report per-weight recall + rank shifts.
+
+Issue #138: H10q on the 10K EnterpriseRAG fixture observed sparse-only
+(arm 1, dense disabled) recovered +19 pp recall@10 over the H10o-fixed
+dense+abs path at the shipped 4.0 weight. This script implements the
+weight sweep the issue requested with `0.0` (dense-off arm) as the lower
+bound rather than a fallback.
+
+Run against an existing genome -- `dense_additive_weight` is a
+QUERY-TIME scoring weight, so no rebuild is needed; the same
+`embedding_dense_v2` blobs are scored with a different multiplier per
+arm. Useful for tuning without spending ingest budget.
+
+Usage:
+    # Default: walks the canonical sweep on the small fixture
+    python benchmarks/sweep_dense_additive_weight.py \\
+        --genome genomes/bench/matrix/small.db \\
+        --queries benchmarks/_dense_weight_sweep_queries.json
+
+    # Minimal smoke (3 queries x 3 weights)
+    python benchmarks/sweep_dense_additive_weight.py --smoke
+
+Inputs:
+  --genome PATH      Path to a .db built with `splade_enabled=True` and
+                     populated `embedding_dense_v2` blobs (anything from
+                     `genomes/bench/matrix/` qualifies).
+  --queries PATH     JSON file: list of {"query": str, "gold_ids": [str]}.
+                     If omitted and --smoke not set, auto-generates from
+                     gene tags (synthetic gold = the gene itself).
+  --weights LIST     Comma-separated floats; default
+                     ``0.0,1.0,2.0,3.0,4.0,6.0``.
+  --topk INT         Cut-off for recall@k (default 10).
+  --out PATH         Per-arm JSON output path (default stdout).
+
+Output:
+  Per-weight row with recall@k, MRR, mean rank-of-gold, and
+  ``gold_evicted_count`` (queries where gold appeared in the baseline
+  weight=0 arm but fell out of top-k in the higher-weight arm — the
+  H10q risk R1 signal).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Allow running directly from the repo root without `pip install -e .`
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_queries(path: str | None, smoke: bool, genome) -> list[dict]:
+    """Return list of {"query": str, "gold_ids": [str]}."""
+    if path:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, list) or not data:
+            raise SystemExit(f"queries file {path} must be a non-empty JSON list")
+        return data
+
+    # Auto-synthesize: pick N random genes, query by their first 6 content
+    # tokens, gold = that gene.
+    cur = genome.conn.execute(
+        "SELECT gene_id, content FROM genes WHERE content IS NOT NULL "
+        "AND length(content) >= 40 ORDER BY random() LIMIT ?",
+        (3 if smoke else 30,),
+    )
+    rows = cur.fetchall()
+    queries = []
+    for r in rows:
+        gid = r["gene_id"] if hasattr(r, "keys") else r[0]
+        content = r["content"] if hasattr(r, "keys") else r[1]
+        toks = content.split()[:8]
+        if len(toks) < 4:
+            continue
+        queries.append({"query": " ".join(toks), "gold_ids": [gid]})
+    if not queries:
+        raise SystemExit("could not auto-synthesize queries from genome")
+    return queries
+
+
+def _eval_arm(genome, queries: list[dict], topk: int) -> dict:
+    """Run all queries against `genome`, return aggregate metrics."""
+    n = len(queries)
+    hits_at_k = 0
+    rr_sum = 0.0
+    rank_of_gold = []
+    per_query = []
+    t0 = time.monotonic()
+
+    for q in queries:
+        query_text = q["query"]
+        gold = set(q["gold_ids"])
+        # Use query_docs through the high-level path (same path /context uses).
+        try:
+            docs = genome.query_docs(
+                domains=query_text.split(),
+                entities=[],
+                max_genes=max(topk, 20),
+            )
+        except Exception as exc:
+            per_query.append({"query": query_text, "error": str(exc)})
+            continue
+        ids = [d.gene_id for d in docs]
+        # Rank of first gold hit (1-indexed; 0 = not found)
+        rank = 0
+        for i, gid in enumerate(ids[:topk], start=1):
+            if gid in gold:
+                rank = i
+                break
+        if rank > 0:
+            hits_at_k += 1
+            rr_sum += 1.0 / rank
+            rank_of_gold.append(rank)
+        per_query.append({
+            "query": query_text, "rank": rank, "topk_ids": ids[:topk],
+        })
+
+    elapsed = time.monotonic() - t0
+    return {
+        "n_queries": n,
+        "recall_at_k": hits_at_k / max(n, 1),
+        "mrr": rr_sum / max(n, 1),
+        "mean_rank_of_gold": (
+            sum(rank_of_gold) / len(rank_of_gold) if rank_of_gold else None
+        ),
+        "wall_s": round(elapsed, 3),
+        "per_query": per_query,
+    }
+
+
+def _evicted_count(baseline_arm: dict, current_arm: dict, topk: int) -> int:
+    """Queries where baseline arm placed gold in top-k but current arm
+    pushed it out (or to rank > topk). Implements the H10q risk R1
+    "gold_delivered True->False" signal at the recall layer.
+    """
+    base_pq = {p["query"]: p for p in baseline_arm.get("per_query", [])}
+    cur_pq = {p["query"]: p for p in current_arm.get("per_query", [])}
+    evicted = 0
+    for q, base in base_pq.items():
+        if not base.get("rank") or base["rank"] > topk:
+            continue
+        cur = cur_pq.get(q)
+        if cur is None:
+            continue
+        if not cur.get("rank") or cur["rank"] > topk:
+            evicted += 1
+    return evicted
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--genome", default="genomes/bench/matrix/small.db",
+                        help="Path to pre-built .db genome")
+    parser.add_argument("--queries", default=None,
+                        help="JSON list of {query, gold_ids}; auto-synth if omitted")
+    parser.add_argument("--weights",
+                        default="0.0,1.0,2.0,3.0,4.0,6.0",
+                        help="Comma-separated float list")
+    parser.add_argument("--topk", type=int, default=10)
+    parser.add_argument("--smoke", action="store_true",
+                        help="3-query, 3-weight smoke run")
+    parser.add_argument("--out", default=None,
+                        help="JSON output path; stdout if omitted")
+    args = parser.parse_args(argv)
+
+    if args.smoke:
+        weights = [0.0, 4.0, 8.0]
+    else:
+        weights = [float(w) for w in args.weights.split(",") if w.strip()]
+
+    if not os.path.exists(args.genome):
+        raise SystemExit(f"genome not found: {args.genome}")
+
+    from helix_context.genome import Genome
+
+    # Build queries once against the first genome instance.
+    bootstrap_g = Genome(path=args.genome, dense_embedding_enabled=False)
+    try:
+        queries = _load_queries(args.queries, args.smoke, bootstrap_g)
+    finally:
+        bootstrap_g.close()
+    print(f"[sweep] {len(queries)} queries, weights={weights}, topk={args.topk}",
+          file=sys.stderr)
+
+    arms = {}
+    baseline_arm = None
+    for w in weights:
+        print(f"[sweep] arm dense_additive_weight={w} ...", file=sys.stderr)
+        g = Genome(
+            path=args.genome,
+            dense_embedding_enabled=True,
+            dense_embedding_dim=1024,
+            fusion_mode="additive",
+            dense_additive_weight=w,
+        )
+        try:
+            arm = _eval_arm(g, queries, args.topk)
+        finally:
+            g.close()
+        if baseline_arm is None:
+            baseline_arm = arm
+        arm["gold_evicted_vs_baseline"] = _evicted_count(
+            baseline_arm, arm, args.topk
+        )
+        arms[str(w)] = arm
+        print(
+            f"  recall@{args.topk}={arm['recall_at_k']:.3f} "
+            f"mrr={arm['mrr']:.3f} "
+            f"mean_rank={arm['mean_rank_of_gold']} "
+            f"evicted_vs_w={weights[0]}={arm['gold_evicted_vs_baseline']}",
+            file=sys.stderr,
+        )
+
+    summary = {
+        "genome": args.genome,
+        "queries_count": len(queries),
+        "topk": args.topk,
+        "weights": weights,
+        "arms": arms,
+    }
+    out_text = json.dumps(summary, indent=2, default=str)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(out_text)
+        print(f"[sweep] wrote {args.out}", file=sys.stderr)
+    else:
+        print(out_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -336,6 +336,16 @@ class RetrievalConfig:
     # fusion_mode == "additive" a dense hit's cosine is scaled by this
     # before entering the gene_scores accumulator. BM25-comparable
     # (tag_exact_weight is 3.0). Unused under RRF.
+    #
+    # Issue #138 (tracked): the H10q investigation on EnterpriseRAG-Bench
+    # 10K observed gold eviction at the shipped 4.0 weight on
+    # adversarial prose queries (per-query dense tier totals ran 9-28 vs
+    # tag-exact ~3 per doc). The smoke sweep harness at
+    # ``benchmarks/sweep_dense_additive_weight.py`` covers
+    # {0.0, 2.0, 3.0, 4.0, 6.0} including the dense-off arm; ship the
+    # winning value once an enterprise-class question set is wired in.
+    # ``0.0`` flips dense additively-off without disabling the dense
+    # write path or RRF participation.
     dense_additive_weight: float = 4.0
     # Tier-0 review fix (2026-05-16): noise floor for the additive-mode
     # dense merge. A dense hit whose cosine is below this does not

--- a/tests/test_dense_recall.py
+++ b/tests/test_dense_recall.py
@@ -743,6 +743,53 @@ def test_dense_additive_min_cosine_default_and_plumbing():
         g_custom.close()
 
 
+def test_dense_additive_weight_zero_disables_additive_dense():
+    """Issue #138 (sweep harness): ``dense_additive_weight=0.0`` flips
+    the additive dense merge OFF — a dense-only gene still appears in
+    ``gene_scores`` via the 1e-9 set-membership epsilon (so the candidate
+    pool is identical to weight=4.0) but contributes 0 to the score and
+    cannot evict a lexical hit.
+
+    This is the "dense-off arm" the H10q write-up calls out as the
+    empirical winner on EnterpriseRAG-10K — exposing it as a true 0-floor
+    rather than a fallback lets the sweep at
+    ``benchmarks/sweep_dense_additive_weight.py`` include it as the
+    lower bound of the weight range without a separate "disable dense"
+    code path.
+    """
+    g = _additive_dense_genome(dense_additive_weight=0.0)
+    try:
+        # Token-disjoint needle reachable only via the dense merge.
+        g.upsert_gene(_make_gene(
+            "alpha lexical anchor body", domains=["alpha"], gene_id="anchor",
+        ))
+        g.upsert_gene(_make_gene(
+            "wholly disjoint surface tokens for the needle body",
+            domains=["needle"], gene_id="needle-zero",
+        ))
+        target = "zero-weight dense target"
+        _populate_v2(g, "needle-zero", _hash_vec(target, 1024))
+        _populate_v2(g, "anchor", _hash_vec("anchor-noise", 1024))
+        g._dense_codec = _FakeCodec(dim=1024, query_target=target)
+
+        g.query_docs(domains=["alpha"], entities=[], max_genes=12)
+        contribs = g.last_tier_contributions
+
+        # The needle was surfaced (its cosine ~1.0 cleared the
+        # min_cosine floor) but contributes ZERO to gene_scores because
+        # cosine * 0.0 == 0.0.
+        assert "needle-zero" in contribs, (
+            "dense-only needle should still be a candidate at weight=0.0 "
+            "(the merge runs and records tier_contrib)"
+        )
+        assert contribs["needle-zero"]["dense"] == pytest.approx(0.0, abs=1e-9), (
+            f"weight=0.0 must zero out the dense contribution; "
+            f"got {contribs['needle-zero'].get('dense')}"
+        )
+    finally:
+        g.close()
+
+
 # ── 8. live — real BGE-M3 dense recall through query_docs (additive) ─
 
 


### PR DESCRIPTION
Closes #138 (harness portion; default flip deferred).

## Summary

The H10q investigation observed that `dense_additive_weight = 4.0` evicted gold documents on EnterpriseRAG-Bench 10K adversarial prose queries. This PR ships the sweep harness the issue asks for and exposes the dense-off arm at weight `0.0`, but keeps the default at `4.0` until enterprise-class data is run -- the matrix-fixture sweep below shows the opposite direction on code/docs-heavy corpora.

## Changes

- `benchmarks/sweep_dense_additive_weight.py` -- sweep harness across {0.0, 1.0, 2.0, 3.0, 4.0, 6.0}. Query-time scoring only, no rebuilds; reports `recall@k`, `MRR`, `mean_rank_of_gold`, and `gold_evicted_vs_baseline` (the H10q risk-R1 signal at the recall layer).
- `RetrievalConfig.dense_additive_weight` docstring cross-references the H10q gold-eviction observation and points at the harness so the issue's concern lives at the config call site.
- `test_dense_recall.py` adds `test_dense_additive_weight_zero_disables_additive_dense` pinning the contract that w=0.0 zeroes the dense contribution while preserving the 1e-9 set-membership epsilon.

## Sweep results (collected on tree-local fixtures)

| Genome     | w=0.0 | w=2.0 | w=4.0 | w=6.0 | evicted vs 0.0 |
|------------|-------|-------|-------|-------|----------------|
| `small.db` (1238 genes) | 0.400 | 0.500 | 0.600 | 0.667 | 0 |
| `medium.db` (17477 genes) | 0.133 | 0.133 | 0.300 | 0.433 | 0 |

On the matrix-fixture set (code+docs-heavy, content-token queries) the dense merge is monotonically net-positive and shows zero eviction. The H10q risk-R1 signal lives at a regime the matrix fixtures don't cover (EnterpriseRAG-Bench prose + adversarial questions on a dense-backfilled `enterprise_rag_10k`).

## Design decisions

- **Default not flipped.** Per the empirical-justification rule, the matrix-fixture data points the other way; flipping ahead of the H10q replication would be net-negative on the corpora I can measure here.
- **w=0.0 as a true 0-floor.** The test pins the contract that `cosine * 0.0 == 0.0` without disabling the dense write path or RRF participation, so the sweep harness can include "dense-off" as the lower bound rather than a fallback.
- **Query-time only.** No rebuilds, no embedding changes. The same `embedding_dense_v2` blobs are scored with a different multiplier per arm.

## Left to follow-up

- Run the sweep with the EnterpriseRAG-Bench question set against an `enterprise_rag_10k` genome that has had `scripts/backfill_bgem3_v2.py` applied -- both prerequisites for replicating the H10q-arm-1 vs H10q-arm-2 +19 pp recall@10 observation. Once that data lands, the default can move from 4.0 -> winning value in a follow-up PR.

## Test plan

- [x] `tests/test_dense_recall.py` -- 15 passed (1 added)
- [x] Sweep ran end-to-end on small + medium with `_FakeCodec`-free real BGE-M3 path (`F:/tmp/bgem3_gpu_venv`)
- [ ] (Follow-up) Run with `enterprise_rag_10k` + EnterpriseRAG question set

Refs: #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)