### PR TITLE
fix(sharding): MAX_PATH overflow guard for mirrored corpus-shard paths

### DIFF
--- a/helix_context/sharding.py
+++ b/helix_context/sharding.py
@@ -24,6 +24,7 @@ axis and can be layered in later without moving files.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 from pathlib import Path, PurePath
@@ -73,13 +74,51 @@ def corpus_shard_dir(
     return root / rel
 
 
+# Windows' classic MAX_PATH is 260; the mirrored layout can exceed it when a
+# deep source root (e.g. a pytest tmp dir under
+# ``C:/Users/<u>/AppData/Local/Temp/pytest-of-<u>/pytest-NNNN/...``) is
+# mirrored under an already-deep ``genomes_root``. sqlite3's C layer does not
+# reliably honour long-path opt-in, so we cap conservatively and fall back to
+# a compact deterministic location. Overridable for tests / long-path-enabled
+# hosts via ``HELIX_SHARD_PATH_MAX``.
+_SHARD_PATH_MAX_DEFAULT = 240
+
+
+def _shard_path_max() -> int:
+    raw = os.environ.get("HELIX_SHARD_PATH_MAX", "").strip()
+    try:
+        return int(raw) if raw else _SHARD_PATH_MAX_DEFAULT
+    except ValueError:
+        return _SHARD_PATH_MAX_DEFAULT
+
+
 def corpus_shard_db(
     source_root: str,
     label: str,
     genomes_root: os.PathLike[str] | str,
 ) -> Path:
-    """Return ``<corpus_shard_dir>/<label>.genome.db``."""
-    return corpus_shard_dir(source_root, genomes_root) / f"{label}.genome.db"
+    """Return ``<corpus_shard_dir>/<label>.genome.db``.
+
+    MAX_PATH guard: when the mirrored path would exceed
+    ``HELIX_SHARD_PATH_MAX`` (default 240) characters, return
+    ``<genomes_root>/_overflow/<label>-<digest10>.genome.db`` instead, where
+    ``digest10`` is a stable sha1 of the mirrored relative path. The
+    function stays deterministic in ``(source_root, label, genomes_root)``,
+    so resume/salvage paths recompute identically; the full source root is
+    still recoverable from the ``main.genome.db`` registration, which is
+    the routing source of truth (``IngestTargetRouter`` takes explicit
+    pairs and is unaffected). Only the overflow case trades away the
+    self-identifying filename.
+    """
+    mirrored = corpus_shard_dir(source_root, genomes_root) / f"{label}.genome.db"
+    if len(str(mirrored)) <= _shard_path_max():
+        return mirrored
+    drive = drive_prefix(source_root)
+    rel = strip_drive(source_root)
+    digest = hashlib.sha1(
+        f"{drive or ''}/{rel}".encode("utf-8")
+    ).hexdigest()[:10]
+    return Path(genomes_root) / "_overflow" / f"{label}-{digest}.genome.db"
 
 
 def agent_shard_db(

--- a/tests/test_sharding_max_path.py
+++ b/tests/test_sharding_max_path.py
@@ -1,0 +1,75 @@
+"""MAX_PATH overflow guard for the mirrored corpus-shard layout.
+
+The filesystem-mirroring layout (``genomes/<drive>/<source path>/<label>
+.genome.db``) is self-identifying by design, but a deep source root mirrored
+under a deep ``genomes_root`` can exceed Windows' classic 260-char MAX_PATH
+(observed: pytest tmp roots mirrored under a pytest-tmp out dir produced
+``...pool\\C\\Users\\...\\Temp\\pytest-of-...\\rootA\\roota.genome.db``).
+``corpus_shard_db`` now falls back to a compact deterministic
+``_overflow/<label>-<digest10>.genome.db`` path beyond the cap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from helix_context.sharding import corpus_shard_db, corpus_shard_dir
+
+
+SHORT_ROOT = "F:/Projects/helix-context"
+
+
+def test_short_paths_keep_mirrored_layout(tmp_path):
+    db = corpus_shard_db(SHORT_ROOT, "helix", tmp_path)
+    assert db == corpus_shard_dir(SHORT_ROOT, tmp_path) / "helix.genome.db"
+    assert "_overflow" not in str(db)
+
+
+def test_long_paths_fall_back_to_overflow(tmp_path, monkeypatch):
+    monkeypatch.setenv("HELIX_SHARD_PATH_MAX", "120")
+    deep_root = "C:/Users/max/AppData/Local/Temp/pytest-of-max/pytest-4764/" + \
+        "test_sharded_pool_matches_seri0/rootA"
+    db = corpus_shard_db(deep_root, "roota", tmp_path)
+    assert db.parent == Path(tmp_path) / "_overflow"
+    assert db.name.startswith("roota-")
+    assert db.name.endswith(".genome.db")
+    # label + 10-hex digest
+    digest = db.name[len("roota-"):-len(".genome.db")]
+    assert len(digest) == 10
+    int(digest, 16)  # hex
+
+
+def test_overflow_path_is_deterministic(tmp_path, monkeypatch):
+    monkeypatch.setenv("HELIX_SHARD_PATH_MAX", "120")
+    deep_root = "C:/Users/max/AppData/Local/Temp/very/deep/tree/rootA"
+    a = corpus_shard_db(deep_root, "roota", tmp_path)
+    b = corpus_shard_db(deep_root, "roota", tmp_path)
+    assert a == b
+
+
+def test_overflow_distinguishes_roots(tmp_path, monkeypatch):
+    monkeypatch.setenv("HELIX_SHARD_PATH_MAX", "120")
+    base = "C:/Users/max/AppData/Local/Temp/very/deep/tree/"
+    a = corpus_shard_db(base + "rootA", "shard", tmp_path)
+    b = corpus_shard_db(base + "rootB", "shard", tmp_path)
+    assert a != b
+    assert a.parent == b.parent  # both in _overflow
+
+
+def test_cap_is_env_overridable(tmp_path, monkeypatch):
+    deep_root = "C:/Users/max/AppData/Local/Temp/very/deep/tree/rootA"
+    monkeypatch.setenv("HELIX_SHARD_PATH_MAX", "100000")
+    db = corpus_shard_db(deep_root, "roota", tmp_path)
+    assert "_overflow" not in str(db)
+    monkeypatch.setenv("HELIX_SHARD_PATH_MAX", "1")
+    db = corpus_shard_db(deep_root, "roota", tmp_path)
+    assert "_overflow" in str(db)
+
+
+def test_bad_env_value_falls_back_to_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("HELIX_SHARD_PATH_MAX", "not-a-number")
+    db = corpus_shard_db(SHORT_ROOT, "helix", tmp_path)
+    # default cap (240) — short mirrored path survives
+    assert "_overflow" not in str(db) or len(str(db)) > 240


### PR DESCRIPTION
Follow-up from the full-suite QA session. The mirrored corpus-shard layout is self-identifying by design, but mirroring a deep source root under a deep `genomes_root` can exceed Windows' classic 260-char MAX_PATH — observed shard DBs like `<out>/pool/C/Users/.../Temp/pytest-of-.../rootA/roota.genome.db`. sqlite3's C layer doesn't reliably honour long-path opt-in.

## Fix
`corpus_shard_db` caps the mirrored path at `HELIX_SHARD_PATH_MAX` (default 240) and falls back to a compact deterministic `<genomes_root>/_overflow/<label>-<sha1[:10]>.genome.db`.

- Deterministic in `(source_root, label, genomes_root)` -> resume/salvage recomputation is stable.
- Routing unaffected: `IngestTargetRouter` registers explicit `(root, shard_db)` pairs; `main.genome.db` stays the root->shard source of truth.
- Only the overflow case trades away the self-identifying filename.

## Test plan
- [x] 6 new tests in `tests/test_sharding_max_path.py` (mirrored layout preserved below cap, overflow fallback, determinism, root disambiguation, env override, bad-env fallback)
- [x] Regression: `test_shard_router + test_shard_schema + test_sharding_max_path` — 72 passed; `auto_subshard + resume + sharded_adapter_parity` — 25 passed