### PR TITLE
feat(ingest): size-aware SPLADE auto-toggle + scale-curve scaffold (#164)

### DIFF
--- a/benchmarks/sweep_splade_scale_curve.py
+++ b/benchmarks/sweep_splade_scale_curve.py
@@ -1,0 +1,292 @@
+"""Scaffold for the issue #164 SPLADE-value scale curve.
+
+Builds a SPLADE-on / SPLADE-off recall comparison across the configured
+genome sizes (1K -> 850K) and reports recall@10, MRR, p95 latency, and
+disk-bytes-per-gene. Output is the curve the issue body asks for so the
+two ``splade_auto_*_genes`` thresholds can be set from data rather than
+from the regime table.
+
+Status: scaffold. The runner is wired and tested against existing matrix
+fixtures (``small`` / ``medium`` / ``large`` / ``xl``, all with
+SPLADE-on at build time). To produce SPLADE-on vs SPLADE-off pairs at
+each size you currently have to either:
+  (a) build a SPLADE-off twin per scale point with
+      ``scripts/build_fixture_matrix.py`` (multi-hour each at 50K+), or
+  (b) drop ``splade_terms`` from a SPLADE-on twin (cheap, but does not
+      simulate the genuine disk-cost arm at ingest).
+
+Either approach is gated on a build budget the dev box has but the CI
+loop does not, so this script ships as a measurement harness; the
+default thresholds in ``IngestionConfig`` stay at 0 (disabled) until
+the scale curve actually lands.
+
+Usage:
+    # Walk one size, compare on/off twins by db path
+    python benchmarks/sweep_splade_scale_curve.py \\
+        --on-genome genomes/bench/matrix/medium.db \\
+        --off-genome genomes/bench/matrix/medium_no_splade.db \\
+        --label medium \\
+        --queries benchmarks/_splade_curve_queries.json
+
+    # Full curve (writes one JSON per size to --out-dir)
+    python benchmarks/sweep_splade_scale_curve.py --curve --out-dir \\
+        benchmarks/results/splade_scale_curve_$(date +%Y%m%d)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# Default scale points. The 50K+ rows reference fixtures that may not
+# exist locally; the runner skips a row whose .db is missing rather
+# than failing.
+SCALE_POINTS = [
+    {"label": "small",   "approx_genes": 1_000,
+     "on_db": "genomes/bench/matrix/small.db",
+     "off_db": "genomes/bench/matrix/small_no_splade.db"},
+    {"label": "medium",  "approx_genes": 17_000,
+     "on_db": "genomes/bench/matrix/medium.db",
+     "off_db": "genomes/bench/matrix/medium_no_splade.db"},
+    {"label": "large",   "approx_genes": 28_000,
+     "on_db": "genomes/bench/matrix/large.db",
+     "off_db": "genomes/bench/matrix/large_no_splade.db"},
+    {"label": "xl",      "approx_genes": 47_000,
+     "on_db": "genomes/bench/matrix/xl.db",
+     "off_db": "genomes/bench/matrix/xl_no_splade.db"},
+    {"label": "erag10k", "approx_genes": 10_000,
+     "on_db": "genomes/bench/matrix/enterprise_rag_10k_batched.db",
+     "off_db": "genomes/bench/matrix/enterprise_rag_10k_no_splade.db"},
+    {"label": "erag50k", "approx_genes": 50_000,
+     "on_db": "genomes/bench/matrix/enterprise_rag_50k_batched.db",
+     "off_db": "genomes/bench/matrix/enterprise_rag_50k_no_splade.db"},
+]
+
+
+def _disk_bytes_per_gene(db_path: str, gene_count: int) -> float:
+    """Total .db + -wal size / gene_count. Issue #164's disk lens."""
+    if gene_count <= 0 or not os.path.exists(db_path):
+        return -1.0
+    total = os.path.getsize(db_path)
+    for suffix in ("-wal", "-shm"):
+        s = db_path + suffix
+        if os.path.exists(s):
+            total += os.path.getsize(s)
+    return round(total / gene_count, 3)
+
+
+def _eval_genome(db_path: str, queries: list[dict], topk: int) -> dict:
+    """Run ``queries`` against the genome and return aggregate metrics
+    plus per-query latencies for p95.
+    """
+    from helix_context.genome import Genome
+
+    g = Genome(path=db_path, dense_embedding_enabled=False)
+    try:
+        n = len(queries)
+        hits_at_k = 0
+        rr_sum = 0.0
+        latencies = []
+
+        total_genes = g.conn.execute(
+            "SELECT COUNT(*) FROM genes"
+        ).fetchone()[0]
+        has_splade_table = g.conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' "
+            "AND name='splade_terms'"
+        ).fetchone()[0]
+        splade_rows = 0
+        if has_splade_table:
+            splade_rows = g.conn.execute(
+                "SELECT COUNT(*) FROM splade_terms"
+            ).fetchone()[0]
+
+        for q in queries:
+            query_text = q["query"]
+            gold = set(q["gold_ids"])
+            t0 = time.monotonic()
+            try:
+                docs = g.query_docs(
+                    domains=query_text.split(),
+                    entities=[],
+                    max_genes=max(topk, 20),
+                )
+            except Exception:
+                continue
+            latencies.append(time.monotonic() - t0)
+            ids = [d.gene_id for d in docs]
+            rank = 0
+            for i, gid in enumerate(ids[:topk], start=1):
+                if gid in gold:
+                    rank = i
+                    break
+            if rank > 0:
+                hits_at_k += 1
+                rr_sum += 1.0 / rank
+
+        latencies.sort()
+        p95 = latencies[max(int(len(latencies) * 0.95) - 1, 0)] if latencies else None
+
+        return {
+            "n_queries": n,
+            "recall_at_k": hits_at_k / max(n, 1),
+            "mrr": rr_sum / max(n, 1),
+            "p95_s": round(p95, 4) if p95 else None,
+            "mean_s": round(statistics.mean(latencies), 4) if latencies else None,
+            "total_genes": total_genes,
+            "splade_rows": splade_rows,
+            "splade_present": bool(has_splade_table) and splade_rows > 0,
+            "disk_bytes_per_gene": _disk_bytes_per_gene(db_path, total_genes),
+        }
+    finally:
+        g.close()
+
+
+def _evaluate_pair(label: str, on_db: str, off_db: str,
+                   queries: list[dict], topk: int) -> dict:
+    """Return the per-scale-point row the curve plot needs."""
+    arms = {}
+    for arm_name, db in (("on", on_db), ("off", off_db)):
+        if not os.path.exists(db):
+            arms[arm_name] = {"missing": db}
+            continue
+        arms[arm_name] = _eval_genome(db, queries, topk)
+
+    on_arm = arms.get("on") or {}
+    off_arm = arms.get("off") or {}
+    delta = {}
+    if "recall_at_k" in on_arm and "recall_at_k" in off_arm:
+        delta["recall_at_k_delta"] = round(
+            on_arm["recall_at_k"] - off_arm["recall_at_k"], 4
+        )
+    if "p95_s" in on_arm and "p95_s" in off_arm and on_arm["p95_s"] and off_arm["p95_s"]:
+        delta["p95_s_delta"] = round(on_arm["p95_s"] - off_arm["p95_s"], 4)
+    if ("disk_bytes_per_gene" in on_arm
+            and "disk_bytes_per_gene" in off_arm
+            and on_arm["disk_bytes_per_gene"] > 0
+            and off_arm["disk_bytes_per_gene"] > 0):
+        delta["disk_bytes_per_gene_delta"] = round(
+            on_arm["disk_bytes_per_gene"] - off_arm["disk_bytes_per_gene"], 3
+        )
+
+    return {
+        "label": label,
+        "on": on_arm,
+        "off": off_arm,
+        "splade_value_signal": delta,
+    }
+
+
+def _auto_queries(db_path: str, n: int) -> list[dict]:
+    """Synthesize ``n`` queries from genome content tokens (cheap smoke).
+
+    For a real curve, supply a question set via ``--queries`` -- this
+    auto-synth is a smoke-only fallback so the harness runs end-to-end
+    without a pre-built fixture pack.
+    """
+    from helix_context.genome import Genome
+    g = Genome(path=db_path, dense_embedding_enabled=False)
+    try:
+        rows = g.conn.execute(
+            "SELECT gene_id, content FROM genes "
+            "WHERE content IS NOT NULL AND length(content) >= 80 "
+            "ORDER BY random() LIMIT ?",
+            (n,),
+        ).fetchall()
+        out = []
+        for r in rows:
+            gid = r["gene_id"]
+            toks = r["content"].split()[:8]
+            if len(toks) < 4:
+                continue
+            out.append({"query": " ".join(toks), "gold_ids": [gid]})
+        return out
+    finally:
+        g.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--on-genome", default=None,
+                        help="Path to SPLADE-on genome (.db)")
+    parser.add_argument("--off-genome", default=None,
+                        help="Path to SPLADE-off genome (.db)")
+    parser.add_argument("--label", default="ad-hoc",
+                        help="Scale-curve label for the report row")
+    parser.add_argument("--queries", default=None,
+                        help="JSON list of {query, gold_ids} (auto-synth if omitted)")
+    parser.add_argument("--auto-query-count", type=int, default=30,
+                        help="Auto-synthesized query count when --queries omitted")
+    parser.add_argument("--topk", type=int, default=10)
+    parser.add_argument("--out", default=None,
+                        help="JSON output path (stdout if omitted)")
+    parser.add_argument("--curve", action="store_true",
+                        help="Walk the canonical scale points (skips missing .db)")
+    parser.add_argument("--out-dir", default=None,
+                        help="Output directory for --curve mode")
+    args = parser.parse_args(argv)
+
+    if args.curve:
+        out_dir = args.out_dir or "benchmarks/results/splade_scale_curve"
+        os.makedirs(out_dir, exist_ok=True)
+        rows = []
+        for pt in SCALE_POINTS:
+            if not os.path.exists(pt["on_db"]):
+                print(f"[curve] skip {pt['label']} (missing {pt['on_db']})",
+                      file=sys.stderr)
+                continue
+            if args.queries:
+                with open(args.queries, "r", encoding="utf-8") as f:
+                    queries = json.load(f)
+            else:
+                queries = _auto_queries(pt["on_db"], args.auto_query_count)
+            row = _evaluate_pair(
+                pt["label"], pt["on_db"], pt["off_db"],
+                queries, args.topk,
+            )
+            row["approx_genes"] = pt["approx_genes"]
+            rows.append(row)
+            print(f"[curve] {pt['label']}: recall_delta="
+                  f"{row['splade_value_signal'].get('recall_at_k_delta')}",
+                  file=sys.stderr)
+            with open(os.path.join(out_dir, f"{pt['label']}.json"), "w",
+                      encoding="utf-8") as f:
+                json.dump(row, f, indent=2, default=str)
+        with open(os.path.join(out_dir, "curve.json"), "w",
+                  encoding="utf-8") as f:
+            json.dump({"rows": rows, "topk": args.topk}, f, indent=2, default=str)
+        print(f"[curve] wrote {out_dir}/curve.json", file=sys.stderr)
+        return 0
+
+    if not args.on_genome or not args.off_genome:
+        parser.error("--on-genome and --off-genome required outside --curve mode")
+    if args.queries:
+        with open(args.queries, "r", encoding="utf-8") as f:
+            queries = json.load(f)
+    else:
+        queries = _auto_queries(args.on_genome, args.auto_query_count)
+    row = _evaluate_pair(
+        args.label, args.on_genome, args.off_genome, queries, args.topk,
+    )
+    out_text = json.dumps(row, indent=2, default=str)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(out_text)
+        print(f"[sweep] wrote {args.out}", file=sys.stderr)
+    else:
+        print(out_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/helix.toml
+++ b/helix.toml
@@ -202,6 +202,21 @@ entity_graph = true                     # Phase 5: entity-based co-activation li
 # [retrieval] dense_embedding_enabled (default true).
 dense_embed_on_ingest = true            # Tier-0 PR-1 (2026-05-16)
 
+# ── Issue #164: size-aware SPLADE auto-toggle (opt-in) ──────────────────
+# SPLADE's value follows a corpus-regime curve: useful below ~50K genes,
+# likely net-negative above ~200K (disk + p95 + SQL fan-out — see issue
+# body's storage breakdown of the 850K v2 Onyx fixture). Below
+# splade_auto_enable_below_genes the per-upsert resolver forces SPLADE
+# ON even when splade_enabled = false; above
+# splade_auto_disable_above_genes it forces OFF even when
+# splade_enabled = true. Both `0` (the default) disables the toggle
+# entirely — byte-identical to pre-#164 behaviour. Replace with
+# non-zero values to opt in once the scale curve at
+# benchmarks/sweep_splade_scale_curve.py has identified the transition
+# band on your corpus shape.
+splade_auto_enable_below_genes = 0
+splade_auto_disable_above_genes = 0
+
 [context]
 # Cold-tier retrieval (C.2 of B->C, 2026-04-10)
 # Heterochromatin-tier genes are demoted by the density gate but their

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -196,6 +196,29 @@ class IngestionConfig:
     # This is purely the WRITE path — retrieval still gates on
     # [retrieval] dense_embedding_enabled (default true).
     dense_embed_on_ingest: bool = True
+    # Issue #164 (size-aware SPLADE auto-toggle): SPLADE expansion's value
+    # follows a corpus-regime curve -- the v2 EnterpriseRAG-Onyx storage
+    # breakdown showed SPLADE at 21.1% of disk on the 850K-gene fixture
+    # while contributing 0 pp recall@10 vs SPLADE-off at the same scale
+    # (n=5 + 100q in-flight; see issue body). Below ~50K it's likely useful;
+    # above ~200K it's likely net-negative (disk + p95 + SQL fan-out).
+    # When BOTH thresholds are 0 (default) the toggle is disabled and the
+    # static ``splade_enabled`` value governs every upsert -- byte-identical
+    # to pre-#164 behaviour. Setting either threshold to a positive value
+    # opts the genome in:
+    #   - splade_auto_enable_below_genes > 0: force SPLADE ON when the
+    #     current gene_count is strictly below the threshold, even if
+    #     ``splade_enabled = false``. The "sparse-corpus rescue" arm.
+    #   - splade_auto_disable_above_genes > 0: force SPLADE OFF when the
+    #     current gene_count is strictly above the threshold, even if
+    #     ``splade_enabled = true``. The "enterprise-scale storage cliff"
+    #     arm.
+    # Both default 0 (opt-in) because the scale curve in #164 is not yet
+    # empirically resolved across the 10K-100K transition band; conservative
+    # defaults will land in a follow-up once the per-fixture sweep is wired
+    # to a head-to-head SPLADE-on/off ablation across that range.
+    splade_auto_enable_below_genes: int = 0
+    splade_auto_disable_above_genes: int = 0
 
 
 @dataclass
@@ -684,6 +707,15 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             dense_embed_on_ingest=i.get(
                 "dense_embed_on_ingest", cfg.ingestion.dense_embed_on_ingest
             ),
+            # Issue #164: size-aware SPLADE auto-toggle thresholds.
+            splade_auto_enable_below_genes=int(i.get(
+                "splade_auto_enable_below_genes",
+                cfg.ingestion.splade_auto_enable_below_genes,
+            )),
+            splade_auto_disable_above_genes=int(i.get(
+                "splade_auto_disable_above_genes",
+                cfg.ingestion.splade_auto_disable_above_genes,
+            )),
         )
 
     # Context (cold-tier retrieval knobs — C.2 of B->C, 2026-04-10)

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -533,6 +533,10 @@ class HelixContextManager:
             synonym_map=config.synonym_map,
             sema_codec=self._sema_codec,
             splade_enabled=config.ingestion.splade_enabled,
+            # Issue #164: size-aware SPLADE auto-toggle thresholds. Both
+            # default 0 (toggle off); see IngestionConfig docstring.
+            splade_auto_enable_below_genes=config.ingestion.splade_auto_enable_below_genes,
+            splade_auto_disable_above_genes=config.ingestion.splade_auto_disable_above_genes,
             entity_graph=config.ingestion.entity_graph,
             # Tier-0 PR-1 (2026-05-16): inline BGE-M3 dense write at ingest.
             dense_embed_on_ingest=config.ingestion.dense_embed_on_ingest,

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -387,6 +387,14 @@ class KnowledgeStore:
         # a precomputed vector). This is the WRITE path only and is
         # independent of dense_embedding_enabled, which gates RETRIEVAL.
         dense_embed_on_ingest: bool = False,
+        # Issue #164: size-aware SPLADE auto-toggle thresholds. Both
+        # default 0 (toggle off; ``splade_enabled`` is authoritative on
+        # every upsert). When non-zero, ``upsert_doc`` consults the
+        # current ``gene_count`` per upsert and routes through
+        # ``storage.indexes.resolve_splade_enabled``. See IngestionConfig
+        # docstring for the regime curve rationale.
+        splade_auto_enable_below_genes: int = 0,
+        splade_auto_disable_above_genes: int = 0,
         # Issue #139 (2026-05-18): default recalibrated 0.35 -> 0.58 for the
         # dim-1024 BGE-M3 v2 vectors. Callers normally pass the configured
         # value (config.retrieval.ann_similarity_threshold); this default is
@@ -454,6 +462,13 @@ class KnowledgeStore:
         self._sema_codec = sema_codec  # Optional SemaCodec for Tier 4 retrieval
         self._replication_mgr = None  # Set by set_replication_manager()
         self._splade_enabled = splade_enabled
+        # Issue #164: per-upsert SPLADE auto-toggle thresholds.
+        self._splade_auto_enable_below: int = int(splade_auto_enable_below_genes or 0)
+        self._splade_auto_disable_above: int = int(splade_auto_disable_above_genes or 0)
+        # Cached gene_count used by the per-upsert auto-toggle resolver.
+        # Refreshed lazily from the DB on each upsert that has the toggle
+        # opted in; avoids hammering COUNT(*) when the toggle is off.
+        self._splade_auto_cached_count: int = 0
         self._entity_graph_enabled = entity_graph
         # Tier 5b: entity graph retrieval boost (Step 3C, 2026-05-08).
         # Separate from _entity_graph_enabled (write-side) — this controls
@@ -612,8 +627,16 @@ class KnowledgeStore:
         else:
             self._reader = None
 
-        # Create SPLADE inverted index if enabled
-        if self._splade_enabled:
+        # Create SPLADE inverted index if enabled, or if the size-aware
+        # auto-toggle (issue #164) could turn it on later. Without this
+        # table the auto-enable arm has nowhere to write and silently
+        # no-ops, so any non-zero ``splade_auto_enable_below_genes`` --
+        # even paired with ``splade_enabled=False`` -- still warrants
+        # the table.
+        _need_splade_table = (
+            self._splade_enabled or self._splade_auto_enable_below > 0
+        )
+        if _need_splade_table:
             try:
                 from .backends import splade_backend
                 splade_backend.create_splade_table(self.conn)
@@ -1249,14 +1272,32 @@ class KnowledgeStore:
             sync_path_key_index,
             sync_filename_index,
             sync_splade_index,
+            resolve_splade_enabled,
         )
         rebuild_promoter_index(cur, gene_id, gene)
         sync_fts5(cur, gene_id, gene, self._fts_available)
         sync_entity_graph(cur, gene_id, gene, self._entity_graph_enabled)
         sync_path_key_index(cur, gene_id, gene)
         sync_filename_index(cur, gene_id, gene.source_id)
+        # Issue #164: size-aware SPLADE auto-toggle. Refresh the cached
+        # gene_count whenever EITHER threshold is opted in; otherwise
+        # the resolver short-circuits to the static flag and the count
+        # is unused.
+        if self._splade_auto_enable_below > 0 or self._splade_auto_disable_above > 0:
+            try:
+                self._splade_auto_cached_count = int(
+                    cur.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+                )
+            except sqlite3.Error:
+                self._splade_auto_cached_count = 0
+        effective_splade = resolve_splade_enabled(
+            splade_enabled=self._splade_enabled,
+            current_gene_count=self._splade_auto_cached_count,
+            auto_enable_below=self._splade_auto_enable_below,
+            auto_disable_above=self._splade_auto_disable_above,
+        )
         sync_splade_index(
-            cur, gene_id, gene.content, self._splade_enabled,
+            cur, gene_id, gene.content, effective_splade,
             splade_sparse=splade_sparse,
         )
 

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -933,6 +933,9 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
                 synonym_map=config.synonym_map,
                 sema_codec=getattr(helix, "_sema_codec", None),
                 splade_enabled=config.ingestion.splade_enabled,
+                # Issue #164: size-aware SPLADE auto-toggle thresholds.
+                splade_auto_enable_below_genes=config.ingestion.splade_auto_enable_below_genes,
+                splade_auto_disable_above_genes=config.ingestion.splade_auto_disable_above_genes,
                 entity_graph=config.ingestion.entity_graph,
                 sr_enabled=config.retrieval.sr_enabled,
                 sr_gamma=config.retrieval.sr_gamma,

--- a/helix_context/storage/indexes.py
+++ b/helix_context/storage/indexes.py
@@ -153,6 +153,61 @@ def sync_filename_index(
 # SPLADE sparse index
 # ---------------------------------------------------------------------------
 
+def resolve_splade_enabled(
+    splade_enabled: bool,
+    current_gene_count: int,
+    auto_enable_below: int = 0,
+    auto_disable_above: int = 0,
+) -> bool:
+    """Apply the size-aware SPLADE auto-toggle (issue #164).
+
+    The static ``splade_enabled`` flag is overridden when the corpus
+    crosses one of the two opt-in thresholds:
+
+      - ``auto_enable_below > 0`` and ``current_gene_count <
+        auto_enable_below``: force ON (sparse-corpus rescue arm). Used
+        when the user wants SPLADE only on small corpora where lexical
+        expansion is most likely to rescue a paraphrase mismatch.
+
+      - ``auto_disable_above > 0`` and ``current_gene_count >
+        auto_disable_above``: force OFF (enterprise-scale storage cliff
+        arm). Used when SPLADE's disk + p95 + SQL fan-out cost dominates
+        at the head of the corpus-size distribution and recall doesn't
+        move (see #164 storage breakdown).
+
+    When BOTH thresholds are ``0`` (the default opt-in floor) the static
+    flag is returned unchanged -- byte-identical to pre-#164 behaviour.
+    When the corpus is in the gray band (``auto_enable_below <=
+    current_gene_count <= auto_disable_above``) the static
+    ``splade_enabled`` value also wins; the toggle is only authoritative
+    at the named ends of the size curve.
+
+    Boundary semantics (deliberately strict so the toggle is a hard
+    binary at the bound, not a fuzzy band):
+      - ``current_gene_count == auto_enable_below`` -> NOT auto-enabled
+        (caller is at-or-above the rescue ceiling)
+      - ``current_gene_count == auto_disable_above`` -> NOT auto-disabled
+        (caller is at-or-below the disable floor)
+
+    Caller contract for ``current_gene_count``:
+        ``upsert_doc`` queries ``COUNT(*) FROM genes`` AFTER the row's
+        INSERT (the INSERT runs before the index-population stage), so
+        ``current_gene_count`` includes the gene being upserted. With
+        ``auto_disable_above_genes=N`` the disable arm fires on the
+        ``(N+1)``-th gene to be upserted.
+
+    Return value:
+        The effective ``splade_enabled`` for the current upsert. The
+        caller (typically ``sync_splade_index``) writes nothing when this
+        is ``False``.
+    """
+    if auto_disable_above > 0 and current_gene_count > auto_disable_above:
+        return False
+    if auto_enable_below > 0 and current_gene_count < auto_enable_below:
+        return True
+    return bool(splade_enabled)
+
+
 def sync_splade_index(
     cur: sqlite3.Cursor,
     gene_id: str,

--- a/tests/test_splade_size_aware_toggle.py
+++ b/tests/test_splade_size_aware_toggle.py
@@ -1,0 +1,298 @@
+"""Size-aware SPLADE auto-toggle (issue #164).
+
+Tests for ``resolve_splade_enabled`` (pure resolver) and the
+``KnowledgeStore.upsert_doc`` integration that consults it per upsert.
+
+The resolver is the unit test surface; the integration test verifies the
+``upsert_doc`` path honors the resolved decision by inspecting the
+``splade_terms`` table after a series of upserts that cross the
+threshold.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from helix_context.knowledge_store import KnowledgeStore
+from helix_context.schemas import Gene
+from helix_context.storage.indexes import resolve_splade_enabled
+
+
+# ── 1. resolve_splade_enabled — pure resolver ────────────────────────────
+
+
+class TestResolveSpladeEnabled:
+    """The pure resolver: no DB, no side effects."""
+
+    def test_default_off_is_byte_identical_to_static(self):
+        """Both thresholds 0 -> static flag wins (byte-identical to pre-#164)."""
+        assert resolve_splade_enabled(True, 0) is True
+        assert resolve_splade_enabled(True, 1_000_000) is True
+        assert resolve_splade_enabled(False, 0) is False
+        assert resolve_splade_enabled(False, 1_000_000) is False
+
+    def test_auto_enable_below_overrides_static_off(self):
+        """``current < auto_enable_below`` -> force ON even if static OFF."""
+        assert resolve_splade_enabled(
+            splade_enabled=False, current_gene_count=100,
+            auto_enable_below=50_000,
+        ) is True
+
+    def test_auto_disable_above_overrides_static_on(self):
+        """``current > auto_disable_above`` -> force OFF even if static ON."""
+        assert resolve_splade_enabled(
+            splade_enabled=True, current_gene_count=200_001,
+            auto_disable_above=200_000,
+        ) is False
+
+    def test_gray_band_respects_static_flag(self):
+        """Between thresholds -> static flag is authoritative."""
+        for static in (True, False):
+            assert resolve_splade_enabled(
+                splade_enabled=static, current_gene_count=75_000,
+                auto_enable_below=50_000,
+                auto_disable_above=200_000,
+            ) is static
+
+    def test_boundary_at_enable_threshold_is_not_auto_enabled(self):
+        """``current == auto_enable_below`` -> static flag wins.
+
+        Strict inequality means the threshold is the smallest count at
+        which auto-enable is NOT applied. Documented in the resolver
+        docstring as the deliberate-binary behaviour at the bound.
+        """
+        assert resolve_splade_enabled(
+            splade_enabled=False, current_gene_count=50_000,
+            auto_enable_below=50_000,
+        ) is False
+
+    def test_boundary_at_disable_threshold_is_not_auto_disabled(self):
+        """``current == auto_disable_above`` -> static flag wins."""
+        assert resolve_splade_enabled(
+            splade_enabled=True, current_gene_count=200_000,
+            auto_disable_above=200_000,
+        ) is True
+
+    def test_disable_above_takes_precedence_over_enable_below(self):
+        """Pathological config: enable_below > disable_above. The disable
+        arm wins when ``current > disable_above`` -- the resolver's order
+        of checks is documented and stable.
+        """
+        # Pathological: caller asked to auto-enable up to 1M and
+        # auto-disable above 100K. current=500K > 100K -> OFF wins.
+        assert resolve_splade_enabled(
+            splade_enabled=True, current_gene_count=500_000,
+            auto_enable_below=1_000_000,
+            auto_disable_above=100_000,
+        ) is False
+
+
+# ── 2. upsert_doc integration ────────────────────────────────────────────
+
+
+def _make_gene(content: str, suffix: str = "") -> Gene:
+    """Fresh Gene with content-derived gene_id so successive
+    ``upsert_doc`` calls insert rather than update.
+    """
+    payload = content + suffix
+    return Gene(
+        gene_id=KnowledgeStore.make_gene_id(payload),
+        content=content,
+        complement=f"Summary: {content[:40]}",
+        codons=["chunk_0"],
+        source_id=f"test://size-aware/{suffix}",
+    )
+
+
+class TestUpsertDocAutoToggleIntegration:
+    """End-to-end through ``upsert_doc``: thresholds drive whether
+    ``splade_terms`` rows land for a given upsert.
+    """
+
+    def test_static_on_default_behaviour_unchanged(self, tmp_path):
+        """Default (both thresholds 0) - splade_enabled=True always writes."""
+        ks = KnowledgeStore(
+            path=str(tmp_path / "g.db"), synonym_map={},
+            splade_enabled=True,
+        )
+        try:
+            ks.upsert_doc(
+                _make_gene("alpha content one", "a"), apply_gate=False,
+                splade_sparse={"t1": 1.0},
+            )
+            ks.upsert_doc(
+                _make_gene("beta content two", "b"), apply_gate=False,
+                splade_sparse={"t2": 1.0},
+            )
+            rows = ks.conn.execute(
+                "SELECT gene_id FROM splade_terms"
+            ).fetchall()
+            assert len(rows) == 2
+        finally:
+            ks.close()
+
+    def test_auto_disable_above_skips_splade_when_corpus_grows(self, tmp_path):
+        """When ``current_gene_count > auto_disable_above`` the SPLADE
+        write is skipped even though the static flag is True.
+
+        ``current_gene_count`` includes the gene being upserted (the
+        ``INSERT INTO genes`` runs before the index-population stage in
+        ``upsert_doc``). So with threshold=2:
+
+          - Upsert #1: count=1, 1 > 2 false -> SPLADE ON
+          - Upsert #2: count=2, 2 > 2 false -> SPLADE ON
+          - Upsert #3: count=3, 3 > 2 true  -> SPLADE OFF
+
+        Result: 2 distinct gene_ids land SPLADE rows; the third is
+        auto-disabled.
+        """
+        ks = KnowledgeStore(
+            path=str(tmp_path / "g.db"), synonym_map={},
+            splade_enabled=True,
+            splade_auto_disable_above_genes=2,
+        )
+        try:
+            ks.upsert_doc(
+                _make_gene("alpha", "a"), apply_gate=False,
+                splade_sparse={"t1": 1.0},
+            )
+            ks.upsert_doc(
+                _make_gene("beta", "b"), apply_gate=False,
+                splade_sparse={"t2": 1.0},
+            )
+            ks.upsert_doc(
+                _make_gene("gamma", "c"), apply_gate=False,
+                splade_sparse={"t3": 1.0},
+            )
+
+            distinct = ks.conn.execute(
+                "SELECT COUNT(DISTINCT gene_id) FROM splade_terms"
+            ).fetchone()[0]
+            assert distinct == 2, (
+                f"expected the 3rd upsert's SPLADE to be auto-disabled; "
+                f"got {distinct} distinct gene_ids in splade_terms"
+            )
+        finally:
+            ks.close()
+
+    def test_auto_enable_below_forces_splade_when_corpus_small(self, tmp_path):
+        """When ``current_gene_count < auto_enable_below`` SPLADE writes
+        land even though the static flag is False.
+
+        ``current_gene_count`` includes the gene being upserted. So with
+        threshold=4 and static_off:
+
+          - Upsert #1: count=1, 1 < 4 true  -> forced ON
+          - Upsert #2: count=2, 2 < 4 true  -> forced ON
+          - Upsert #3: count=3, 3 < 4 true  -> forced ON
+          - Upsert #4: count=4, 4 < 4 false -> static (False) wins -> OFF
+
+        Result: first three upserts land SPLADE; the fourth does not.
+        """
+        ks = KnowledgeStore(
+            path=str(tmp_path / "g.db"), synonym_map={},
+            splade_enabled=False,    # statically OFF
+            splade_auto_enable_below_genes=4,
+        )
+        try:
+            ks.upsert_doc(
+                _make_gene("alpha", "a"), apply_gate=False,
+                splade_sparse={"t1": 1.0},
+            )
+            ks.upsert_doc(
+                _make_gene("beta", "b"), apply_gate=False,
+                splade_sparse={"t2": 1.0},
+            )
+            ks.upsert_doc(
+                _make_gene("gamma", "c"), apply_gate=False,
+                splade_sparse={"t3": 1.0},
+            )
+            ks.upsert_doc(
+                _make_gene("delta", "d"), apply_gate=False,
+                splade_sparse={"t4": 1.0},
+            )
+
+            distinct = ks.conn.execute(
+                "SELECT COUNT(DISTINCT gene_id) FROM splade_terms"
+            ).fetchone()[0]
+            assert distinct == 3, (
+                f"first three upserts should land SPLADE rows via "
+                f"auto-enable-below; got {distinct}"
+            )
+        finally:
+            ks.close()
+
+    def test_static_off_with_thresholds_zero_writes_nothing(self, tmp_path):
+        """splade_enabled=False with both thresholds 0 -> SPLADE never
+        writes (the byte-identical pre-#164 negative-path control).
+
+        Pre-#164 behaviour skipped creating the ``splade_terms`` table
+        entirely when SPLADE was off; that is preserved when both
+        thresholds are 0. We assert either the table is absent OR (if
+        present for some unrelated reason) it has zero rows.
+        """
+        ks = KnowledgeStore(
+            path=str(tmp_path / "g.db"), synonym_map={},
+            splade_enabled=False,
+        )
+        try:
+            for s in ("a", "b", "c"):
+                ks.upsert_doc(
+                    _make_gene(f"content-{s}", s), apply_gate=False,
+                    splade_sparse={"t": 1.0},
+                )
+            has_table = ks.conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='splade_terms'"
+            ).fetchone()[0]
+            if has_table:
+                row = ks.conn.execute(
+                    "SELECT COUNT(*) FROM splade_terms"
+                ).fetchone()
+                assert row[0] == 0
+            # The pre-#164 path (both thresholds 0) skips table
+            # creation entirely; that's the byte-identical control.
+        finally:
+            ks.close()
+
+
+# ── 3. config plumbing ────────────────────────────────────────────────────
+
+
+class TestConfigPlumbing:
+    """The two thresholds round-trip through the dataclass + TOML loader."""
+
+    def test_defaults_are_off(self):
+        from helix_context.config import IngestionConfig
+        cfg = IngestionConfig()
+        assert cfg.splade_auto_enable_below_genes == 0
+        assert cfg.splade_auto_disable_above_genes == 0
+
+    def test_loader_reads_overrides(self, tmp_path):
+        from helix_context.config import load_config
+
+        path = tmp_path / "helix.toml"
+        path.write_text(
+            "[ingestion]\n"
+            "splade_enabled = true\n"
+            "splade_auto_enable_below_genes = 5000\n"
+            "splade_auto_disable_above_genes = 250000\n",
+            encoding="utf-8",
+        )
+
+        cfg = load_config(str(path))
+        assert cfg.ingestion.splade_auto_enable_below_genes == 5000
+        assert cfg.ingestion.splade_auto_disable_above_genes == 250000
+
+    def test_knowledge_store_stores_thresholds(self, tmp_path):
+        ks = KnowledgeStore(
+            path=str(tmp_path / "g.db"), synonym_map={},
+            splade_enabled=True,
+            splade_auto_enable_below_genes=7,
+            splade_auto_disable_above_genes=70,
+        )
+        try:
+            assert ks._splade_auto_enable_below == 7
+            assert ks._splade_auto_disable_above == 70
+        finally:
+            ks.close()


### PR DESCRIPTION
Closes #164 (plumbing portion; production threshold flip deferred to a follow-up gated on the scale curve).

## Summary

Adds the two `splade_auto_*_genes` knobs the issue calls for so SPLADE can be auto-disabled at the head of the corpus-size distribution (where its 21.1%-of-disk cost on the 850K Onyx fixture contributed 0 pp recall@10 in the issue's measurements) or auto-enabled at the tail (where lexical expansion is most likely to rescue paraphrase mismatch). Conservative opt-in defaults (`0` -> toggle disabled), so behaviour is byte-identical to pre-#164 until the operator opts in.

## Knobs

Both live in `[ingestion]`:

```toml
splade_auto_enable_below_genes = 0    # force SPLADE ON when corpus < N
splade_auto_disable_above_genes = 0   # force SPLADE OFF when corpus > N
```

`0` (default) disables the toggle entirely -- byte-identical to pre-#164. Setting either to a positive value opts the genome in.

## Wire-up

- `IngestionConfig` (helix_context/config.py): two new `int` fields, plumbed through the TOML loader.
- `resolve_splade_enabled` (helix_context/storage/indexes.py): pure resolver with documented strict-inequality boundary semantics. Static flag wins in the gray band and at-the-bound; when both thresholds are 0 the static flag is byte-identically authoritative.
- `KnowledgeStore.upsert_doc`: queries `COUNT(*) FROM genes` after the row INSERT and routes through `resolve_splade_enabled`. The COUNT is skipped (no perf regression) when both thresholds are 0. The `splade_terms` table is now also created when `splade_auto_enable_below_genes > 0` so the auto-enable arm has somewhere to write even with `splade_enabled=false`.
- `HelixContextManager` + admin `/reload-genome`: forward the two new fields through `open_read_source` so both boot and hot-swap paths pick them up.
- `helix.toml`: documented `[ingestion]` block with `0` default + pointer to the scale-curve scaffold.

## Bench scaffold (`benchmarks/sweep_splade_scale_curve.py`)

Reports `recall@10`, `MRR`, `p95` latency, and `disk_bytes_per_gene` per SPLADE-on / SPLADE-off arm across the canonical scale points (1K -> 850K). Skips a scale point whose `.db` is missing rather than failing -- the runner is end-to-end tested but actual SPLADE-on/off twin builds (multi-hour at 50K+) are gated on dev-box budget the CI loop doesn't own. Default thresholds therefore stay 0 pending real data.

Smoke run produced sensible numbers on `small.db`:
- `splade_rows = 144,743` over 1238 genes -> ~117 SPLADE terms / gene (issue body cites 121/gene avg across 850K -> matches)
- `disk_bytes_per_gene = 38 KB` (mostly code, code-heavy expected)

## Test plan

- [x] 14 new tests in `tests/test_splade_size_aware_toggle.py` covering resolver (7), `upsert_doc` integration (4), config plumbing (3). All four corners of the resolver matrix (static-on/off x auto-enable/disable) pinned plus the byte-identical default-off control.
- [x] Regression: 66 tests passed across `test_splade_size_aware_toggle.py + test_splade_precompute.py + test_dense_recall.py + test_config.py + test_build_fixture_matrix_parallel.py + test_ann_threshold.py + test_admin_refresh.py`.
- [x] Bench scaffold `--help` works; smoke run produced valid metrics.
- [ ] (Follow-up) Build SPLADE-on/off twin fixtures + run the curve to set thresholds from data.

## Left to follow-up

1. **Run the scale curve.** Build SPLADE-off twin `.db`s for at least the 1K / 10K / 25K / 47K / 100K scale points and run the new scaffold to identify the actual transition band. Issue body's regime map (enable < 50K, disable > 200K) is a hypothesis, not a result. Once the curve lands, ship the production threshold flip in a follow-up PR.

2. **Wire the toggle through `scripts/build_fixture_matrix.py`.** `build_profile` and `_build_one_shard` currently hard-code `splade_enabled=True` rather than reading from the config; adding `--splade-auto-enable-below` / `--splade-auto-disable-above` CLI flags would let the fixture-matrix produce SPLADE-off twins without monkeypatching.

3. **Per-shard SPLADE policy phase-2** (issue body section "Phase 2: per-shard SPLADE policy"). The `linear` / `slack__incidents` / `google-drive` shards are structurally different from a 1K Confluence shard and warrant their own decision.

Refs: #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)