### PR TITLE
release: 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.7.1 — 2026-06-09
+
+- **fix(launcher): usable stdio under pythonw (#199).** The 0.7.0
+  headless tray (`start-helix-tray.bat` via `pythonw`) failed to bind
+  the dashboard port: detached pythonw has `sys.stdout`/`sys.stderr` =
+  None and uvicorn's default loggers write to them, killing the
+  launcher's server thread before bind (tray icon alive, dashboard
+  dead, no traceback). `_ensure_streams()` now routes the missing
+  streams into `--log-file` (or `os.devnull`) right after arg parsing.
+  Caught during a live v0.7.0 install.
+
 ## 0.7.0 — 2026-06-09
 
 Dashboard + UX release: the tray-hosted web dashboard graduates from a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helix-context"
-version = "0.7.0"
+version = "0.7.1"
 description = "Coordinate index layer for LLM context — Helix weighs, doesn't retrieve"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Patch release carrying the pythonw headless-stdio hotfix (#199). Tag v0.7.1 + GitHub release (PyPI via publish.yml) follow the merge.