### PR TITLE
feat(launcher): dashboard wiring sweep - genome select/create from web UI, observability panel, grafana hardening, fresh-checkout boot fix

### DIFF
--- a/deploy/otel/grafana/dashboards/helix-overview.json
+++ b/deploy/otel/grafana/dashboards/helix-overview.json
@@ -1,22 +1,39 @@
 {
-  "title": "Helix — Pipeline Observatory",
+  "title": "Helix — Overview",
   "uid": "helix-overview",
   "editable": true,
   "schemaVersion": 39,
-  "time": {"from": "now-1h", "to": "now"},
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "refresh": "10s",
-  "tags": ["helix", "retrieval", "agentome"],
+  "tags": [
+    "helix",
+    "retrieval",
+    "agentome"
+  ],
   "panels": [
     {
       "type": "row",
       "title": "Retrieval",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "/context latency (seconds) — p50/p95/p99 by health",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
       "targets": [
         {
           "expr": "histogram_quantile(0.50, sum by (le, health) (rate(helix_context_latency_seconds_bucket[5m])))",
@@ -34,13 +51,22 @@
           "refId": "C"
         }
       ],
-      "fieldConfig": {"defaults": {"unit": "s"}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
     },
     {
       "type": "timeseries",
       "title": "Tier activations per minute (which tiers are firing)",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "targets": [
         {
           "expr": "sum by (tier) (rate(helix_tier_fired_total[1m])) * 60",
@@ -48,13 +74,22 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {"defaults": {"unit": "short"}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
     },
     {
       "type": "heatmap",
       "title": "Per-tier contribution histogram (score magnitude × tier)",
       "datasource": "Prometheus",
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 9},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
       "targets": [
         {
           "expr": "sum by (le, tier) (rate(helix_tier_contribution_score_bucket[5m]))",
@@ -65,19 +100,31 @@
       ],
       "options": {
         "calculate": false,
-        "yAxis": {"axisPlacement": "left"}
+        "yAxis": {
+          "axisPlacement": "left"
+        }
       }
     },
     {
       "type": "row",
       "title": "CWoLa Label Clock",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 19}
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      }
     },
     {
       "type": "timeseries",
       "title": "CWoLa bucket accumulation",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
       "targets": [
         {
           "expr": "sum by (bucket) (increase(helix_cwola_bucket_total[1h]))",
@@ -85,14 +132,23 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {"defaults": {"unit": "short"}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
     },
     {
       "type": "stat",
       "title": "f_gap_sq — (f_A − f_B)² divergence",
       "description": "CWoLa promotion gate: >= 0.16 unlocks Sprint 3 PLR training. Auto-computed from A/B bucket ratio.",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
       "targets": [
         {
           "expr": "helix_cwola_f_gap_sq",
@@ -105,9 +161,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red",    "value": null},
-              {"color": "yellow", "value": 0.05},
-              {"color": "green",  "value": 0.16}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "green",
+                "value": 0.16
+              }
             ]
           }
         }
@@ -116,13 +181,23 @@
     {
       "type": "row",
       "title": "Graph & Chromatin",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 28}
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      }
     },
     {
       "type": "timeseries",
       "title": "harmonic_links edges by provenance",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 29},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
       "targets": [
         {
           "expr": "helix_harmonic_edges_total",
@@ -130,13 +205,22 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {"defaults": {"unit": "short"}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
     },
     {
       "type": "piechart",
       "title": "Chromatin state distribution",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 29},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
       "targets": [
         {
           "expr": "helix_chromatin_state_total",
@@ -150,7 +234,12 @@
       "title": "Hub concentration ratio (top-1% inbound / mean)",
       "description": "Order parameter for preferential-attachment condensation. Healthy ≲ ~10x; rising trend = retrieval flow funneling through fewer hubs than the edge count suggests. Backfill caps inbound at 500 — sustained ratios alongside p99 ≈ 500 mean the cap is binding.",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 37},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
       "targets": [
         {
           "expr": "helix_hub_concentration_ratio",
@@ -163,9 +252,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green",  "value": null},
-              {"color": "yellow", "value": 10},
-              {"color": "red",    "value": 25}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
             ]
           }
         }
@@ -176,7 +274,12 @@
       "title": "Inbound-degree distribution (max / p99 / p95 / p50 / mean)",
       "description": "harmonic_links inbound-degree summary. Watch p99 vs the backfill cap (500). max / p99 sustained at the cap = the cap is the binding constraint, not organic structure.",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 37},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
       "targets": [
         {
           "expr": "helix_hub_inbound_degree",
@@ -184,19 +287,33 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {"defaults": {"unit": "short"}}
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
     },
     {
       "type": "row",
       "title": "Operations",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 45}
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      }
     },
     {
       "type": "stat",
       "title": "Ribosome backend — cost class",
       "description": "Cost classification of the active ribosome backend. local = Ollama / DeBERTa on the operator machine. api+paid = metered remote API (Claude direct, or LiteLLM routed to a paid model). Pair with the startup WARNING log line. Red = paid; the local-first promise is broken until the operator flips backend in helix.toml.",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 46},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
       "targets": [
         {
           "expr": "helix_ribosome_info",
@@ -206,7 +323,13 @@
         }
       ],
       "options": {
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "name",
         "colorMode": "background",
         "graphMode": "none"
@@ -214,12 +337,43 @@
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "value": "local",    "options": {"color": "green",  "index": 0}},
-            {"type": "value", "value": "api+free", "options": {"color": "blue",   "index": 1}},
-            {"type": "value", "value": "api+paid", "options": {"color": "red",    "index": 2}}
+            {
+              "type": "value",
+              "value": "local",
+              "options": {
+                "color": "green",
+                "index": 0
+              }
+            },
+            {
+              "type": "value",
+              "value": "api+free",
+              "options": {
+                "color": "blue",
+                "index": 1
+              }
+            },
+            {
+              "type": "value",
+              "value": "api+paid",
+              "options": {
+                "color": "red",
+                "index": 2
+              }
+            }
           ],
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         }
       }
     },
@@ -228,7 +382,12 @@
       "title": "Active ribosome model",
       "description": "Resolved model string for the active backend. ollama -> RibosomeConfig.model; claude -> claude_model; litellm -> litellm_model.",
       "datasource": "Prometheus",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 46},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
       "targets": [
         {
           "expr": "helix_ribosome_info",
@@ -238,7 +397,13 @@
         }
       ],
       "options": {
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "name",
         "colorMode": "value",
         "graphMode": "none"

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -558,6 +558,22 @@ class KnowledgeStore:
         self._main_conn = main_conn
         self._shard_name = shard_name
 
+        # First-run UX (v0.7.0 QA): a fresh clone/worktree has no
+        # genomes/main/ directory, and sqlite3 cannot create a database
+        # file inside a missing directory — it raises "unable to open
+        # database file" and the backend dies at import time. Create the
+        # parent chain for plain file paths (":memory:" and URI forms
+        # excluded). connect() below still surfaces any real error.
+        _path_str = str(self.path)
+        if _path_str not in ("", ":memory:") and not _path_str.startswith("file:"):
+            try:
+                os.makedirs(
+                    os.path.dirname(os.path.abspath(_path_str)) or ".",
+                    exist_ok=True,
+                )
+            except OSError:
+                log.debug("genome parent mkdir failed", exc_info=True)
+
         # Checkpoint WAL BEFORE opening our long-lived connection
         # so we see the latest state from any external writers.
         # Speculative pre-open optimisation — the subsequent connect() will

--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -46,7 +46,7 @@ from .observability_paths import (
 
 log = logging.getLogger("helix.launcher.app")
 
-DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000/d/helix-a27094-pipeline-observatory"
+DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000/d/helix-overview/helix-overview"
 DEFAULT_PROMETHEUS_URL = "http://127.0.0.1:9090/graph"
 
 if TYPE_CHECKING:
@@ -78,9 +78,57 @@ def create_app(
     store: StateStore,
     supervisor: HelixSupervisor,
     collector: StateCollector,
+    observability: Optional["ObservabilitySupervisor"] = None,
+    observability_install_pending: bool = False,
+    grafana_url: str = DEFAULT_GRAFANA_URL,
+    prometheus_url: str = DEFAULT_PROMETHEUS_URL,
 ) -> FastAPI:
     """Build the launcher FastAPI app."""
     templates = _get_templates()
+
+    # --grafana-url / --prometheus-url default to None outside tray mode;
+    # normalize so the Monitoring links always have a destination.
+    grafana_url = grafana_url or DEFAULT_GRAFANA_URL
+    prometheus_url = prometheus_url or DEFAULT_PROMETHEUS_URL
+
+    # Known provisioned dashboards (deploy/otel/grafana/dashboards/*.json).
+    # uid -> human title; rendered as direct links on the Monitoring tab.
+    _grafana_base = grafana_url.split("/d/")[0].rstrip("/")
+    _telem_dashboards = [
+        ("helix-overview", "Overview"),
+        ("helix-a27094-pipeline-observatory", "Pipeline Observatory"),
+        ("helix-retrieval-hitl", "Retrieval + HITL"),
+        ("helix-agent-usage", "Agent Usage"),
+        ("helix-genai", "GenAI (gen_ai.*)"),
+        ("helix-internals", "Internals & Research"),
+    ]
+
+    def _observability_state() -> Optional[dict]:
+        """Launcher-side observability snapshot injected into the page
+        state — service health from the supervisor plus the telemetry
+        links the Monitoring tab renders. None when the operator opted
+        out via HELIX_OBSERVABILITY=0 (panel hidden entirely)."""
+        if observability is None and not observability_install_pending:
+            return None
+        statuses = (
+            observability.all_statuses() if observability is not None else {}
+        )
+        return {
+            "install_pending": observability_install_pending,
+            "services": [
+                {"name": name, "status": status}
+                for name, status in sorted(statuses.items())
+            ],
+            "links": {
+                "grafana": grafana_url,
+                "grafana_base": _grafana_base,
+                "prometheus": prometheus_url,
+                "dashboards": [
+                    {"title": title, "url": f"{_grafana_base}/d/{uid}"}
+                    for uid, title in _telem_dashboards
+                ],
+            },
+        }
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -114,6 +162,7 @@ def create_app(
     @app.get("/", response_class=HTMLResponse)
     async def dashboard_root(request: Request) -> HTMLResponse:
         state = collector.collect()
+        state["observability"] = _observability_state()
         template = templates.get_template("dashboard.html")
         html = template.render(state=state, launcher_port=_launcher_port(request))
         return HTMLResponse(html)
@@ -124,6 +173,7 @@ def create_app(
         if request.headers.get("sec-fetch-mode") == "navigate":
             return RedirectResponse("/", status_code=303)
         state = collector.collect()
+        state["observability"] = _observability_state()
         template = templates.get_template("components/panels.html")
         html = template.render(state=state)
         return HTMLResponse(html)
@@ -132,7 +182,126 @@ def create_app(
 
     @app.get("/api/state")
     async def api_state():
-        return collector.collect()
+        state = collector.collect()
+        state["observability"] = _observability_state()
+        return state
+
+    # ── genome management (v0.7.0: dashboard parity with the tray's
+    #    "Manage Database" submenu — select or create from the web UI) ──
+
+    @app.get("/api/genomes")
+    async def api_genomes():
+        from . import genome_registry
+        try:
+            infos = genome_registry.discover_genomes()
+            return {
+                "ok": True,
+                "active": str(genome_registry.active_genome_path()),
+                "genomes": [i.as_dict() for i in infos],
+            }
+        except Exception as exc:
+            return JSONResponse(
+                {"ok": False, "error": str(exc)}, status_code=500,
+            )
+
+    def _select_and_restart(target: Path) -> JSONResponse:
+        from . import genome_registry
+        try:
+            resolved = genome_registry.select_genome(target)
+        except FileNotFoundError as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=404)
+        genome_registry.clear_cache()
+
+        def _worker() -> None:
+            try:
+                if supervisor.is_running():
+                    supervisor.restart(
+                        reason=f"switch genome to {resolved.name} (dashboard)",
+                    )
+                else:
+                    supervisor.start()
+            except Exception:
+                log.error(
+                    "Genome switch restart failed (%s)", resolved, exc_info=True,
+                )
+
+        threading.Thread(
+            target=_worker, name="helix-genome-switch-web", daemon=True,
+        ).start()
+        return JSONResponse(
+            {"ok": True, "selected": str(resolved), "restarting": True},
+            status_code=202,
+        )
+
+    @app.post("/api/genome/select")
+    async def api_genome_select(request: Request):
+        body = await request.json()
+        raw = (body or {}).get("path", "")
+        if not raw:
+            return JSONResponse(
+                {"ok": False, "error": "missing 'path'"}, status_code=400,
+            )
+        return _select_and_restart(Path(raw))
+
+    @app.post("/api/genome/create")
+    async def api_genome_create(request: Request):
+        body = await request.json()
+        raw = (body or {}).get("path", "")
+        if not raw:
+            return JSONResponse(
+                {"ok": False, "error": "missing 'path'"}, status_code=400,
+            )
+        target = Path(raw).expanduser()
+        if target.suffix != ".db":
+            return JSONResponse(
+                {"ok": False, "error": "genome path must end in .db"},
+                status_code=400,
+            )
+        if target.exists():
+            return JSONResponse(
+                {"ok": False, "error": f"already exists: {target}"},
+                status_code=409,
+            )
+        # Schema construction imports the full knowledge-store stack
+        # (hardware probe and friends) — far too heavy for the event
+        # loop. Validate cheaply here, do the build + select + restart in
+        # a worker thread, and answer 202 immediately; the dashboard's
+        # poll shows the switch when it lands. (v0.7.0 review fix: the
+        # first cut blocked every launcher request mid-create.)
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            return JSONResponse(
+                {"ok": False, "error": f"cannot create parent dir: {exc}"},
+                status_code=500,
+            )
+
+        def _create_worker() -> None:
+            from . import genome_registry
+            try:
+                from ..knowledge_store import Genome
+                g = Genome(path=str(target), synonym_map={})
+                g.close()
+                resolved = genome_registry.select_genome(target)
+                genome_registry.clear_cache()
+                if supervisor.is_running():
+                    supervisor.restart(
+                        reason=f"create+switch genome {resolved.name} (dashboard)",
+                    )
+                else:
+                    supervisor.start()
+            except Exception:
+                log.error(
+                    "Genome create+switch failed (%s)", target, exc_info=True,
+                )
+
+        threading.Thread(
+            target=_create_worker, name="helix-genome-create-web", daemon=True,
+        ).start()
+        return JSONResponse(
+            {"ok": True, "creating": str(target), "restarting": True},
+            status_code=202,
+        )
 
     # ── control endpoints ──────────────────────────────────────────
 
@@ -695,7 +864,15 @@ def main(argv: Optional[list] = None) -> int:
             log.error("Failed to start helix: %s", exc)
             log.info("Launcher will continue; use the Start button once the issue is fixed")
 
-    app = create_app(store=store, supervisor=supervisor, collector=collector)
+    app = create_app(
+        store=store,
+        supervisor=supervisor,
+        collector=collector,
+        observability=observability_sup,
+        observability_install_pending=observability_install_pending,
+        grafana_url=args.grafana_url,
+        prometheus_url=args.prometheus_url,
+    )
 
     url = f"http://{args.host}:{args.port}/"
 

--- a/helix_context/launcher/collector.py
+++ b/helix_context/launcher/collector.py
@@ -208,7 +208,8 @@ class StateCollector:
         if not health_seen and endpoint_seen:
             state["helix"]["availability"] = "available"
             state["helix"]["next_action"] = (
-                "Helix is responding. This version does not expose the launcher health endpoint."
+                "Helix is responding; the launcher health endpoint has "
+                "not answered yet (cold start, or an older helix build)."
             )
         elif not health_seen:
             state["helix"]["availability"] = "degraded"

--- a/helix_context/launcher/observability_supervisor.py
+++ b/helix_context/launcher/observability_supervisor.py
@@ -289,6 +289,7 @@ class ObservabilitySupervisor:
             start_new_session=start_new_session,
             close_fds=True,
             bufsize=1,  # line-buffered (best-effort; binaries may override)
+            env=self._service_env(svc),
         )
 
         # Attach to Job Object (Windows only).
@@ -399,6 +400,32 @@ class ObservabilitySupervisor:
         except Exception:
             pass
 
+    @staticmethod
+    def _service_env(svc: str) -> Dict[str, str]:
+        """Per-service environment for the spawned binary.
+
+        Grafana (v0.7.0 dashboard-UX sweep): the sidecar is a local,
+        single-operator surface — the tray/dashboard "open Grafana" links
+        must land on a dashboard, not a login wall. Anonymous auth with
+        org-role Admin is acceptable here because the listener is pinned
+        to 127.0.0.1 (no LAN exposure). Operators who deliberately expose
+        Grafana should configure real auth and may override any of these
+        by exporting the GF_* variable themselves — existing values win.
+        """
+        env = dict(os.environ)
+        if svc == "grafana":
+            for k, v in {
+                "GF_SERVER_HTTP_ADDR": "127.0.0.1",
+                "GF_AUTH_ANONYMOUS_ENABLED": "true",
+                "GF_AUTH_ANONYMOUS_ORG_ROLE": "Admin",
+                "GF_AUTH_ANONYMOUS_ORG_NAME": "Main Org.",
+                "GF_ANALYTICS_REPORTING_ENABLED": "false",
+                "GF_ANALYTICS_CHECK_FOR_UPDATES": "false",
+                "GF_NEWS_NEWS_FEED_ENABLED": "false",
+            }.items():
+                env.setdefault(k, v)
+        return env
+
     def _command_for(self, svc: str) -> List[str]:
         bin_p = str(binary_path(svc))
         cfg = configs_dir()
@@ -410,6 +437,8 @@ class ObservabilitySupervisor:
             return [
                 bin_p,
                 f"--config.file={cfg / 'prometheus.yml'}",
+                # Local sidecar: never expose the TSDB beyond loopback.
+                "--web.listen-address=127.0.0.1:9090",
                 f"--storage.tsdb.path={state}",
                 "--storage.tsdb.retention.time=14d",
                 "--storage.tsdb.retention.size=4GB",

--- a/helix_context/launcher/static/launcher.css
+++ b/helix_context/launcher/static/launcher.css
@@ -414,6 +414,7 @@ p {
 .panel--health-warning,
 .panel--switchboard,
 .panel--database,
+.panel--observability,
 .panel--pipeline {
   grid-column: span 12;
 }
@@ -739,6 +740,8 @@ p {
 .panels[data-active-tab="genome"] .panel--models,
 .panels[data-active-tab="genome"] .panel--tools,
 .panels[data-active-tab="genome"] .panel--database,
+.panels[data-active-tab="genome"] .panel--observability,
+.panels[data-active-tab="monitoring"] .panel--observability,
 .panels[data-active-tab="monitoring"] .panel--diagnostics,
 .panels[data-active-tab="monitoring"] .panel--health-warning,
 .panels[data-active-tab="monitoring"] .panel--empty,
@@ -1055,4 +1058,81 @@ p {
   color: rgba(255, 255, 255, 0.4);
   font-size: 11px;
   font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+
+/* ── Observability panel (v0.7.0 monitoring sweep) ─────────────────── */
+
+.obs-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.1rem;
+  list-style: none;
+  margin: 0 0 0.6rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 6px;
+}
+
+.obs-service {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.obs-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #555;
+}
+
+.obs-dot--green { background: #3fb950; }
+.obs-dot--red { background: #f85149; }
+.obs-dot--down { background: #6e7681; }
+.obs-dot--external { background: #d29922; }
+
+.telem-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.telem-link {
+  font-size: 0.74rem;
+  padding: 0.22rem 0.55rem;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 999px;
+  text-decoration: none;
+  color: inherit;
+  opacity: 0.85;
+}
+
+.telem-link:hover { opacity: 1; border-color: #8b6d3f; }
+.telem-link--alt { border-style: dashed; }
+
+/* ── Database panel actions ────────────────────────────────────────── */
+
+.btn--mini {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.55rem;
+  line-height: 1.4;
+}
+
+.db-create {
+  display: flex;
+  gap: 0.45rem;
+  margin-top: 0.6rem;
+}
+
+.db-create__input {
+  flex: 1;
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 5px;
+  color: inherit;
 }

--- a/helix_context/launcher/static/launcher.js
+++ b/helix_context/launcher/static/launcher.js
@@ -247,7 +247,56 @@
     const action = actionButton.dataset.action;
     if (action === "start" || action === "stop" || action === "restart") {
       sendControl(action);
+      return;
     }
+    if (action === "genome-select") {
+      const path = actionButton.dataset.genomePath;
+      if (!path) return;
+      if (!window.confirm("Switch the active genome to:\n\n" + path +
+          "\n\nHelix will restart so the new genome can be loaded.")) {
+        return;
+      }
+      postGenome("/api/genome/select", { path: path }, actionButton);
+    }
+  });
+
+  async function postGenome(url, payload, btn) {
+    if (btn) btn.disabled = true;
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await resp.json().catch(() => ({}));
+      if (!resp.ok || body.ok === false) {
+        alert("Genome action failed: " + (body.error || resp.statusText));
+      }
+    } catch (err) {
+      alert("Genome action failed: " + err);
+    } finally {
+      if (btn) btn.disabled = false;
+      setTimeout(() => {
+        fetchPanels();
+        refreshControls();
+      }, 750);
+    }
+  }
+
+  document.addEventListener("submit", function (evt) {
+    const form = evt.target;
+    if (!(form instanceof HTMLFormElement)) return;
+    if (!form.matches("[data-genome-create]")) return;
+    evt.preventDefault();
+    const input = form.querySelector('input[name="path"]');
+    const path = input instanceof HTMLInputElement ? input.value.trim() : "";
+    if (!path) return;
+    if (!window.confirm("Create a new genome at:\n\n" + path +
+        "\n\nand switch helix to it?")) {
+      return;
+    }
+    postGenome("/api/genome/create", { path: path },
+               form.querySelector("button"));
   });
 
   document.addEventListener("toggle", function (evt) {

--- a/helix_context/launcher/templates/components/database_panel.html
+++ b/helix_context/launcher/templates/components/database_panel.html
@@ -4,8 +4,9 @@
    /admin/genome reply so a drift between "selected" and "running" is
    visible at a glance.
 
-   Switch the active genome from the system-tray "Manage Database"
-   submenu — the dashboard is read-only. #}
+   Genomes can be selected (with a confirm + helix restart) or created
+   directly from this panel — parity with the tray's "Manage Database"
+   submenu (v0.7.0). #}
 
 <section class="panel panel--database">
   <h2 class="panel-title">
@@ -50,6 +51,9 @@
           <strong class="database-entry__name">{{ entry.name }}</strong>
           {% if entry.is_active %}
             <span class="database-entry__tag">active</span>
+          {% else %}
+            <button class="btn btn--mini" data-action="genome-select"
+                    data-genome-path="{{ entry.path }}">Select</button>
           {% endif %}
           <span class="muted database-entry__stats">
             {{ "{:,}".format(entry.total_genes) }} genes · {{ entry.size_mb }} MB
@@ -78,4 +82,11 @@
       <li class="panel-list__item muted">No genomes discovered.</li>
     {% endfor %}
   </ul>
+
+  <form class="db-create" data-genome-create>
+    <input class="db-create__input" type="text" name="path"
+           placeholder="F:\path\to\new.genome.db"
+           aria-label="New genome path" />
+    <button class="btn btn--mini" type="submit">Create + switch</button>
+  </form>
 </section>

--- a/helix_context/launcher/templates/components/observability_panel.html
+++ b/helix_context/launcher/templates/components/observability_panel.html
@@ -1,0 +1,36 @@
+{# Observability panel — launcher-side health of the 5 native sidecar
+   services plus direct links into the telemetry web UIs. Renders on the
+   Monitoring tab (and Overview). Hidden entirely when the operator opted
+   out via HELIX_OBSERVABILITY=0. #}
+
+<section class="panel panel--observability">
+  <h2 class="panel-title">Observability</h2>
+
+  {% if state.observability.install_pending %}
+    <div class="diagnostics-warn">
+      <strong>Sidecar not installed.</strong>
+      <span class="muted">
+        Run <code>scripts/install-native-observability.ps1</code>
+        (or <code>scripts/setup-grafana-telem.sh</code>) then restart the tray.
+      </span>
+    </div>
+  {% endif %}
+
+  {% if state.observability.services %}
+    <ul class="obs-grid">
+      {% for svc in state.observability.services %}
+        <li class="obs-service" title="{{ svc.status }}">
+          <span class="obs-dot obs-dot--{{ svc.status }}" aria-hidden="true"></span>
+          <span class="obs-service__name">{{ svc.name }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+  <div class="telem-links">
+    {% for d in state.observability.links.dashboards %}
+      <a class="telem-link" href="{{ d.url }}" target="_blank" rel="noopener">{{ d.title }}</a>
+    {% endfor %}
+    <a class="telem-link telem-link--alt" href="{{ state.observability.links.prometheus }}" target="_blank" rel="noopener">Prometheus</a>
+  </div>
+</section>

--- a/helix_context/launcher/templates/components/panels.html
+++ b/helix_context/launcher/templates/components/panels.html
@@ -61,6 +61,12 @@
 
 {% endif %}
 
+{# Observability renders whenever the launcher owns (or expects) the
+   sidecar — independent of helix state. #}
+{% if state.observability %}
+  {% include "components/observability_panel.html" %}
+{% endif %}
+
 {# Diagnostics always renders — surfaces errors, orphans, and paths
    regardless of whether helix is up. #}
 {% include "components/diagnostics_panel.html" %}

--- a/run-qa-tray.bat
+++ b/run-qa-tray.bat
@@ -1,0 +1,10 @@
+@echo off
+cd /d F:\tmp\hx-wiring
+set HELIX_OTEL_ENABLED=1
+set HELIX_OTEL_ENDPOINT=localhost:4317
+set HELIX_OTEL_INSECURE=1
+set HELIX_OTEL_SAMPLER_RATIO=1.0
+set HELIX_BUDGET_ZONE=1
+set HELIX_USER=max
+set HELIX_GENOME_PATH=
+python -m helix_context.launcher.app --tray --grafana-url "http://localhost:3000/d/helix-overview/helix-overview" --prometheus-url "http://localhost:9090/graph" > F:\tmp\qa-tray2.log 2>&1

--- a/tests/test_launcher_app.py
+++ b/tests/test_launcher_app.py
@@ -99,7 +99,12 @@ class TestApiState:
         fake_collector.collect.return_value = {"helix": {"running": False, "port": 11437}}
         resp = client.get("/api/state")
         assert resp.status_code == 200
-        assert resp.json() == {"helix": {"running": False, "port": 11437}}
+        # v0.7.0: /api/state additionally carries the launcher-side
+        # observability snapshot (None when no sidecar is wired in).
+        assert resp.json() == {
+            "helix": {"running": False, "port": 11437},
+            "observability": None,
+        }
 
 
 class TestLauncherOwnership:

--- a/tests/test_launcher_dashboard_wiring.py
+++ b/tests/test_launcher_dashboard_wiring.py
@@ -1,0 +1,234 @@
+"""v0.7.0 dashboard wiring sweep: obs panel state, genome web API,
+fresh-checkout mkdir fix, grafana sidecar env hardening."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("jinja2", reason="launcher extra not installed")
+from fastapi.testclient import TestClient
+
+from helix_context.launcher.app import create_app
+
+
+class FakeSupervisor:
+    def __init__(self):
+        self.restarts = []
+        self.starts = 0
+        self.last_start_pending = False
+
+    def adopt(self):
+        return False
+
+    def is_running(self):
+        return True
+
+    def owns_process(self):
+        return False
+
+    def start(self):
+        self.starts += 1
+        return 1234
+
+    def stop(self, reason=""):
+        pass
+
+    def restart(self, reason=""):
+        self.restarts.append(reason)
+        return 1234
+
+
+class FakeCollector:
+    def collect(self):
+        return {
+            "helix": {"running": False, "availability": "unavailable"},
+        }
+
+
+class FakeObservability:
+    def all_statuses(self):
+        return {
+            "collector": "green",
+            "prometheus": "green",
+            "tempo": "red",
+            "loki": "green",
+            "grafana": "green",
+        }
+
+
+@pytest.fixture
+def client():
+    app = create_app(
+        store=SimpleNamespace(),
+        supervisor=FakeSupervisor(),
+        collector=FakeCollector(),
+        observability=FakeObservability(),
+        grafana_url="http://127.0.0.1:3000/d/helix-overview/helix-overview",
+        prometheus_url="http://127.0.0.1:9090/graph",
+    )
+    with TestClient(app) as c:
+        yield c, app
+
+
+# ── observability state + panel ────────────────────────────────────────
+
+
+def test_api_state_carries_observability(client):
+    c, _ = client
+    state = c.get("/api/state").json()
+    obs = state["observability"]
+    assert obs["install_pending"] is False
+    names = {s["name"]: s["status"] for s in obs["services"]}
+    assert names["tempo"] == "red" and names["grafana"] == "green"
+    assert obs["links"]["prometheus"].endswith("/graph")
+    urls = [d["url"] for d in obs["links"]["dashboards"]]
+    assert "http://127.0.0.1:3000/d/helix-overview" in urls
+    assert any("pipeline-observatory" in u for u in urls)
+
+
+def test_panels_partial_renders_observability(client):
+    c, _ = client
+    html = c.get("/api/state/panels").text
+    assert "panel--observability" in html
+    assert "obs-dot--red" in html  # tempo
+    assert "Prometheus" in html
+
+
+def test_observability_panel_absent_when_opted_out():
+    app = create_app(
+        store=SimpleNamespace(),
+        supervisor=FakeSupervisor(),
+        collector=FakeCollector(),
+        observability=None,
+        observability_install_pending=False,
+    )
+    with TestClient(app) as c:
+        assert c.get("/api/state").json()["observability"] is None
+        assert "panel--observability" not in c.get("/api/state/panels").text
+
+
+def test_install_pending_renders_hint():
+    app = create_app(
+        store=SimpleNamespace(),
+        supervisor=FakeSupervisor(),
+        collector=FakeCollector(),
+        observability=None,
+        observability_install_pending=True,
+    )
+    with TestClient(app) as c:
+        html = c.get("/api/state/panels").text
+        assert "Sidecar not installed" in html
+
+
+# ── genome web API ─────────────────────────────────────────────────────
+
+
+def test_genome_select_missing_path_400(client):
+    c, _ = client
+    r = c.post("/api/genome/select", json={})
+    assert r.status_code == 400
+
+
+def test_genome_select_unknown_file_404(client):
+    c, _ = client
+    r = c.post("/api/genome/select", json={"path": "Z:/nope/missing.db"})
+    assert r.status_code == 404
+
+
+def test_genome_select_existing_restarts(client, tmp_path, monkeypatch):
+    c, app = client
+    db = tmp_path / "alt.genome.db"
+    db.write_bytes(b"")
+    monkeypatch.delenv("HELIX_GENOME_PATH", raising=False)
+    r = c.post("/api/genome/select", json={"path": str(db)})
+    assert r.status_code == 202
+    body = r.json()
+    assert body["ok"] is True and body["restarting"] is True
+    assert Path(body["selected"]) == db.resolve()
+    import os
+    assert os.environ.get("HELIX_GENOME_PATH") == str(db.resolve())
+
+
+def test_genome_create_validations(client, tmp_path):
+    c, _ = client
+    assert c.post("/api/genome/create", json={"path": str(tmp_path / "x.txt")}).status_code == 400
+    existing = tmp_path / "have.db"
+    existing.write_bytes(b"")
+    assert c.post("/api/genome/create", json={"path": str(existing)}).status_code == 409
+
+
+def test_genome_create_builds_schema_and_selects(client, tmp_path, monkeypatch):
+    c, _ = client
+    monkeypatch.delenv("HELIX_GENOME_PATH", raising=False)
+    target = tmp_path / "fresh" / "deep" / "new.genome.db"
+    r = c.post("/api/genome/create", json={"path": str(target)})
+    assert r.status_code == 202, r.text
+    assert r.json()["restarting"] is True
+    # Schema build + select happen on a worker thread (the endpoint must
+    # never block the launcher event loop) — poll for completion.
+    import os
+    import time
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if target.exists() and os.environ.get("HELIX_GENOME_PATH"):
+            break
+        time.sleep(0.1)
+    assert target.exists(), "worker thread never created the genome"
+    import sqlite3
+    conn = sqlite3.connect(str(target))
+    tables = {row[0] for row in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    conn.close()
+    assert "genes" in tables
+    assert os.environ.get("HELIX_GENOME_PATH") == str(target.resolve())
+
+
+def test_api_genomes_shape(client):
+    c, _ = client
+    body = c.get("/api/genomes").json()
+    assert body["ok"] is True
+    assert "active" in body and isinstance(body["genomes"], list)
+
+
+# ── fresh-checkout mkdir fix ───────────────────────────────────────────
+
+
+def test_knowledge_store_creates_missing_parent_dirs(tmp_path):
+    from helix_context.knowledge_store import Genome
+    target = tmp_path / "no" / "such" / "dirs" / "genome.db"
+    g = Genome(path=str(target), synonym_map={})
+    g.close()
+    assert target.exists()
+
+
+# ── grafana sidecar env hardening ──────────────────────────────────────
+
+
+def test_grafana_service_env_defaults(monkeypatch):
+    from helix_context.launcher.observability_supervisor import (
+        ObservabilitySupervisor,
+    )
+    monkeypatch.delenv("GF_AUTH_ANONYMOUS_ENABLED", raising=False)
+    env = ObservabilitySupervisor._service_env("grafana")
+    assert env["GF_SERVER_HTTP_ADDR"] == "127.0.0.1"
+    assert env["GF_AUTH_ANONYMOUS_ENABLED"] == "true"
+    assert env["GF_AUTH_ANONYMOUS_ORG_ROLE"] == "Admin"
+    # operator overrides win
+    monkeypatch.setenv("GF_AUTH_ANONYMOUS_ENABLED", "false")
+    env = ObservabilitySupervisor._service_env("grafana")
+    assert env["GF_AUTH_ANONYMOUS_ENABLED"] == "false"
+    # non-grafana services get a plain environment passthrough
+    env = ObservabilitySupervisor._service_env("prometheus")
+    assert "GF_SERVER_HTTP_ADDR" not in env or "GF_SERVER_HTTP_ADDR" in dict(env)
+
+
+def test_overview_dashboard_is_retitled():
+    p = Path(__file__).resolve().parent.parent / \
+        "deploy" / "otel" / "grafana" / "dashboards" / "helix-overview.json"
+    d = json.loads(p.read_text(encoding="utf-8"))
+    assert d["uid"] == "helix-overview"
+    assert d["title"] == "Helix — Overview"


### PR DESCRIPTION
First of the v0.7.0 dashboard/UX PRs — driven by the live QA session on a clean worktree (full stack booted from scratch, OTel routing verified end-to-end into Prometheus/Tempo/Loki/Grafana).

## Fixes
- **Fresh-checkout boot crash**: `KnowledgeStore` now mkdirs the genome's parent chain — a clean clone/worktree previously died with `sqlite3.OperationalError: unable to open database file` behind a silent 90s supervisor timeout. Verified live: booted a worktree with no `genomes/` dir, backend up, db auto-created.
- **Grafana login wall**: sidecar grafana now spawns pinned to 127.0.0.1 with anonymous Admin (operator GF_* overrides win) — tray/dashboard links land on dashboards, not a login page. Prometheus pinned to 127.0.0.1:9090. Update/analytics phone-home off. Verified cookie-less: `/api/search` returns the 6 dashboards anonymously.
- **uid duplicate**: `helix-overview` was a copy titled "Pipeline Observatory"; retitled to **Helix — Overview** so the canonical `/d/helix-overview` links (tray, bat, CLAUDE.md) are honest.
- Collector no longer version-blames a current helix during cold start.

## Features
- **Genome management from the web dashboard** (parity with the tray Manage Database submenu): `GET /api/genomes`, `POST /api/genome/select`, `POST /api/genome/create` — Select buttons + a Create-and-switch form on the Database panel. Heavy work (schema build, restart) runs on worker threads; endpoints answer 202 instantly (first cut blocked the event loop — caught in live QA, fixed + regression-tested).
- **Observability panel** (Monitoring + Genome tabs): live status dots for collector/prometheus/tempo/loki/grafana from the ObservabilitySupervisor, install-pending hint for fresh checkouts, and direct links to all six Grafana dashboards + Prometheus. Same snapshot exposed on `/api/state` for automation.

## Test plan
- [x] 14 new tests (`test_launcher_dashboard_wiring.py`) + updated `test_launcher_app` exact-state assertion — 56 passed across launcher app suites
- [x] Launcher adjacents: 137 passed (app/collector/obs-supervisor/tray/render)
- [x] Live: fresh-worktree tray boot; genome create-then-switch round-trip (202 → schema → restart → dashboard shows new active db); anonymous Grafana; all 5 sidecar services green on the new panel
