### PR TITLE
feat(bench): crawl watchdog - throughput-triggered escalation ladder for dense ingest/backfill (#212)

### DIFF
--- a/docs/operations/DENSE_VRAM.md
+++ b/docs/operations/DENSE_VRAM.md
@@ -89,10 +89,93 @@ correct.
   in-process fan-out from loading ~100 copies of the ~2 GB model. Does
   **not** help across separate worker *processes* — each process loads
   its own model.
+- `HELIX_BFM_CRAWL_FACTOR` / `HELIX_BFM_CRAWL_WINDOW` /
+  `HELIX_BFM_CRAWL_ACTION` — the crawl watchdog's escalation ladder for
+  the fixture-builder ingest and dense-backfill drivers; see
+  [Crawl watchdog (automatic)](#crawl-watchdog-automatic) below.
 - `OMP_NUM_THREADS=4`, `MKL_NUM_THREADS=4` — CPU dense ingest only.
   Caps each worker's BLAS thread pool so N workers don't oversubscribe.
 - `transformers==4.49.0` — pin. The 5.x line breaks the `PreTrainedModel`
   import path that helix's dense and SPLADE encoders use.
+
+## Crawl watchdog (automatic)
+
+Issue #212. As of v0.7.x the two long-haul dense drivers — the fixture
+builder's ingest loop (`build_fixture_matrix._drain_with_batched_splade`)
+and the shared dense backfill (`backfill_bgem3_v2.backfill_dense_db`,
+which both the standalone script and the builder's post-build pass call)
+— carry a **throughput-triggered escalation ladder** that detects the
+#176 WDDM-spill crawl and recovers without an operator.
+
+### Why empty_cache alone is not enough
+
+Two live incidents during the 2026-06-10/11 ERB 500K rebuild on the
+reference 12 GB rig:
+
+- **confluence shard, 06-10:** throughput decayed **15.3 → 2.3 genes/s**
+  while dedicated VRAM pinned at 11.85/12 GB. It recovered only because
+  the shard happened to finish.
+- **slack__eng-oncall, 06-11:** collapsed to **64 genes in 47 minutes**
+  (~0.02 genes/s, ~66 h projected for the shard) *with the release knobs
+  active* (`HELIX_DENSE_VRAM_RELEASE_EVERY=64` +
+  `expandable_segments:True`). This is the proof that periodic
+  `empty_cache` bounds a healthy context but **does not un-crawl an
+  already-spilled one** — once WDDM has demoted allocations to shared
+  system memory, only a context recycle (fresh process) or CPU demotion
+  fixes the rate. The manual fix that worked: kill + resume (salvage +
+  file-level resume are lossless), then `BGEM3_DEVICE=cpu` for the
+  remainder — GPU dropped 11.9 GB → 884 MiB with byte-identical vectors.
+- **Validation of the recycle action:** the external watchdog performed
+  two live auto-recycles on 06-11 (12:00 and 18:41). The 18:41 one fired
+  at **1.03 genes/s with 11941 MiB VRAM**, recycled the worker, and the
+  build finished **33 minutes later**.
+
+### Trigger (not a wall-clock timer)
+
+A per-shard timer false-positives on legitimately large shards and
+misses crawls on small ones. The watchdog instead trips on the
+unambiguous signature, per batch:
+
+- genes/s **EMA** < the shard's **own early-batch baseline** (median of
+  the first `HELIX_BFM_CRAWL_WINDOW` batches) ÷ `HELIX_BFM_CRAWL_FACTOR`,
+  for `HELIX_BFM_CRAWL_WINDOW` **consecutive** batches (any healthy batch
+  resets the streak), **AND**
+- dedicated VRAM near device capacity
+  (`max(memory_allocated, memory_reserved) / total_memory > 0.92`).
+
+A slow disk alone is therefore not a crawl, and CPU-only boxes can never
+trip (the VRAM probe is try/except-guarded and returns "unknown").
+
+### Ladder
+
+| Rung | Ingest path (`_drain_with_batched_splade`) | Backfill path (`backfill_dense_db`) |
+|---|---|---|
+| 1 | `gc.collect()` + `torch.cuda.empty_cache()`, log, continue | same |
+| 2 (still crawling after another window) | raise the existing `_PauseRequested` at the batch boundary → shard pauses cleanly, salvage + file-level resume restart it with a fresh CUDA context | tear down the codec and reload it with `device=cpu` for the **remainder of the shard** (byte-identical vectors, no VRAM ceiling) |
+
+`HELIX_BFM_CRAWL_ACTION=cpu` jumps straight to rung 2; `off` detects and
+logs only. After the terminal rung the watchdog disarms for that shard.
+
+Every watchdog line carries the stable grep-able prefix
+`[crawl-watchdog]` and includes rate, baseline, VRAM fraction and the
+action taken:
+
+```
+[crawl-watchdog] CRAWL detected name=slack__eng-oncall: rate=1.03 genes/s ema=1.10 genes/s baseline=15.30 genes/s threshold=3.06 genes/s vram_frac=0.971 window=8 action=empty_cache (ladder rung 1/2: gc.collect + torch.cuda.empty_cache)
+```
+
+### Knobs
+
+- `HELIX_BFM_CRAWL_FACTOR` — crawl threshold = baseline / factor.
+  Default `5`.
+- `HELIX_BFM_CRAWL_WINDOW` — batches in the baseline AND in the
+  consecutive-slow streak. Default `8`.
+- `HELIX_BFM_CRAWL_ACTION` — `ladder` (default) | `cpu` (straight to the
+  terminal rung) | `off` (detect + log only).
+
+On ≤12 GB rigs the watchdog is a backstop, not a license to run dense
+backfill on GPU unattended — the config matrix above still says **prefer
+CPU** for offline batch work on those cards.
 
 ## Choosing the dense-backfill path
 
@@ -118,5 +201,13 @@ inline-ingest path.
 - **Code:** `helix_context/backends/bgem3_codec.py`
   (`_vram_release_interval`, `_maybe_release_vram`, `encode_batch`).
 - **Backfill:** `scripts/backfill_bgem3_v2.py`.
+- **Crawl watchdog:** issue #212 → `scripts/crawl_watchdog.py`
+  (detector), wired into `scripts/build_fixture_matrix.py`
+  (`_drain_with_batched_splade`) and
+  `scripts/backfill_bgem3_v2.py` (`backfill_dense_db`). Incident
+  evidence: 2026-06-10/11 ERB 500K rebuild (confluence 15.3 → 2.3
+  genes/s; slack__eng-oncall 64 genes/47 min with release knobs active;
+  two live auto-recycles on 06-11, the 18:41 one at 1.03 genes/s /
+  11941 MiB finishing the build 33 min after recycle).
 - **Source of measurements:** ContextBench code-retrieval track, frozen
   v0.6.3 wheel, 2026-06-07.

--- a/scripts/backfill_bgem3_v2.py
+++ b/scripts/backfill_bgem3_v2.py
@@ -41,7 +41,20 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# Sibling-module import (crawl_watchdog) must resolve whether this file is
+# run directly or imported as a module by build_fixture_matrix / the tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+# Issue #212: crawl watchdog -- throughput-triggered escalation ladder. The
+# detector is pure; the CUDA helpers are guarded no-ops on CPU-only boxes.
+from crawl_watchdog import (
+    ACTION_DEMOTE,
+    ACTION_EMPTY_CACHE,
+    LOG_PREFIX as CRAWL_LOG_PREFIX,
+    CrawlDetector,
+    cuda_vram_fraction,
+    release_cuda_cache,
+)
 from helix_context.backends.bgem3_codec import (
     PASSAGE_CHAR_CAP,
     BGEM3Codec,
@@ -80,6 +93,7 @@ def backfill_dense_db(
     limit: int | None = None,
     codec=None,
     log_fn=print,
+    crawl_detector=None,
 ) -> dict:
     """Backfill ``genes.embedding_dense_v2`` on the SQLite DB at ``db_path``.
 
@@ -110,6 +124,19 @@ def backfill_dense_db(
             → a fresh :class:`BGEM3Codec` at ``dim``. Tests inject a fake.
         log_fn: callable taking one string for progress lines. Default
             :func:`print`; pass a no-op (``lambda _msg: None``) to silence.
+        crawl_detector: an object exposing ``feed(genes, dt, vram_frac)``
+            (the issue #212 crawl watchdog). ``None`` -> a
+            :class:`crawl_watchdog.CrawlDetector` built from the
+            ``HELIX_BFM_CRAWL_*`` env knobs -- honored HERE so both the
+            standalone operator script and the fixture builder's
+            ``_backfill_dense`` pass get the watchdog. On a sustained
+            crawl (per-batch genes/s EMA below the run's own early-batch
+            baseline / ``HELIX_BFM_CRAWL_FACTOR`` for
+            ``HELIX_BFM_CRAWL_WINDOW`` consecutive batches with dedicated
+            VRAM > 0.92 of capacity) the ladder first releases the CUDA
+            cache, then tears the codec down and reloads it on CPU for
+            the REMAINDER of this DB (``BGEM3_DEVICE=cpu`` semantics,
+            byte-identical vectors). Tests inject a fake.
 
     Returns:
         A coverage report dict with keys: ``db_path``, ``dim``,
@@ -122,6 +149,10 @@ def backfill_dense_db(
         dim = int(load_config().retrieval.dense_embedding_dim)
     dim = int(dim)
     expected_bytes = dim * 4
+    # Issue #212: only a codec WE constructed can be torn down and reloaded
+    # on CPU by the crawl watchdog's terminal rung. A caller-injected codec
+    # (tests, exotic embedders) is left alone -- demote becomes log-only.
+    owns_codec = codec is None
     if codec is None:
         # Backfill codec device, in priority order:
         #   1. an explicit ``BGEM3_DEVICE`` env var — operator override (#134);
@@ -186,6 +217,17 @@ def backfill_dense_db(
         t0 = time.monotonic()
         processed = 0
         skipped = 0
+        # Issue #212 crawl watchdog: one observation per batch, env knobs
+        # (HELIX_BFM_CRAWL_WINDOW / _FACTOR / _ACTION) honored here so the
+        # standalone script and build_fixture_matrix._backfill_dense share
+        # one implementation. CPU-only boxes never trip (vram probe = None).
+        watchdog = (
+            crawl_detector
+            if crawl_detector is not None
+            else CrawlDetector.from_env(log_fn=log_fn, name=Path(db_path).name)
+        )
+        demoted = False
+        last_feed_t = t0
         for start in range(0, len(rows), max(1, batch)):
             chunk = rows[start:start + max(1, batch)]
             encodable = [
@@ -230,6 +272,42 @@ def backfill_dense_db(
                 f"[backfill] {db_path}: {min(start + len(chunk), len(rows))}/{len(rows)} "
                 f"processed={processed} skipped={skipped} rate={rate:.1f} genes/s"
             )
+            # Issue #212: feed the crawl watchdog and apply its escalation
+            # ladder at this batch boundary.
+            now = time.monotonic()
+            crawl_action = watchdog.feed(
+                len(encodable), now - last_feed_t, cuda_vram_fraction(),
+            )
+            last_feed_t = now
+            if crawl_action == ACTION_EMPTY_CACHE:
+                released = release_cuda_cache()
+                log_fn(
+                    f"{CRAWL_LOG_PREFIX} rung 1 applied: gc.collect + "
+                    f"torch.cuda.empty_cache (released={released})"
+                )
+            elif crawl_action == ACTION_DEMOTE and not demoted:
+                demoted = True
+                if owns_codec:
+                    log_fn(
+                        f"{CRAWL_LOG_PREFIX} DEMOTING to CPU: tearing down the "
+                        f"codec and reloading with device=cpu for the remainder "
+                        f"of {db_path} (BGEM3_DEVICE=cpu semantics -- vectors "
+                        f"are byte-identical, no VRAM ceiling; see "
+                        f"docs/operations/DENSE_VRAM.md)"
+                    )
+                    codec = None
+                    release_cuda_cache()
+                    codec = BGEM3Codec(dim=dim, device="cpu")
+                    log_fn(
+                        f"{CRAWL_LOG_PREFIX} codec reloaded on CPU; resuming "
+                        f"backfill of {db_path}"
+                    )
+                else:
+                    log_fn(
+                        f"{CRAWL_LOG_PREFIX} demote requested but the codec was "
+                        f"injected by the caller -- cannot rebuild it on CPU; "
+                        f"continuing as-is"
+                    )
 
         conn.commit()
         elapsed = time.monotonic() - t0

--- a/scripts/build_fixture_matrix.py
+++ b/scripts/build_fixture_matrix.py
@@ -96,6 +96,18 @@ from helix_context.shard_schema import (
 # ``scripts/backfill_bgem3_v2.py`` share one implementation and cannot drift.
 from backfill_bgem3_v2 import backfill_dense_db
 
+# Issue #212: crawl watchdog -- throughput-triggered escalation ladder for
+# the dense ingest/backfill paths. The detector is pure (tests drive it
+# with a fake feed); the CUDA helpers are guarded no-ops on CPU-only boxes.
+from crawl_watchdog import (
+    ACTION_DEMOTE,
+    ACTION_EMPTY_CACHE,
+    LOG_PREFIX as CRAWL_LOG_PREFIX,
+    CrawlDetector,
+    cuda_vram_fraction,
+    release_cuda_cache,
+)
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -458,6 +470,7 @@ def _drain_with_batched_splade(
     genome,
     stats: dict,
     batch_size: int = 64,
+    crawl_detector=None,
 ) -> None:
     """Drain ``gene_dict_iter`` (yielding lists of gene dicts per file)
     into ``genome``. SPLADE encoding is batched across ``batch_size`` genes
@@ -471,11 +484,27 @@ def _drain_with_batched_splade(
     prevents a systematic upsert failure (schema mismatch, disk full,
     etc.) from being hidden behind a silently-ticking ``stats["errors"]``
     counter that nobody looks at until the full-run summary lands.
+
+    Crawl watchdog (issue #212): every flushed batch feeds
+    ``crawl_detector`` (``None`` -> a :class:`crawl_watchdog.CrawlDetector`
+    built from the ``HELIX_BFM_CRAWL_*`` env knobs) with the end-to-end
+    genes/s for that batch plus the dedicated-VRAM fraction. Ladder rung 1
+    releases the CUDA cache and continues; the terminal rung raises the
+    existing :class:`_PauseRequested` at this (already-committed) batch
+    boundary so the shard pauses cleanly and the #183 salvage +
+    file-level-resume machinery restarts it with a fresh CUDA context --
+    the only thing that reliably un-crawls an already-spilled WDDM
+    context (2026-06-11 slack__eng-oncall incident). CPU-only boxes never
+    trip: the VRAM probe returns ``None`` there.
     """
     from helix_context.backends import splade_backend
     from helix_context.schemas import Gene
 
+    if crawl_detector is None:
+        crawl_detector = CrawlDetector.from_env(log_fn=log.warning, name="ingest")
+
     buf: list = []  # Gene instances buffered before batch flush
+    last_feed_t = time.perf_counter()
     logged_drain_errors: set[str] = set()
 
     def _log_once(stage: str, exc: Exception) -> None:
@@ -524,6 +553,35 @@ def _drain_with_batched_splade(
         while len(buf) >= batch_size:
             _flush(buf[:batch_size])
             del buf[:batch_size]
+            # Crawl watchdog (issue #212): one observation per flushed
+            # batch. dt spans producer + encode + upsert time since the
+            # previous flush, i.e. true end-to-end genes/s -- the metric
+            # the 2026-06-10/11 incidents were measured in.
+            now = time.perf_counter()
+            crawl_action = crawl_detector.feed(
+                batch_size, now - last_feed_t, cuda_vram_fraction(),
+            )
+            last_feed_t = now
+            if crawl_action == ACTION_EMPTY_CACHE:
+                released = release_cuda_cache()
+                log.warning(
+                    "%s rung 1 applied: gc.collect + torch.cuda.empty_cache "
+                    "(released=%s)", CRAWL_LOG_PREFIX, released,
+                )
+            elif crawl_action == ACTION_DEMOTE:
+                # Terminal rung for the ingest path: process recycle via
+                # the existing #183 pause machinery. The batch above is
+                # already committed, so this boundary is a safe
+                # checkpoint; ``_build_one_shard`` writes the marker and
+                # the salvage + file-level-resume path picks the shard
+                # back up with a fresh CUDA context on the next run.
+                log.warning(
+                    "%s recycle requested -- raising _PauseRequested at the "
+                    "batch boundary (shard pauses cleanly; restart the same "
+                    "command to resume with a fresh CUDA context)",
+                    CRAWL_LOG_PREFIX,
+                )
+                raise _PauseRequested()
             # SIGINT batch boundary (issue #151): the previous _flush call
             # already committed the batch's genes to the shard DB, so this
             # is a safe checkpoint. Raise so ``_build_one_shard`` can
@@ -1269,6 +1327,10 @@ def _build_one_shard(
             try:
                 _drain_with_batched_splade(
                     gen, shard, s_stats, batch_size=batch_size,
+                    # Issue #212: shard-attributed crawl-watchdog logs.
+                    crawl_detector=CrawlDetector.from_env(
+                        log_fn=log.warning, name=label,
+                    ),
                 )
             except _PauseRequested:
                 # SIGINT was raised at a batch boundary. The genes in

--- a/scripts/crawl_watchdog.py
+++ b/scripts/crawl_watchdog.py
@@ -1,0 +1,317 @@
+"""Crawl watchdog: throughput-triggered escalation ladder for dense ingest/backfill.
+
+Issue #212. Detects the #176 WDDM-spill crawl -- a CUDA context that has
+silently spilled into shared system memory and degraded to a fraction of
+its early-shard throughput -- and escalates through cheap-to-terminal
+recovery actions instead of letting a shard run at ~0.02 genes/s for a
+projected ~66 hours (slack__eng-oncall, 2026-06-11).
+
+Design, from two live incidents during the 2026-06-10/11 ERB 500K rebuild
+on a 12 GB rig:
+
+* NOT a wall-clock per-shard timer -- that false-positives on legitimately
+  large shards and misses crawls on small ones. The trigger is the
+  unambiguous signature: the per-batch genes/s EMA drops below the shard's
+  OWN early-batch baseline divided by ``HELIX_BFM_CRAWL_FACTOR`` for
+  ``HELIX_BFM_CRAWL_WINDOW`` consecutive batches, AND dedicated VRAM sits
+  near device capacity (fraction > 0.92). A slow disk alone is not a
+  crawl; a CPU-only box (no probe-able CUDA device) structurally cannot
+  trip.
+
+* Escalation ladder (``HELIX_BFM_CRAWL_ACTION=ladder``, the default):
+  rung 1 -- ``gc.collect()`` + ``torch.cuda.empty_cache()`` (cheap,
+  occasionally sufficient early). Rung 2, if the crawl persists for
+  another full window -- terminal action: the dense BACKFILL path tears
+  down the codec and reloads it on CPU for the remainder of the shard
+  (``BGEM3_DEVICE=cpu`` semantics: byte-identical vectors, no VRAM
+  ceiling), while the INGEST path raises the existing ``_PauseRequested``
+  so the shard pauses cleanly at a batch boundary and the #183 salvage +
+  file-level-resume machinery restarts it with a fresh CUDA context.
+  ``HELIX_BFM_CRAWL_ACTION=cpu`` jumps straight to the terminal rung;
+  ``off`` detects and logs only. The 2026-06-11 slack__eng-oncall
+  incident proved ``empty_cache`` alone does not un-crawl an
+  already-spilled context -- context recycle / CPU demotion is the fix.
+
+Every watchdog log line carries the stable grep-able prefix
+``[crawl-watchdog]`` and includes rate, baseline, VRAM fraction and the
+action taken.
+
+The detector is a pure class (no torch import, no clock reads) so tests
+drive it with a fake feed; CUDA probing lives in the two small helpers
+:func:`cuda_vram_fraction` and :func:`release_cuda_cache`, both guarded
+with try/except so CPU-only boxes degrade to harmless no-ops.
+"""
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import statistics
+
+log = logging.getLogger("helix.crawl_watchdog")
+
+#: Stable grep-able prefix for every watchdog log line.
+LOG_PREFIX = "[crawl-watchdog]"
+
+#: Rung 1: caller should run :func:`release_cuda_cache` and continue.
+ACTION_EMPTY_CACHE = "empty_cache"
+#: Terminal rung: backfill path reloads the codec on CPU for the rest of
+#: the shard; ingest path raises ``_PauseRequested`` (process recycle).
+ACTION_DEMOTE = "demote"
+
+DEFAULT_CRAWL_WINDOW = 8
+DEFAULT_CRAWL_FACTOR = 5.0
+DEFAULT_VRAM_THRESHOLD = 0.92
+DEFAULT_EMA_ALPHA = 0.3
+
+_VALID_ACTIONS = ("ladder", "cpu", "off")
+
+
+# -- Env knobs (read at call time so tests can monkeypatch.setenv) --------
+
+
+def _env_parse(name: str, default, cast):
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "%s ignoring unparseable %s=%r (using default %r)",
+            LOG_PREFIX, name, raw, default,
+        )
+        return default
+
+
+def env_crawl_window() -> int:
+    """``HELIX_BFM_CRAWL_WINDOW`` -- baseline length AND consecutive-slow
+    streak length, in batches. Default 8; clamped to >= 1."""
+    return max(1, _env_parse("HELIX_BFM_CRAWL_WINDOW", DEFAULT_CRAWL_WINDOW, int))
+
+
+def env_crawl_factor() -> float:
+    """``HELIX_BFM_CRAWL_FACTOR`` -- crawl threshold = baseline / factor.
+    Default 5.0; non-positive values fall back to the default."""
+    val = _env_parse("HELIX_BFM_CRAWL_FACTOR", DEFAULT_CRAWL_FACTOR, float)
+    return val if val > 0 else DEFAULT_CRAWL_FACTOR
+
+
+def env_crawl_action() -> str:
+    """``HELIX_BFM_CRAWL_ACTION`` -- ``ladder`` (default) | ``cpu`` | ``off``."""
+    raw = os.environ.get("HELIX_BFM_CRAWL_ACTION", "").strip().lower()
+    if not raw:
+        return "ladder"
+    if raw not in _VALID_ACTIONS:
+        log.warning(
+            "%s ignoring unknown HELIX_BFM_CRAWL_ACTION=%r (using 'ladder')",
+            LOG_PREFIX, raw,
+        )
+        return "ladder"
+    return raw
+
+
+# -- Guarded CUDA helpers (no-ops on CPU-only boxes) ----------------------
+
+
+def cuda_vram_fraction() -> "float | None":
+    """Fraction of the current CUDA device's dedicated memory in use.
+
+    ``max(memory_allocated, memory_reserved) / total_memory`` on the
+    current device. Returns ``None`` when torch is missing, no CUDA
+    device is visible, or any probe call fails -- and the detector treats
+    ``None`` as "cannot trip", so CPU-only boxes never escalate.
+    """
+    try:
+        import torch
+        if not torch.cuda.is_available():
+            return None
+        dev = torch.cuda.current_device()
+        total = float(torch.cuda.get_device_properties(dev).total_memory)
+        if total <= 0:
+            return None
+        used = float(max(
+            torch.cuda.memory_allocated(dev),
+            torch.cuda.memory_reserved(dev),
+        ))
+        return used / total
+    except Exception:  # noqa: BLE001 -- any probe failure means "don't trip"
+        return None
+
+
+def release_cuda_cache() -> bool:
+    """Rung 1: ``gc.collect()`` then ``torch.cuda.empty_cache()``.
+
+    gc first so collected tensors return their blocks to the caching
+    allocator before the cache is released. Returns True iff the CUDA
+    cache release actually ran (False on CPU-only / torch-less boxes,
+    where only the gc pass happens).
+    """
+    gc.collect()
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            return True
+    except Exception:  # noqa: BLE001 -- best effort; never break the build
+        pass
+    return False
+
+
+# -- The pure detector -----------------------------------------------------
+
+
+class CrawlDetector:
+    """Pure throughput-crawl detector with an escalation ladder.
+
+    Feed one observation per completed batch::
+
+        action = detector.feed(genes, dt_seconds, vram_frac)
+
+    Returns ``None`` (healthy / warming up / disarmed),
+    :data:`ACTION_EMPTY_CACHE` (ladder rung 1) or :data:`ACTION_DEMOTE`
+    (terminal rung). Pure: no clock reads, no torch imports -- callers
+    supply the elapsed time and the VRAM fraction (production call sites
+    use :func:`cuda_vram_fraction`, which yields ``None`` on CPU-only
+    boxes, making the detector structurally unable to trip there).
+
+    Mechanics:
+
+    * rate tracker: EMA (``ema_alpha``, default 0.3) of per-batch genes/s;
+    * baseline: median of the first ``baseline_window`` per-batch rates --
+      the shard's own healthy speed, so big-slow shards don't false-trip;
+    * crawl: EMA < baseline / ``factor`` AND ``vram_frac`` >
+      ``vram_threshold`` for ``baseline_window`` CONSECUTIVE batches.
+      Any healthy batch resets the streak (hysteresis);
+    * on trip the streak re-arms, so the next rung requires another full
+      window of sustained crawling;
+    * ``action="off"`` logs every trip but never returns an action;
+      ``action="cpu"`` returns :data:`ACTION_DEMOTE` on the first trip;
+      ``action="ladder"`` returns rung 1 then rung 2. After the terminal
+      rung the detector disarms (all further feeds return ``None``).
+    """
+
+    def __init__(
+        self,
+        baseline_window: int = DEFAULT_CRAWL_WINDOW,
+        factor: float = DEFAULT_CRAWL_FACTOR,
+        *,
+        action: str = "ladder",
+        vram_threshold: float = DEFAULT_VRAM_THRESHOLD,
+        ema_alpha: float = DEFAULT_EMA_ALPHA,
+        log_fn=None,
+        name: str = "",
+    ):
+        self.baseline_window = max(1, int(baseline_window))
+        self.factor = float(factor) if float(factor) > 0 else DEFAULT_CRAWL_FACTOR
+        self.action = action if action in _VALID_ACTIONS else "ladder"
+        self.vram_threshold = float(vram_threshold)
+        self.ema_alpha = min(1.0, max(0.01, float(ema_alpha)))
+        self.log_fn = log_fn if log_fn is not None else log.warning
+        self.name = name
+
+        self.baseline: "float | None" = None
+        self.ema: "float | None" = None
+        self.streak = 0
+        self.rung = 0
+        self.trips = 0
+        self.batches = 0
+        self.disarmed = False
+        self._warmup: list[float] = []
+
+    @classmethod
+    def from_env(cls, *, log_fn=None, name: str = "") -> "CrawlDetector":
+        """Build a detector from the ``HELIX_BFM_CRAWL_*`` env knobs
+        (read now, not at import time, so tests can monkeypatch)."""
+        return cls(
+            baseline_window=env_crawl_window(),
+            factor=env_crawl_factor(),
+            action=env_crawl_action(),
+            log_fn=log_fn,
+            name=name,
+        )
+
+    # -- internals --
+
+    def _tag(self) -> str:
+        return f" name={self.name}" if self.name else ""
+
+    def feed(self, genes: float, dt: float, vram_frac: "float | None" = None):
+        """Record one batch: ``genes`` processed in ``dt`` seconds with the
+        device at ``vram_frac`` (``None`` = unknown / no CUDA). Returns the
+        escalation action for the caller to apply, or ``None``."""
+        if self.disarmed:
+            return None
+        if genes <= 0 or dt <= 0:
+            return None  # nothing measurable; neither counts nor resets
+        rate = genes / dt
+        self.batches += 1
+        if self.ema is None:
+            self.ema = rate
+        else:
+            self.ema = self.ema_alpha * rate + (1.0 - self.ema_alpha) * self.ema
+
+        if self.baseline is None:
+            self._warmup.append(rate)
+            if len(self._warmup) >= self.baseline_window:
+                self.baseline = statistics.median(self._warmup)
+                self.log_fn(
+                    f"{LOG_PREFIX} baseline established{self._tag()}: "
+                    f"{self.baseline:.2f} genes/s (median of first "
+                    f"{self.baseline_window} batches) "
+                    f"crawl_threshold={self.baseline / self.factor:.2f} genes/s "
+                    f"factor={self.factor:g} window={self.baseline_window} "
+                    f"action={self.action}"
+                )
+            return None
+
+        threshold = self.baseline / self.factor
+        slow = self.ema < threshold
+        vram_high = vram_frac is not None and vram_frac > self.vram_threshold
+        if slow and vram_high:
+            self.streak += 1
+        else:
+            self.streak = 0  # hysteresis: recovery re-arms from zero
+        if self.streak < self.baseline_window:
+            return None
+
+        # Tripped: a full window of consecutive slow-and-VRAM-pinned batches.
+        self.streak = 0
+        self.trips += 1
+        return self._escalate(rate, vram_frac)
+
+    def _escalate(self, rate: float, vram_frac: float):
+        ctx = (
+            f"{LOG_PREFIX} CRAWL detected{self._tag()}: "
+            f"rate={rate:.2f} genes/s ema={self.ema:.2f} genes/s "
+            f"baseline={self.baseline:.2f} genes/s "
+            f"threshold={self.baseline / self.factor:.2f} genes/s "
+            f"vram_frac={vram_frac:.3f} window={self.baseline_window}"
+        )
+        if self.action == "off":
+            self.log_fn(
+                ctx + " action=none (HELIX_BFM_CRAWL_ACTION=off: log-only)"
+            )
+            return None
+        if self.action == "cpu":
+            self.disarmed = True
+            self.log_fn(
+                ctx + " action=demote (HELIX_BFM_CRAWL_ACTION=cpu: straight "
+                "to terminal rung; watchdog disarmed for this shard)"
+            )
+            return ACTION_DEMOTE
+        # ladder
+        self.rung += 1
+        if self.rung == 1:
+            self.log_fn(
+                ctx + " action=empty_cache (ladder rung 1/2: gc.collect + "
+                "torch.cuda.empty_cache)"
+            )
+            return ACTION_EMPTY_CACHE
+        self.disarmed = True
+        self.log_fn(
+            ctx + " action=demote (ladder rung 2/2: empty_cache was not "
+            "enough -- an already-spilled context needs recycle/CPU-demote; "
+            "watchdog disarmed for this shard)"
+        )
+        return ACTION_DEMOTE

--- a/tests/test_crawl_watchdog.py
+++ b/tests/test_crawl_watchdog.py
@@ -1,0 +1,420 @@
+"""Tests for issue #212 -- crawl watchdog: throughput-triggered escalation
+ladder for the dense ingest/backfill paths.
+
+NO GPU anywhere in this file. The detector is a pure class (callers
+inject ``vram_frac``), so these tests drive it with a fake feed; the
+wire-level tests stub the heavy collaborators the same way
+``test_build_fixture_matrix_resume.py`` does. On a CPU-only box the
+production probe ``cuda_vram_fraction()`` returns ``None``, which the
+detector treats as "cannot trip".
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable.
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "scripts")
+)
+
+import crawl_watchdog as cw
+from crawl_watchdog import ACTION_DEMOTE, ACTION_EMPTY_CACHE, CrawlDetector
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _detector(window=4, factor=5.0, action="ladder", **kw):
+    """Detector with ``ema_alpha=1.0`` so the EMA equals the instantaneous
+    rate -- crisp, batch-exact trip timing for tests. Production keeps the
+    default 0.3 smoothing."""
+    kw.setdefault("ema_alpha", 1.0)
+    kw.setdefault("log_fn", lambda _msg: None)
+    return CrawlDetector(window, factor, action=action, **kw)
+
+
+def _warm(det, rate=10.0, vram=0.5):
+    """Feed ``baseline_window`` healthy batches to establish the baseline."""
+    for _ in range(det.baseline_window):
+        assert det.feed(genes=rate, dt=1.0, vram_frac=vram) is None
+    assert det.baseline == pytest.approx(rate)
+
+
+# -- baseline establishment ------------------------------------------------
+
+
+def test_baseline_is_median_of_first_window_batches():
+    logs: list[str] = []
+    det = CrawlDetector(5, 5.0, action="ladder", ema_alpha=1.0,
+                        log_fn=logs.append)
+    rates = [10.0, 30.0, 20.0, 1000.0, 15.0]  # median = 20
+    for r in rates:
+        # Warmup batches never trip, even with VRAM pinned: there is no
+        # baseline to compare against yet.
+        assert det.feed(genes=r, dt=1.0, vram_frac=0.99) is None
+    assert det.baseline == pytest.approx(20.0)
+    assert any(
+        "[crawl-watchdog]" in m and "baseline established" in m for m in logs
+    )
+
+
+def test_zero_gene_or_zero_dt_batches_are_ignored():
+    det = _detector(window=3)
+    assert det.feed(genes=0, dt=1.0, vram_frac=0.99) is None
+    assert det.feed(genes=10.0, dt=0.0, vram_frac=0.99) is None
+    assert det.batches == 0
+    assert det.baseline is None
+
+
+# -- no-trip paths ----------------------------------------------------------
+
+
+def test_no_trip_under_healthy_rate():
+    det = _detector()
+    _warm(det, rate=10.0)
+    for _ in range(10 * det.baseline_window):
+        assert det.feed(genes=10.0, dt=1.0, vram_frac=0.99) is None
+    assert det.trips == 0
+    assert det.streak == 0
+
+
+def test_no_trip_when_vram_low_slow_disk_alone_is_not_a_crawl():
+    det = _detector(window=4)
+    _warm(det, rate=10.0)
+    for _ in range(5 * det.baseline_window):
+        assert det.feed(genes=0.1, dt=1.0, vram_frac=0.40) is None
+    assert det.trips == 0
+
+
+def test_no_trip_when_vram_unknown_cpu_only_box():
+    """``cuda_vram_fraction()`` returns None on CPU-only boxes; the
+    detector must treat that as 'structurally cannot trip'."""
+    det = _detector(window=4)
+    _warm(det, rate=10.0)
+    for _ in range(5 * det.baseline_window):
+        assert det.feed(genes=0.1, dt=1.0, vram_frac=None) is None
+    assert det.trips == 0
+
+
+# -- tripping + hysteresis ---------------------------------------------------
+
+
+def test_trip_after_window_consecutive_slow_high_vram_batches():
+    det = _detector(window=4)
+    _warm(det, rate=10.0)  # threshold = 10 / 5 = 2.0 genes/s
+    for i in range(3):
+        assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) is None, (
+            f"slow batch {i + 1}/4 must not trip yet"
+        )
+    assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) == ACTION_EMPTY_CACHE
+    assert det.trips == 1
+
+
+def test_hysteresis_recovery_resets_the_streak():
+    det = _detector(window=4)
+    _warm(det, rate=10.0)
+    for _ in range(3):
+        assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) is None
+    # One healthy batch resets the consecutive counter ...
+    assert det.feed(genes=10.0, dt=1.0, vram_frac=0.97) is None
+    assert det.streak == 0
+    # ... so window-1 further slow batches still must not trip ...
+    for _ in range(3):
+        assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) is None
+    assert det.trips == 0
+    # ... and only a full window of sustained crawling after recovery does.
+    assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) == ACTION_EMPTY_CACHE
+
+
+def test_ema_smooths_a_single_transient_stall():
+    """With the production alpha (0.3) one stalled batch cannot drag the
+    EMA below the threshold, so transient hiccups don't start a streak."""
+    det = CrawlDetector(4, 5.0, action="ladder", ema_alpha=0.3,
+                        log_fn=lambda _m: None)
+    for _ in range(4):
+        det.feed(genes=10.0, dt=1.0, vram_frac=0.5)
+    assert det.baseline == pytest.approx(10.0)
+    # EMA = 0.3 * 0.1 + 0.7 * 10.0 = 7.03 > threshold 2.0 -> no streak.
+    assert det.feed(genes=0.1, dt=1.0, vram_frac=0.97) is None
+    assert det.streak == 0
+
+
+# -- actions -----------------------------------------------------------------
+
+
+def test_action_off_logs_but_returns_none():
+    logs: list[str] = []
+    det = _detector(window=4, action="off", log_fn=logs.append)
+    _warm(det, rate=10.0)
+    for _ in range(4):
+        assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) is None
+    assert det.trips == 1
+    assert not det.disarmed
+    crawl_lines = [m for m in logs if "CRAWL detected" in m]
+    assert crawl_lines and all("[crawl-watchdog]" in m for m in crawl_lines)
+    assert "log-only" in crawl_lines[0]
+    # Detection stays armed: the next full window logs again.
+    for _ in range(4):
+        assert det.feed(genes=0.5, dt=1.0, vram_frac=0.97) is None
+    assert det.trips == 2
+
+
+def test_action_cpu_returns_demote_immediately_on_first_trip():
+    det = _detector(window=4, action="cpu")
+    _warm(det, rate=10.0)
+    out = [det.feed(genes=0.5, dt=1.0, vram_frac=0.97) for _ in range(4)]
+    assert out == [None, None, None, ACTION_DEMOTE]
+    assert det.disarmed
+
+
+def test_ladder_escalates_rung1_then_rung2_across_two_windows():
+    logs: list[str] = []
+    det = _detector(window=4, action="ladder", log_fn=logs.append)
+    _warm(det, rate=10.0)
+    first = [det.feed(genes=0.5, dt=1.0, vram_frac=0.97) for _ in range(4)]
+    assert first == [None, None, None, ACTION_EMPTY_CACHE]
+    assert det.rung == 1
+    second = [det.feed(genes=0.5, dt=1.0, vram_frac=0.97) for _ in range(4)]
+    assert second == [None, None, None, ACTION_DEMOTE]
+    assert det.rung == 2
+    assert det.disarmed
+    # Terminal rung reached: the detector goes quiescent.
+    assert det.feed(genes=0.5, dt=1.0, vram_frac=0.99) is None
+    # The mandated grep-able evidence trail: rate, baseline, vram, action.
+    trip_lines = [m for m in logs if "CRAWL detected" in m]
+    assert len(trip_lines) == 2
+    for line in trip_lines:
+        assert line.startswith("[crawl-watchdog]")
+        for field in ("ema=", "baseline=", "vram_frac=", "action="):
+            assert field in line
+
+
+# -- env knobs ----------------------------------------------------------------
+
+
+def test_from_env_defaults(monkeypatch):
+    for var in ("HELIX_BFM_CRAWL_WINDOW", "HELIX_BFM_CRAWL_FACTOR",
+                "HELIX_BFM_CRAWL_ACTION"):
+        monkeypatch.delenv(var, raising=False)
+    det = CrawlDetector.from_env()
+    assert det.baseline_window == 8
+    assert det.factor == 5.0
+    assert det.action == "ladder"
+
+
+def test_from_env_overrides(monkeypatch):
+    monkeypatch.setenv("HELIX_BFM_CRAWL_WINDOW", "3")
+    monkeypatch.setenv("HELIX_BFM_CRAWL_FACTOR", "2.5")
+    monkeypatch.setenv("HELIX_BFM_CRAWL_ACTION", "CPU")
+    det = CrawlDetector.from_env()
+    assert (det.baseline_window, det.factor, det.action) == (3, 2.5, "cpu")
+
+
+def test_from_env_garbage_falls_back_to_defaults(monkeypatch):
+    monkeypatch.setenv("HELIX_BFM_CRAWL_WINDOW", "banana")
+    monkeypatch.setenv("HELIX_BFM_CRAWL_FACTOR", "-3")
+    monkeypatch.setenv("HELIX_BFM_CRAWL_ACTION", "explode")
+    det = CrawlDetector.from_env()
+    assert (det.baseline_window, det.factor, det.action) == (8, 5.0, "ladder")
+
+
+# -- guarded CUDA helpers (must never raise on CPU-only boxes) ---------------
+
+
+def test_cuda_vram_fraction_never_raises_without_a_gpu():
+    frac = cw.cuda_vram_fraction()
+    assert frac is None or 0.0 <= frac <= 1.5
+
+
+def test_release_cuda_cache_never_raises_without_a_gpu():
+    assert cw.release_cuda_cache() in (True, False)
+
+
+# -- wire level: ingest path (_drain_with_batched_splade) --------------------
+
+
+class _StubGene:
+    def __init__(self, **kw):
+        self.content = kw.get("content", "x" * 50)
+
+
+class _StubSplade:
+    @staticmethod
+    def encode_batch(_texts):
+        return [None] * len(_texts)
+
+
+class _StubGenome:
+    def upsert_doc(self, *a, **kw):
+        pass
+
+
+def _install_drain_stubs(monkeypatch):
+    """Patch the late imports inside ``_drain_with_batched_splade`` (same
+    technique as test_build_fixture_matrix_resume.py) and make sure the
+    SIGINT flag can't be the thing that raises."""
+    import build_fixture_matrix as bfm
+    fake_backends = types.ModuleType("helix_context.backends")
+    fake_backends.splade_backend = _StubSplade
+    fake_schemas = types.ModuleType("helix_context.schemas")
+    fake_schemas.Gene = _StubGene
+    monkeypatch.setitem(sys.modules, "helix_context.backends", fake_backends)
+    monkeypatch.setitem(sys.modules, "helix_context.schemas", fake_schemas)
+    monkeypatch.setattr(bfm, "_PAUSE_REQUESTED", False)
+    return bfm
+
+
+def test_drain_raises_pause_requested_when_detector_demotes(monkeypatch):
+    """Terminal rung on the ingest path = process recycle via the existing
+    #183 ``_PauseRequested`` batch-boundary machinery -- reused, not
+    reinvented."""
+    bfm = _install_drain_stubs(monkeypatch)
+
+    class _DemotingDetector:
+        def feed(self, genes, dt, vram_frac=None):
+            return ACTION_DEMOTE
+
+    gene_dict_iter = iter([
+        [{"content": "alpha"}],
+        [{"content": "beta"}],  # never reached -- recycle fires first
+    ])
+    stats = {"files": 0, "genes": 0, "errors": 0, "t0": 0.0}
+    with pytest.raises(bfm._PauseRequested):
+        bfm._drain_with_batched_splade(
+            gene_dict_iter, _StubGenome(), stats, batch_size=1,
+            crawl_detector=_DemotingDetector(),
+        )
+    # The demote batch itself was already flushed before the raise.
+    assert stats["genes"] == 1
+
+
+def test_drain_applies_rung1_empty_cache_and_continues(monkeypatch):
+    bfm = _install_drain_stubs(monkeypatch)
+
+    calls = {"release": 0}
+    monkeypatch.setattr(
+        bfm, "release_cuda_cache",
+        lambda: calls.__setitem__("release", calls["release"] + 1) or True,
+    )
+
+    class _Rung1Detector:
+        def __init__(self):
+            self.feeds = 0
+
+        def feed(self, genes, dt, vram_frac=None):
+            self.feeds += 1
+            return ACTION_EMPTY_CACHE if self.feeds == 1 else None
+
+    det = _Rung1Detector()
+    gene_dict_iter = iter([[{"content": "alpha"}], [{"content": "beta"}]])
+    stats = {"files": 0, "genes": 0, "errors": 0, "t0": 0.0}
+    bfm._drain_with_batched_splade(
+        gene_dict_iter, _StubGenome(), stats, batch_size=1,
+        crawl_detector=det,
+    )
+    assert calls["release"] == 1, "rung 1 must release the CUDA cache"
+    assert det.feeds == 2, "detector is fed once per flushed batch"
+    assert stats["genes"] == 2, "rung 1 continues the drain, no pause"
+
+
+# -- wire level: backfill path (backfill_bgem3_v2.backfill_dense_db) ---------
+
+
+def _make_genes_db(path: Path, n: int) -> None:
+    """Minimal ``genes`` schema for ``backfill_dense_db``: gene_id +
+    content + the ``chromatin`` column its partial index references."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE genes ("
+        "gene_id TEXT PRIMARY KEY, content TEXT, "
+        "chromatin INTEGER DEFAULT 0)"
+    )
+    conn.executemany(
+        "INSERT INTO genes (gene_id, content) VALUES (?, ?)",
+        [(f"g{i}", f"some content {i} " * 4) for i in range(n)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_backfill_demotes_codec_to_cpu_on_demote(tmp_path, monkeypatch):
+    """Terminal rung on the backfill path: tear down the codec and reload
+    it with device=cpu for the remainder of the shard."""
+    import backfill_bgem3_v2 as bf2
+
+    db = tmp_path / "shard.db"
+    _make_genes_db(db, n=6)
+
+    constructed: list[str] = []
+
+    class _FakeCodec:
+        def __init__(self, dim=4, device="cpu", **_kw):
+            self.device = device
+            constructed.append(device)
+
+        def encode_batch(self, texts, task="passage"):
+            return [[0.0, 0.0, 0.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(bf2, "BGEM3Codec", _FakeCodec)
+    # Pretend to be a GPU box; the codec is fake so no CUDA is touched.
+    monkeypatch.setenv("BGEM3_DEVICE", "cuda")
+
+    class _DemoteOnFirstFeed:
+        def __init__(self):
+            self.feeds = 0
+
+        def feed(self, genes, dt, vram_frac=None):
+            self.feeds += 1
+            return ACTION_DEMOTE if self.feeds == 1 else None
+
+    logs: list[str] = []
+    report = bf2.backfill_dense_db(
+        str(db), dim=4, batch=2,
+        crawl_detector=_DemoteOnFirstFeed(),
+        log_fn=logs.append,
+    )
+    assert constructed == ["cuda", "cpu"], (
+        "codec must be torn down and reloaded on CPU after the demote"
+    )
+    assert report["rows_processed"] == 6
+    assert report["dense_coverage"] == pytest.approx(1.0)
+    assert any(
+        m.startswith("[crawl-watchdog]") and "DEMOTING to CPU" in m
+        for m in logs
+    )
+
+
+def test_backfill_leaves_injected_codec_alone_on_demote(tmp_path):
+    """A caller-injected codec can't be rebuilt on CPU -- demote degrades
+    to a loud log line and the backfill keeps going."""
+    import backfill_bgem3_v2 as bf2
+
+    db = tmp_path / "shard2.db"
+    _make_genes_db(db, n=4)
+
+    class _InjectedCodec:
+        def encode_batch(self, texts, task="passage"):
+            return [[0.0, 0.0] for _ in texts]
+
+    class _AlwaysDemote:
+        def feed(self, genes, dt, vram_frac=None):
+            return ACTION_DEMOTE
+
+    logs: list[str] = []
+    report = bf2.backfill_dense_db(
+        str(db), dim=2, batch=2,
+        codec=_InjectedCodec(),
+        crawl_detector=_AlwaysDemote(),
+        log_fn=logs.append,
+    )
+    assert report["rows_processed"] == 4
+    assert report["dense_coverage"] == pytest.approx(1.0)
+    assert any(
+        m.startswith("[crawl-watchdog]") and "injected" in m for m in logs
+    )


### PR DESCRIPTION
Closes #212. Pure CrawlDetector (EMA genes/s vs first-window median baseline; trip = EMA < baseline/HELIX_BFM_CRAWL_FACTOR for HELIX_BFM_CRAWL_WINDOW consecutive batches AND vram_frac > 0.92; hysteresis; disarms after terminal rung). Backfill path: ladder in backfill_bgem3_v2.backfill_dense_db (standalone script + fixture builder both covered) - rung 1 gc+empty_cache, rung 2 reload codec on CPU for the shard remainder. Ingest path: _drain_with_batched_splade raises the existing #183 _PauseRequested at a committed batch boundary (salvage + file-level resume reused). Knobs: HELIX_BFM_CRAWL_FACTOR=5 / _WINDOW=8 / _ACTION=ladder|cpu|off. All logs grep-able via [crawl-watchdog]. DENSE_VRAM.md documents the 2026-06-10/11 incidents this automates: confluence 15.3->2.3 genes/s; eng-oncall 64 genes/47min WITH release knobs active (empty_cache cannot un-spill - context recycle/CPU demotion is the fix); two live auto-recycles by the interim external watchdog, incl. 18:41 @ 1.03 genes/s / 11,941 MiB -> build finished 33 min later. Tests: 20 new GPU-free detector/wire tests; 35 passed locally across watchdog+resume+auto-subshard suites.