### PR TITLE
fix(public): de-hardcode wave 1 + retrieval-profiles spec + evidence roadmap

### DIFF
--- a/docs/audits/2026-06-09-next-steps-evidence.md
+++ b/docs/audits/2026-06-09-next-steps-evidence.md
@@ -1,0 +1,62 @@
+# Next Steps — evidence-backed roadmap (2026-06-09 research loop)
+
+Produced by a 3-agent research/examine/document loop (issues+PRs audit,
+public-product hardcoding audit, retrieval-tuning evidence study) at
+v0.7.1. Companion spec: `docs/specs/2026-06-09-retrieval-profiles.md`.
+
+## State
+
+Backlog flushed 2026-06-09 (merge train #182–#200). Open: #165 (storage —
+~70% executed by #193, needs corpus-scale verification) and #93 (500K
+blob-vs-sharded bench — every named blocker now merged). The bottleneck is
+measurement, not triage.
+
+## Ranked next steps
+
+1. **Rerun the 500K ERB sharded build** (auto-subshard + resume now merged).
+   Prior attempt: 19h32m, throughput collapse 27→0.12 genes/s on an 18 GB
+   single shard; predicted clean build 10–14 h. (M)
+2. **500K recall sweep + scored Q&A vs published baselines** (BM25 recall
+   68.4%; correctness BM25 68.8 / Vector 51.4 / Onyx+GPT-4 72.4). Closes #93.
+   Helix's own curve so far: 83% @10K → 71% @50K (all misses `basic`,
+   14/17 monotone). (M)
+3. **Verify #193 at corpus scale and close #165** (predicted ~13 GB back;
+   single-shard confirmation measured −24% file size). Then ship the
+   residual schema wins: drop legacy `embedding` TEXT column + `complement`
+   for chromatin<2 (~2–3 GB, zero recall risk). (S)
+4. **Run the dense_additive_weight sweep on ERB and flip the default**
+   (#138 evidence: −19pp from gold eviction at 4.0 on prose). Harness ships
+   (#188); no tracking issue existed before this loop. (S)
+5. **Run the SPLADE scale curve; set auto-toggle thresholds** (#164:
+   21.1% disk for 0pp at 850K; knobs shipped in #189). (M)
+6. **Investigate the `basic`-type monotone miss-set** (83→71→? recall
+   curve) once the 500K fixture exists — stable misses are a targeted
+   lexical/synonym fix. (M)
+7. **Implement retrieval profiles per the spec** (3 layers: auto-calibrate,
+   classifier-owned semantic arm, 3 small corpus profiles). (L)
+8. **Decide the Wall-2 orphans**: PRs #158/#160 (parallel fan-out + SPLADE
+   prefilter for ~870M FLOPs/query dense cost) were closed UNMERGED;
+   master has no Wall-2 lever. Re-land or document supersession. (M–L)
+
+## Public-product hardcoding (wave 2 — wave 1 shipped in this PR)
+
+- Plumb the documented `[retrieval]` tier weights into the ADDITIVE path
+  (today they only bind under RRF — 9 documented knobs are dead in the
+  default mode; inline literals at knowledge_store.py 1846/1886/1940/1979/
+  2037/2084/2218/2281/2341).
+- Citation shortener anchors on literal `Projects`/`sources` path segments
+  (context_manager.py ~1527-1535) → strip configured ingest roots instead.
+- Model-ID config knobs: `[ingestion] splade_model`, `[retrieval]
+  dense_model`, sema model (currently hardwired naver/BAAI/MiniLM).
+- Expose silent recall ceilings: SPLADE indexes only `content[:1000]`
+  (storage/indexes.py), dense passage cap 2000 chars (bgem3_codec.py).
+- Budget-tier + abstain constants (tier_logic.py 144-145, 221-239) were
+  calibrated on owner-corpus probes and set per-turn token spend — expose
+  as `[budget]`/`[abstain]` knobs (pairs with profiles work).
+- Deny-list extensibility + non-English `locale/` demotion policy
+  (knowledge_store.py 75-110).
+- Small-model/MoE decoder table (context_manager.py 218-231) misses
+  mistral/deepseek/granite — parse `:NNb` tags generically + override knob.
+- De-Windows the tray edges (powershell-only installer spawn, .bat-only
+  restart); repo hygiene: scripts/.ingest_progress, overnight_logs/,
+  GEMINI.md, `[classifier]`/`[know]` doc-vs-code drift in CLAUDE.md.

--- a/docs/specs/2026-06-09-retrieval-profiles.md
+++ b/docs/specs/2026-06-09-retrieval-profiles.md
@@ -1,0 +1,90 @@
+# Spec: Retrieval Profiles / Modes (3-layer design)
+
+Date: 2026-06-09 · Status: proposed · Evidence: 3-agent research loop over
+issues, benches, and the config surface (v0.7.1).
+
+## Product question
+
+Does helix-context need per-workload profiles, or can one highly tuned
+pipeline serve all retrieval?
+
+## Verdict
+
+**One static pipeline cannot serve all workloads — but only ~6 knobs are
+genuinely corpus-sensitive.** Everything else either has one good value or
+should adapt per-query. Profiles should therefore be SMALL, and most
+"tuning" should be automatic.
+
+Measured break points for a single pipeline:
+
+| Knob | Evidence |
+|---|---|
+| `dense_additive_weight` | 4.0 evicts gold on EnterpriseRAG 10K prose (−19pp recall@10 vs dense-off, #138); the semantic arm needed 16.0 on the same corpus family; own-code needles insensitive (sub-noise). Optimum spans 0–16 by corpus + query shape. |
+| `[ingestion] splade_enabled` | 0pp recall@10 at every size tested on ERB while costing 21.1% of disk (9.96 GB @ 850K, #164); hypothesized positive only <~50K genes — corpus-size regime knob by design. |
+| `ann_similarity_threshold` | 0.58 measured on ONE own-code fixture's random-pair distribution (#139); the repo already had to recalibrate 0.35→0.58 and cold-tier 0.25→0.15 between its OWN fixtures. Absolute thresholds don't transfer. |
+| `filename_anchor_*` | +24pp recall@1 where queries name files (Dewey spike); structurally meaningless on slack/gmail/fireflies shards. |
+| `[synonyms]` | 100% corpus-specific. |
+| abstain floors / know betas / PLR artifact | calibrated from one corpus's score distributions; dense tier totals alone ran 9–28 on ERB vs ~3 on own-code. |
+
+Workload-INDEPENDENT (one value, keep static): `expression_tokens≈7000`
+(8.4% utilization — cap never binds, #73), `per_gene_budget="dynamic"`
+(4%→43% correctness), `dense_embedding_dim=1024`, cosine cymatics (w1
+measured identical), sr/seeded_edges/ray_trace (measured 0 — default off),
+per-query classifier caps/decoder modes, dense_additive_min_cosine 0.15.
+
+## Design: three layers
+
+### Layer 1 — corpus-time auto-calibration (preferred over presets)
+Machinery exists; finish and default it:
+- `ann_threshold_mode="margin_over_random"` default-on, calibration written
+  into the genome (`genome_calibration` via `scripts/calibrate_thresholds.py`)
+  at ingest-finish — calibration travels with the corpus.
+- `[abstain] mode="per_classifier"` from the same script.
+- `splade_auto_enable_below_genes` / `_disable_above_genes` set from the
+  #164 scale curve once run (`benchmarks/sweep_splade_scale_curve.py`).
+- Synonym-map bootstrap from corpus tag vocabulary (today a silent-failure
+  hand-tuned knob).
+
+### Layer 2 — query-time adaptation (classifier-owned, not profiles)
+- Keep: decoder_mode, assembly caps, abstain floors per query class.
+- **Promote the semantic arm into the classifier**: detect prose-shaped /
+  low-identifier-density queries and swap dense weight 4.0↔16.0 per query;
+  drop the `HELIX_SEMANTIC_ARM` env gate. This dissolves most of the #138
+  conflict: identifier queries keep lexical dominance, prose queries get
+  dense dominance.
+- Candidate: `bm25_shortlist` per class (BM25 won 8/8 on config-value
+  queries; −1/8 on helix_only) — needs the gap-4 bench first.
+
+### Layer 3 — minimal static corpus profiles (ingest-time choices only)
+Three profiles, chosen at genome create/ingest, stored in the genome:
+
+| Knob | `code` (default) | `prose` (enterprise) | `small-mixed` (<~20K genes) |
+|---|---|---|---|
+| dense_additive_weight base | 4.0 (pending #138 sweep; likely 2–3) | 2.0 (+16 semantic via Layer 2) | 2–3 |
+| filename_anchor_enabled | true (+24pp) | false (no filename semantics) | true |
+| splade policy | auto (#164 thresholds) | off >100K (0pp, 21% disk) | on (hypothesized rescue regime — unproven) |
+| synonyms | code-vocab seed | empty + bootstrap | bootstrap |
+| shard routing | default | semantic_broaden_routing + prefilter (#159/#160) | n/a |
+
+Precedents to reuse: `/fingerprint` already accepts `profile: fast|balanced|quality`
+(API pattern), `HELIX_MEM_PROFILE` (naming pattern).
+
+Also reconcile the silent divergence between code defaults and the shipped
+helix.toml (expression_tokens 6000 vs 7000, max_genes 8 vs 12,
+splice_aggressiveness 0.5 vs 0.3, decoder_mode full vs condensed,
+sr_enabled false vs true) — today these are two undocumented products.
+
+## Blocking measurements (ranked)
+1. `sweep_dense_additive_weight.py` {0,1,2,3,4,6} on enterprise_rag_10k +
+   _50k (ERB question set, recall@10 + gold_evicted) AND on medium/SIKE-50 —
+   decides whether code/prose differ on the headline knob.
+2. `sweep_splade_scale_curve.py` on/off twins at 1K/17K/50K/100K — sets the
+   auto-toggle thresholds.
+3. RRF gate run (located_n1000, ≥+15pp retrieval@1 to flip fusion default) —
+   profiles can't own per-tier weights until RRF is default OR the additive
+   path honors the weight knobs (see dead-knobs issue).
+4. filename_anchor on/off on ERB 10K (confirm predicted no-op on prose).
+5. bm25_shortlist × query-class grid.
+6. Cross-corpus threshold transfer: run calibrate_thresholds.py on
+   enterprise_rag_10k, diff vs own-code 0.58/5.0/2.5 — quantifies how wrong
+   shipped absolutes are off-corpus.

--- a/helix.toml
+++ b/helix.toml
@@ -432,12 +432,16 @@ enabled = false                         # Set true + run scripts/run_mem_sync.py
 helix_url = "http://127.0.0.1:11437"
 sync_interval_s = 60                    # Poll cadence; human-speed writes, cheap stat+hash
 agent_kind = "claude-code"              # Stamp on every ingest; identifies writer tool
-watch_dirs = [                          # Expand ~ automatically; add more as needed
-  "~/.claude/projects/f--Projects-Education/memory",
-]
+# Empty by default for the public release — point this at your own
+# memory/notes directories, e.g.:
+#   watch_dirs = ["~/.claude/projects/<your-project>/memory"]
+watch_dirs = []                         # Expands ~ automatically; add as needed
 
 [synonyms]
 # Fix 1: lightweight synonym expansion for promoter queries
+# NOTE (public release): owner-project synonym rows that used to ship
+# here (biged / bookkeeper / cosmictasha / fleet) were removed — add
+# rows for your own project vocabulary instead.
 slow = ["performance", "latency", "bottleneck", "timeout", "lag"]
 fast = ["performance", "speed", "optimization", "cache"]
 cache = ["redis", "ttl", "invalidation", "cdn", "caching", "eviction"]
@@ -446,12 +450,9 @@ protein = ["folding", "amino", "alpha_helix", "beta_sheet", "alphafold", "bioche
 tree = ["btree", "b-tree", "data_structures", "index", "binary_tree"]
 helix = ["genome", "ribosome", "codons", "splice", "chromatin", "promoter", "context compression"]
 pipeline = ["steps", "expression", "workflow", "process", "stages"]
-scoring = ["scorerift", "divergence", "audit", "grades", "ratchet", "dimensions"]
+scoring = ["divergence", "audit", "grades", "ratchet", "dimensions"]
 compress = ["compression", "ratio", "target", "context_compression"]
 ratio = ["compression", "ratio", "target", "factor"]
-biged = ["biged-rs", "rust", "axum", "egui", "pyo3", "supervisor", "fleet"]
-bookkeeper = ["bookkeeping", "financial", "transactions", "xero", "invoices", "tenant"]
-cosmictasha = ["cosmic", "tasha", "novabridge", "biged-rs"]
 error = ["exception", "crash", "failure", "bug", "traceback"]
 port = ["proxy", "server", "configuration", "system_settings", "api"]
 threshold = ["divergence", "scoring", "reconciliation", "configuration"]
@@ -481,10 +482,9 @@ maintenance = ["admin", "vacuum", "refresh", "checkpoint", "compact"]
 # Fix #124: unmapped query tokens from sharded-bench misses. Each key is a
 # token produced by extract_query_signals() for a documented miss query that
 # previously had NO synonym entry — so it could only match via raw FTS.
-fleet = ["biged", "biged-rs", "agents", "workers", "supervisor", "skills"]
 ribosome = ["decoder", "ribosome_prompt", "compressor", "splice", "budget", "tokens"]
 expression = ["pipeline", "stages", "steps", "expressed_context", "decoder"]
-agents = ["agent", "fleet", "conductor", "worker", "orchestration", "biged"]
+agents = ["agent", "fleet", "conductor", "worker", "orchestration"]
 dashboard = ["port", "ui", "frontend", "server", "fleet"]
 tables = ["database", "db", "sqlite", "schema", "ddl"]
 

--- a/helix_context/bridge.py
+++ b/helix_context/bridge.py
@@ -159,7 +159,7 @@ class AgentBridge:
 
         lines.extend([
             "## How to Use",
-            "- **Query:** POST http://127.0.0.1:11437/context with `{\"query\": \"...\", \"decoder_mode\": \"none\"}`",
+            f"- **Query:** POST {self.helix_base_url}/context with `{{\"query\": \"...\", \"decoder_mode\": \"none\"}}`",
             "- **Ingest:** Drop .md/.txt files into `~/.helix/shared/inbox/`",
             "- **Signal:** Write JSON to `~/.helix/shared/signals/<name>.json`",
             "",

--- a/helix_context/launcher/app.py
+++ b/helix_context/launcher/app.py
@@ -758,7 +758,7 @@ def _maybe_build_observability() -> tuple[
         return None, False
 
 
-def _handle_service_command(command: str, dry_run: bool) -> int:
+def _handle_service_command(command: str, dry_run: bool, port: int = 11438) -> int:
     """Handle install-service / uninstall-service subcommands.
 
     Returns exit code 0 on success, non-zero on failure. Prints the
@@ -766,7 +766,7 @@ def _handle_service_command(command: str, dry_run: bool) -> int:
     """
     from .installer import install_service, uninstall_service
     if command == "install-service":
-        ok, msg = install_service(dry_run=dry_run)
+        ok, msg = install_service(dry_run=dry_run, port=port)
     else:  # uninstall-service
         ok, msg = uninstall_service(dry_run=dry_run)
     print(msg)
@@ -854,7 +854,7 @@ def main(argv: Optional[list] = None) -> int:
 
     # Service install/uninstall subcommands — do not start any server.
     if args.command in ("install-service", "uninstall-service"):
-        return _handle_service_command(args.command, dry_run=args.dry_run)
+        return _handle_service_command(args.command, dry_run=args.dry_run, port=args.port)
 
     # --tray and --native combined is only supported on Windows today.
     #

--- a/helix_context/launcher/installer.py
+++ b/helix_context/launcher/installer.py
@@ -142,12 +142,15 @@ def _darwin_replacements(launcher_path: Path) -> dict:
 
 # ── install ──────────────────────────────────────────────────────
 
-def install_service(dry_run: bool = False) -> Tuple[bool, str]:
+def install_service(dry_run: bool = False, port: int = 11438) -> Tuple[bool, str]:
     """Install the service file for the current platform.
 
     Returns (success, message). On Windows, returns (False, instructions)
     because there is no NSSM auto-install path; the message contains the
     recipe.
+
+    ``port`` is the launcher UI port shown in the printed next-step URL
+    (threaded from the CLI's --port flag; default 11438).
     """
     platform = current_platform()
     if platform == "unsupported":
@@ -218,7 +221,7 @@ def install_service(dry_run: bool = False) -> Tuple[bool, str]:
             "Verify:\n\n"
             "    systemctl --user status helix-launcher.service\n"
             "    journalctl --user -u helix-launcher.service -f\n\n"
-            "Open http://127.0.0.1:11438/ in your browser."
+            f"Open http://127.0.0.1:{port}/ in your browser."
         )
     else:  # darwin
         next_steps = (
@@ -228,7 +231,7 @@ def install_service(dry_run: bool = False) -> Tuple[bool, str]:
             "Verify:\n\n"
             "    launchctl list | grep helix-launcher\n"
             "    tail -f ~/Library/Logs/helix-launcher.log\n\n"
-            "Open http://127.0.0.1:11438/ in your browser."
+            f"Open http://127.0.0.1:{port}/ in your browser."
         )
 
     return True, next_steps

--- a/helix_context/launcher/templates/components/database_panel.html
+++ b/helix_context/launcher/templates/components/database_panel.html
@@ -85,7 +85,7 @@
 
   <form class="db-create" data-genome-create>
     <input class="db-create__input" type="text" name="path"
-           placeholder="F:\path\to\new.genome.db"
+           placeholder="path/to/new.genome.db"
            aria-label="New genome path" />
     <button class="btn btn--mini" type="submit">Create + switch</button>
   </form>

--- a/helix_context/launcher/templates/dashboard.html
+++ b/helix_context/launcher/templates/dashboard.html
@@ -46,7 +46,7 @@
       </ul>
       <form class="db-create" data-genome-create>
         <input class="db-create__input" type="text" name="path"
-               placeholder="F:\path\to\new.genome.db"
+               placeholder="path/to/new.genome.db"
                aria-label="New genome path" />
         <button class="btn btn--mini" type="submit">Create + start</button>
       </form>

--- a/helix_context/retrieval/lexical_rescue.py
+++ b/helix_context/retrieval/lexical_rescue.py
@@ -4,6 +4,17 @@ Helix should not become plain BM25, but BM25 is an excellent safety net
 for tiny literal needles. This module returns a small ordered list of
 source_ids from ``genes_fts`` so callers can merge them after packet
 sources and before DAL fetch.
+
+Path-bonus scoring contract (``_source_path_bonus``) — generic,
+corpus-neutral heuristics only:
+
+* config-like extension: +1.5 (+1.0 more on config-flavored queries)
+* query-term substring agreement with the path: +0.4 per term (len > 3)
+* a query term (len >= 4) naming a whole path segment or filename stem:
+  +2.0, applied once
+* tests-path penalty: -0.75
+
+No repository- or product-specific path is special-cased.
 """
 
 from __future__ import annotations
@@ -53,6 +64,19 @@ def _fts_match_expr(query: str) -> str:
     return " OR ".join(f'"{term}"' for term in keep)
 
 
+def _path_segments(path: str) -> set[str]:
+    """Split a normalized path into its segments plus extension-less stems."""
+    segments: set[str] = set()
+    for segment in path.split("/"):
+        if not segment:
+            continue
+        segments.add(segment)
+        stem = segment.split(".", 1)[0]
+        if stem:
+            segments.add(stem)
+    return segments
+
+
 def _source_path_bonus(source_id: str, query_terms: set[str]) -> float:
     path = normalize_source_id(source_id)
     score = 0.0
@@ -66,12 +90,16 @@ def _source_path_bonus(source_id: str, query_terms: set[str]) -> float:
     for term in query_terms:
         if len(term) > 3 and term in path:
             score += 0.4
-    if "helix" in query_terms and "helix-context" in path:
+    # Generic path affinity: a sufficiently specific query term (len >= 4)
+    # naming a whole path segment (directory, filename, or filename stem)
+    # is strong evidence the source belongs to the thing being asked about.
+    # Applied once per path. Replaces the pre-public hardwired boosts for
+    # this repository's own paths ("helix-context", "/helix.toml") and the
+    # owner-specific "/_worktrees/" penalty, so rescue scoring stays
+    # corpus-neutral.
+    segments = _path_segments(path)
+    if any(len(term) >= 4 and term in segments for term in query_terms):
         score += 2.0
-    if "helix" in query_terms and path.endswith("/helix.toml"):
-        score += 2.0
-    if "/_worktrees/" in path:
-        score -= 1.0
     if "/tests/" in path or "\\tests\\" in source_id.lower():
         score -= 0.75
     return score

--- a/helix_context/tagger.py
+++ b/helix_context/tagger.py
@@ -13,12 +13,19 @@ Performance:
     LLM pack: ~6s/chunk (2x E4B autoregressive calls)
     CpuTagger: ~7ms/chunk (spaCy + regex, single-threaded)
     3,500 chunks: ~1 hour → ~25 seconds
+
+Operator extension:
+    The rule-based vocabulary ships project-neutral. Extend it per
+    deployment via the HELIX_TAGGER_EXTRA_ENTITIES and
+    HELIX_TAGGER_EXTRA_TERMS env vars, read once at module import —
+    see _extend_vocabulary_from_env().
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import re
 from typing import Dict, List, Optional, Set
 
@@ -65,17 +72,24 @@ def _get_nlp():
 
 
 # ── Project entity vocabulary (rule-based NER) ──────────────────
+#
+# Ships project-neutral: only this repository's own stack plus generic
+# IR/NLP artifacts. Earlier builds bundled the original author's private
+# project names here (BigEd, BookKeeper, CosmicTasha, ModuleHub, FleetDB,
+# SwiftWing21, ...) as EntityRuler patterns — those owner-specific
+# defaults were removed for the public release. Operators add their own
+# vocabulary via HELIX_TAGGER_EXTRA_ENTITIES instead (see
+# _extend_vocabulary_from_env below).
 
 _PROJECT_ENTITIES = {
     "PRODUCT": [
-        "BigEd", "BigEd CC", "Helix Context", "Agentome", "ScoreRift",
-        "BookKeeper", "CosmicTasha", "two-brain", "ModuleHub",
-        "CpuTagger", "SemaCodec", "FleetDB", "Dr. Ders", "DeBERTa",
-        "fleet.toml", "helix.toml", "genome.db",
+        "Helix Context", "Agentome", "ScoreRift",
+        "CpuTagger", "SemaCodec", "DeBERTa",
+        "helix.toml", "genome.db",
         "SPLADE", "FTS5", "MiniLM", "ColBERT", "RaBitQ",
     ],
     "ORG": [
-        "SwiftWing21", "Anthropic", "Naver Labs",
+        "Anthropic", "Naver Labs",
     ],
 }
 
@@ -115,14 +129,59 @@ _TECH_TERMS: Set[str] = {
     "test", "benchmark", "smoke", "unittest", "pytest",
     "security", "audit", "compliance", "soc2", "encryption",
     "deploy", "ci", "cd", "release", "build", "binary",
-    # Project-specific terms (Agentome ecosystem)
-    "biged", "helix", "agentome", "scorerift", "bookkeeper",
-    "cosmictasha", "modulehub", "ribosome", "genome", "chromatin",
+    # Project-specific terms (this repository's own stack). Owner-project
+    # names that used to ship here (biged, bookkeeper, cosmictasha,
+    # modulehub, fleetdb, "dr ders") were removed for the public release —
+    # extend per deployment via HELIX_TAGGER_EXTRA_TERMS instead.
+    "helix", "agentome", "scorerift",
+    "ribosome", "genome", "chromatin",
     "ellipticity", "codon", "promoter", "epigenetics", "sema",
     "splade", "deberta", "colbert", "rabitq", "fts5",
-    "cputagger", "semacodec", "fleetdb", "fleet",
-    "supervisor", "dr ders", "needle", "gene",
+    "cputagger", "semacodec", "fleet",
+    "supervisor", "needle", "gene",
 }
+
+
+# ── Operator vocabulary extension (env-driven) ──────────────────
+
+def _extend_vocabulary_from_env() -> None:
+    """Append operator-supplied vocabulary from the environment.
+
+    Two env vars, read once at module import (importlib.reload re-reads
+    them in long-lived processes; the spaCy EntityRuler is built lazily
+    on first _get_nlp(), so set them before the tagger's first use):
+
+    HELIX_TAGGER_EXTRA_ENTITIES
+        Comma-separated "Label:Text" pairs appended to
+        ``_PROJECT_ENTITIES``, e.g. "PRODUCT:AcmeApp,ORG:AcmeCorp".
+        Malformed pairs (missing label or text) are skipped with a
+        warning.
+    HELIX_TAGGER_EXTRA_TERMS
+        Comma-separated terms, lowercased and added to ``_TECH_TERMS``,
+        e.g. "acmeapp,acmecorp".
+    """
+    for pair in os.environ.get("HELIX_TAGGER_EXTRA_ENTITIES", "").split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        label, sep, text = pair.partition(":")
+        label, text = label.strip(), text.strip()
+        if not sep or not label or not text:
+            log.warning(
+                "Skipping malformed HELIX_TAGGER_EXTRA_ENTITIES entry %r "
+                "(expected 'Label:Text')",
+                pair,
+            )
+            continue
+        _PROJECT_ENTITIES.setdefault(label.upper(), []).append(text)
+    for term in os.environ.get("HELIX_TAGGER_EXTRA_TERMS", "").split(","):
+        term = term.strip().lower()
+        if term:
+            _TECH_TERMS.add(term)
+
+
+_extend_vocabulary_from_env()
+
 
 # ── Regex patterns for KV extraction ──────────────────────────────
 

--- a/tests/test_bench_needles.py
+++ b/tests/test_bench_needles.py
@@ -74,7 +74,7 @@ def test_multi_gold_miss_when_neither_source_appears():
     gold = ["helix-context/helix.toml", "helix-context/docs/SETUP.md"]
     delivered = [
         "F:/Projects/Education/CLAUDE.md",
-        "F:/Projects/BookKeeper/CLAUDE.md",
+        "F:/Projects/OtherRepo/CLAUDE.md",
     ]
     assert _gold_delivered(delivered, gold) is False
 

--- a/tests/test_density_gate.py
+++ b/tests/test_density_gate.py
@@ -51,9 +51,9 @@ class TestIsDeniedSource:
         """Real helix-context source files must never be denied."""
         assert is_denied_source("F:/Projects/helix-context/helix_context/genome.py") is False
         assert is_denied_source("helix-context/docs/RESEARCH.md") is False
-        assert is_denied_source("BookKeeper/src/ledger.py") is False
-        assert is_denied_source("Education/fleet/dashboard.py") is False
-        assert is_denied_source("two-brain-audit/scorerift/core.py") is False
+        assert is_denied_source("accounting/src/ledger.py") is False
+        assert is_denied_source("projects/fleet/dashboard.py") is False
+        assert is_denied_source("side-project/audit/core.py") is False
 
     # Steam / game content
     # ─── Steam / game content is SIGNAL, not noise (reframed 2026-04-10) ───
@@ -86,7 +86,7 @@ class TestIsDeniedSource:
 
     # Build artifacts
     def test_next_build_denied(self):
-        assert is_denied_source("F:/CosmicTasha/.next/server/app/page.js") is True
+        assert is_denied_source("F:/webshop/.next/server/app/page.js") is True
 
     def test_node_modules_denied(self):
         assert is_denied_source("project/node_modules/react/index.js") is True
@@ -98,20 +98,20 @@ class TestIsDeniedSource:
         assert is_denied_source("project/dist/bundle.js") is True
 
     def test_target_debug_denied(self):
-        assert is_denied_source("biged-rs/target/debug/deps/libcore.rlib") is True
+        assert is_denied_source("acme-rs/target/debug/deps/libcore.rlib") is True
 
     def test_target_release_denied(self):
-        assert is_denied_source("biged-rs/target/release/biged.exe") is True
+        assert is_denied_source("acme-rs/target/release/acme.exe") is True
 
     # Lockfiles
     def test_package_lock_denied(self):
-        assert is_denied_source("F:/CosmicTasha/package-lock.json") is True
+        assert is_denied_source("F:/webshop/package-lock.json") is True
 
     def test_yarn_lock_denied(self):
         assert is_denied_source("project/yarn.lock") is True
 
     def test_cargo_lock_denied(self):
-        assert is_denied_source("biged-rs/Cargo.lock") is True
+        assert is_denied_source("acme-rs/Cargo.lock") is True
 
     def test_uv_lock_denied(self):
         assert is_denied_source("helix-context/uv.lock") is True
@@ -128,7 +128,7 @@ class TestIsDeniedSource:
 
     # Next.js manifests
     def test_app_paths_manifest_denied(self):
-        assert is_denied_source("F:/CosmicTasha/.next/server/app-paths-manifest.json") is True
+        assert is_denied_source("F:/webshop/.next/server/app-paths-manifest.json") is True
 
     def test_client_reference_manifest_denied(self):
         assert is_denied_source(".next/server/app/client-reference-manifest.js") is True
@@ -156,8 +156,8 @@ class TestIsDeniedSource:
     # CRITICAL: CSVs are NOT in the deny list — business content
     def test_business_csv_not_denied(self):
         """Future business CSVs (customer data, invoices, etc.) must pass."""
-        assert is_denied_source("F:/BookKeeper/customers.csv") is False
-        assert is_denied_source("F:/BigEd/fleet/metrics/daily_report.csv") is False
+        assert is_denied_source("F:/accounting/customers.csv") is False
+        assert is_denied_source("F:/acme/fleet/metrics/daily_report.csv") is False
         assert is_denied_source("project/data/financial_records.csv") is False
 
     def test_case_insensitive(self):

--- a/tests/test_launcher_installer.py
+++ b/tests/test_launcher_installer.py
@@ -196,4 +196,4 @@ class TestCLIIntegration:
         with patch("helix_context.launcher.installer.install_service",
                    return_value=(True, "dry")) as mock_install:
             app_mod.main(["install-service", "--dry-run"])
-        mock_install.assert_called_once_with(dry_run=True)
+        mock_install.assert_called_once_with(dry_run=True, port=11438)

--- a/tests/test_public_dehardcode.py
+++ b/tests/test_public_dehardcode.py
@@ -1,0 +1,216 @@
+"""Public-product de-hardcoding guards (wave 1).
+
+Pins the removal of owner-specific vocabulary from the shipped defaults:
+
+* ``helix_context.tagger`` ships no private project names in its
+  EntityRuler patterns or tech-term dictionary, and supports
+  per-deployment extension via the HELIX_TAGGER_EXTRA_ENTITIES /
+  HELIX_TAGGER_EXTRA_TERMS env vars.
+* ``lexical_rescue`` path scoring is corpus-neutral — a generic
+  query-term / path-segment match earns the boost, and this
+  repository's own paths get no special treatment.
+* ``helix.toml`` ships no owner-project synonym rows and no personal
+  ``watch_dirs``.
+
+None of these tests require the spaCy model — they assert on the
+module-level vocabulary and the regex/scoring helpers only (mirrors
+tests/test_tagger_kv.py, which exercises CpuTagger without _get_nlp()).
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import helix_context.tagger as tagger_mod
+from helix_context.retrieval.lexical_rescue import _source_path_bonus
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Owner-project vocabulary that pre-public builds shipped as defaults.
+OWNER_ENTITY_MARKERS = (
+    "BigEd", "BookKeeper", "CosmicTasha", "two-brain", "ModuleHub",
+    "Dr. Ders", "FleetDB", "SwiftWing21",
+)
+OWNER_TECH_TERMS = (
+    "biged", "bookkeeper", "cosmictasha", "modulehub", "dr ders", "fleetdb",
+)
+
+
+# ── (a) tagger ships neutral vocabulary ─────────────────────────────
+
+class TestTaggerShipsNeutralVocabulary:
+    def test_no_owner_entities_in_vocabulary(self):
+        rendered = repr(tagger_mod._PROJECT_ENTITIES)
+        for marker in OWNER_ENTITY_MARKERS:
+            assert marker not in rendered, marker
+
+    def test_no_owner_entities_in_built_patterns(self):
+        rendered = repr(tagger_mod._build_project_patterns())
+        for marker in OWNER_ENTITY_MARKERS:
+            assert marker not in rendered, marker
+
+    def test_no_owner_tech_terms(self):
+        for term in OWNER_TECH_TERMS:
+            assert term not in tagger_mod._TECH_TERMS, term
+
+    def test_own_stack_vocabulary_survives(self):
+        # The product's own stack stays taggable out of the box.
+        assert "Helix Context" in tagger_mod._PROJECT_ENTITIES["PRODUCT"]
+        assert "helix" in tagger_mod._TECH_TERMS
+        assert "splade" in tagger_mod._TECH_TERMS
+
+
+# ── (b) env-var vocabulary extension ────────────────────────────────
+
+class TestTaggerEnvExtension:
+    def test_extra_entities_and_terms_appended(self, monkeypatch):
+        monkeypatch.setenv(
+            "HELIX_TAGGER_EXTRA_ENTITIES", "PRODUCT:AcmeApp, ORG:AcmeCorp"
+        )
+        monkeypatch.setenv("HELIX_TAGGER_EXTRA_TERMS", "acmeapp, AcmeCorp")
+        mod = importlib.reload(tagger_mod)
+        try:
+            assert "AcmeApp" in mod._PROJECT_ENTITIES["PRODUCT"]
+            assert "AcmeCorp" in mod._PROJECT_ENTITIES["ORG"]
+            assert "acmeapp" in mod._TECH_TERMS
+            assert "acmecorp" in mod._TECH_TERMS  # lowercased on ingest
+            patterns = mod._build_project_patterns()
+            assert {"label": "PRODUCT", "pattern": "AcmeApp"} in patterns
+        finally:
+            monkeypatch.delenv("HELIX_TAGGER_EXTRA_ENTITIES", raising=False)
+            monkeypatch.delenv("HELIX_TAGGER_EXTRA_TERMS", raising=False)
+            importlib.reload(tagger_mod)
+
+    def test_new_label_creates_bucket(self, monkeypatch):
+        monkeypatch.setenv("HELIX_TAGGER_EXTRA_ENTITIES", "gpe:Acmeville")
+        mod = importlib.reload(tagger_mod)
+        try:
+            assert "Acmeville" in mod._PROJECT_ENTITIES["GPE"]
+        finally:
+            monkeypatch.delenv("HELIX_TAGGER_EXTRA_ENTITIES", raising=False)
+            importlib.reload(tagger_mod)
+
+    def test_malformed_entity_pairs_skipped(self, monkeypatch):
+        monkeypatch.setenv(
+            "HELIX_TAGGER_EXTRA_ENTITIES", "NoColonHere,:NoLabel,PRODUCT:Good"
+        )
+        mod = importlib.reload(tagger_mod)
+        try:
+            assert "Good" in mod._PROJECT_ENTITIES["PRODUCT"]
+            rendered = repr(mod._PROJECT_ENTITIES)
+            assert "NoColonHere" not in rendered
+            assert "NoLabel" not in rendered
+        finally:
+            monkeypatch.delenv("HELIX_TAGGER_EXTRA_ENTITIES", raising=False)
+            importlib.reload(tagger_mod)
+
+    def test_clean_env_reload_restores_defaults(self, monkeypatch):
+        monkeypatch.delenv("HELIX_TAGGER_EXTRA_ENTITIES", raising=False)
+        monkeypatch.delenv("HELIX_TAGGER_EXTRA_TERMS", raising=False)
+        mod = importlib.reload(tagger_mod)
+        assert "AcmeApp" not in repr(mod._PROJECT_ENTITIES)
+        assert "acmeapp" not in mod._TECH_TERMS
+
+
+# ── (c) lexical rescue is corpus-neutral ────────────────────────────
+
+class TestLexicalRescuePathAffinity:
+    def test_query_term_path_segment_earns_boost(self):
+        # Whole-segment match (+2.0) on top of substring agreement (+0.4)
+        seg = _source_path_bonus("F:/work/acme/policies.md", {"acme"})
+        # Substring-only match: "acme" is inside "acmeology" but names no
+        # whole segment / stem.
+        sub = _source_path_bonus("F:/work/acmeology/policies.md", {"acme"})
+        assert seg - sub == pytest.approx(2.0)
+
+    def test_filename_stem_counts_as_segment(self):
+        with_stem = _source_path_bonus("F:/repo/conf/acme.toml", {"acme"})
+        without = _source_path_bonus("F:/repo/conf/other.toml", {"acme"})
+        # +2.0 segment-stem boost +0.4 substring agreement
+        assert with_stem - without == pytest.approx(2.4)
+
+    def test_short_terms_do_not_trigger_segment_boost(self):
+        # len < 4 terms are too unspecific for the +2.0 path-affinity boost
+        assert _source_path_bonus("F:/work/api/handlers.py", {"api"}) == 0.0
+
+    def test_helix_context_paths_are_not_special_cased(self):
+        # Structurally identical paths must score identically whether they
+        # mention this product or any other project.
+        helix = _source_path_bonus(
+            "F:/projects/helix-context/server.py", {"helix"}
+        )
+        acme = _source_path_bonus(
+            "F:/projects/acme-context/server.py", {"acme"}
+        )
+        assert helix == pytest.approx(acme)
+
+        helix_toml = _source_path_bonus(
+            "F:/projects/helix-context/helix.toml", {"helix"}
+        )
+        acme_toml = _source_path_bonus(
+            "F:/projects/acme-context/acme.toml", {"acme"}
+        )
+        assert helix_toml == pytest.approx(acme_toml)
+
+    def test_worktrees_penalty_removed_tests_penalty_kept(self):
+        assert _source_path_bonus("F:/x/_worktrees/y.py", set()) == 0.0
+        assert _source_path_bonus("F:/x/tests/y.py", set()) == -0.75
+
+    def test_rescue_prefers_query_term_path_segment(self, tmp_path):
+        from helix_context.genome import Genome
+        from helix_context.retrieval.lexical_rescue import lexical_rescue_sources
+
+        from tests.conftest import make_gene
+
+        db = tmp_path / "genome.db"
+        genome = Genome(str(db))
+        try:
+            generic = make_gene(
+                "retention policy schedule for backups", domains=["retention"]
+            )
+            generic.source_id = "F:/work/other/policies.md"
+            genome.upsert_gene(generic, apply_gate=False)
+
+            acme = make_gene(
+                "retention policy schedule for acme backups",
+                domains=["retention"],
+            )
+            acme.source_id = "F:/work/acme/policies.md"
+            genome.upsert_gene(acme, apply_gate=False)
+        finally:
+            genome.close()
+
+        sources = lexical_rescue_sources(
+            "acme retention policy", genome_path=str(db), limit=2
+        )
+
+        assert sources[0] == "F:/work/acme/policies.md"
+
+
+# ── (d) helix.toml ships neutral config ─────────────────────────────
+
+class TestHelixTomlShipsNeutral:
+    @pytest.fixture()
+    def cfg(self):
+        with open(REPO_ROOT / "helix.toml", "rb") as fh:
+            return tomllib.load(fh)
+
+    def test_synonyms_have_no_owner_rows(self, cfg):
+        synonyms = cfg["synonyms"]
+        for owner_key in ("biged", "bookkeeper", "cosmictasha", "fleet"):
+            assert owner_key not in synonyms, owner_key
+        flat_values = {v for values in synonyms.values() for v in values}
+        assert not flat_values & {
+            "biged", "biged-rs", "bookkeeper", "cosmictasha", "scorerift"
+        }
+
+    def test_mem_sync_watch_dirs_empty(self, cfg):
+        assert cfg["mem_sync"]["watch_dirs"] == []

--- a/tests/test_shard_router.py
+++ b/tests/test_shard_router.py
@@ -1169,7 +1169,7 @@ def test_doc_type_boost_for_matches_summary_basenames():
     )
 
     # Summary docs — boosted, regardless of separator / case / depth.
-    assert _doc_type_boost_for("Education/biged-rs/README.md") == DOC_TYPE_BOOST
+    assert _doc_type_boost_for("projects/acme-rs/README.md") == DOC_TYPE_BOOST
     assert _doc_type_boost_for("repo/CLAUDE.md") == DOC_TYPE_BOOST
     assert _doc_type_boost_for("docs/INDEX.md") == DOC_TYPE_BOOST
     assert _doc_type_boost_for("readme.md") == DOC_TYPE_BOOST
@@ -1177,7 +1177,7 @@ def test_doc_type_boost_for_matches_summary_basenames():
     assert _doc_type_boost_for("C:\\proj\\sub\\claude.md") == DOC_TYPE_BOOST
 
     # Implementation / non-summary files — identity (NOT boosted).
-    assert _doc_type_boost_for("Education/biged-rs/src/main.rs") == 1.0
+    assert _doc_type_boost_for("projects/acme-rs/src/main.rs") == 1.0
     assert _doc_type_boost_for("helix_context/shard_router.py") == 1.0
     assert _doc_type_boost_for("docs/architecture/OBSERVABILITY.md") == 1.0
     # A file that merely contains "readme" but isn't the basename.
@@ -1232,10 +1232,10 @@ def doc_type_boost_setup():
     # the keyword-dense implementation file. This is the #121 symptom:
     # the README holds the answer conceptually yet loses the ranking.
     readme = _mk_gene(
-        "BigEd Rust build overview. The release binary is around 4 MB.",
-        domains=["biged"],
+        "Acme Rust build overview. The release binary is around 4 MB.",
+        domains=["acme"],
         entities=["rust"],
-        source="Education/biged-rs/README.md",
+        source="projects/acme-rs/README.md",
     )
     readme_id = ga.upsert_gene(readme, apply_gate=False)
     # Implementation file: keyword-dense AND its path contains the query
@@ -1245,9 +1245,9 @@ def doc_type_boost_setup():
     impl = _mk_gene(
         "binary binary binary size size build target binary measured "
         "binary size binary footprint binary size binary",
-        domains=["biged"],
+        domains=["acme"],
         entities=["binary"],
-        source="Education/biged-rs/src/binary_size_report.rs",
+        source="projects/acme-rs/src/binary_size_report.rs",
     )
     impl_id = ga.upsert_gene(impl, apply_gate=False)
     ga.conn.close()
@@ -1257,7 +1257,7 @@ def doc_type_boost_setup():
     gb = Genome(shard_b_path)
     other = _mk_gene(
         "Unrelated second shard. Auth tokens and JWT sessions.",
-        domains=["biged"],
+        domains=["acme"],
         entities=["binary"],
         source="other/notes.md",
     )
@@ -1271,19 +1271,19 @@ def doc_type_boost_setup():
     register_shard(main, "shard_a", "reference", shard_a_path, gene_count=2)
     register_shard(main, "shard_b", "participant", shard_b_path, gene_count=1)
     for gid, src, ents in (
-        (readme_id, "Education/biged-rs/README.md", ["rust"]),
-        (impl_id, "Education/biged-rs/src/binary_size_report.rs", ["binary"]),
+        (readme_id, "projects/acme-rs/README.md", ["rust"]),
+        (impl_id, "projects/acme-rs/src/binary_size_report.rs", ["binary"]),
     ):
         upsert_fingerprint(
             main, gene_id=gid, shard_name="shard_a", source_id=src,
-            domains_json=json.dumps(["biged"]),
+            domains_json=json.dumps(["acme"]),
             entities_json=json.dumps(ents),
             key_values_json="[]",
         )
     upsert_fingerprint(
         main, gene_id=other_id, shard_name="shard_b",
         source_id="other/notes.md",
-        domains_json=json.dumps(["biged"]),
+        domains_json=json.dumps(["acme"]),
         entities_json=json.dumps(["binary"]),
         key_values_json="[]",
     )
@@ -1319,7 +1319,7 @@ def test_doc_type_boost_lifts_readme_score_on_cross_shard_merge(
         router = ShardRouter(doc_type_boost_setup["main_path"])
         try:
             router.query_genes(
-                domains=["biged"], entities=["binary"], max_genes=10,
+                domains=["acme"], entities=["binary"], max_genes=10,
             )
             return dict(router.last_query_scores)
         finally:
@@ -1365,7 +1365,7 @@ def test_doc_type_boost_does_not_regress_deep_implementation_file(
     router = ShardRouter(doc_type_boost_setup["main_path"])
     try:
         results = router.query_genes(
-            domains=["biged"], entities=["binary"], max_genes=10,
+            domains=["acme"], entities=["binary"], max_genes=10,
         )
         ids = [g.gene_id for g in results]
         scores = router.last_query_scores


### PR DESCRIPTION
Output of the 2026-06-09 research → examine → document loop (3 parallel research agents: issues/PRs evidence audit, public-product hardcoding audit, retrieval-tuning evidence study).

## De-hardcode wave 1 (runtime retrieval code)

- **Tagger**: owner-project vocabulary (BigEd/BookKeeper/CosmicTasha/ModuleHub/Dr. Ders/FleetDB/SwiftWing21 + matching tech terms) removed from `_PROJECT_ENTITIES`/`_TECH_TERMS` — these drive the tag_exact tier, so every public user's corpus was being tagged against the owner's project names. Operators extend via `HELIX_TAGGER_EXTRA_ENTITIES` ("Label:Text" pairs) / `HELIX_TAGGER_EXTRA_TERMS`.
- **lexical_rescue**: removed the product's self-boost (`helix` query + `helix-context` path +2.0, `/helix.toml` +2.0) and the owner's `/_worktrees/` −1.0 layout penalty; replaced with a generic +2.0 when a query term (len≥4) names a path segment/filename stem. Structural bias toward the product's own repo is gone (helix/acme now score identically).
- **helix.toml template**: owner-project synonym rows and the personal `mem_sync.watch_dirs` path scrubbed.
- **Dashboard placeholders**: `F:\path\to\new.genome.db` → `path/to/new.genome.db`.
- **bridge.py** How-to-Use renders the instance `helix_base_url` (was hardcoded :11437); **installer** service message threads the real `--port`.

## Docs (same loop)

- `docs/specs/2026-06-09-retrieval-profiles.md` — the profiles/modes answer: **one pipeline can't serve all workloads, but only ~6 knobs are corpus-sensitive** (dense_additive_weight ±19pp on prose, SPLADE 21.1% disk for 0pp at 850K, non-transferable absolute thresholds, filename anchor +24pp code-only, synonyms, abstain floors). Design = Layer 1 auto-calibration (genome_calibration machinery exists) + Layer 2 classifier-owned semantic arm (kills the HELIX_SEMANTIC_ARM env gate) + Layer 3 three small corpus profiles (code/prose/small-mixed). Blocking measurements ranked.
- `docs/audits/2026-06-09-next-steps-evidence.md` — ranked roadmap with evidence (500K rebuild+bench vs published 68.4/68.8/72.4 baselines, #165 verification + residual ~2–3 GB schema wins, the two deferred default-flips, Wall-2 orphaned PRs #158/#160, hardcoding wave 2 list).

## Test plan
- [x] 16 new tests (`test_public_dehardcode.py`): owner-vocab absence, env extension, generic-vs-helix score equality, template neutrality
- [x] Updated fixtures in density-gate / shard-router / bench-needles / installer tests
- [x] 157 passed across touched suites on Windows; 114 passed + compileall clean in sandbox
