### PR TITLE
fix(tests): de-flake suite — GPU livelock, persist livelock, README-v3 doc contracts, WSL bash shim

### DIFF
--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -547,6 +547,21 @@ def ingest_tree(
 # ── Build one profile ─────────────────────────────────────────────────────
 
 
+def _env_flag(name: str, default: str = "1") -> bool:
+    """Read a boolean env toggle. Truthy unless set to 0/false/no/off.
+
+    Used for the test/CI kill-switches ``HELIX_BFM_SPLADE`` and
+    ``HELIX_BFM_DENSE_BACKFILL``. Read at call time (not import time) and
+    inherited by spawn workers via the process environment, so a test can
+    ``monkeypatch.setenv`` in the parent and have the ProcessPoolExecutor
+    children honour it — monkeypatching module attributes does NOT cross
+    the Windows spawn boundary.
+    """
+    return os.environ.get(name, default).strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
 def _backfill_dense(db_path: str) -> dict:
     """Post-build pass: populate ``genes.embedding_dense_v2`` on ``db_path``.
 
@@ -577,6 +592,16 @@ def _backfill_dense(db_path: str) -> dict:
     and an ``error`` key is returned, so a dense-encode failure surfaces
     in the manifest rather than silently producing a dense-dark fixture.
     """
+    if not _env_flag("HELIX_BFM_DENSE_BACKFILL"):
+        log.info(
+            "dense backfill skipped (HELIX_BFM_DENSE_BACKFILL=0): %s", db_path,
+        )
+        return {
+            "db_path": db_path,
+            "dense_coverage": 0.0,
+            "rows_processed": 0,
+            "skipped": True,
+        }
     log.info("dense backfill: %s", db_path)
     try:
         report = backfill_dense_db(db_path, log_fn=lambda msg: log.info("%s", msg))
@@ -630,7 +655,7 @@ def build_profile(
     genome = Genome(
         path=db_path,
         synonym_map={},
-        splade_enabled=True,
+        splade_enabled=_env_flag("HELIX_BFM_SPLADE"),
         entity_graph=True,
     )
 
@@ -898,7 +923,7 @@ def _build_one_shard(
 
     shard = Genome(
         path=str(p), synonym_map={},
-        splade_enabled=True, entity_graph=True,
+        splade_enabled=_env_flag("HELIX_BFM_SPLADE"), entity_graph=True,
     )
     s_stats = {
         "files": 0, "genes": 0, "skipped": 0, "errors": 0,

--- a/tests/test_build_fixture_matrix_parallel.py
+++ b/tests/test_build_fixture_matrix_parallel.py
@@ -51,6 +51,23 @@ def _collect_gene_summary(db_path: Path) -> set[tuple[str, str]]:
     }
 
 
+@pytest.fixture(autouse=True)
+def _lean_builder_env(monkeypatch):
+    """Force the lean ingest path for every test in this module.
+
+    Without these, ``_build_one_shard`` loads SPLADE + BGE-M3 onto the
+    GPU **in every spawn worker AND the parent** — three CUDA contexts on
+    a <=12 GB card is the documented #176 WDDM-spill livelock and hung the
+    whole suite (parent stuck in ``as_completed`` while workers crept at
+    the serialized-VRAM floor). Parity assertions here compare shard
+    routing + fingerprint rows, which are independent of SPLADE/dense.
+    Env vars (unlike monkeypatched module attrs) cross the Windows spawn
+    boundary, so the workers inherit the kill-switches.
+    """
+    monkeypatch.setenv("HELIX_BFM_SPLADE", "0")
+    monkeypatch.setenv("HELIX_BFM_DENSE_BACKFILL", "0")
+
+
 @pytest.mark.slow
 def test_parallel_matches_sequential(tmp_path, monkeypatch):
     """build_profile(parallel=False) and (parallel=True) should produce

--- a/tests/test_install_observability.py
+++ b/tests/test_install_observability.py
@@ -109,6 +109,19 @@ def test_bash_install_script_parses():
     if bash is None:
         pytest.skip("bash not on PATH")
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    # Windows ships a WindowsApps ``bash.EXE`` shim that relays into WSL;
+    # when no (working) WSL distro is installed it exits non-zero with
+    # "execvpe(/bin/bash) failed" without parsing anything. Probe it
+    # before trusting it as a syntax checker.
+    probe = subprocess.run(
+        [bash, "-c", "true"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        creationflags=creationflags,
+    )
+    if probe.returncode != 0:
+        pytest.skip(f"bash present but not functional: {probe.stderr.strip()[:120]}")
     proc = subprocess.run(
         [bash, "-n", str(SH_SCRIPT)],
         capture_output=True,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -168,7 +168,17 @@ class TestResetLifetime:
 
 
 class TestThreadSafety:
-    def test_concurrent_adds_are_atomic(self, counter):
+    def test_concurrent_adds_are_atomic(self, counter_path):
+        # NOTE: deliberately NOT the shared ``counter`` fixture. That
+        # fixture sets ``persist_interval_s=0.0`` so persistence tests can
+        # trigger a write on every add — but here 10 threads x 10k adds
+        # would then do 200,000 locked mkstemp+os.replace disk writes
+        # (each one AV-scanned on Windows), turning a <1s atomicity check
+        # into a multi-minute suite-hanger. A long interval keeps every
+        # add in-memory, which is exactly what this test measures.
+        counter = TokenCounter(
+            persist_path=counter_path, persist_interval_s=3600.0,
+        )
         # 10 threads, each adding (1, 1) ten thousand times.
         # Final session total should be exactly 200000.
         N_THREADS = 10

--- a/tests/test_observability_docs.py
+++ b/tests/test_observability_docs.py
@@ -38,48 +38,63 @@ def _read(rel: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_root_readme_has_native_observability_section():
+# NOTE (post README-v3, commit 97e1ed6): the proof-first restructure moved
+# the deep observability / tray / Docker content out of the root README and
+# into docs/SETUP.md + docs/architecture/OBSERVABILITY.md. These four tests
+# now pin the v3 contract: README keeps a compact "## Observability" section
+# that links out, and the moved content must actually exist at the link
+# targets so the chain README -> SETUP/OBSERVABILITY -> deploy/otel stays
+# unbroken.
+
+
+def test_root_readme_has_observability_section():
     body = _read("README.md")
-    assert "Native observability (default)" in body, (
-        "Root README is missing the 'Native observability (default)' section"
+    assert "## Observability" in body, (
+        "Root README is missing the '## Observability' section"
+    )
+    assert "setup-grafana-telem" in body, (
+        "Root README's Observability section must show the sidecar setup script"
+    )
+    assert "docs/architecture/OBSERVABILITY.md" in body, (
+        "Root README must link to the full observability doc"
     )
 
 
-def test_root_readme_mentions_tray_lifecycle_and_opt_out():
-    body = _read("README.md")
-    # Tray manages the binaries' lifecycle.
-    assert "tray" in body.lower()
-    # Opt-out env var is documented.
-    assert "HELIX_OBSERVABILITY=0" in body, (
-        "Root README must document the HELIX_OBSERVABILITY=0 opt-out"
+def test_setup_doc_carries_tray_lifecycle_and_opt_out():
+    # v3 moved tray lifecycle + opt-out documentation to docs/SETUP.md;
+    # the README must link there and the content must exist.
+    readme = _read("README.md")
+    assert "docs/SETUP.md" in readme, "Root README must link to docs/SETUP.md"
+    setup = _read("docs/SETUP.md")
+    assert "tray" in setup.lower()
+    assert "HELIX_OBSERVABILITY" in setup, (
+        "docs/SETUP.md must document the HELIX_OBSERVABILITY=0 opt-out"
     )
-    # Native binaries directory is referenced.
-    assert "tools/native-otel" in body
+    assert "tools/native-otel" in setup
 
 
-def test_root_readme_demotes_docker_to_advanced_footnote():
-    body = _read("README.md")
-    # The docker-compose mention is now framed as "Advanced — Docker stack",
-    # not as the primary install path.
-    assert "Advanced" in body and "Docker" in body
-    # Footnote points at the new doc.
-    assert "deploy/otel/README.md" in body, (
-        "Root README must link to deploy/otel/README.md"
+def test_setup_doc_keeps_docker_as_alternate_path():
+    # The docker-compose stack stays documented as the alternate (not
+    # primary) path, now from docs/SETUP.md rather than the root README.
+    setup = _read("docs/SETUP.md")
+    assert "deploy/otel" in setup, (
+        "docs/SETUP.md must point at the deploy/otel Docker stack"
     )
+    assert "docker" in setup.lower()
 
 
 def test_root_readme_preserves_canonical_launch_section():
-    """Regression: don't rip out existing Quick Start ▸ Launch content.
+    """Regression: don't rip out the launch/get-started content.
 
-    The original 'Canonical path' marker was reworded by the R2 rename
-    sweep (commit 5c00a21); pin on the section header + the tray entry
-    point, both of which the launch flow can't function without.
+    README v3 renamed 'Quick Start' to 'Get started'; the tray entry point
+    (start-helix-tray.bat) is documented in docs/SETUP.md.
     """
     body = _read("README.md")
-    assert "## Quick Start" in body, (
-        "Root README must keep the '## Quick Start' section"
+    assert "## Get started" in body or "## Quick Start" in body, (
+        "Root README must keep a Get started / Quick Start section"
     )
-    assert "start-helix-tray.bat" in body.lower()
+    setup = _read("docs/SETUP.md")
+    assert "start-helix-tray.bat" in setup.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Full-suite QA on a Windows dev rig (12 GB VRAM, Ollama resident) found two suite-hanging tests and five failures, **all reproducible on clean master** (verified at 27fe5fc). With these fixes + the 8 open PRs merged as a train, the suite is green: **2259 passed**.

## 1. `test_sharded_pool_matches_serial` hung the entire suite (GPU livelock)
Parent + 2 spawn workers each loaded SPLADE + BGE-M3 onto `cuda:0` — three CUDA contexts on a <=12 GB card is the documented #176 WDDM-spill livelock. Workers crept at the serialized-VRAM floor; faulthandler showed the parent parked in `as_completed` (orphaned workers were still stuck 10+ min after the run was killed). On Windows, pytest-timeout's `thread` method then kills the whole run.

**Fix:** `HELIX_BFM_SPLADE` / `HELIX_BFM_DENSE_BACKFILL` env kill-switches in `build_fixture_matrix` (read at call time and inherited across the spawn boundary — module monkeypatches are not), plus an autouse fixture forcing the lean path for the parity module. Parity assertions compare shard routing + fingerprint rows, independent of SPLADE/dense. File now runs in ~35s.

## 2. `test_concurrent_adds_are_atomic` multi-minute hang
The shared fixture's `persist_interval_s=0.0` made 10x10k adds perform 200,000 locked `mkstemp`+`os.replace` disk writes (each AV-scanned on Windows). The atomicity test now builds its own counter with a 1h interval; persistence tests keep the 0.0 fixture.

## 3. Four `test_observability_docs` failures (stale doc contract)
Still pinned the pre-v3 README layout; the v3 restructure (97e1ed6) moved tray/Docker/opt-out content to `docs/SETUP.md`. Re-pinned to the v3 contract: README keeps a compact Observability section + links, and the link targets must carry the moved content (chain README -> SETUP/OBSERVABILITY -> deploy/otel stays unbroken).

## 4. `test_bash_install_script_parses` false failure
Windows' WindowsApps `bash.EXE` is a WSL relay that fails with `execvpe(/bin/bash)` when no working distro exists. Probe `bash -c true` first; skip when non-functional.

## Test plan
- [x] `test_build_fixture_matrix_parallel.py` — 14 passed in 34.9s (was: suite-killer)
- [x] `test_observability_docs.py + test_install_observability.py + test_metrics.py` — 49 passed, 1 skipped
- [x] Merges clean with all 8 open PRs (validated on the merge train)