### PR TITLE
perf(storage): path_key_index Option-B — drop dead index, prune noise pairs, WITHOUT ROWID (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **perf(storage): path_key_index Option-B compaction (#165).** The
+  fingerprint-routing index was 34.1% of the v2 Onyx corpus; probes
+  showed the live Tier-0 lookup never uses `idx_pki_lookup` (covering
+  PK scan), 38% of rows sit in pairs above `PKI_NOISE_CUTOFF` (hard-
+  skipped by the scorer — zero score contribution), and the rowid
+  table + 3-col-PK autoindex stored every row twice. New DBs now create
+  `path_key_index` WITHOUT ROWID and skip the dead index; existing DBs
+  convert via `storage.indexes.compact_path_key_index` /
+  `POST /admin/compact-pki` (transactional, dry-run supported; follow
+  with `/admin/vacuum`). ~21% corpus reduction on the audit fixture,
+  score-invariant (40/40-query ablation). Tier-0 scoring constants
+  (`PKI_BASE/FLOOR/NOISE_CUTOFF`) moved to `storage.indexes` as the
+  canonical home so the scorer and compactor cannot drift.
+
 ## 0.6.4 — 2026-06-09
 
 Three landed PRs since v0.6.2. v0.6.3 remains the frozen Onyx

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -1732,10 +1732,12 @@ class KnowledgeStore:
                 #   PKI_FLOOR =  2.0  (caps top-end at +5 for 2-document pairs)
                 # A pair with 100 documents contributes only +0.1 per document —
                 # essentially noise. A pair with 5 documents contributes +2.
-                PKI_BASE = 10.0
-                PKI_FLOOR = 2.0
-                # Hard-skip pairs with cardinality > this — they're noise
-                PKI_NOISE_CUTOFF = 200
+                # Canonical constants live in storage.indexes (issue
+                # #165) so the scorer and compact_path_key_index cannot
+                # drift on the noise cutoff.
+                from .storage.indexes import (
+                    PKI_BASE, PKI_FLOOR, PKI_NOISE_CUTOFF,
+                )
                 _pki_ranked: List[Tuple[str, float]] = []  # Stage 3 RRF
                 for gid, pairs in gene_pairs.items():
                     bonus = 0.0

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -623,6 +623,31 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
         )
         return result
 
+    @app.post("/admin/compact-pki")
+    async def admin_compact_pki(dry_run: bool = False, noise_cutoff: int = -1):
+        """Issue #165 Option-B: compact ``path_key_index``.
+
+        Drops the dead ``idx_pki_lookup``, prunes rows in pairs above the
+        Tier-0 noise cutoff (score-invariant — those pairs are hard-skipped
+        by the scorer), and rebuilds the table WITHOUT ROWID. Follow with
+        ``/admin/vacuum`` to reclaim the freed pages. ``dry_run=true``
+        reports what would change without touching the DB.
+        """
+        from ..storage.indexes import (
+            PKI_NOISE_CUTOFF, compact_path_key_index,
+        )
+        cutoff = noise_cutoff if noise_cutoff >= 0 else PKI_NOISE_CUTOFF
+        try:
+            result = compact_path_key_index(
+                helix.genome.conn, noise_cutoff=cutoff, dry_run=dry_run,
+            )
+            return {"ok": True, **result}
+        except Exception as exc:
+            log.warning("compact-pki failed: %s", exc, exc_info=True)
+            return JSONResponse(
+                {"ok": False, "error": str(exc)}, status_code=500,
+            )
+
     @app.post("/admin/checkpoint")
     async def admin_checkpoint(mode: str = "PASSIVE"):
         """Force a WAL checkpoint."""

--- a/helix_context/storage/ddl.py
+++ b/helix_context/storage/ddl.py
@@ -242,18 +242,24 @@ def _create_entity_graph(cur: sqlite3.Cursor) -> None:
 # ---------------------------------------------------------------------------
 
 def _create_path_key_index(cur: sqlite3.Cursor) -> None:
+    # Issue #165: WITHOUT ROWID — a rowid table with a 3-col PK stores
+    # every row twice (table + sqlite_autoindex); the WITHOUT ROWID form
+    # stores it once in PK order and serves the same covering Tier-0
+    # lookup plan. Existing rowid-table DBs keep working unchanged
+    # (CREATE IF NOT EXISTS no-ops); convert them with
+    # ``storage.indexes.compact_path_key_index`` (/admin/compact-pki).
+    #
+    # idx_pki_lookup is gone: EXPLAIN QUERY PLAN proved the live lookup
+    # never chose it (strict prefix of the PK). idx_pki_gene stays — it
+    # serves the upsert DELETE path.
     cur.execute("""
     CREATE TABLE IF NOT EXISTS path_key_index (
         path_token TEXT NOT NULL,
         kv_key     TEXT NOT NULL,
         gene_id    TEXT NOT NULL,
         PRIMARY KEY (path_token, kv_key, gene_id)
-    )
+    ) WITHOUT ROWID
     """)
-    cur.execute(
-        "CREATE INDEX IF NOT EXISTS idx_pki_lookup "
-        "ON path_key_index(path_token, kv_key)"
-    )
     cur.execute(
         "CREATE INDEX IF NOT EXISTS idx_pki_gene "
         "ON path_key_index(gene_id)"

--- a/helix_context/storage/indexes.py
+++ b/helix_context/storage/indexes.py
@@ -107,6 +107,153 @@ def sync_entity_graph(
 # path_key_index
 # ---------------------------------------------------------------------------
 
+# Tier-0 scoring constants (issue #165: canonical home — the retrieval
+# scorer in knowledge_store.py and the compactor below MUST agree on the
+# noise cutoff, otherwise compaction could prune rows the scorer still
+# credits).
+#
+#   per-pair bonus = PKI_BASE / max(pair_cardinality, PKI_FLOOR)
+#   pairs with cardinality > PKI_NOISE_CUTOFF are hard-skipped (no score)
+PKI_BASE = 10.0
+PKI_FLOOR = 2.0
+PKI_NOISE_CUTOFF = 200
+
+
+def compact_path_key_index(
+    conn: sqlite3.Connection,
+    noise_cutoff: int = PKI_NOISE_CUTOFF,
+    dry_run: bool = False,
+) -> Dict:
+    """Issue #165 Option-B compaction for ``path_key_index``.
+
+    Three probe-backed, score-invariant moves (see
+    ``165_path_key_index_consensus.md`` / issue #165 audit):
+
+    1. **Drop ``idx_pki_lookup``** — EXPLAIN QUERY PLAN shows the live
+       Tier-0 lookup runs as a COVERING scan of the (path_token, kv_key,
+       gene_id) primary key; the (path_token, kv_key) index is a strict
+       prefix of it and is never chosen (~7% of corpus dead weight on the
+       v2 Onyx audit).
+    2. **Prune dead pairs** — rows whose (path_token, kv_key) pair has
+       cardinality > ``noise_cutoff`` are hard-skipped by the scorer
+       (``PKI_NOISE_CUTOFF``), so they can never contribute score
+       (38% of rows on the v2 Onyx audit). 40/40-query ablation showed
+       byte-identical Tier-0 bonuses after pruning.
+    3. **Rebuild WITHOUT ROWID** — the legacy rowid table + 3-column PK
+       autoindex store every row twice; a WITHOUT ROWID table stores it
+       once, in PK order (same covering-lookup plan).
+
+    The rebuild runs in a single transaction (CREATE new / anti-join copy
+    / DROP old / RENAME), so a crash rolls back to the untouched legacy
+    table. Freed pages go to the SQLite freelist — run ``VACUUM``
+    (``/admin/vacuum``) afterwards to shrink the file.
+
+    Pruned rows regrow for newly-upserted genes (cardinality is only
+    knowable globally), but stay inert at query time thanks to the same
+    cutoff — re-run compaction periodically on bulk-ingest corpora.
+
+    Returns a report dict; with ``dry_run=True`` nothing is modified.
+    """
+    cur = conn.cursor()
+
+    def _exists(kind: str, name: str) -> bool:
+        return cur.execute(
+            "SELECT 1 FROM sqlite_master WHERE type=? AND name=?",
+            (kind, name),
+        ).fetchone() is not None
+
+    report: Dict = {
+        "dry_run": dry_run,
+        "noise_cutoff": noise_cutoff,
+        "had_lookup_index": _exists("index", "idx_pki_lookup"),
+        # A legacy rowid table materializes its 3-col PK as a
+        # sqlite_autoindex; the WITHOUT ROWID rebuild has none.
+        "was_rowid_table": _exists(
+            "index", "sqlite_autoindex_path_key_index_1"
+        ),
+    }
+    if not _exists("table", "path_key_index"):
+        report["skipped"] = "no path_key_index table"
+        return report
+
+    rows_before = cur.execute(
+        "SELECT COUNT(*) FROM path_key_index").fetchone()[0]
+    dead = cur.execute(
+        "SELECT COALESCE(SUM(c), 0), COUNT(*) FROM ("
+        "  SELECT COUNT(*) c FROM path_key_index"
+        "  GROUP BY path_token, kv_key HAVING COUNT(*) > ?)",
+        (noise_cutoff,),
+    ).fetchone()
+    report["rows_before"] = rows_before
+    report["dead_rows"] = dead[0]
+    report["dead_pairs"] = dead[1]
+
+    needs_rebuild = (
+        report["was_rowid_table"] or report["dead_rows"] > 0
+    )
+    report["needs_rebuild"] = needs_rebuild
+    if dry_run:
+        return report
+
+    try:
+        cur.execute("BEGIN IMMEDIATE")
+        if report["had_lookup_index"]:
+            cur.execute("DROP INDEX idx_pki_lookup")
+        if needs_rebuild:
+            cur.execute("""
+            CREATE TABLE path_key_index_compact (
+                path_token TEXT NOT NULL,
+                kv_key     TEXT NOT NULL,
+                gene_id    TEXT NOT NULL,
+                PRIMARY KEY (path_token, kv_key, gene_id)
+            ) WITHOUT ROWID
+            """)
+            cur.execute(
+                "CREATE TEMP TABLE _dead_pairs AS "
+                "SELECT path_token, kv_key FROM path_key_index "
+                "GROUP BY path_token, kv_key HAVING COUNT(*) > ?",
+                (noise_cutoff,),
+            )
+            cur.execute(
+                "CREATE INDEX temp._dead_pairs_idx "
+                "ON _dead_pairs(path_token, kv_key)"
+            )
+            cur.execute(
+                "INSERT INTO path_key_index_compact "
+                "SELECT path_token, kv_key, gene_id FROM path_key_index o "
+                "WHERE NOT EXISTS ("
+                "  SELECT 1 FROM _dead_pairs d "
+                "  WHERE d.path_token = o.path_token "
+                "  AND d.kv_key = o.kv_key)"
+            )
+            cur.execute("DROP TABLE path_key_index")
+            cur.execute(
+                "ALTER TABLE path_key_index_compact "
+                "RENAME TO path_key_index"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pki_gene "
+                "ON path_key_index(gene_id)"
+            )
+            cur.execute("DROP TABLE _dead_pairs")
+        conn.commit()
+    except sqlite3.Error:
+        conn.rollback()
+        raise
+
+    report["rows_after"] = cur.execute(
+        "SELECT COUNT(*) FROM path_key_index").fetchone()[0]
+    report["rows_pruned"] = rows_before - report["rows_after"]
+    report["hint"] = "run VACUUM (/admin/vacuum) to reclaim freed pages"
+    log.info(
+        "path_key_index compaction: %d -> %d rows (-%d dead, cutoff=%d), "
+        "lookup_index_dropped=%s, without_rowid=%s",
+        rows_before, report["rows_after"], report["rows_pruned"],
+        noise_cutoff, report["had_lookup_index"], needs_rebuild,
+    )
+    return report
+
+
 def sync_path_key_index(
     cur: sqlite3.Cursor,
     gene_id: str,

--- a/tests/test_pki_compaction.py
+++ b/tests/test_pki_compaction.py
@@ -1,0 +1,213 @@
+"""Issue #165 Option-B: path_key_index compaction + new-DDL shape.
+
+Covers the three probe-backed moves: drop idx_pki_lookup, prune
+dead pairs above PKI_NOISE_CUTOFF, rebuild WITHOUT ROWID — plus the
+invariants that make them safe (scorer-visible rows unchanged, delete
+path intact, constants shared with the Tier-0 scorer).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from helix_context.storage.indexes import (
+    PKI_NOISE_CUTOFF,
+    compact_path_key_index,
+)
+
+
+# ── fixtures ───────────────────────────────────────────────────────────
+
+
+def _legacy_db(path, live_pairs=3, live_genes=5, dead_genes=12,
+               cutoff=8):
+    """Build a pre-#165 (rowid + idx_pki_lookup) path_key_index.
+
+    ``live_pairs`` pairs with ``live_genes`` rows each (scoreable) and
+    one dead pair with ``dead_genes`` rows (> cutoff → scorer-skipped).
+    """
+    conn = sqlite3.connect(str(path))
+    cur = conn.cursor()
+    cur.execute("""
+    CREATE TABLE path_key_index (
+        path_token TEXT NOT NULL,
+        kv_key     TEXT NOT NULL,
+        gene_id    TEXT NOT NULL,
+        PRIMARY KEY (path_token, kv_key, gene_id)
+    )
+    """)
+    cur.execute(
+        "CREATE INDEX idx_pki_lookup ON path_key_index(path_token, kv_key)"
+    )
+    cur.execute("CREATE INDEX idx_pki_gene ON path_key_index(gene_id)")
+    for p in range(live_pairs):
+        for g in range(live_genes):
+            cur.execute(
+                "INSERT INTO path_key_index VALUES (?,?,?)",
+                (f"proj{p}", f"key{p}", f"g{p}_{g}"),
+            )
+    for g in range(dead_genes):
+        cur.execute(
+            "INSERT INTO path_key_index VALUES (?,?,?)",
+            ("sources", "url", f"dead_{g}"),
+        )
+    conn.commit()
+    return conn
+
+
+def _names(conn, kind):
+    return {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type=?", (kind,)
+        ).fetchall()
+    }
+
+
+# ── compaction on a legacy DB ──────────────────────────────────────────
+
+
+def test_compaction_drops_lookup_index_and_autoindex(tmp_path):
+    conn = _legacy_db(tmp_path / "g.db")
+    assert "idx_pki_lookup" in _names(conn, "index")
+    assert "sqlite_autoindex_path_key_index_1" in _names(conn, "index")
+
+    report = compact_path_key_index(conn, noise_cutoff=8)
+
+    idx = _names(conn, "index")
+    assert "idx_pki_lookup" not in idx
+    # WITHOUT ROWID tables have no PK autoindex
+    assert "sqlite_autoindex_path_key_index_1" not in idx
+    assert "idx_pki_gene" in idx
+    assert report["had_lookup_index"] is True
+    assert report["was_rowid_table"] is True
+
+
+def test_compaction_prunes_only_dead_pairs(tmp_path):
+    conn = _legacy_db(tmp_path / "g.db", live_pairs=3, live_genes=5,
+                      dead_genes=12)
+    report = compact_path_key_index(conn, noise_cutoff=8)
+    rows = conn.execute(
+        "SELECT path_token, kv_key, gene_id FROM path_key_index"
+    ).fetchall()
+    # all 15 live rows survive, all 12 dead rows pruned
+    assert len(rows) == 15
+    assert report["rows_before"] == 27
+    assert report["rows_after"] == 15
+    assert report["rows_pruned"] == 12
+    assert report["dead_pairs"] == 1
+    assert all(r[0] != "sources" for r in rows)
+
+
+def test_compaction_is_scorer_visible_row_invariant(tmp_path):
+    """Rows the Tier-0 scorer can credit are byte-identical pre/post.
+
+    The scorer hard-skips pairs with cardinality > cutoff, so the set of
+    rows in pairs <= cutoff IS the scorer-visible surface.
+    """
+    conn = _legacy_db(tmp_path / "g.db")
+    cutoff = 8
+    visible_before = set(conn.execute(
+        "SELECT path_token, kv_key, gene_id FROM path_key_index "
+        "WHERE (path_token, kv_key) IN ("
+        "  SELECT path_token, kv_key FROM path_key_index "
+        "  GROUP BY 1,2 HAVING COUNT(*) <= ?)", (cutoff,)
+    ).fetchall())
+    compact_path_key_index(conn, noise_cutoff=cutoff)
+    visible_after = set(conn.execute(
+        "SELECT path_token, kv_key, gene_id FROM path_key_index"
+    ).fetchall())
+    assert visible_before == visible_after
+
+
+def test_compaction_lookup_plan_stays_covering(tmp_path):
+    conn = _legacy_db(tmp_path / "g.db")
+    compact_path_key_index(conn, noise_cutoff=8)
+    plan = " ".join(
+        r[3] for r in conn.execute(
+            "EXPLAIN QUERY PLAN SELECT path_token, kv_key, gene_id "
+            "FROM path_key_index WHERE path_token IN (?,?) "
+            "AND kv_key IN (?,?)", ("a", "b", "c", "d")
+        ).fetchall()
+    )
+    # WITHOUT ROWID: the table btree IS the PK — same covering shape
+    assert "PRIMARY KEY" in plan
+    assert "idx_pki_lookup" not in plan
+
+
+def test_compaction_delete_path_intact(tmp_path):
+    conn = _legacy_db(tmp_path / "g.db")
+    compact_path_key_index(conn, noise_cutoff=8)
+    plan = " ".join(
+        r[3] for r in conn.execute(
+            "EXPLAIN QUERY PLAN DELETE FROM path_key_index "
+            "WHERE gene_id = ?", ("g0_0",)
+        ).fetchall()
+    )
+    assert "idx_pki_gene" in plan
+    conn.execute("DELETE FROM path_key_index WHERE gene_id = 'g0_0'")
+    n = conn.execute(
+        "SELECT COUNT(*) FROM path_key_index WHERE gene_id='g0_0'"
+    ).fetchone()[0]
+    assert n == 0
+
+
+def test_dry_run_reports_without_modifying(tmp_path):
+    conn = _legacy_db(tmp_path / "g.db")
+    report = compact_path_key_index(conn, noise_cutoff=8, dry_run=True)
+    assert report["dry_run"] is True
+    assert report["needs_rebuild"] is True
+    assert report["dead_rows"] == 12
+    assert "rows_after" not in report
+    assert "idx_pki_lookup" in _names(conn, "index")
+    assert conn.execute(
+        "SELECT COUNT(*) FROM path_key_index").fetchone()[0] == 27
+
+
+def test_compaction_idempotent(tmp_path):
+    conn = _legacy_db(tmp_path / "g.db")
+    compact_path_key_index(conn, noise_cutoff=8)
+    report2 = compact_path_key_index(conn, noise_cutoff=8)
+    assert report2["was_rowid_table"] is False
+    assert report2["had_lookup_index"] is False
+    assert report2["needs_rebuild"] is False
+    assert report2["rows_after"] == report2["rows_before"]
+
+
+def test_compaction_no_table_is_graceful(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "empty.db"))
+    report = compact_path_key_index(conn)
+    assert report["skipped"] == "no path_key_index table"
+
+
+# ── new-DB DDL shape ───────────────────────────────────────────────────
+
+
+def test_new_ddl_is_without_rowid_and_lookup_free(tmp_path):
+    from helix_context.storage.ddl import _create_path_key_index
+    conn = sqlite3.connect(str(tmp_path / "new.db"))
+    _create_path_key_index(conn.cursor())
+    conn.commit()
+    idx = _names(conn, "index")
+    assert "idx_pki_lookup" not in idx
+    assert "sqlite_autoindex_path_key_index_1" not in idx
+    assert "idx_pki_gene" in idx
+    # round-trip a row through the PK
+    conn.execute(
+        "INSERT OR IGNORE INTO path_key_index VALUES ('p','k','g')")
+    conn.execute(
+        "INSERT OR IGNORE INTO path_key_index VALUES ('p','k','g')")
+    assert conn.execute(
+        "SELECT COUNT(*) FROM path_key_index").fetchone()[0] == 1
+
+
+def test_scorer_and_compactor_share_cutoff():
+    """Guard against drift: the Tier-0 scorer must import the canonical
+    constants from storage.indexes (the compactor's defaults)."""
+    import inspect
+    from helix_context import knowledge_store
+    src = inspect.getsource(knowledge_store)
+    assert "from .storage.indexes import" in src
+    assert "PKI_NOISE_CUTOFF = 200" not in src  # no local shadow
+    assert PKI_NOISE_CUTOFF == 200


### PR DESCRIPTION
Implements the Option-B consensus from the #165 audit (probes + 4-persona council, see `165_path_key_index_consensus.md` from the audit session). All three moves are probe-backed and score-invariant.

## Evidence (v2 Onyx `linear` 70,159 genes + `slack__incidents` 46,312 genes)

| Probe | Result |
|---|---|
| Rows are exact path_tokens x kv_keys cartesian | 100% sampled; **0/69,001 genes deviate globally** |
| Rows per gene | 123.5 vs 23.2 normalized (5.4x expansion) |
| Rows in pairs above `PKI_NOISE_CUTOFF=200` | **38.4%** — hard-skipped by the Tier-0 scorer, can never contribute score |
| EXPLAIN QUERY PLAN, live lookup | always `COVERING INDEX sqlite_autoindex_path_key_index_1` — **`idx_pki_lookup` is never used** |
| Tier-0 score ablation (40 realistic queries, replicated IDF + cutoff + cap) | prune: **40/40 identical** · normalize: 40/40 identical (1e-9) |

## Changes

- **`storage/ddl.py`** — new DBs create `path_key_index` `WITHOUT ROWID` (rowid table + 3-col PK autoindex stored every row twice) and skip `idx_pki_lookup`. `idx_pki_gene` stays (serves the upsert DELETE — EQP-verified).
- **`storage/indexes.py`** — `compact_path_key_index(conn, noise_cutoff, dry_run)` converts existing DBs: drop dead index, anti-join copy minus dead pairs, swap, recreate `idx_pki_gene` — one transaction, crash = rollback to legacy table. `PKI_BASE/FLOOR/NOISE_CUTOFF` now live here as the canonical home.
- **`knowledge_store.py`** — Tier-0 scorer imports the canonical constants (no local shadow; compactor and scorer cannot drift on the cutoff).
- **`server/routes_admin.py`** — `POST /admin/compact-pki?dry_run=&noise_cutoff=` (follow with `/admin/vacuum` to reclaim pages).

Estimated ~21% corpus reduction on the audit fixture (16.0 GB of pki structures -> ~5.8 GB). Pruned rows regrow on fresh ingest but stay inert under the query-time cutoff — re-run compaction periodically on bulk-ingest corpora (council mitigation for the decay concern).

**Deliberately NOT in this PR** (per council): Option-C normalization (5.4x row cut) is deferred into the #159 fingerprint redesign so the schema-change budget is spent once; `_PATH_NOISE_TOKENS` corpus-root noise fix is a separate small follow-up.

## Test plan
- [x] `tests/test_pki_compaction.py` — 10 new tests: index shapes, prune exactness, scorer-visible row invariance, EQP plans (covering PK + delete via `idx_pki_gene`), dry-run, idempotence, missing-table grace, new-DDL shape, constants-drift guard
- [x] Full suite: **2281 passed, 0 failed** (8m24s)
- [ ] Operator follow-up: `/admin/compact-pki?dry_run=true` then live run + `/admin/vacuum` on the v2 Onyx shards; expect ~10 GB back

Refs #165.