### PR TITLE
fix(retrieval): plumb documented [retrieval] tier weights into the additive path (#202)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -487,11 +487,14 @@ enabled = true
 
 **Purpose.** The big one. Configures every recall and rerank tier in
 `Genome.query_genes()` and the new Stage-2 / Stage-3 / Stage-4 paths
-(dense recall, RRF fusion, margin-over-random ANN threshold). Every
-RRF tier weight is a post-multiplier applied to `1 / (k + rank)`; the
-weights below preserve the implicit weights baked into the legacy
-additive accumulator so `fusion_mode = "rrf"` is a clean rank-fusion
-swap, not a re-tuning.
+(dense recall, RRF fusion, margin-over-random ANN threshold). Since
+issue #202 the per-tier weights bind in **both** fusion modes: under
+`"additive"` (the default) each weight is the tier's coefficient/cap
+itself (defaults equal the old inline literals, so untouched configs
+keep byte-identical rankings); under `"rrf"` each weight is a
+post-multiplier applied to `1 / (k + rank)`. The defaults preserve the
+implicit weights baked into the legacy additive accumulator so
+`fusion_mode = "rrf"` is a clean rank-fusion swap, not a re-tuning.
 
 The full Stage-3 tier inventory (which tiers participate in RRF and
 which stay additive) lives in
@@ -527,14 +530,15 @@ which stay additive) lives in
 | `dense_pool_size` | int | `500` | **NEW (Stage 2, 2026-05-08).** Dense recall pool width — decoupled from `ann_threshold_max_genes` (the final cut). 500 hits ~3% of an 18.9k-corpus per spec §4. Resolves at the top of `query_genes_ann` via `pool_size = pool_size or self._dense_pool_size` (Stage-2 spec §6). When dense is disabled, falls back to `max_genes` for back-compat. The shipped value (`helix.toml:269`). |
 | `fusion_mode` | str | `"additive"` | **NEW (Stage 3, 2026-05-08).** One of `"additive"` (default for one release — legacy `gene_scores += tier_score` accumulator path) or `"rrf"` (Reciprocal Rank Fusion via `helix_context/fusion.py:Fuser`; final sort uses fused scores). Per-tier weights below are RRF post-multipliers. Spec: `docs/specs/2026-05-08-stage-3-rrf-fusion.md`. The shipped value (`helix.toml:278`). |
 | `rrf_k` | int | `60` | Cormack 2009 default. Used in `score(d) = Σ weight_t · 1/(k + rank_t(d))`. The shipped value (`helix.toml:279`). |
-| `fts5_weight` | float | `3.0` | RRF post-multiplier for the `fts5` tier. Preserves the current FTS5 implicit cap. The shipped value (`helix.toml:280`). |
-| `splade_weight` | float | `3.5` | RRF post-multiplier for the `splade` tier. Preserves the current SPLADE cap. The shipped value (`helix.toml:281`). |
-| `tag_exact_weight` | float | `3.0` | RRF post-multiplier for `tag_exact` (Tier-1 weight × match_count). The shipped value (`helix.toml:282`). |
-| `tag_prefix_weight` | float | `1.5` | RRF post-multiplier for `tag_prefix` (Tier-2 weight × match_count). The shipped value (`helix.toml:283`). |
-| `sema_cold_weight` | float | `3.0` | RRF post-multiplier for `sema_cold` (cold-start `sim · 3.0` multiplier). The shipped value (`helix.toml:284`). |
-| `lex_anchor_weight` | float | `1.5` | RRF post-multiplier for `lex_anchor` (current `idf · 1.5`, capped at 3.0). The shipped value (`helix.toml:285`). |
-| `harmonic_weight` | float | `1.0` | RRF post-multiplier for `harmonic` (per-link weight, cap stays at 3.0). The shipped value (`helix.toml:286`). |
-| `entity_graph_weight` | float | `0.5` | RRF post-multiplier for `entity_graph` (Tier-5b implicit `1.0 · 0.5`). The shipped value (`helix.toml:287`). |
+| `fts5_weight` | float | `3.0` | Binds in both fusion modes (#202). Additive: cap-only knob — the tier adds the raw BM25 magnitude capped at `2.0 × fts5_weight` (default → the legacy 6.0 cap). RRF: post-multiplier for the `fts5` tier. The shipped value (`helix.toml:280`). |
+| `splade_weight` | float | `3.5` | Binds in both fusion modes (#202). Additive: leading coefficient — `min(score, 20) × weight / 20`, so the tier caps at the weight itself. RRF: post-multiplier for the `splade` tier. The shipped value (`helix.toml:281`). |
+| `tag_exact_weight` | float | `3.0` | Binds in both fusion modes (#202). Additive: Tier-1 score = `match_count × weight`. RRF: post-multiplier for `tag_exact`. The shipped value (`helix.toml:282`). |
+| `tag_prefix_weight` | float | `1.5` | Binds in both fusion modes (#202). Additive: Tier-2 score = `match_count × weight`. RRF: post-multiplier for `tag_prefix`. The shipped value (`helix.toml:283`). |
+| `sema_boost_weight` | float | `2.0` | **NEW (#202).** Warm ΣĒMA boost (Tier 4 Mode A): `sim × weight × scale`. Additive-mode coefficient AND the post-fusion re-rank additive under RRF (this tier never rank-fuses). Default equals the old inline `2.0` literal. |
+| `sema_cold_weight` | float | `3.0` | Binds in both fusion modes (#202). Additive: cold-start score = `sim × weight`. RRF: post-multiplier for `sema_cold`. The shipped value (`helix.toml:284`). |
+| `lex_anchor_weight` | float | `1.5` | Binds in both fusion modes (#202). Additive: boost = `min(idf × weight, 2.0 × weight)` (default cap → the legacy 3.0). RRF: post-multiplier for `lex_anchor`. The shipped value (`helix.toml:285`). |
+| `harmonic_weight` | float | `1.0` | Binds in both fusion modes (#202). Additive: `weight` per link, capped at `3.0 × weight` total (default cap → the legacy 3.0). RRF: post-multiplier for `harmonic`. The shipped value (`helix.toml:286`). |
+| `entity_graph_weight` | float | `0.5` | Binds in both fusion modes (#202). Additive: per-row bonus = `min(1.0 × weight, 4.0 × weight)` (default → the legacy 0.5/2.0). RRF: post-multiplier for `entity_graph`. The shipped value (`helix.toml:287`). |
 | `dense_weight` | float | `1.0` | RRF post-multiplier for the Stage-2 `dense` tier. The shipped value (`helix.toml:288`). |
 | `pki_weight` | float | `1.0` | RRF post-multiplier for the path-key-index (`pki`) tier. The shipped value (`helix.toml:289`). |
 
@@ -554,11 +558,11 @@ authoritative?" semantics survive unchanged. The split:
 | `splade` | yes | `splade_weight` |
 | `sema_cold` | yes (only when fires) | `sema_cold_weight` |
 | `lex_anchor` (IDF) | yes | `lex_anchor_weight` |
-| `harmonic` | yes | `harmonic_weight` (cap stays at 3.0) |
+| `harmonic` | yes | `harmonic_weight` (additive cap = 3.0 × weight) |
 | `sr` (Successor Repr.) | yes | `sr_weight` (reused) |
 | `entity_graph` | yes | `entity_graph_weight` |
 | `dense` (Stage 2) | yes | `dense_weight` |
-| `sema_boost` (gate-only re-rank) | **no** — tiebreaker, applied AFTER RRF | n/a |
+| `sema_boost` (gate-only re-rank) | **no** — tiebreaker, applied AFTER RRF | `sema_boost_weight` (#202; additive/re-rank coefficient) |
 | `authority_*` (source/domain/recency) | **no** — flat boost on existing pool | n/a |
 | `party_attr` | **no** — flat additive AFTER RRF | n/a |
 | `access_rate` | **no** — explicit tiebreaker AFTER RRF | n/a |

--- a/helix.toml
+++ b/helix.toml
@@ -331,20 +331,24 @@ dense_pool_size = 500
 # docs/specs/2026-05-08-stage-3-rrf-fusion.md replaces the additive
 # gene_scores += tier_score accumulator with rank-level RRF (Cormack 2009).
 # Default "additive" is byte-identical to pre-Stage-3 behavior. Flip to
-# "rrf" to enable the new path. Per-tier weights below are RRF
-# post-multipliers (preserve current implicit weights).
+# "rrf" to enable the new path. Issue #202: the per-tier weights below
+# bind in BOTH fusion modes — under "additive" (the default) they are the
+# tier coefficients/caps themselves (defaults == the old inline literals,
+# so untouched configs keep byte-identical rankings); under "rrf" they
+# are rank post-multipliers.
 # Deprecation timeline: v(N) ships additive default; v(N+1) flips to rrf
 # default; v(N+2) removes the additive code path.
 fusion_mode = "additive"                # "additive" | "rrf"
 rrf_k = 60                              # Cormack 2009 default
-fts5_weight = 3.0                       # current FTS5 cap
-splade_weight = 3.5                     # current SPLADE cap
+fts5_weight = 3.0                       # FTS5 cap-only knob: additive cap = 2.0 × this (6.0)
+splade_weight = 3.5                     # SPLADE leading coeff (== tier cap)
 tag_exact_weight = 3.0                  # Tier 1 weight × match_count
 tag_prefix_weight = 1.5                 # Tier 2 weight × match_count
+sema_boost_weight = 2.0                 # ΣĒMA warm boost (Tier 4 Mode A) — new knob (#202)
 sema_cold_weight = 3.0                  # ΣĒMA cold-start sim multiplier
-lex_anchor_weight = 1.5                 # IDF anchor multiplier
-harmonic_weight = 1.0                   # Tier 5 per-link weight
-entity_graph_weight = 0.5               # Tier 5b entity boost
+lex_anchor_weight = 1.5                 # IDF anchor coeff; cap = 2.0 × this (3.0)
+harmonic_weight = 1.0                   # Tier 5 per-link weight; cap = 3.0 × this (3.0)
+entity_graph_weight = 0.5               # Tier 5b per-row bonus; cap = 4.0 × this (2.0)
 dense_weight = 1.0                      # Stage 2 dense recall, RRF participant
 # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight. Under
 # fusion_mode == "additive" (the default below), a dense hit's cosine is

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -352,17 +352,26 @@ class RetrievalConfig:
     # legacy ``gene_scores += tier_score`` accumulator path is unchanged.
     # When ``"rrf"``, each tier writes both raw scores AND ranks the
     # tier output through the Fuser; the final sort uses fused scores.
-    # Per-tier weights below are RRF post-multipliers.
+    # Issue #202: the per-tier weights below bind in BOTH fusion modes.
+    # Under "additive" they are the tier coefficients/caps themselves
+    # (defaults == the old inline literals, so untouched configs keep
+    # byte-identical rankings); under "rrf" they are rank
+    # post-multipliers.
     fusion_mode: str = "additive"           # "additive" | "rrf"
     rrf_k: int = 60                         # Cormack 2009 default
-    fts5_weight: float = 3.0                # current implicit cap (see genome.py FTS tier)
-    splade_weight: float = 3.5              # current implicit cap
+    fts5_weight: float = 3.0                # cap-only in additive: cap = 2.0 × this (6.0)
+    splade_weight: float = 3.5              # leading coeff == tier cap
     tag_exact_weight: float = 3.0           # current weight × match_count
     tag_prefix_weight: float = 1.5          # current weight × match_count
+    # Issue #202: warm ΣĒMA boost (Tier 4 Mode A) weight — NEW knob; the
+    # additive literal was sim·2.0·scale and the tier previously had no
+    # weight knob at all (post-fusion additive under RRF, never fused).
+    # Default == old literal, so untouched configs are bit-identical.
+    sema_boost_weight: float = 2.0
     sema_cold_weight: float = 3.0           # current sim·3.0 multiplier
-    lex_anchor_weight: float = 1.5          # current idf·1.5 (capped at 3.0)
-    harmonic_weight: float = 1.0            # current per-link weight
-    entity_graph_weight: float = 0.5        # current 1.0·0.5 implicit
+    lex_anchor_weight: float = 1.5          # idf coeff; cap = 2.0 × this (3.0)
+    harmonic_weight: float = 1.0            # per-link weight; cap = 3.0 × this (3.0)
+    entity_graph_weight: float = 0.5        # per-row bonus; cap = 4.0 × this (2.0)
     dense_weight: float = 1.0               # Stage 2 dense recall, RRF participant
     # Tier-0 PR-3 (2026-05-16): additive-mode dense merge weight. Under
     # fusion_mode == "additive" a dense hit's cosine is scaled by this
@@ -816,6 +825,8 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             splade_weight=float(r.get("splade_weight", cfg.retrieval.splade_weight)),
             tag_exact_weight=float(r.get("tag_exact_weight", cfg.retrieval.tag_exact_weight)),
             tag_prefix_weight=float(r.get("tag_prefix_weight", cfg.retrieval.tag_prefix_weight)),
+            # Issue #202: warm ΣĒMA boost knob (new).
+            sema_boost_weight=float(r.get("sema_boost_weight", cfg.retrieval.sema_boost_weight)),
             sema_cold_weight=float(r.get("sema_cold_weight", cfg.retrieval.sema_cold_weight)),
             lex_anchor_weight=float(r.get("lex_anchor_weight", cfg.retrieval.lex_anchor_weight)),
             harmonic_weight=float(r.get("harmonic_weight", cfg.retrieval.harmonic_weight)),

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -573,6 +573,8 @@ class HelixContextManager:
             splade_weight=config.retrieval.splade_weight,
             tag_exact_weight=config.retrieval.tag_exact_weight,
             tag_prefix_weight=config.retrieval.tag_prefix_weight,
+            # Issue #202: warm ΣĒMA boost knob (new; additive-mode Tier 4A).
+            sema_boost_weight=config.retrieval.sema_boost_weight,
             sema_cold_weight=config.retrieval.sema_cold_weight,
             lex_anchor_weight=config.retrieval.lex_anchor_weight,
             harmonic_weight=config.retrieval.harmonic_weight,

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -415,15 +415,22 @@ class KnowledgeStore:
         # Stage 3 (2026-05-08): Reciprocal Rank Fusion (spec
         # docs/specs/2026-05-08-stage-3-rrf-fusion.md). Default
         # "additive" preserves pre-Stage-3 ranking byte-for-byte; flip
-        # to "rrf" to enable rank fusion. Per-tier weights are RRF
-        # post-multipliers; defaults map to the existing implicit
-        # additive weights.
+        # to "rrf" to enable rank fusion. Issue #202: the per-tier
+        # weights bind in BOTH fusion modes -- under "additive" they are
+        # the tier coefficients/caps themselves (defaults == the old
+        # inline literals, so untouched configs are bit-identical);
+        # under "rrf" they are rank post-multipliers.
         fusion_mode: str = "additive",
         rrf_k: int = 60,
         fts5_weight: float = 3.0,
         splade_weight: float = 3.5,
         tag_exact_weight: float = 3.0,
         tag_prefix_weight: float = 1.5,
+        # Issue #202: warm ΣĒMA boost (Tier 4 Mode A) weight. NEW knob --
+        # the tier's additive literal was 2.0 and it had no per-tier
+        # weight at all (under RRF it is a post-fusion additive, so it
+        # never went through fuser.add_tier()). Default == old literal.
+        sema_boost_weight: float = 2.0,
         sema_cold_weight: float = 3.0,
         lex_anchor_weight: float = 1.5,
         harmonic_weight: float = 1.0,
@@ -522,9 +529,12 @@ class KnowledgeStore:
         # ── Stage 3 (2026-05-08): RRF fusion mode + per-tier weights ──
         # Spec: docs/specs/2026-05-08-stage-3-rrf-fusion.md.
         # When "additive", query_genes() uses the legacy gene_scores +=
-        # tier_score accumulator unchanged. When "rrf", each tier ALSO
-        # ranks its output through the Fuser and the final sort uses
-        # fused scores. Per-tier weights below are RRF post-multipliers.
+        # tier_score accumulator. When "rrf", each tier ALSO ranks its
+        # output through the Fuser and the final sort uses fused scores.
+        # Issue #202: the per-tier weights bind in BOTH modes -- additive
+        # consumes them as tier coefficients/caps (defaults == the old
+        # inline literals -> bit-identical when untouched); RRF consumes
+        # them as rank post-multipliers.
         # Validate now so a typo in helix.toml fails fast at construction
         # instead of producing surprising rankings at query time.
         if fusion_mode not in ("additive", "rrf"):
@@ -537,6 +547,7 @@ class KnowledgeStore:
         self._splade_weight: float = float(splade_weight)
         self._tag_exact_weight: float = float(tag_exact_weight)
         self._tag_prefix_weight: float = float(tag_prefix_weight)
+        self._sema_boost_weight: float = float(sema_boost_weight)
         self._sema_cold_weight: float = float(sema_cold_weight)
         self._lex_anchor_weight: float = float(lex_anchor_weight)
         self._harmonic_weight: float = float(harmonic_weight)
@@ -1824,7 +1835,7 @@ class KnowledgeStore:
             except Exception as exc:
                 log.debug("filename_anchor tier skipped: %s", exc)
 
-        # ── Tier 1: exact tag match (weight 3.0) ──────────
+        # ── Tier 1: exact tag match (weight: tag_exact_weight) ────
         _tag_exact_t0 = time.monotonic()
         placeholders = ",".join("?" * len(query_terms))
         rows = cur.execute(
@@ -1843,11 +1854,13 @@ class KnowledgeStore:
 
         _tag_exact_ranked: List[Tuple[str, float]] = []  # Stage 3 RRF
         for r in rows:
-            tag_score = r["match_count"] * 3.0
+            # #202: tag_exact_weight (default 3.0 == legacy literal).
+            tag_score = r["match_count"] * self._tag_exact_weight
             gene_scores[r["gene_id"]] = tag_score
             tier_contrib.setdefault(r["gene_id"], {})["tag_exact"] = tag_score
             _tag_exact_ranked.append((r["gene_id"], tag_score))
-        # Stage 3: count tier — rank by raw score (= match_count × 3.0)
+        # Stage 3: count tier — rank by raw score (= match_count ×
+        # tag_exact_weight)
         # which is monotone in match_count, so the rank order matches
         # the spec's "rank by match_count descending" rule (§4).
         fuser.add_tier("tag_exact", _tag_exact_ranked, weight=self._tag_exact_weight)
@@ -1859,7 +1872,7 @@ class KnowledgeStore:
         except Exception:
             pass
 
-        # ── Tier 2: prefix tag match (weight 1.5) ──────────────────
+        # ── Tier 2: prefix tag match (weight: tag_prefix_weight) ───
         # "server" matches "serverconfig", "server_api", etc.
         _tag_prefix_t0 = time.monotonic()
         prefix_conditions = " OR ".join(
@@ -1883,7 +1896,8 @@ class KnowledgeStore:
         _tag_prefix_ranked: List[Tuple[str, float]] = []  # Stage 3 RRF
         for r in rows:
             gid = r["gene_id"]
-            prefix_score = r["match_count"] * 1.5
+            # #202: tag_prefix_weight (default 1.5 == legacy literal).
+            prefix_score = r["match_count"] * self._tag_prefix_weight
             gene_scores[gid] = gene_scores.get(gid, 0) + prefix_score
             tier_contrib.setdefault(gid, {})["tag_prefix"] = prefix_score
             _tag_prefix_ranked.append((gid, prefix_score))
@@ -1896,7 +1910,7 @@ class KnowledgeStore:
         except Exception:
             pass
 
-        # ── Tier 3: FTS5 content search (weight 3.0) ───────────────
+        # ── Tier 3: FTS5 content search (cap: 2.0 × fts5_weight) ───
         if self._fts_available:
             # Build FTS5 query: OR-join all terms
             _fts5_t0 = time.monotonic()
@@ -1935,9 +1949,13 @@ class KnowledgeStore:
                             if gid not in valid_ids:
                                 continue
                             # FTS5 rank is negative (lower = better match)
-                            # Normalize: -rank gives positive, cap at 6.0
-                            # (was 15*3=45 — drowned out tag matches at 3-9)
-                            fts_score = min(-fts_ranks[gid], 6.0)
+                            # Normalize: -rank gives positive. The additive
+                            # tier has no leading coefficient -- it adds the
+                            # raw BM25 magnitude -- so fts5_weight acts as a
+                            # cap-only knob here (#202): cap = 2.0 ×
+                            # fts5_weight (default 3.0 -> the legacy 6.0 cap;
+                            # was 15*3=45 — drowned out tag matches at 3-9).
+                            fts_score = min(-fts_ranks[gid], 2.0 * self._fts5_weight)
                             gene_scores[gid] = gene_scores.get(gid, 0) + fts_score
                             tier_contrib.setdefault(gid, {})["fts5"] = fts_score
                             # Stage 3: feed Fuser with the RAW
@@ -1958,7 +1976,7 @@ class KnowledgeStore:
                     except Exception:
                         pass
 
-        # ── Tier 3.5: SPLADE sparse retrieval (weight 3.5) ─────────
+        # ── Tier 3.5: SPLADE sparse retrieval (weight: splade_weight) ─
         if self._splade_enabled:
             _splade_t0 = time.monotonic()
             try:
@@ -1975,8 +1993,11 @@ class KnowledgeStore:
                         splade_hits = [(gid, s) for gid, s in splade_hits if gid in _prefilter_set]
                     _splade_ranked: List[Tuple[str, float]] = []  # Stage 3 RRF
                     for gid, score in splade_hits:
-                        # Normalize SPLADE score to be comparable with other tiers
-                        splade_score = min(score, 20.0) * 3.5 / 20.0  # Cap at 3.5
+                        # Normalize SPLADE score to be comparable with
+                        # other tiers. #202: leading coefficient =
+                        # splade_weight (default 3.5 == legacy literal), so
+                        # the tier caps at splade_weight.
+                        splade_score = min(score, 20.0) * self._splade_weight / 20.0
                         gene_scores[gid] = gene_scores.get(gid, 0) + splade_score
                         tier_contrib.setdefault(gid, {})["splade"] = splade_score
                         # Stage 3: feed Fuser with the RAW SPLADE score
@@ -2035,7 +2056,9 @@ class KnowledgeStore:
                             for gid, sim in nearest:
                                 if sim > 0.3:
                                     boost_scale = max(0.5, 1.0 - top_score / 40.0)
-                                    sema_boost = sim * 2.0 * boost_scale
+                                    # #202: sema_boost_weight (default 2.0
+                                    # == legacy literal).
+                                    sema_boost = sim * self._sema_boost_weight * boost_scale
                                     gene_scores[gid] += sema_boost
                                     tier_contrib.setdefault(gid, {})["sema_boost"] = sema_boost
                                     # Stage 3: post-fusion additive (re-rank class).
@@ -2081,11 +2104,13 @@ class KnowledgeStore:
                                     if gid in existing:
                                         continue
                                     if sim > 0.4:
-                                        sema_new = sim * 3.0
+                                        # #202: sema_cold_weight (default
+                                        # 3.0 == legacy literal).
+                                        sema_new = sim * self._sema_cold_weight
                                         gene_scores[gid] = sema_new
                                         tier_contrib.setdefault(gid, {})["sema_cold"] = sema_new
                                         # Stage 3: rank by RAW cosine
-                                        # similarity, not the *3.0
+                                        # similarity, not the weight-
                                         # multiplied score — the
                                         # multiplier is the additive
                                         # weight, but rank comes from
@@ -2212,10 +2237,13 @@ class KnowledgeStore:
             ).fetchone()[0]
             if term_freq == 0:
                 continue
-            # IDF boost: rare terms get up to 3.0, common terms ~0.5
-            # Capped at 3.0 (was 5.0) to reduce tangential rare-term over-boost.
+            # IDF boost: rare terms get up to the cap, common terms ~0.5.
+            # #202: leading coefficient = lex_anchor_weight (default 1.5 ==
+            # legacy literal); the cap scales proportionally at 2.0 × weight
+            # (default 3.0 == the legacy cap, which had been lowered from
+            # 5.0 to reduce tangential rare-term over-boost).
             idf = _math.log(total_genes_est / term_freq) if term_freq > 0 else 0
-            boost = min(idf * 1.5, 3.0)
+            boost = min(idf * self._lex_anchor_weight, 2.0 * self._lex_anchor_weight)
             if boost > 1.0:
                 anchor_genes = cur.execute(
                     f"SELECT pi.gene_id FROM promoter_index pi "
@@ -2255,7 +2283,8 @@ class KnowledgeStore:
         # ── Tier 5: harmonic co-activation boost ──────────────────
         # For each candidate, add a score bonus from documents that are
         # harmonically linked to OTHER candidates (mutual reinforcement).
-        # Weight: 1.0 per link, capped at 3.0 total bonus.
+        # Weight: harmonic_weight per link (default 1.0), capped at a
+        # total bonus of 3.0 × harmonic_weight (default 3.0) — #202.
         if use_harmonic and gene_scores:
             try:
                 _has_harmonic = cur.execute(
@@ -2279,7 +2308,8 @@ class KnowledgeStore:
                     for hr in harmonic_rows:
                         for gid in (hr["gene_id_a"], hr["gene_id_b"]):
                             harmonic_bonus[gid] = min(
-                                harmonic_bonus.get(gid, 0) + 1.0, 3.0,
+                                harmonic_bonus.get(gid, 0) + self._harmonic_weight,
+                                3.0 * self._harmonic_weight,
                             )
                     _harmonic_ranked: List[Tuple[str, float]] = []  # Stage 3 RRF
                     for gid, bonus in harmonic_bonus.items():
@@ -2322,7 +2352,8 @@ class KnowledgeStore:
 
         # ── Tier 5b: entity graph co-occurrence boost ─────────────────────
         # Documents sharing entity nodes with query entities get a score boost.
-        # Additive on top of Tier 5 harmonic; capped at +2.0 per document.
+        # Additive on top of Tier 5 harmonic; +entity_graph_weight per
+        # row, capped at 4.0 × entity_graph_weight (default 2.0) — #202.
         # entity_graph schema: entity (TEXT), gene_id (TEXT) — no weight col.
         _eg_enabled = self._entity_graph_retrieval_enabled if use_entity_graph is None else bool(use_entity_graph)
         if _eg_enabled and entities and gene_scores:
@@ -2338,7 +2369,13 @@ class KnowledgeStore:
                 for row in eg_rows:
                     gid = row["gene_id"]
                     if gid in gene_scores:
-                        bonus = min(1.0 * 0.5, 2.0)  # weight=1.0, cap 2.0
+                        # #202: per-row bonus = 1.0 × entity_graph_weight
+                        # (default 0.5 == the legacy 1.0*0.5); cap scales at
+                        # 4.0 × weight (default 2.0 == legacy cap).
+                        bonus = min(
+                            1.0 * self._entity_graph_weight,
+                            4.0 * self._entity_graph_weight,
+                        )
                         gene_scores[gid] += bonus
                         tier_contrib.setdefault(gid, {})["entity_graph"] = (
                             tier_contrib.get(gid, {}).get("entity_graph", 0.0) + bonus

--- a/tests/test_additive_weight_plumbing.py
+++ b/tests/test_additive_weight_plumbing.py
@@ -1,0 +1,474 @@
+"""Issue #202: the documented ``[retrieval]`` tier weights must bind in
+ADDITIVE fusion mode (the default), not just under RRF.
+
+Before the fix, ``fts5_weight``, ``splade_weight``, ``tag_exact_weight``,
+``tag_prefix_weight``, ``sema_cold_weight``, ``lex_anchor_weight``,
+``harmonic_weight`` and ``entity_graph_weight`` were consumed ONLY via
+``fuser.add_tier()`` — dead knobs under ``fusion_mode="additive"`` whose
+tier scores were inline literals.  The warm ΣĒMA boost (``sim * 2.0``)
+had no knob at all; the fix adds ``sema_boost_weight`` (default 2.0).
+
+Three test families:
+
+1. **Golden byte-identity** — a 10-document corpus that fires every
+   additive tier; final scores and per-tier contributions must equal,
+   bit-for-bit, the numbers captured on the PRE-FIX tree (commit
+   266e9aa, the additive literals).  Regenerate after a deliberate
+   ranking change with::
+
+       python -c "import sys; sys.path.insert(0, '.'); \
+from tests.test_additive_weight_plumbing import print_golden; print_golden()"
+
+   Caveat: the fts5 contributions embed raw SQLite BM25 magnitudes and
+   the sema tiers go through numpy float32 dot products.  Both are
+   deterministic for a fixed corpus and chosen so no reduction-order
+   ambiguity exists (single-overlap unit vectors), but a future SQLite
+   bm25 change would require a regen (the additive snapshot test in
+   ``test_fusion_rrf.py`` would trip too).
+
+2. **Knob moves its tier** — setting a weight scales exactly that
+   tier's contribution (asserted against a same-process default run,
+   so no embedded floats are involved).
+
+3. **Zero weight kills the tier** — contribution drops to 0.0 (or the
+   tier stops firing entirely for gated tiers like lex_anchor).
+"""
+from __future__ import annotations
+
+import contextlib
+import math
+
+import pytest
+
+from helix_context.genome import Genome
+from helix_context.schemas import (
+    ChromatinState, EpigeneticMarkers, Gene, PromoterTags,
+)
+
+# ─── Query + corpus fixtures ─────────────────────────────────────────
+
+QUERY_DOMAINS = ["alpha"]
+QUERY_ENTITIES = ["epsilon"]
+MAX_GENES = 12  # limit = 24 → cold-tier gate len(gene_scores) < 12 holds
+
+
+class FakeSemaCodec:
+    """Deterministic stand-in for backends.sema.SemaCodec.
+
+    ``encode`` returns a fixed unit vector; ``nearest`` reimplements the
+    real codec's cosine contract in pure python (no numpy reductions →
+    bit-stable across BLAS implementations).
+    """
+
+    QUERY_VEC = [1.0] + [0.0] * 19
+
+    def encode(self, text: str):
+        return list(self.QUERY_VEC)
+
+    def nearest(self, query_vec, candidates, k=5):
+        def cos(a, b):
+            num = sum(x * y for x, y in zip(a, b))
+            na = math.sqrt(sum(x * x for x in a))
+            nb = math.sqrt(sum(y * y for y in b))
+            if na < 1e-8 or nb < 1e-8:
+                return 0.0
+            return num / (na * nb)
+
+        scored = [(gid, cos(query_vec, vec)) for gid, vec in candidates]
+        scored.sort(key=lambda t: (-t[1], t[0]))
+        return scored[:k]
+
+
+def _vec(first: float, second: float = 0.0):
+    """20-dim vector overlapping the query vec on dim 0 only.
+
+    Cosine vs QUERY_VEC == first / ||v|| — a single multiply, no
+    summation-order ambiguity in the numpy cold-tier matmul.
+    """
+    v = [0.0] * 20
+    v[0] = first
+    v[1] = second
+    return v
+
+
+def _gene(gid, content, domains, entities=(), embedding=None) -> Gene:
+    return Gene(
+        gene_id=gid,
+        content=content,
+        complement="",
+        codons=[],
+        promoter=PromoterTags(domains=list(domains), entities=list(entities)),
+        epigenetics=EpigeneticMarkers(),
+        chromatin=ChromatinState.OPEN,
+        is_fragment=False,
+        embedding=embedding,
+    )
+
+
+@contextlib.contextmanager
+def patched_splade():
+    """Replace the SPLADE model calls with fixed, deterministic hits.
+
+    ``encode`` (used at ingest AND for the query) returns an empty
+    sparse dict; ``query_splade`` returns two raw scores chosen so one
+    saturates the 20.0 normalization cap (gA) and one does not (gD).
+    """
+    from helix_context.backends import splade_backend
+
+    old_encode = splade_backend.encode
+    old_query = splade_backend.query_splade
+    splade_backend.encode = lambda text, **kw: {}
+    splade_backend.query_splade = (
+        lambda conn, sparse, limit=20: [("gA", 30.0), ("gD", 10.0)]
+    )
+    try:
+        yield
+    finally:
+        splade_backend.encode = old_encode
+        splade_backend.query_splade = old_query
+
+
+def build_corpus(g: Genome) -> None:
+    """10 synthetic documents lighting up every additive tier.
+
+    gA — exact tag 'alpha' + prefix + FTS + SPLADE(sat) + warm ΣĒMA +
+         lex anchor + harmonic + entity_graph + authority
+    gB — prefix tag 'alphabeta' + harmonic link to gA + entity_graph
+    gC — exact tag 'epsilon' + FTS + lex anchor
+    gD — SPLADE-only candidate (no lexical hit)
+    gE/gF — cold ΣĒMA fills (sim 1.0 / cos vs query 0.7071...)
+    gG — embedding below the 0.4 cold floor (control, never retrieved)
+    gH/gI/gJ — inert filler (corpus size / IDF stability)
+    """
+    docs = [
+        _gene("gA",
+              "alpha configures the parser pipeline. alpha owns the retry "
+              "policy and alpha gates the splice budget.",
+              domains=["alpha", "parser"],
+              embedding=_vec(0.75, 0.5)),
+        _gene("gB",
+              "the merge stage rewrites stale buffers before compaction.",
+              domains=["alphabeta"]),
+        _gene("gC",
+              "epsilon thresholds for the scheduler retry loop.",
+              domains=["epsilon"]),
+        _gene("gD",
+              "vector quantization keeps the shard logic compact.",
+              domains=["gamma"]),
+        _gene("gE",
+              "the cold start path warms caches in the background.",
+              domains=["delta"],
+              embedding=_vec(1.0)),
+        _gene("gF",
+              "queue depth metrics feed the backpressure controller.",
+              domains=["zeta"],
+              embedding=_vec(0.5, 0.5)),
+        _gene("gG",
+              "log rotation happens at midnight local time.",
+              domains=["eta"],
+              embedding=_vec(0.125, 1.0)),
+        _gene("gH", "summaries are spooled to the export bucket.",
+              domains=["omega"]),
+        _gene("gI", "the watchdog restarts wedged workers.",
+              domains=["sigma"]),
+        _gene("gJ", "tracing spans are sampled at one percent.",
+              domains=["kappa"]),
+    ]
+    for d in docs:
+        g.upsert_gene(d, apply_gate=False)
+
+    # Tier 5 fixture: harmonic link between two lexical candidates.
+    g.conn.execute(
+        "INSERT INTO harmonic_links "
+        "(gene_id_a, gene_id_b, weight, updated_at, source) "
+        "VALUES ('gA', 'gB', 1.0, 0.0, 'co_retrieved')"
+    )
+    # Tier 5b fixture: entity co-occurrence rows for the query entity.
+    g.conn.execute(
+        "INSERT INTO entity_graph (entity, gene_id) VALUES ('epsilon', 'gA')"
+    )
+    g.conn.execute(
+        "INSERT INTO entity_graph (entity, gene_id) VALUES ('epsilon', 'gB')"
+    )
+    g.conn.commit()
+
+
+def make_genome(**weight_kwargs) -> Genome:
+    g = Genome(
+        path=":memory:",
+        sema_codec=FakeSemaCodec(),
+        splade_enabled=True,
+        entity_graph_retrieval_enabled=True,
+        **weight_kwargs,
+    )
+    with patched_splade():
+        build_corpus(g)
+    return g
+
+
+def run_query(g: Genome):
+    """Run the canonical query; return (ranked_ids, scores, tier_contrib)."""
+    with patched_splade():
+        genes = g.query_genes(
+            domains=list(QUERY_DOMAINS),
+            entities=list(QUERY_ENTITIES),
+            max_genes=MAX_GENES,
+            read_only=True,
+        )
+    ranked = [x.gene_id for x in genes]
+    scores = dict(g.last_query_scores)
+    contrib = {gid: dict(t) for gid, t in g.last_tier_contributions.items()}
+    return ranked, scores, contrib
+
+
+def capture():
+    g = make_genome()
+    try:
+        return run_query(g)
+    finally:
+        g.close()
+
+
+def print_golden():  # pragma: no cover — regen helper, run by hand
+    ranked, scores, contrib = capture()
+    print("_GOLDEN_RANKED =", repr(ranked))
+    print("_GOLDEN_SCORES =", repr(scores))
+    print("_GOLDEN_CONTRIB =", repr(contrib))
+
+
+# ─── Golden numbers (captured on the PRE-FIX tree, commit 266e9aa) ───
+
+_GOLDEN_RANKED = ['gA', 'gC', 'gB', 'gE', 'gF', 'gD']
+_GOLDEN_SCORES = {'gA': 18.428866615370232, 'gC': 12.118210600885599, 'gB': 3.5, 'gD': 2.25, 'gE': 3.5, 'gF': 2.6213203072547913}
+_GOLDEN_CONTRIB = {'gA': {'tag_exact': 3.0, 'tag_prefix': 1.5, 'fts5': 2.71034323891445, 'splade': 3.5, 'sema_boost': 1.2185233764557821, 'lex_anchor': 3.0, 'authority': 2.0, 'harmonic': 1.0, 'entity_graph': 0.5}, 'gC': {'tag_exact': 3.0, 'tag_prefix': 1.5, 'fts5': 2.618210600885599, 'lex_anchor': 3.0, 'authority': 2.0}, 'gB': {'tag_prefix': 1.5, 'authority': 0.5, 'harmonic': 1.0, 'entity_graph': 0.5}, 'gD': {'splade': 1.75, 'authority': 0.5}, 'gE': {'sema_cold': 3.0, 'authority': 0.5}, 'gF': {'sema_cold': 2.1213203072547913, 'authority': 0.5}}
+
+
+# ─── 1. byte-identity with the pre-fix additive literals ─────────────
+
+
+def test_additive_default_scores_byte_identical_to_prefix_golden():
+    ranked, scores, contrib = capture()
+    assert ranked == _GOLDEN_RANKED, (
+        f"ranking diverged from pre-#202 additive literals:\n"
+        f"  expected {_GOLDEN_RANKED}\n  got      {ranked}"
+    )
+    assert scores == _GOLDEN_SCORES, (
+        "final additive scores diverged from pre-#202 literals "
+        "(must be bit-identical at default weights):\n"
+        f"  expected {_GOLDEN_SCORES}\n  got      {scores}"
+    )
+    assert contrib == _GOLDEN_CONTRIB, (
+        "per-tier contributions diverged from pre-#202 literals:\n"
+        f"  expected {_GOLDEN_CONTRIB}\n  got      {contrib}"
+    )
+
+
+def test_every_plumbed_tier_fired_in_golden_corpus():
+    """Guard the fixture itself: all 9 knob-bound tiers must appear."""
+    _, _, contrib = capture()
+    fired = {tier for tiers in contrib.values() for tier in tiers}
+    expected = {
+        "tag_exact", "tag_prefix", "fts5", "splade",
+        "sema_boost", "sema_cold", "lex_anchor", "harmonic",
+        "entity_graph",
+    }
+    missing = expected - fired
+    assert not missing, f"corpus no longer exercises tiers: {missing}"
+
+
+def test_explicit_default_weights_byte_identical():
+    """Passing the documented defaults explicitly == passing nothing."""
+    g = make_genome(
+        fts5_weight=3.0,
+        splade_weight=3.5,
+        tag_exact_weight=3.0,
+        tag_prefix_weight=1.5,
+        sema_boost_weight=2.0,
+        sema_cold_weight=3.0,
+        lex_anchor_weight=1.5,
+        harmonic_weight=1.0,
+        entity_graph_weight=0.5,
+    )
+    try:
+        ranked, scores, contrib = run_query(g)
+    finally:
+        g.close()
+    assert ranked == _GOLDEN_RANKED
+    assert scores == _GOLDEN_SCORES
+    assert contrib == _GOLDEN_CONTRIB
+
+
+# ─── 2. each knob moves exactly its tier ──────────────────────────────
+
+
+def _contrib_for(weight_kwargs):
+    g = make_genome(**weight_kwargs)
+    try:
+        _, scores, contrib = run_query(g)
+    finally:
+        g.close()
+    return scores, contrib
+
+
+@pytest.fixture(scope="module")
+def default_run():
+    return capture()
+
+
+def test_tag_exact_weight_scales_tier(default_run):
+    _, _, base = default_run
+    _, contrib = _contrib_for({"tag_exact_weight": 6.0})
+    assert contrib["gA"]["tag_exact"] == 2 * base["gA"]["tag_exact"]
+    assert contrib["gC"]["tag_exact"] == 2 * base["gC"]["tag_exact"]
+
+
+def test_tag_prefix_weight_scales_tier(default_run):
+    _, _, base = default_run
+    _, contrib = _contrib_for({"tag_prefix_weight": 3.0})
+    assert contrib["gB"]["tag_prefix"] == 2 * base["gB"]["tag_prefix"]
+
+
+def test_fts5_weight_scales_cap(default_run):
+    """Additive fts5 has no leading coefficient — the knob owns the cap
+    (cap = 2.0 × fts5_weight; 2.0 × default 3.0 == legacy literal 6.0).
+    gA's raw BM25 magnitude exceeds 0.5, so a 0.25 weight must clamp the
+    contribution to exactly 0.5."""
+    _, _, base = default_run
+    assert base["gA"]["fts5"] > 0.5  # fixture guard: raw above the test cap
+    _, contrib = _contrib_for({"fts5_weight": 0.25})
+    assert contrib["gA"]["fts5"] == 0.5
+
+
+def test_splade_weight_scales_tier(default_run):
+    _, _, base = default_run
+    _, contrib = _contrib_for({"splade_weight": 7.0})
+    # gA saturates the 20.0 normalization: min(30,20) * 7/20 == 7.0
+    assert contrib["gA"]["splade"] == 2 * base["gA"]["splade"] == 7.0
+    assert contrib["gD"]["splade"] == 2 * base["gD"]["splade"]
+
+
+def test_sema_boost_weight_scales_tier(default_run):
+    _, _, base = default_run
+    _, contrib = _contrib_for({"sema_boost_weight": 4.0})
+    assert contrib["gA"]["sema_boost"] == 2 * base["gA"]["sema_boost"]
+
+
+def test_sema_cold_weight_scales_tier(default_run):
+    _, _, base = default_run
+    _, contrib = _contrib_for({"sema_cold_weight": 6.0})
+    assert contrib["gE"]["sema_cold"] == 2 * base["gE"]["sema_cold"]
+    assert contrib["gF"]["sema_cold"] == 2 * base["gF"]["sema_cold"]
+
+
+def test_lex_anchor_weight_scales_tier(default_run):
+    """Cap scales with the knob (cap = 2.0 × weight; 2.0 × default 1.5
+    == legacy literal 3.0), so a capped contribution doubles too."""
+    _, _, base = default_run
+    assert base["gA"]["lex_anchor"] == 3.0  # capped at default
+    _, contrib = _contrib_for({"lex_anchor_weight": 3.0})
+    assert contrib["gA"]["lex_anchor"] == 6.0
+    assert contrib["gC"]["lex_anchor"] == 2 * base["gC"]["lex_anchor"]
+
+
+def test_harmonic_weight_scales_tier(default_run):
+    """Cap scales with the knob (cap = 3.0 × weight; 3.0 × default 1.0
+    == legacy literal 3.0)."""
+    _, _, base = default_run
+    _, contrib = _contrib_for({"harmonic_weight": 2.0})
+    assert contrib["gA"]["harmonic"] == 2 * base["gA"]["harmonic"]
+    assert contrib["gB"]["harmonic"] == 2 * base["gB"]["harmonic"]
+
+
+def test_entity_graph_weight_scales_tier(default_run):
+    """Cap scales with the knob (cap = 4.0 × weight; 4.0 × default 0.5
+    == legacy literal 2.0)."""
+    _, _, base = default_run
+    _, contrib = _contrib_for({"entity_graph_weight": 1.0})
+    assert contrib["gA"]["entity_graph"] == 2 * base["gA"]["entity_graph"]
+    assert contrib["gB"]["entity_graph"] == 2 * base["gB"]["entity_graph"]
+
+
+# ─── 3. zero weight kills the tier ────────────────────────────────────
+
+
+def test_zero_tag_exact_weight_kills_tier():
+    _, contrib = _contrib_for({"tag_exact_weight": 0.0})
+    assert contrib["gA"].get("tag_exact", 0.0) == 0.0
+    assert contrib["gC"].get("tag_exact", 0.0) == 0.0
+
+
+def test_zero_tag_prefix_weight_kills_tier():
+    _, contrib = _contrib_for({"tag_prefix_weight": 0.0})
+    assert contrib["gB"].get("tag_prefix", 0.0) == 0.0
+
+
+def test_zero_fts5_weight_kills_tier():
+    _, contrib = _contrib_for({"fts5_weight": 0.0})
+    assert contrib["gA"].get("fts5", 0.0) == 0.0
+    assert contrib["gC"].get("fts5", 0.0) == 0.0
+
+
+def test_zero_splade_weight_kills_tier():
+    _, contrib = _contrib_for({"splade_weight": 0.0})
+    assert contrib["gA"].get("splade", 0.0) == 0.0
+    assert contrib["gD"].get("splade", 0.0) == 0.0
+
+
+def test_zero_sema_boost_weight_kills_tier():
+    _, contrib = _contrib_for({"sema_boost_weight": 0.0})
+    assert contrib["gA"].get("sema_boost", 0.0) == 0.0
+
+
+def test_zero_sema_cold_weight_kills_tier():
+    _, contrib = _contrib_for({"sema_cold_weight": 0.0})
+    assert contrib.get("gE", {}).get("sema_cold", 0.0) == 0.0
+    assert contrib.get("gF", {}).get("sema_cold", 0.0) == 0.0
+
+
+def test_zero_lex_anchor_weight_kills_tier():
+    _, contrib = _contrib_for({"lex_anchor_weight": 0.0})
+    # boost gate (> 1.0) never opens at weight 0 — tier never fires.
+    assert "lex_anchor" not in contrib.get("gA", {})
+    assert "lex_anchor" not in contrib.get("gC", {})
+
+
+def test_zero_harmonic_weight_kills_tier():
+    _, contrib = _contrib_for({"harmonic_weight": 0.0})
+    assert contrib["gA"].get("harmonic", 0.0) == 0.0
+    assert contrib["gB"].get("harmonic", 0.0) == 0.0
+
+
+def test_zero_entity_graph_weight_kills_tier():
+    _, contrib = _contrib_for({"entity_graph_weight": 0.0})
+    assert contrib["gA"].get("entity_graph", 0.0) == 0.0
+    assert contrib["gB"].get("entity_graph", 0.0) == 0.0
+
+
+# ─── config plumbing: TOML → RetrievalConfig → Genome kwargs ─────────
+
+
+def test_retrieval_config_defaults_match_additive_literals():
+    """The dataclass defaults ARE the legacy additive literals (the
+    leading coefficients), so untouched configs stay bit-identical."""
+    from helix_context.config import RetrievalConfig
+    cfg = RetrievalConfig()
+    assert cfg.fts5_weight == 3.0          # additive cap = 2.0 × 3.0 = 6.0
+    assert cfg.splade_weight == 3.5
+    assert cfg.tag_exact_weight == 3.0
+    assert cfg.tag_prefix_weight == 1.5
+    assert cfg.sema_boost_weight == 2.0    # new knob (#202)
+    assert cfg.sema_cold_weight == 3.0
+    assert cfg.lex_anchor_weight == 1.5    # additive cap = 2.0 × 1.5 = 3.0
+    assert cfg.harmonic_weight == 1.0      # additive cap = 3.0 × 1.0 = 3.0
+    assert cfg.entity_graph_weight == 0.5  # additive cap = 4.0 × 0.5 = 2.0
+
+
+def test_toml_loader_plumbs_sema_boost_weight(tmp_path):
+    cfg_file = tmp_path / "helix.toml"
+    cfg_file.write_text(
+        "[retrieval]\nsema_boost_weight = 9.0\ntag_exact_weight = 4.5\n"
+    )
+    from helix_context.config import load_config
+    cfg = load_config(str(cfg_file))
+    assert cfg.retrieval.sema_boost_weight == 9.0
+    assert cfg.retrieval.tag_exact_weight == 4.5


### PR DESCRIPTION
Closes #202. All 9 tier weights (incl. new sema_boost_weight, default 2.0 - the tier had no knob) now bind in BOTH fusion modes. Zero config-default changes (defaults already equaled the literals); caps scale proportionally with their weight (2x fts5, 2x lex, 3x harmonic, 4x entity - documented per site). Byte-identity proven: golden test captured on pre-fix tree asserts == on scores and per-tier contributions across a 9-tier corpus; the existing 50-query additive snapshot passes unchanged. 23 new tests; ~2,255 passed full sweep in sandbox (4 failures pre-existing on master). Unblocks per-tier weight tuning ahead of the RRF gate (roadmap section 5).