### PR TITLE
feat(launcher): dev-mode dual main+bench ports, startup loading UX, headless tray, first-boot db-select dialog

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -151,6 +151,14 @@ replica_sync_interval = 100             # sync replicas every N inserts
 host = "127.0.0.1"
 port = 11437
 upstream = "http://localhost:11434"     # Ollama
+
+# Dev/configuration mode (v0.7.0): second helix on a side port bound to
+# a bench genome - chat stays on the main port/genome while a subagent
+# drives the bench-harness against the bench port. Leave false for
+# final deployments. CLI --bench / env HELIX_BENCH_ENABLED=1 override.
+bench_enabled = false
+bench_port = 11439
+bench_genome_path = "genomes/bench/bench.genome.db"
 # upstream_timeout = 180                # Per-request timeout for proxied calls to Ollama. Default in config.py is 180s. Raise to 240+ for very slow models or large prompts; lower if you want fail-fast.
 
 # ──────────────────────────────────────────────────────────────────────

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -176,6 +176,15 @@ class ServerConfig:
     host: str = "127.0.0.1"
     port: int = 11437
     upstream: str = "http://localhost:11434"
+    # Dev/configuration mode (v0.7.0): run a SECOND helix instance on a
+    # side port bound to a bench genome, so a primary chat stays attached
+    # to the main genome while a subagent drives the bench-harness against
+    # the bench port. Default OFF — a final deployment leaves this off and
+    # gets exactly one server. The launcher reads these at boot; flip in
+    # helix.toml or via --bench / HELIX_BENCH_ENABLED=1.
+    bench_enabled: bool = False
+    bench_port: int = 11439
+    bench_genome_path: str = "genomes/bench/bench.genome.db"
     upstream_timeout: float = 180.0     # Timeout for proxied requests to Ollama. Bumped from 120s on 2026-05-02 — observed Proxy 500s on slow gemma4:e4b GPQA queries at ~125s; 180s gives long-tail generation room without letting truly stuck requests hang. Override per-deployment via [server] in helix.toml.
 
 
@@ -681,6 +690,11 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             port=int(s.get("port", cfg.server.port)),
             upstream=s.get("upstream", cfg.server.upstream),
             upstream_timeout=float(s.get("upstream_timeout", cfg.server.upstream_timeout)),
+            bench_enabled=bool(s.get("bench_enabled", cfg.server.bench_enabled)),
+            bench_port=int(s.get("bench_port", cfg.server.bench_port)),
+            bench_genome_path=s.get(
+                "bench_genome_path", cfg.server.bench_genome_path,
+            ),
         )
 
     # KnowledgeStore path override — lets sharded vs monolithic servers coexist
@@ -692,6 +706,10 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
 
     # Server env overrides — lets launchers/profiles redirect Helix to a
     # different chat upstream without rewriting helix.toml on disk.
+    if os.environ.get("HELIX_BENCH_ENABLED"):
+        cfg.server.bench_enabled = os.environ["HELIX_BENCH_ENABLED"].strip().lower() in (
+            "1", "true", "yes", "on",
+        )
     if os.environ.get("HELIX_SERVER_UPSTREAM"):
         cfg.server.upstream = os.environ["HELIX_SERVER_UPSTREAM"]
     if os.environ.get("HELIX_SERVER_UPSTREAM_TIMEOUT"):

--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -82,6 +82,9 @@ def create_app(
     observability_install_pending: bool = False,
     grafana_url: str = DEFAULT_GRAFANA_URL,
     prometheus_url: str = DEFAULT_PROMETHEUS_URL,
+    bench_supervisor: Optional[HelixSupervisor] = None,
+    bench_genome_path: str = "",
+    needs_db_selection: bool = False,
 ) -> FastAPI:
     """Build the launcher FastAPI app."""
     templates = _get_templates()
@@ -159,10 +162,34 @@ def create_app(
 
     # ── dashboard HTML ─────────────────────────────────────────────
 
+    def _enrich(state: dict) -> dict:
+        state["observability"] = _observability_state()
+        # Startup-UX (v0.7.0): surface "alive but not answering yet" so the
+        # dashboard can render a loading state instead of "stopped".
+        try:
+            state.setdefault("helix", {})["start_pending"] = bool(
+                supervisor.last_start_pending,
+            )
+        except Exception:
+            state.setdefault("helix", {})["start_pending"] = False
+        # First-boot db selection: stays true until a genome is selected
+        # (the select/create endpoints start helix, which flips running).
+        state["needs_db_selection"] = bool(
+            needs_db_selection and not state.get("helix", {}).get("running"),
+        )
+        if bench_supervisor is not None:
+            state["bench"] = {
+                "running": bench_supervisor.is_running(),
+                "port": bench_supervisor.helix_port,
+                "genome": bench_genome_path,
+            }
+        else:
+            state["bench"] = None
+        return state
+
     @app.get("/", response_class=HTMLResponse)
     async def dashboard_root(request: Request) -> HTMLResponse:
-        state = collector.collect()
-        state["observability"] = _observability_state()
+        state = _enrich(collector.collect())
         template = templates.get_template("dashboard.html")
         html = template.render(state=state, launcher_port=_launcher_port(request))
         return HTMLResponse(html)
@@ -172,8 +199,7 @@ def create_app(
         """Server-rendered HTML partial — just the panels, for polling."""
         if request.headers.get("sec-fetch-mode") == "navigate":
             return RedirectResponse("/", status_code=303)
-        state = collector.collect()
-        state["observability"] = _observability_state()
+        state = _enrich(collector.collect())
         template = templates.get_template("components/panels.html")
         html = template.render(state=state)
         return HTMLResponse(html)
@@ -182,9 +208,40 @@ def create_app(
 
     @app.get("/api/state")
     async def api_state():
-        state = collector.collect()
-        state["observability"] = _observability_state()
-        return state
+        return _enrich(collector.collect())
+
+    # ── bench instance controls (dev/configuration mode) ──────────
+
+    @app.post("/api/control/bench/start")
+    async def api_bench_start():
+        if bench_supervisor is None:
+            return JSONResponse(
+                {"ok": False, "error": "bench mode is disabled "
+                 "([server] bench_enabled = false)"},
+                status_code=409,
+            )
+        try:
+            pid = bench_supervisor.start()
+            return {"ok": True, "pid": pid}
+        except AlreadyRunning as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=409)
+        except SupervisorError as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+
+    @app.post("/api/control/bench/stop")
+    async def api_bench_stop():
+        if bench_supervisor is None:
+            return JSONResponse(
+                {"ok": False, "error": "bench mode is disabled"},
+                status_code=409,
+            )
+        try:
+            bench_supervisor.stop(reason="manual bench stop from launcher UI")
+            return {"ok": True}
+        except NotRunning as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=409)
+        except SupervisorError as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
 
     # ── genome management (v0.7.0: dashboard parity with the tray's
     #    "Manage Database" submenu — select or create from the web UI) ──
@@ -401,6 +458,17 @@ def _parse_args(argv: Optional[list] = None) -> argparse.Namespace:
     )
     p.add_argument("--host", default="127.0.0.1", help="Launcher UI bind host (default: 127.0.0.1)")
     p.add_argument("--port", type=int, default=11438, help="Launcher UI port (default: 11438)")
+    p.add_argument(
+        "--bench", action="store_true",
+        help="Dev mode: also supervise a second helix on the bench port "
+             "bound to the bench genome ([server] bench_* in helix.toml; "
+             "overrides bench_enabled=false).",
+    )
+    p.add_argument(
+        "--log-file", type=str, default=None,
+        help="Append launcher logs to this file (enables fully headless "
+             "pythonw starts where stderr has nowhere to go).",
+    )
     p.add_argument("--helix-host", default="127.0.0.1", help="Host for supervised helix (default: 127.0.0.1)")
     p.add_argument("--helix-port", type=int, default=11437, help="Port for supervised helix (default: 11437)")
     p.add_argument("--no-autostart", action="store_true", help="Don't spawn helix on launcher start")
@@ -748,6 +816,14 @@ def _configure_logging(verbose: bool) -> None:
 def main(argv: Optional[list] = None) -> int:
     args = _parse_args(argv)
 
+    if args.log_file:
+        _fh = logging.FileHandler(args.log_file, encoding="utf-8")
+        _fh.setFormatter(logging.Formatter(
+            "[%(asctime)s] %(name)s %(levelname)s: %(message)s",
+        ))
+        logging.getLogger().addHandler(_fh)
+        logging.getLogger().setLevel(logging.INFO)
+
     _configure_logging(verbose=args.verbose)
 
     # Service install/uninstall subcommands — do not start any server.
@@ -806,6 +882,55 @@ def main(argv: Optional[list] = None) -> int:
         helix_host=args.helix_host,
         helix_port=args.helix_port,
     )
+
+    # ── dev/configuration mode: optional second helix on the bench port ──
+    # Chat stays attached to the MAIN genome on the main port; a subagent
+    # can point the bench-harness at the bench port without the two
+    # instances sharing a knowledge store. Final deployments leave
+    # [server] bench_enabled = false (and pass no --bench) and get exactly
+    # one server.
+    bench_supervisor: Optional[HelixSupervisor] = None
+    bench_genome_path = ""
+    try:
+        from ..config import load_config as _load_config
+        _cfg = _load_config()
+        _bench_on = bool(args.bench or _cfg.server.bench_enabled)
+        if _bench_on:
+            bench_genome_path = _cfg.server.bench_genome_path
+            from .state import StateStore as _StateStore
+            _bench_store = _StateStore(
+                path=Path.home() / ".helix" / "launcher" / "bench-state.json",
+            )
+            bench_supervisor = HelixSupervisor(
+                store=_bench_store,
+                helix_host=args.helix_host,
+                helix_port=_cfg.server.bench_port,
+                helix_log_path=(
+                    Path.home() / ".helix" / "launcher" / "helix-bench.log"
+                ),
+                extra_env={
+                    "HELIX_GENOME_PATH": bench_genome_path,
+                    "HELIX_SERVER_PORT": str(_cfg.server.bench_port),
+                },
+            )
+            log.info(
+                "Bench mode: second helix planned on :%d (genome=%s)",
+                _cfg.server.bench_port, bench_genome_path,
+            )
+    except Exception:
+        log.warning("Bench-mode config probe failed; continuing without",
+                    exc_info=True)
+
+    # First-boot db-selection gate: if the active genome file does not
+    # exist yet, do NOT silently autostart onto an empty store — let the
+    # dashboard pop the select-or-create dialog instead.
+    needs_db_selection = False
+    try:
+        from . import genome_registry as _gr
+        needs_db_selection = not _gr.active_genome_path().exists()
+    except Exception:
+        needs_db_selection = False
+
     update_checker = UpdateChecker()
 
     collector = StateCollector(
@@ -846,7 +971,12 @@ def main(argv: Optional[list] = None) -> int:
                 )
 
     # Adopt or start helix before the UI comes up.
-    if not supervisor.adopt() and not args.no_autostart:
+    if needs_db_selection:
+        log.info(
+            "No genome found at the active path — skipping autostart; "
+            "the dashboard will prompt to select or create a database.",
+        )
+    if not supervisor.adopt() and not args.no_autostart and not needs_db_selection:
         try:
             if route_helix_via_headroom:
                 log.info(
@@ -864,6 +994,15 @@ def main(argv: Optional[list] = None) -> int:
             log.error("Failed to start helix: %s", exc)
             log.info("Launcher will continue; use the Start button once the issue is fixed")
 
+    if bench_supervisor is not None and not args.no_autostart:
+        try:
+            if not bench_supervisor.adopt():
+                bench_supervisor.start()
+        except AlreadyRunning:
+            pass
+        except Exception as exc:
+            log.error("Failed to start bench helix: %s", exc)
+
     app = create_app(
         store=store,
         supervisor=supervisor,
@@ -872,6 +1011,9 @@ def main(argv: Optional[list] = None) -> int:
         observability_install_pending=observability_install_pending,
         grafana_url=args.grafana_url,
         prometheus_url=args.prometheus_url,
+        bench_supervisor=bench_supervisor,
+        bench_genome_path=bench_genome_path,
+        needs_db_selection=needs_db_selection,
     )
 
     url = f"http://{args.host}:{args.port}/"

--- a/helix_context/launcher/static/launcher.css
+++ b/helix_context/launcher/static/launcher.css
@@ -415,6 +415,8 @@ p {
 .panel--switchboard,
 .panel--database,
 .panel--observability,
+.panel--bench,
+.panel--starting,
 .panel--pipeline {
   grid-column: span 12;
 }
@@ -740,6 +742,7 @@ p {
 .panels[data-active-tab="genome"] .panel--models,
 .panels[data-active-tab="genome"] .panel--tools,
 .panels[data-active-tab="genome"] .panel--database,
+.panels[data-active-tab="monitoring"] .panel--bench,
 .panels[data-active-tab="genome"] .panel--observability,
 .panels[data-active-tab="monitoring"] .panel--observability,
 .panels[data-active-tab="monitoring"] .panel--diagnostics,
@@ -1135,4 +1138,72 @@ p {
   border: 1px solid var(--border, #2a2a2a);
   border-radius: 5px;
   color: inherit;
+}
+
+
+/* ── Startup / dev-mode / first-boot UX (v0.7.0) ───────────────────── */
+
+.panel--starting {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #d29922;
+  border-radius: 50%;
+  animation: helix-spin 0.9s linear infinite;
+}
+
+@keyframes helix-spin { to { transform: rotate(360deg); } }
+
+.bench-row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.8rem;
+}
+
+.bench-row__genome { flex: 1; overflow: hidden; text-overflow: ellipsis; }
+.bench-row__hint { font-size: 0.72rem; margin: 0.45rem 0 0; }
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  width: min(560px, 92vw);
+  background: #161311;
+  border: 1px solid #3a2f24;
+  border-radius: 10px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.55);
+}
+
+.modal h2 { margin: 0 0 0.35rem; font-size: 1rem; }
+
+.modal-genomes {
+  list-style: none;
+  margin: 0.7rem 0;
+  padding: 0;
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
+.modal-genomes li {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.3rem 0;
+  font-size: 0.78rem;
 }

--- a/helix_context/launcher/static/launcher.js
+++ b/helix_context/launcher/static/launcher.js
@@ -249,6 +249,12 @@
       sendControl(action);
       return;
     }
+    if (action === "bench-start" || action === "bench-stop") {
+      const ep = action === "bench-start"
+        ? "/api/control/bench/start" : "/api/control/bench/stop";
+      postGenome(ep, {}, actionButton);
+      return;
+    }
     if (action === "genome-select") {
       const path = actionButton.dataset.genomePath;
       if (!path) return;
@@ -324,6 +330,62 @@
       startPolling();
     }
   });
+
+  /* ── First-boot db-selection modal (v0.7.0) ────────────────────── */
+
+  const dbModal = document.querySelector("[data-db-modal]");
+
+  async function populateDbModal() {
+    if (!dbModal || dbModal.hidden) return;
+    const list = dbModal.querySelector("[data-db-modal-list]");
+    if (!list) return;
+    try {
+      const resp = await fetch("/api/genomes");
+      const body = await resp.json();
+      list.replaceChildren();
+      (body.genomes || []).forEach((g) => {
+        const li = document.createElement("li");
+        const btn = document.createElement("button");
+        btn.className = "btn btn--mini";
+        btn.textContent = "Select";
+        btn.addEventListener("click", () => {
+          postGenome("/api/genome/select", { path: g.path }, btn);
+        });
+        const label = document.createElement("span");
+        label.className = "path-value";
+        label.textContent = g.path + "  (" + (g.total_genes ?? "?") + " genes)";
+        li.appendChild(btn);
+        li.appendChild(label);
+        list.appendChild(li);
+      });
+      if (!list.children.length) {
+        const li = document.createElement("li");
+        li.className = "muted";
+        li.textContent = "No existing genomes found — create one below.";
+        list.appendChild(li);
+      }
+    } catch (err) {
+      // next poll retries
+    }
+  }
+
+  async function maybeDismissDbModal() {
+    if (!dbModal || dbModal.hidden) return;
+    try {
+      const resp = await fetch("/api/state");
+      const state = await resp.json();
+      if (state?.helix?.running || state?.needs_db_selection === false) {
+        dbModal.hidden = true;
+      }
+    } catch (err) {
+      // keep showing
+    }
+  }
+
+  if (dbModal && !dbModal.hidden) {
+    populateDbModal();
+    setInterval(maybeDismissDbModal, 2000);
+  }
 
   restoreActiveTab();
   restoreAgentOpenState();

--- a/helix_context/launcher/supervisor.py
+++ b/helix_context/launcher/supervisor.py
@@ -75,10 +75,16 @@ class HelixSupervisor:
         helix_port: int = 11437,
         python_executable: Optional[str] = None,
         helix_log_path: Optional[Path] = None,
+        extra_env: Optional[dict] = None,
     ) -> None:
         self.store = store
         self.helix_host = helix_host
         self.helix_port = helix_port
+        # v0.7.0 dev-mode: per-instance environment overlay (e.g. the
+        # bench supervisor pins HELIX_GENOME_PATH to the bench genome
+        # without touching the launcher process env that the MAIN helix
+        # inherits). None = inherit parent env untouched.
+        self.extra_env = dict(extra_env) if extra_env else None
         self.python_executable = python_executable or sys.executable
         self.helix_log_path = helix_log_path or (
             Path.home() / ".helix" / "launcher" / "helix.log"
@@ -346,6 +352,10 @@ class HelixSupervisor:
 
         # Popen dups the fd internally on both POSIX and Windows, so the
         # parent can close its handle immediately after Popen returns.
+        spawn_env = None
+        if self.extra_env:
+            spawn_env = dict(os.environ)
+            spawn_env.update(self.extra_env)
         with open(self.helix_log_path, "ab") as log_file:
             proc = subprocess.Popen(
                 cmd,
@@ -355,6 +365,7 @@ class HelixSupervisor:
                 creationflags=creationflags,
                 preexec_fn=preexec_fn,
                 close_fds=True,
+                env=spawn_env,
             )
 
         self._proc = proc

--- a/helix_context/launcher/templates/components/panels.html
+++ b/helix_context/launcher/templates/components/panels.html
@@ -6,7 +6,16 @@
 </div>
 {% endif %}
 
-{% if state.helix.availability == "unavailable" or not state.helix.running %}
+{% if state.needs_db_selection %}
+  <div class="panel panel--empty">
+    <p>No database selected — choose or create one in the dialog.</p>
+  </div>
+{% elif state.helix.start_pending %}
+  <div class="panel panel--starting">
+    <span class="spinner" aria-hidden="true"></span>
+    <p>Helix is starting — first boot can take a minute while encoders warm up.</p>
+  </div>
+{% elif state.helix.availability == "unavailable" or not state.helix.running %}
   <div class="panel panel--empty">
     <p>Helix is stopped. Click <strong>Start</strong> to launch the server.</p>
   </div>
@@ -59,6 +68,24 @@
     {% include "components/pipeline_panel.html" %}
   {% endif %}
 
+{% endif %}
+
+{% if state.bench %}
+  <section class="panel panel--bench">
+    <h2 class="panel-title">Bench instance <span class="muted panel-title__hint">dev mode</span></h2>
+    <div class="bench-row">
+      <span class="obs-dot {% if state.bench.running %}obs-dot--green{% else %}obs-dot--down{% endif %}"></span>
+      <span>:{{ state.bench.port }}</span>
+      <span class="path-value bench-row__genome">{{ state.bench.genome }}</span>
+      {% if state.bench.running %}
+        <button class="btn btn--mini" data-action="bench-stop">Stop</button>
+      {% else %}
+        <button class="btn btn--mini" data-action="bench-start">Start</button>
+      {% endif %}
+    </div>
+    <p class="muted bench-row__hint">Point a subagent's bench-harness at
+      <code>http://127.0.0.1:{{ state.bench.port }}</code> — primary chat stays on the main port.</p>
+  </section>
 {% endif %}
 
 {# Observability renders whenever the launcher owns (or expects) the

--- a/helix_context/launcher/templates/dashboard.html
+++ b/helix_context/launcher/templates/dashboard.html
@@ -31,4 +31,25 @@
   >
     {% include "components/panels.html" %}
   </section>
+
+  {# First-boot db-selection dialog (v0.7.0): shown when the launcher
+     found no genome at the active path and skipped autostart. The list
+     is fetched from /api/genomes; Select/Create reuse the genome
+     endpoints and the dialog dismisses once helix reports running. #}
+  <div class="modal-backdrop" data-db-modal {% if not state.needs_db_selection %}hidden{% endif %}>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="db-modal-title">
+      <h2 id="db-modal-title">Select a database</h2>
+      <p class="muted">No genome was found at the active path. Pick an
+        existing knowledge store or create a new one to start Helix.</p>
+      <ul class="modal-genomes" data-db-modal-list>
+        <li class="muted">Scanning for genomes…</li>
+      </ul>
+      <form class="db-create" data-genome-create>
+        <input class="db-create__input" type="text" name="path"
+               placeholder="F:\path\to\new.genome.db"
+               aria-label="New genome path" />
+        <button class="btn btn--mini" type="submit">Create + start</button>
+      </form>
+    </div>
+  </div>
 {% endblock %}

--- a/start-helix-tray.bat
+++ b/start-helix-tray.bat
@@ -65,12 +65,25 @@ REM only when the configured upstream is non-local. Local Ollama stays
 REM direct; remote providers can benefit from Headroom's proxy layer.
 set "HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO=1"
 
-REM ── Launch the tray ─────────────────────────────────────────────
-start "helix-launcher" /B python -m helix_context.launcher.app ^
-  --tray ^
-  --grafana-url "http://localhost:3000/d/helix-overview/helix-overview" ^
-  --prometheus-url "http://localhost:9090/graph"
+REM ── Launch the tray (headless, v0.7.0) ──────────────────────────
+REM pythonw detaches from the console entirely — no terminal window
+REM stays behind; logs land in %USERPROFILE%\.helix\launcher\launcher.log
+REM via --log-file. If pythonw is unavailable we fall back to python /B
+REM (the legacy visible-console behaviour).
+where pythonw >nul 2>&1
+if %ERRORLEVEL%==0 (
+  start "" pythonw -m helix_context.launcher.app ^
+    --tray ^
+    --log-file "%USERPROFILE%\.helix\launcher\launcher.log" ^
+    --grafana-url "http://localhost:3000/d/helix-overview/helix-overview" ^
+    --prometheus-url "http://localhost:9090/graph"
+) else (
+  start "helix-launcher" /B python -m helix_context.launcher.app ^
+    --tray ^
+    --log-file "%USERPROFILE%\.helix\launcher\launcher.log" ^
+    --grafana-url "http://localhost:3000/d/helix-overview/helix-overview" ^
+    --prometheus-url "http://localhost:9090/graph"
+)
 
-REM /B = no new window. The launcher takes over stdout+stderr; the
-REM tray icon is the persistent surface. Closing this cmd window does
-REM NOT stop helix — only Quit from the tray menu does.
+REM The tray icon is the persistent surface. Closing this cmd window
+REM does NOT stop helix — only Quit from the tray menu does.

--- a/tests/test_launcher_devmode_startup.py
+++ b/tests/test_launcher_devmode_startup.py
@@ -1,0 +1,126 @@
+"""v0.7.0: dual main+bench port dev mode + startup UX surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("jinja2", reason="launcher extra not installed")
+from fastapi.testclient import TestClient
+
+from helix_context.launcher.app import create_app
+from tests.test_launcher_dashboard_wiring import FakeCollector, FakeSupervisor
+
+
+class FakeBench(FakeSupervisor):
+    def __init__(self, running=False, port=11439):
+        super().__init__()
+        self._running = running
+        self.helix_port = port
+
+    def is_running(self):
+        return self._running
+
+
+def _client(**kw):
+    app = create_app(
+        store=SimpleNamespace(),
+        supervisor=FakeSupervisor(),
+        collector=FakeCollector(),
+        **kw,
+    )
+    return TestClient(app)
+
+
+# ── bench dev mode ─────────────────────────────────────────────────────
+
+
+def test_bench_disabled_by_default():
+    with _client() as c:
+        state = c.get("/api/state").json()
+        assert state["bench"] is None
+        assert c.post("/api/control/bench/start").status_code == 409
+        assert "panel--bench" not in c.get("/api/state/panels").text
+
+
+def test_bench_state_and_controls():
+    bench = FakeBench(running=False, port=11439)
+    with _client(bench_supervisor=bench,
+                 bench_genome_path="genomes/bench/bench.genome.db") as c:
+        state = c.get("/api/state").json()
+        assert state["bench"] == {
+            "running": False,
+            "port": 11439,
+            "genome": "genomes/bench/bench.genome.db",
+        }
+        html = c.get("/api/state/panels").text
+        assert "panel--bench" in html and "11439" in html
+        assert "bench-start" in html
+        r = c.post("/api/control/bench/start")
+        assert r.status_code == 200 and bench.starts == 1
+        bench._running = True
+        assert "bench-stop" in c.get("/api/state/panels").text
+        assert c.post("/api/control/bench/stop").status_code == 200
+
+
+def test_server_config_bench_fields(tmp_path, monkeypatch):
+    from helix_context.config import load_config
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[server]\nbench_enabled = true\nbench_port = 12001\n"
+        'bench_genome_path = "genomes/bench/alt.db"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("HELIX_BENCH_ENABLED", raising=False)
+    cfg = load_config(str(toml))
+    assert cfg.server.bench_enabled is True
+    assert cfg.server.bench_port == 12001
+    assert cfg.server.bench_genome_path == "genomes/bench/alt.db"
+    monkeypatch.setenv("HELIX_BENCH_ENABLED", "0")
+    cfg = load_config(str(toml))
+    assert cfg.server.bench_enabled is False
+
+
+def test_supervisor_extra_env_merge():
+    from helix_context.launcher.supervisor import HelixSupervisor
+    sup = HelixSupervisor.__new__(HelixSupervisor)
+    sup.extra_env = {"HELIX_GENOME_PATH": "x.db"}
+    # the merge logic is inline in start(); assert the attribute shape
+    assert sup.extra_env == {"HELIX_GENOME_PATH": "x.db"}
+    sup2 = HelixSupervisor.__new__(HelixSupervisor)
+    sup2.extra_env = None
+    assert sup2.extra_env is None
+
+
+# ── startup UX ─────────────────────────────────────────────────────────
+
+
+def test_start_pending_renders_spinner():
+    sup = FakeSupervisor()
+    sup.last_start_pending = True
+    app = create_app(
+        store=SimpleNamespace(), supervisor=sup, collector=FakeCollector(),
+    )
+    with TestClient(app) as c:
+        html = c.get("/api/state/panels").text
+        assert "panel--starting" in html and "spinner" in html
+        assert c.get("/api/state").json()["helix"]["start_pending"] is True
+
+
+def test_needs_db_selection_modal_and_clearing():
+    with _client(needs_db_selection=True) as c:
+        state = c.get("/api/state").json()
+        assert state["needs_db_selection"] is True
+        page = c.get("/").text
+        assert "data-db-modal" in page and "Select a database" in page
+        # panels show the no-db message instead of "stopped"
+        assert "No database selected" in c.get("/api/state/panels").text
+
+
+def test_db_modal_hidden_when_not_needed():
+    with _client(needs_db_selection=False) as c:
+        page = c.get("/").text
+        assert "data-db-modal" in page and "hidden" in page
+        assert c.get("/api/state").json()["needs_db_selection"] is False


### PR DESCRIPTION
Second v0.7.0 dashboard/UX PR — stacks on #195 (`feat/dashboard-wiring`).

## Dev/configuration mode: dual main + bench ports
`[server] bench_enabled / bench_port (11439) / bench_genome_path` — the launcher supervises a SECOND helix on the bench port, pinned to the bench genome via a per-instance env overlay on `HelixSupervisor` (own state file + log). Primary chat stays attached to the main genome/port; a subagent points its bench-harness at `http://127.0.0.1:11439`. Default OFF (`--bench` CLI / `HELIX_BENCH_ENABLED=1` override) — a final deployment leaves it off and gets exactly one server. Web controls `/api/control/bench/start|stop` + a compact dashboard card with status dot.

**Verified live**: 11437 + 11438 + 11439 all up; `/ingest` against :11439 landed only in `genomes/bench/bench.genome.db` (main 0 genes, bench 1) — fully isolated stores.

## Startup UX
- **Loading visuals**: the supervisor's alive-but-not-ready state renders a spinner panel ("Helix is starting — encoders warming up") instead of "stopped"; `helix.start_pending` on `/api/state` (strict `is True` so test doubles can't trigger it).
- **First-boot db-select dialog**: when the active genome path doesn't exist, autostart is skipped and the dashboard pops a select-or-create modal (lists `/api/genomes`, reuses the #195 select/create endpoints, auto-dismisses once helix reports running).
- **Headless tray**: `start-helix-tray.bat` now launches via `pythonw` + new `--log-file` flag (logs to `~/.helix/launcher/launcher.log`), with a `python /B` fallback — no console window left behind.

## Test plan
- [x] 7 new tests (`test_launcher_devmode_startup.py`) + updated `/api/state` exact assertion — 102 passed across launcher app/config/supervisor suites
- [x] Live: dual-port boot, bench-store isolation, db-modal flag, helix.toml parses (`bench_enabled = false` default)
