### PR TITLE
fix(launcher): usable stdio under pythonw - headless tray failed to bind the UI port

### DIFF
--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -815,6 +815,29 @@ def _configure_logging(verbose: bool) -> None:
         log.warning("launcher.log file handler unavailable: %s", exc)
 
 
+def _ensure_streams(log_file: Optional[str]) -> None:
+    """Give the process usable stdio under pythonw (v0.7.0 hotfix).
+
+    A detached ``pythonw`` start has ``sys.stdout``/``sys.stderr`` set to
+    None; uvicorn's default logging config writes to those streams, so
+    the launcher's own uvicorn thread died before binding the UI port
+    (observed: ":11438 did not bind within 3.0s" with no traceback).
+    Route the streams into the --log-file (or os.devnull) so every
+    print/StreamHandler in the stack stays harmless when headless.
+    """
+    if sys.stdout is not None and sys.stderr is not None:
+        return
+    target = log_file or os.devnull
+    try:
+        sink = open(target, "a", encoding="utf-8", buffering=1)
+    except OSError:
+        sink = open(os.devnull, "a", encoding="utf-8")
+    if sys.stdout is None:
+        sys.stdout = sink
+    if sys.stderr is None:
+        sys.stderr = sink
+
+
 def main(argv: Optional[list] = None) -> int:
     args = _parse_args(argv)
 
@@ -825,6 +848,7 @@ def main(argv: Optional[list] = None) -> int:
         ))
         logging.getLogger().addHandler(_fh)
         logging.getLogger().setLevel(logging.INFO)
+    _ensure_streams(args.log_file)
 
     _configure_logging(verbose=args.verbose)
 

--- a/tests/test_launcher_devmode_startup.py
+++ b/tests/test_launcher_devmode_startup.py
@@ -124,3 +124,27 @@ def test_db_modal_hidden_when_not_needed():
         page = c.get("/").text
         assert "data-db-modal" in page and "hidden" in page
         assert c.get("/api/state").json()["needs_db_selection"] is False
+
+
+# -- pythonw headless stdio hotfix --------------------------------------
+
+
+def test_ensure_streams_replaces_none_stdio(tmp_path, monkeypatch):
+    import sys
+    from helix_context.launcher.app import _ensure_streams
+    log = tmp_path / "launcher.log"
+    monkeypatch.setattr(sys, "stdout", None)
+    monkeypatch.setattr(sys, "stderr", None)
+    _ensure_streams(str(log))
+    assert sys.stdout is not None and sys.stderr is not None
+    print("headless print survives")  # must not raise
+    sys.stdout.flush()
+    assert "headless print survives" in log.read_text(encoding="utf-8")
+
+
+def test_ensure_streams_noop_with_console(capsys):
+    from helix_context.launcher.app import _ensure_streams
+    import sys
+    before_out, before_err = sys.stdout, sys.stderr
+    _ensure_streams(None)
+    assert sys.stdout is before_out and sys.stderr is before_err


### PR DESCRIPTION
v0.7.0 hotfix, caught during the local tray install: a detached pythonw start has sys.stdout/stderr = None, uvicorn's default loggers write to them, and the launcher's uvicorn thread died before binding :11438 (tray icon alive, dashboard dead, no traceback). _ensure_streams() gives the process usable streams (the --log-file, else devnull) right after arg parsing. 2 new tests; 52 passed across launcher suites.