### PR TITLE
fix(retrieval): dense pool floor + true-pair calibration cap - dense leg can no longer be gated to zero (#214)

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -326,6 +326,14 @@ ann_threshold_max_genes = 12
 # ann_similarity_threshold (with one-time WARN) if the row is missing.
 ann_threshold_mode = "absolute"           # "absolute" | "margin_over_random"
 ann_threshold_sigma_multiplier = 3.0      # mu + N*sigma over random pairs
+# Issue #214: dense pool floor. If the (mis-)calibrated ANN threshold leaves
+# fewer than N dense-scored candidates in the pool, the top-N dense hits by
+# cosine are admitted anyway and compete normally in fusion. Two independent
+# measurements showed the random-pair bound can sit ABOVE every real
+# query-doc cosine (calibrated 0.779 vs corpus max ~0.713 -> 0/5000 dense
+# admissions; 70.0% never-surfaced golds on a 480-question ERB run vs an
+# independent 67.2%). 0 = legacy gate-only.
+dense_pool_floor_genes = 8
 dense_pool_size = 500
 # Stage 3 (2026-05-08): Reciprocal Rank Fusion. Spec
 # docs/specs/2026-05-08-stage-3-rrf-fusion.md replaces the additive

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -342,6 +342,23 @@ class RetrievalConfig:
     # ``scripts/calibrate_thresholds.py``).
     ann_threshold_mode: str = "absolute"
     ann_threshold_sigma_multiplier: float = 3.0
+    # Issue #214 (2026-06-12): dense pool floor. The margin-over-random
+    # calibration measures mu + sigma_mult*sigma over RANDOM gene pairs;
+    # embedding anisotropy can push that bound ABOVE every real query-doc
+    # cosine. Measured twice, independently: (a) cc-exchange
+    # embedding-upgrade L1b — calibrated threshold 0.779 vs corpus max
+    # query-doc cosine ~0.713 (golds 0.46-0.68), so 0/5000 pool docs cleared
+    # the gate by dense; (b) a 480-question ERB run with 70.0% never-surfaced
+    # golds (gold absent from top-10), matching an independent 67.2%
+    # measurement. A threshold that admits ZERO dense candidates is
+    # mis-calibration by definition, and pool membership is strictly upstream
+    # of fusion ranking — no re-weighting can recover a candidate the gate
+    # already dropped. When fewer than this many dense-scored candidates
+    # survive the ANN threshold cut (but the dense leg HAD scored
+    # candidates), the top-N dense hits by cosine are admitted into the pool
+    # anyway; they then compete normally in fusion scoring. 0 disables
+    # (legacy gate-only). See knowledge_store.apply_ann_gate.
+    dense_pool_floor_genes: int = 8
     # Stage 2 (2026-05-08): dense recall pool size. Decoupled from
     # ann_threshold_max_genes (the final cut). 500 hits ~3% of an 18.9k
     # corpus per spec §4.
@@ -812,6 +829,12 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             ann_threshold_sigma_multiplier=float(r.get(
                 "ann_threshold_sigma_multiplier",
                 cfg.retrieval.ann_threshold_sigma_multiplier,
+            )),
+            # Issue #214: dense pool floor — graceful degradation when a
+            # mis-calibrated ANN threshold gates the dense leg to zero.
+            dense_pool_floor_genes=int(r.get(
+                "dense_pool_floor_genes",
+                cfg.retrieval.dense_pool_floor_genes,
             )),
             # Stage 2 (2026-05-08): dense recall pool size, decoupled from final cut.
             dense_pool_size=int(r.get("dense_pool_size", cfg.retrieval.dense_pool_size)),

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -569,6 +569,10 @@ class HelixContextManager:
             # Stage 4 (2026-05-08): margin-over-random calibration mode.
             ann_threshold_mode=config.retrieval.ann_threshold_mode,
             ann_threshold_sigma_multiplier=config.retrieval.ann_threshold_sigma_multiplier,
+            # Issue #214: dense pool floor — the dense leg can no longer be
+            # threshold-gated to zero during pool construction. Fanned to the
+            # solo Genome AND every per-shard Genome via open_read_source.
+            dense_pool_floor_genes=config.retrieval.dense_pool_floor_genes,
             dense_pool_size=config.retrieval.dense_pool_size,
             # Stage 3 (2026-05-08): RRF fusion + per-tier weights.
             fusion_mode=config.retrieval.fusion_mode,

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -355,6 +355,94 @@ def _dense_matrix_dtype():
     return _np.float16 if val in ("float16", "fp16", "half") else _np.float32
 
 
+def apply_ann_gate(
+    scored: "list[tuple[str, float]]",
+    dense_hits: "list[tuple[str, float]]",
+    *,
+    threshold: float,
+    min_genes: int,
+    max_genes: int,
+    dense_pool_floor_genes: int = 0,
+) -> "list[str]":
+    """ANN pool cut: threshold + ``min_genes`` floor + ``max_genes`` cap,
+    plus the Issue #214 dense pool floor.
+
+    Pure function over ``(gene_id, score)`` pairs so the gate semantics are
+    unit-testable without a KnowledgeStore (``tests/test_dense_pool_floor.py``).
+
+    Parameters
+    ----------
+    scored:
+        Full union pool, sorted descending by score. Lexical-only candidates
+        carry the ``threshold - 0.01`` pin from ``query_docs_ann``;
+        dense-scored candidates carry their real cosine.
+    dense_hits:
+        The dense leg — ``(gene_id, cosine)`` sorted descending by cosine,
+        exactly as ``query_docs_dense_recall`` returns it.
+    dense_pool_floor_genes:
+        Issue #214. The margin-over-random calibration computes
+        ``mu + sigma_mult*sigma`` over RANDOM gene pairs; embedding
+        anisotropy can push that bound ABOVE every real query-doc cosine.
+        Measured twice, independently:
+
+        * cc-exchange embedding-upgrade L1b: calibrated threshold 0.779 sat
+          above the corpus max query-doc cosine ~0.713 (golds 0.46-0.68) —
+          0/5000 pool-doc chunks cleared the gate by dense, so the 200-pool
+          was built almost entirely from lexically-pinned docs;
+        * a 480-question ERB run with 70.0% never-surfaced golds (gold not
+          in top-10), corroborating an independent 67.2% measurement.
+
+        Pool membership is strictly upstream of fusion ranking, so no dense
+        re-weighting can recover candidates the gate already dropped. A
+        threshold that admits ZERO dense candidates is mis-calibration by
+        definition; the floor makes the dense leg degrade gracefully instead
+        of dying. When fewer than N dense-scored candidates survive the
+        legacy cut — but the dense leg HAD scored candidates — the top-N
+        dense hits by cosine are appended to the pool. They then compete
+        normally in downstream fusion scoring; nothing else about them is
+        marked different. ``0`` disables (legacy gate-only behavior).
+
+    Returns the kept ``gene_id`` list: the legacy cut order (score
+    descending, truncated at ``max_genes``) with any floor-rescued dense ids
+    appended in cosine order. When the gate is healthy (>= N dense-scored
+    survivors) the output is byte-identical to the legacy cut.
+
+    Blast-radius note: the floor appends AFTER the ``max_genes`` cap, so the
+    pool exceeds ``max_genes`` only while the threshold is starving the
+    dense leg, and by at most ``dense_pool_floor_genes`` entries.
+    """
+    # Legacy cut (pre-#214, byte-for-byte): admit everything at/above the
+    # threshold; below it, only the min_genes rescue keeps admitting; stop at
+    # the first non-rescued below-threshold candidate; cap at max_genes.
+    kept: list[str] = []
+    for gid, score in scored:
+        if score >= threshold or len(kept) < min_genes:
+            kept.append(gid)
+        else:
+            break
+    kept = kept[:max_genes]
+
+    if dense_pool_floor_genes <= 0 or not dense_hits:
+        return kept
+
+    dense_ids = {gid for gid, _ in dense_hits}
+    admitted = sum(1 for gid in kept if gid in dense_ids)
+    if admitted >= dense_pool_floor_genes:
+        # Gate is healthy — the floor changes nothing.
+        return kept
+
+    kept_set = set(kept)
+    for gid, _cosine in dense_hits:  # already sorted descending by cosine
+        if admitted >= dense_pool_floor_genes:
+            break
+        if gid in kept_set:
+            continue
+        kept.append(gid)
+        kept_set.add(gid)
+        admitted += 1
+    return kept
+
+
 class KnowledgeStore:
     """SQLite-backed document storage with tags-tag retrieval."""
 
@@ -410,6 +498,12 @@ class KnowledgeStore:
         # See docs/specs/2026-05-08-stage-4-threshold-calibration.md §3.
         ann_threshold_mode: str = "absolute",
         ann_threshold_sigma_multiplier: float = 3.0,
+        # Issue #214: minimum dense-leg presence in the query_docs_ann pool
+        # cut. When fewer than this many dense-scored candidates survive the
+        # ANN threshold (but the dense leg had scored candidates), the top-N
+        # dense hits by cosine are admitted anyway. 0 disables (legacy
+        # gate-only). Full rationale + evidence: apply_ann_gate docstring.
+        dense_pool_floor_genes: int = 8,
         # Stage 2: dense recall pool size, decoupled from ann_threshold_max_genes.
         dense_pool_size: int = 500,
         # Stage 3 (2026-05-08): Reciprocal Rank Fusion (spec
@@ -514,6 +608,11 @@ class KnowledgeStore:
         self._ann_threshold_calibrated: Optional[float] = None
         self._ann_threshold_calibration_meta: Optional[Dict[str, Any]] = None
         self._ann_threshold_fallback_warned: bool = False
+        # Issue #214: dense pool floor (0 = legacy gate-only). Applies inside
+        # apply_ann_gate, i.e. per-store — in sharded mode each per-shard
+        # KnowledgeStore receives this via the fanned genome_kwargs, so the
+        # floor holds per shard and the router-level merge dedups as usual.
+        self._dense_pool_floor_genes: int = int(dense_pool_floor_genes)
         # Stage 2 (2026-05-08): pool size for dense + lex recall, decoupled
         # from max_genes (the post-ranking final cut).
         self._dense_pool_size: int = int(dense_pool_size)
@@ -2913,6 +3012,10 @@ class KnowledgeStore:
         3. Union by gene_id, preserving best score per source.
         4. Body-fetch once via ``_load_genes_by_ids``.
         5. Apply threshold + ``min_genes`` floor; cap at ``max_genes``.
+           Issue #214: if fewer than ``dense_pool_floor_genes`` dense-scored
+           candidates survive, admit the top-N dense hits by cosine anyway
+           (see ``apply_ann_gate``) so a mis-calibrated threshold can no
+           longer gate the dense leg out of pool construction entirely.
 
         ``ann_similarity_threshold`` was recalibrated for dim=1024 v2 vectors
         in Issue #139 / Stage 4 (2026-05-18): measured unrelated-pair cosine
@@ -2987,14 +3090,22 @@ class KnowledgeStore:
             scored.append((doc, sim_by_id[gid]))
         scored.sort(key=lambda x: x[1], reverse=True)
 
-        # ── 5. Threshold cut + min_genes floor + max_genes cap. ──────
-        result: list[Gene] = []
-        for doc, sim in scored:
-            if sim >= threshold or len(result) < min_genes:
-                result.append(doc)
-            else:
-                break
-        return result[:max_genes]
+        # ── 5. Threshold cut + min_genes floor + max_genes cap, plus the
+        # Issue #214 dense pool floor. The cut is a module-level pure
+        # function (apply_ann_gate) so the gate semantics are unit-testable
+        # without a store; with the floor disabled — or whenever >= N
+        # dense-scored candidates survive — it reproduces the legacy loop
+        # byte-for-byte.
+        kept_ids = apply_ann_gate(
+            [(doc.gene_id, sim) for doc, sim in scored],
+            dense_hits,
+            threshold=threshold,
+            min_genes=min_genes,
+            max_genes=max_genes,
+            dense_pool_floor_genes=self._dense_pool_floor_genes,
+        )
+        by_id = {doc.gene_id: doc for doc, _ in scored}
+        return [by_id[gid] for gid in kept_ids if gid in by_id]
 
     def _load_genes_by_ids(self, gene_ids: list[str]) -> dict[str, Gene]:
         """Bulk-load Document objects by id. Used by query_genes_ann to fetch

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -981,6 +981,8 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
                 ann_threshold_max_genes=config.retrieval.ann_threshold_max_genes,
                 ann_threshold_mode=config.retrieval.ann_threshold_mode,
                 ann_threshold_sigma_multiplier=config.retrieval.ann_threshold_sigma_multiplier,
+                # Issue #214: dense pool floor (keep the swap path in sync).
+                dense_pool_floor_genes=config.retrieval.dense_pool_floor_genes,
                 dense_pool_size=config.retrieval.dense_pool_size,
                 fusion_mode=config.retrieval.fusion_mode,
                 rrf_k=config.retrieval.rrf_k,

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -46,6 +46,14 @@ from typing import Any, Dict, List, Optional, Tuple
 
 log = logging.getLogger("calibrate_thresholds")
 
+# Allow running directly from a source checkout without `pip install -e .`
+# (same convention as benchmarks/). The #214 true-pair guard imports
+# helix_context.backends.bgem3_codec, and the floors path imports
+# helix_context.retrieval.query_classifier.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 
 # Classes the rule-based classifier emits (see helix_context.query_classifier).
 # ``default`` is the catch-all + fallback for missing per-class blocks at runtime.
@@ -70,6 +78,18 @@ class AnnCalibrationResult:
     sigma_mult: float
     seed: int
     n_genes: int
+    # Issue #214 true-pair guard. ``threshold`` above is the FINAL value
+    # (min of the two bounds when the guard ran); the fields below record
+    # both bounds and which one won, so the calibration artifact always
+    # carries the full story. Defaults = guard not run (threshold is the
+    # raw random-pair bound); existing keyword-constructors keep working.
+    random_pair_threshold: Optional[float] = None
+    true_pair_p05: Optional[float] = None
+    true_pair_cap: Optional[float] = None
+    true_pair_n: int = 0
+    winning_bound: str = "random_pair"
+    guard_skipped: bool = True
+    guard_skip_reason: Optional[str] = None
 
 
 def _load_dense_vectors(genome_path: Path, dim: int) -> Tuple[List[str], "Any"]:
@@ -186,6 +206,221 @@ def calibrate_ann_threshold(
         sigma_mult=sigma_mult,
         seed=seed,
         n_genes=n_genes,
+        # Issue #214: keep the raw random-pair bound on record even before
+        # (or without) the true-pair guard.
+        random_pair_threshold=threshold,
+    )
+
+
+# ─── Issue #214: true-pair guard ─────────────────────────────────────────
+#
+# The margin-over-random method above computes mu + sigma_mult*sigma over
+# RANDOM gene-pair cosines. Embedding anisotropy can push that bound ABOVE
+# the entire real query-doc cosine range — measured on a 5000-doc corpus:
+# calibrated 0.779 vs max query-doc cosine ~0.713 (golds 0.46-0.68), so the
+# dense leg admitted NOTHING into pool construction; corroborated by 70.0%
+# never-surfaced golds on a 480-question ERB run (independent measurement:
+# 67.2%). The guard samples genes, synthesizes a query per gene from its own
+# content, measures TRUE query-doc cosines with the same codec the runtime
+# uses, and caps the threshold so ~95% of true pairs clear it:
+#
+#     final = min(random_pair_mu_plus_sigma, P05(true_pairs) - 0.02)
+#
+# When the codec/model is unavailable (no GPU, no transformers), the guard
+# is skipped with a WARNING and the legacy random-pair value is emitted —
+# tests never need a model (they exercise cap_threshold_with_true_pairs).
+
+TRUE_PAIR_MARGIN = 0.02
+TRUE_PAIR_PCT = 5.0
+
+
+def _synthesize_query(content: str, n_tokens: int = 12) -> Optional[str]:
+    """Synthesize a stand-in query from a gene's own content.
+
+    Mirrors the auto-synth convention in
+    ``benchmarks/sweep_dense_additive_weight.py`` (query = leading content
+    tokens, gold = the gene itself). That synthesis lives inline in the
+    sweep's ``_load_queries`` and needs a live genome handle, so the token
+    rule is restated here (first ~12 tokens, >= 4 required) rather than
+    imported.
+    """
+    toks = content.split()[:n_tokens]
+    if len(toks) < 4:
+        return None
+    return " ".join(toks)
+
+
+def measure_true_pair_cosines(
+    genome_path: Path,
+    *,
+    dim: int,
+    n_genes: int = 200,
+    seed: int = 42,
+    query_tokens: int = 12,
+) -> Tuple[Optional[List[float]], Optional[str]]:
+    """Sample up to ``n_genes`` genes and measure TRUE query-doc cosines.
+
+    Per sampled gene: synthesize a query from its content, encode it with
+    the same BGE-M3 codec the runtime uses (``task="query"``), and take the
+    cosine against the gene's own stored ``embedding_dense_v2`` vector.
+
+    Returns ``(cosines, None)`` on success or ``(None, reason)`` when the
+    measurement cannot run (no eligible genes, codec/model unavailable).
+    Callers must then skip the guard with a WARNING and emit the legacy
+    random-pair value.
+    """
+    try:
+        import numpy as np
+    except ImportError:  # pragma: no cover - numpy is a hard dep elsewhere
+        return None, "numpy unavailable"
+
+    conn = sqlite3.connect(str(genome_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT gene_id, content, embedding_dense_v2 FROM genes "
+            "WHERE embedding_dense_v2 IS NOT NULL AND content IS NOT NULL "
+            "AND length(content) >= 40"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    expected_bytes = dim * 4  # fp32 little-endian
+    candidates: List[Tuple[str, bytes]] = []
+    for r in rows:
+        blob = r["embedding_dense_v2"]
+        if blob is None or len(blob) != expected_bytes:
+            continue
+        q = _synthesize_query(r["content"], n_tokens=query_tokens)
+        if q is None:
+            continue
+        candidates.append((q, blob))
+    if not candidates:
+        return None, "no genes with content + dim-matched embedding_dense_v2"
+
+    rng = random.Random(seed)
+    if len(candidates) > n_genes:
+        candidates = rng.sample(candidates, n_genes)
+
+    # Same codec as the runtime retrieval path. Anything that goes wrong
+    # here (missing transformers, no weights, no GPU, OOM) downgrades the
+    # guard to a WARNING + legacy value — calibration must not hard-require
+    # a model.
+    try:
+        from helix_context.backends.bgem3_codec import get_shared_codec
+        codec = get_shared_codec(dim=dim)
+        cosines: List[float] = []
+        for q, blob in candidates:
+            qv = np.asarray(codec.encode(q, task="query"), dtype=np.float32)
+            dv = np.frombuffer(blob, dtype="<f4").astype(np.float32)
+            qn = float(np.linalg.norm(qv))
+            dn = float(np.linalg.norm(dv))
+            if qn < 1e-12 or dn < 1e-12 or qv.shape != dv.shape:
+                continue
+            cosines.append(float(np.dot(qv / qn, dv / dn)))
+        if not cosines:
+            return None, "codec produced no usable query vectors"
+        return cosines, None
+    except Exception as exc:
+        return None, f"dense codec unavailable: {exc.__class__.__name__}: {exc}"
+
+
+def cap_threshold_with_true_pairs(
+    random_pair_threshold: float,
+    true_pair_cosines: Optional[List[float]],
+    *,
+    margin: float = TRUE_PAIR_MARGIN,
+    pct: float = TRUE_PAIR_PCT,
+) -> Dict[str, Any]:
+    """Issue #214 cap math (pure function — no model, no I/O).
+
+    ``final = min(random_pair_threshold, P05(true_pair_cosines) - margin)``
+
+    Returns a dict carrying the final ``threshold``, BOTH bounds, and
+    ``winning_bound`` ("random_pair" | "true_pair_cap") so the calibration
+    artifact records which bound won. Empty/missing ``true_pair_cosines``
+    -> legacy random-pair value with ``guard_skipped=True``.
+    """
+    if not true_pair_cosines:
+        return {
+            "threshold": float(random_pair_threshold),
+            "random_pair_threshold": float(random_pair_threshold),
+            "true_pair_p05": None,
+            "true_pair_cap": None,
+            "true_pair_n": 0,
+            "winning_bound": "random_pair",
+            "guard_skipped": True,
+        }
+    p05 = _percentile([float(c) for c in true_pair_cosines], pct)
+    cap = p05 - margin
+    if cap < float(random_pair_threshold):
+        final, winner = float(cap), "true_pair_cap"
+    else:
+        final, winner = float(random_pair_threshold), "random_pair"
+    return {
+        "threshold": final,
+        "random_pair_threshold": float(random_pair_threshold),
+        "true_pair_p05": float(p05),
+        "true_pair_cap": float(cap),
+        "true_pair_n": len(true_pair_cosines),
+        "winning_bound": winner,
+        "guard_skipped": False,
+    }
+
+
+def apply_true_pair_guard(
+    ann: AnnCalibrationResult,
+    genome_path: Path,
+    *,
+    dim: int,
+    n_genes: int = 200,
+    seed: int = 42,
+    margin: float = TRUE_PAIR_MARGIN,
+    pct: float = TRUE_PAIR_PCT,
+) -> AnnCalibrationResult:
+    """Apply the Issue #214 true-pair guard to a random-pair calibration.
+
+    Returns a new ``AnnCalibrationResult`` whose ``threshold`` is the capped
+    value and whose guard fields record both bounds + which one won. When
+    the measurement is unavailable, the result keeps the legacy random-pair
+    threshold with ``guard_skipped=True`` and a ``guard_skip_reason``.
+    """
+    import dataclasses
+
+    if n_genes <= 0:
+        return dataclasses.replace(
+            ann,
+            random_pair_threshold=ann.threshold,
+            winning_bound="random_pair",
+            guard_skipped=True,
+            guard_skip_reason="disabled (--true-pairs 0)",
+        )
+
+    cosines, skip_reason = measure_true_pair_cosines(
+        genome_path, dim=dim, n_genes=n_genes, seed=seed,
+    )
+    if skip_reason is not None:
+        return dataclasses.replace(
+            ann,
+            random_pair_threshold=ann.threshold,
+            winning_bound="random_pair",
+            guard_skipped=True,
+            guard_skip_reason=skip_reason,
+        )
+
+    capped = cap_threshold_with_true_pairs(
+        ann.threshold, cosines, margin=margin, pct=pct,
+    )
+    return dataclasses.replace(
+        ann,
+        threshold=capped["threshold"],
+        random_pair_threshold=capped["random_pair_threshold"],
+        true_pair_p05=capped["true_pair_p05"],
+        true_pair_cap=capped["true_pair_cap"],
+        true_pair_n=capped["true_pair_n"],
+        winning_bound=capped["winning_bound"],
+        guard_skipped=False,
+        guard_skip_reason=None,
     )
 
 
@@ -370,6 +605,20 @@ def emit_toml_snippet(
         f"# mu={ann.mu:.4f} sigma={ann.sigma:.4f} N={ann.n_pairs} dim={ann.dim} "
         f"-> {ann.threshold:.4f} (n_genes={ann.n_genes}, seed={ann.seed})"
     )
+    # Issue #214: record both bounds + which one won (or why the guard
+    # was skipped) directly in the operator-facing snippet.
+    if ann.guard_skipped:
+        lines.append(
+            f"# #214 true-pair guard: SKIPPED"
+            f" ({ann.guard_skip_reason or 'not run'});"
+            f" value above is the raw random-pair bound."
+        )
+    else:
+        lines.append(
+            f"# #214 true-pair guard: random_pair={ann.random_pair_threshold:.4f}"
+            f" p05(true)={ann.true_pair_p05:.4f} cap={ann.true_pair_cap:.4f}"
+            f" n={ann.true_pair_n} -> winning bound: {ann.winning_bound}"
+        )
     lines.append("")
     lines.append("[abstain]")
     lines.append('mode = "per_classifier"')
@@ -418,6 +667,20 @@ def emit_report(
             "sigma_mult": ann.sigma_mult,
             "n_pairs": ann.n_pairs,
             "seed": ann.seed,
+            # Issue #214: both bounds + which one won.
+            "random_pair_threshold": (
+                ann.random_pair_threshold
+                if ann.random_pair_threshold is not None
+                else ann.threshold
+            ),
+            "true_pair_guard": {
+                "skipped": ann.guard_skipped,
+                "skip_reason": ann.guard_skip_reason,
+                "p05": ann.true_pair_p05,
+                "cap": ann.true_pair_cap,
+                "n": ann.true_pair_n,
+                "winning_bound": ann.winning_bound,
+            },
         },
         "floors": {
             "abstain_pct": floors.abstain_pct,
@@ -465,6 +728,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--sigma-mult", type=float, default=3.0)
     p.add_argument("--random-pairs", type=int, default=10000)
+    p.add_argument(
+        "--true-pairs", type=int, default=200,
+        help="Issue #214: genes to sample for the true-pair guard (a query "
+             "is synthesized from each gene's content and encoded with the "
+             "same codec; final threshold = min(random-pair bound, "
+             "P05(true pairs) - 0.02)). 0 disables the guard.",
+    )
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--abstain-pct", type=float, default=85.0)
     p.add_argument("--focused-pct", type=float, default=25.0)
@@ -521,6 +791,21 @@ def _write_calibration_to_db(
             "dim": ann.dim,
             "sigma_mult": ann.sigma_mult,
             "seed": ann.seed,
+            # Issue #214: both bounds + which one won (extra keys are
+            # ignored by KnowledgeStore._get_effective_ann_threshold, which
+            # only requires "value", and surface verbatim through
+            # get_calibration_provenance / /admin diagnostics).
+            "random_pair_threshold": (
+                ann.random_pair_threshold
+                if ann.random_pair_threshold is not None
+                else ann.threshold
+            ),
+            "true_pair_p05": ann.true_pair_p05,
+            "true_pair_cap": ann.true_pair_cap,
+            "true_pair_n": ann.true_pair_n,
+            "winning_bound": ann.winning_bound,
+            "true_pair_guard_skipped": ann.guard_skipped,
+            "true_pair_guard_skip_reason": ann.guard_skip_reason,
         })
         import time
         conn.execute(
@@ -564,6 +849,34 @@ def main(argv: Optional[List[str]] = None) -> int:
         "ann_threshold: mu=%.4f sigma=%.4f N=%d dim=%d -> %.4f",
         ann.mu, ann.sigma, ann.n_pairs, ann.dim, ann.threshold,
     )
+
+    # Issue #214: cap the random-pair bound at P05(true query-doc cosines)
+    # - 0.02 so the threshold can never sit above the real cosine range and
+    # gate the dense leg to zero. Skips (with WARNING) when the codec/model
+    # is unavailable — the legacy value is emitted unchanged.
+    ann = apply_true_pair_guard(
+        ann, args.genome, dim=args.dim, n_genes=args.true_pairs,
+        seed=args.seed,
+    )
+    if ann.guard_skipped:
+        reason = ann.guard_skip_reason or "not run"
+        if reason.startswith("disabled"):
+            log.info("true-pair guard %s; emitting random-pair value %.4f",
+                     reason, ann.threshold)
+        else:
+            log.warning(
+                "true-pair guard SKIPPED (%s); emitting legacy random-pair "
+                "value %.4f — beware: an un-guarded mu+sigma bound can sit "
+                "above the real query-doc cosine range (#214).",
+                reason, ann.threshold,
+            )
+    else:
+        log.info(
+            "true-pair guard: random_pair=%.4f p05(true)=%.4f cap=%.4f "
+            "n=%d -> %.4f (winning bound: %s)",
+            ann.random_pair_threshold, ann.true_pair_p05, ann.true_pair_cap,
+            ann.true_pair_n, ann.threshold, ann.winning_bound,
+        )
 
     log.info("Calibrating per-classifier floors")
     floors = calibrate_floors(

--- a/tests/test_dense_pool_floor.py
+++ b/tests/test_dense_pool_floor.py
@@ -1,0 +1,399 @@
+"""Issue #214: dense pool floor + true-pair calibration cap.
+
+The margin-over-random ANN calibration (``mu + sigma_mult*sigma`` over
+RANDOM gene pairs) can land ABOVE every real query-doc cosine — measured
+calibrated threshold 0.779 vs corpus max ~0.713 (golds 0.46-0.68), so
+0/5000 pool docs cleared the gate by dense and 70.0% of golds on a
+480-question ERB run never surfaced in top-10 (independent measurement:
+67.2%). Pool membership is strictly upstream of fusion ranking. Two fixes
+under test, neither requiring a model:
+
+1. ``knowledge_store.apply_ann_gate`` — runtime floor: when fewer than
+   ``dense_pool_floor_genes`` dense-scored candidates survive the threshold
+   cut (but the dense leg HAD scored candidates), the top-N dense hits by
+   cosine are admitted into the pool anyway. Default 8; 0 = legacy.
+2. ``scripts.calibrate_thresholds.cap_threshold_with_true_pairs`` — the
+   calibration-method cap: ``final = min(random_pair_bound,
+   P05(true_pairs) - 0.02)``; codec unavailable -> legacy value + flag.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable (same convention as tests/test_calibration.py).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from helix_context.config import HelixConfig, load_config
+from helix_context.genome import Genome
+from helix_context.knowledge_store import apply_ann_gate
+from helix_context.schemas import (
+    ChromatinState, EpigeneticMarkers, Gene, PromoterTags,
+)
+from tests.conftest import FakeBGEM3Codec, hash_vec
+
+
+# ─── apply_ann_gate unit tests (pure gate, synthetic cosines) ─────────────
+
+
+def _dense(n: int, start: float = 0.70, step: float = 0.01):
+    """n synthetic dense hits, cosine-descending: d0=start, d1=start-step, ..."""
+    return [(f"d{i}", start - i * step) for i in range(n)]
+
+
+def test_threshold_above_all_floor_admits_top8():
+    """The #214 shape: calibrated threshold sits above every real cosine.
+
+    Legacy gate admits nothing (min_genes=0); the floor admits the top-8
+    dense candidates by cosine.
+    """
+    dense = _dense(20)  # 0.70 .. 0.51 — all below 0.779
+    out = apply_ann_gate(
+        dense, dense,
+        threshold=0.779, min_genes=0, max_genes=12,
+        dense_pool_floor_genes=8,
+    )
+    assert out == [f"d{i}" for i in range(8)]
+
+
+def test_healthy_gate_is_byte_identical_with_floor_on():
+    """>= 8 dense candidates pass the threshold -> floor changes nothing."""
+    dense = _dense(20, start=0.90)  # 0.90 .. 0.71; threshold 0.58 passes all
+    legacy = apply_ann_gate(
+        dense, dense, threshold=0.58, min_genes=1, max_genes=12,
+        dense_pool_floor_genes=0,
+    )
+    floored = apply_ann_gate(
+        dense, dense, threshold=0.58, min_genes=1, max_genes=12,
+        dense_pool_floor_genes=8,
+    )
+    assert floored == legacy
+    assert len(legacy) == 12  # max_genes cap still binds
+
+
+def test_floor_zero_keeps_legacy_empty_result():
+    """floor=0 is the legacy gate: nothing passes, nothing returned."""
+    dense = _dense(20)
+    out = apply_ann_gate(
+        dense, dense, threshold=0.779, min_genes=0, max_genes=12,
+        dense_pool_floor_genes=0,
+    )
+    assert out == []
+
+
+def test_fewer_than_floor_total_candidates_all_admitted():
+    """Only 3 dense candidates exist -> the floor admits all 3, not 8."""
+    dense = _dense(3)
+    out = apply_ann_gate(
+        dense, dense, threshold=0.99, min_genes=0, max_genes=12,
+        dense_pool_floor_genes=8,
+    )
+    assert out == ["d0", "d1", "d2"]
+
+
+def test_rescued_ordering_follows_cosine_not_id():
+    """Floor-rescued candidates come back in cosine order (dense_hits
+    order), regardless of gene_id lexicographic order."""
+    dense = [("zz", 0.70), ("aa", 0.65), ("mm", 0.60), ("qq", 0.55)]
+    out = apply_ann_gate(
+        dense, dense, threshold=0.9, min_genes=0, max_genes=12,
+        dense_pool_floor_genes=3,
+    )
+    assert out == ["zz", "aa", "mm"]
+
+
+def test_min_genes_rescues_stay_ahead_of_floor_appends():
+    """The exact broken-calibration shape: lex pins (threshold-0.01) sort
+    ABOVE every dense cosine, so the min_genes floor rescues only lex docs.
+    The dense floor appends after the legacy result without displacing it.
+    """
+    threshold = 0.779
+    dense = _dense(5)  # 0.70 .. 0.66, all below the lex pin 0.769
+    scored = [("lex1", threshold - 0.01)] + dense
+    out = apply_ann_gate(
+        scored, dense, threshold=threshold, min_genes=1, max_genes=12,
+        dense_pool_floor_genes=8,
+    )
+    assert out[0] == "lex1"  # legacy min_genes rescue untouched, still first
+    assert out[1:] == [f"d{i}" for i in range(5)]
+
+
+def test_floor_counts_dense_already_admitted_and_tops_up():
+    """5 dense pass the threshold on their own; floor=8 only appends 3."""
+    dense = [
+        ("d0", 0.95), ("d1", 0.93), ("d2", 0.91), ("d3", 0.89), ("d4", 0.87),
+        ("d5", 0.40), ("d6", 0.38), ("d7", 0.36), ("d8", 0.34), ("d9", 0.32),
+    ]
+    out = apply_ann_gate(
+        dense, dense, threshold=0.85, min_genes=0, max_genes=12,
+        dense_pool_floor_genes=8,
+    )
+    assert out == [f"d{i}" for i in range(8)]
+
+
+def test_no_dense_candidates_floor_is_noop():
+    """Dense leg scored nothing (empty corpus / no vectors): the floor must
+    not invent candidates — legacy behavior exactly."""
+    scored = [("lex1", 0.57), ("lex2", 0.57)]
+    out = apply_ann_gate(
+        scored, [], threshold=0.58, min_genes=1, max_genes=12,
+        dense_pool_floor_genes=8,
+    )
+    assert out == ["lex1"]
+
+
+# ─── Config plumbing ──────────────────────────────────────────────────────
+
+
+def test_dense_pool_floor_default_is_8():
+    cfg = HelixConfig()
+    assert cfg.retrieval.dense_pool_floor_genes == 8
+
+
+def test_dense_pool_floor_loads_from_toml(tmp_path):
+    toml = tmp_path / "helix.toml"
+    toml.write_text("[retrieval]\ndense_pool_floor_genes = 3\n", encoding="utf-8")
+    cfg = load_config(str(toml))
+    assert cfg.retrieval.dense_pool_floor_genes == 3
+
+
+def test_dense_pool_floor_toml_zero_disables(tmp_path):
+    toml = tmp_path / "helix.toml"
+    toml.write_text("[retrieval]\ndense_pool_floor_genes = 0\n", encoding="utf-8")
+    cfg = load_config(str(toml))
+    assert cfg.retrieval.dense_pool_floor_genes == 0
+
+
+def test_dense_pool_floor_reaches_store():
+    g = Genome(path=":memory:", dense_pool_floor_genes=5)
+    try:
+        assert g._dense_pool_floor_genes == 5
+    finally:
+        g.close()
+
+
+def test_dense_pool_floor_store_default():
+    g = Genome(path=":memory:")
+    try:
+        assert g._dense_pool_floor_genes == 8
+    finally:
+        g.close()
+
+
+# ─── Calibration cap math (pure functions, no model) ─────────────────────
+
+
+def test_true_pair_cap_wins_when_random_bound_above_real_cosines():
+    """The #214 shape: random-pair bound 0.779 vs true pairs 0.46..0.68 ->
+    the cap (P05 - 0.02) wins and lands inside the real cosine range."""
+    from scripts.calibrate_thresholds import (
+        _percentile, cap_threshold_with_true_pairs,
+    )
+    true_pairs = [0.46 + 0.002 * i for i in range(111)]  # 0.46 .. 0.68
+    out = cap_threshold_with_true_pairs(0.779, true_pairs)
+    expected = _percentile(true_pairs, 5.0) - 0.02
+    assert out["winning_bound"] == "true_pair_cap"
+    assert out["guard_skipped"] is False
+    assert out["threshold"] == pytest.approx(expected)
+    assert out["threshold"] < 0.713  # below the real query-doc cosine max
+    assert out["random_pair_threshold"] == pytest.approx(0.779)
+    assert out["true_pair_p05"] == pytest.approx(_percentile(true_pairs, 5.0))
+    assert out["true_pair_n"] == 111
+
+
+def test_random_pair_bound_wins_when_already_below_true_pairs():
+    """Healthy calibration: the random-pair bound sits below the true-pair
+    cap -> it is kept unchanged (the guard is a cap, never a raise)."""
+    from scripts.calibrate_thresholds import cap_threshold_with_true_pairs
+    out = cap_threshold_with_true_pairs(0.40, [0.80, 0.82, 0.84, 0.86, 0.88])
+    assert out["winning_bound"] == "random_pair"
+    assert out["threshold"] == pytest.approx(0.40)
+    assert out["guard_skipped"] is False
+
+
+def test_missing_true_pairs_falls_back_to_legacy_with_flag():
+    from scripts.calibrate_thresholds import cap_threshold_with_true_pairs
+    for missing in (None, []):
+        out = cap_threshold_with_true_pairs(0.779, missing)
+        assert out["guard_skipped"] is True
+        assert out["winning_bound"] == "random_pair"
+        assert out["threshold"] == pytest.approx(0.779)
+        assert out["true_pair_p05"] is None
+
+
+def test_guard_skip_threads_legacy_value_into_result_and_report(monkeypatch):
+    """Codec unavailable -> apply_true_pair_guard keeps the legacy value,
+    flags the skip, and emit_report records both bounds."""
+    import scripts.calibrate_thresholds as ct
+    ann = ct.AnnCalibrationResult(
+        threshold=0.779, mu=0.5, sigma=0.093, n_pairs=1000,
+        dim=64, sigma_mult=3.0, seed=42, n_genes=50,
+    )
+    monkeypatch.setattr(
+        ct, "measure_true_pair_cosines",
+        lambda *a, **k: (None, "dense codec unavailable: stub"),
+    )
+    out = ct.apply_true_pair_guard(ann, Path("unused.db"), dim=64)
+    assert out.guard_skipped is True
+    assert out.threshold == pytest.approx(0.779)
+    assert out.winning_bound == "random_pair"
+    assert "codec unavailable" in (out.guard_skip_reason or "")
+
+    report = ct.emit_report(
+        out, ct.FloorCalibrationResult(), genome_path=Path("unused.db"),
+    )
+    blk = report["ann_threshold"]
+    assert blk["value"] == pytest.approx(0.779)
+    assert blk["random_pair_threshold"] == pytest.approx(0.779)
+    assert blk["true_pair_guard"]["skipped"] is True
+    assert blk["true_pair_guard"]["winning_bound"] == "random_pair"
+
+
+def test_guard_caps_threshold_end_to_end_through_apply(monkeypatch):
+    """Measured true pairs below the random bound -> apply_true_pair_guard
+    rewrites threshold to P05-0.02 and records the winning bound."""
+    import scripts.calibrate_thresholds as ct
+    ann = ct.AnnCalibrationResult(
+        threshold=0.779, mu=0.5, sigma=0.093, n_pairs=1000,
+        dim=64, sigma_mult=3.0, seed=42, n_genes=50,
+        random_pair_threshold=0.779,
+    )
+    true_pairs = [0.46 + 0.002 * i for i in range(111)]
+    monkeypatch.setattr(
+        ct, "measure_true_pair_cosines", lambda *a, **k: (true_pairs, None),
+    )
+    out = ct.apply_true_pair_guard(ann, Path("unused.db"), dim=64)
+    assert out.guard_skipped is False
+    assert out.winning_bound == "true_pair_cap"
+    assert out.threshold == pytest.approx(ct._percentile(true_pairs, 5.0) - 0.02)
+    assert out.random_pair_threshold == pytest.approx(0.779)
+    # The snippet must carry both bounds for the operator.
+    snippet = ct.emit_toml_snippet(out, ct.FloorCalibrationResult())
+    assert "true-pair guard" in snippet
+    assert "winning bound: true_pair_cap" in snippet
+
+
+def test_query_synthesis_first_tokens():
+    from scripts.calibrate_thresholds import _synthesize_query
+    content = " ".join(f"tok{i}" for i in range(40))
+    q = _synthesize_query(content)
+    assert q == " ".join(f"tok{i}" for i in range(12))
+    assert _synthesize_query("too short") is None  # < 4 tokens
+
+
+# ─── Integration-lite: in-memory Genome, absurd threshold ────────────────
+#
+# Fixture style mirrors tests/test_dense_recall.py (FakeBGEM3Codec +
+# hash_vec from tests/conftest.py; v2 BLOBs written directly).
+
+
+def _make_gene(content: str, *, domains, gene_id: str) -> Gene:
+    return Gene(
+        gene_id=gene_id,
+        content=content,
+        complement="",
+        codons=[],
+        promoter=PromoterTags(domains=domains, entities=[]),
+        epigenetics=EpigeneticMarkers(),
+        chromatin=ChromatinState.OPEN,
+        is_fragment=False,
+    )
+
+
+def _populate_v2(genome: Genome, gene_id: str, vec) -> None:
+    blob = vec.astype("<f4").tobytes()
+    genome.conn.execute(
+        "UPDATE genes SET embedding_dense_v2 = ? WHERE gene_id = ?",
+        (sqlite3.Binary(blob), gene_id),
+    )
+    genome.conn.commit()
+    genome._invalidate_dense_matrix()
+
+
+@pytest.fixture
+def floor_genome():
+    """In-memory genome, dense retrieval on, default floor (8)."""
+    g = Genome(
+        path=":memory:",
+        dense_embedding_enabled=True,
+        dense_embedding_dim=1024,
+        dense_pool_size=500,
+    )
+    _orig_upsert = g.upsert_doc
+    def _ungated(gene, apply_gate=False):
+        return _orig_upsert(gene, apply_gate=apply_gate)
+    g.upsert_doc = _ungated
+    g.upsert_gene = _ungated
+    yield g
+    g.close()
+
+
+def _seed_corpus(g: Genome) -> None:
+    # 4 lexical docs matching domain "alpha"; NO dense vectors (they enter
+    # the union as threshold-0.01 lex pins only).
+    for i in range(4):
+        g.upsert_gene(_make_gene(
+            f"alpha lexical doc number {i} body text",
+            domains=["alpha"], gene_id=f"lex-{i}",
+        ))
+    # 6 dense-only docs: no lexical overlap with the query; v2 vectors set
+    # (hash_vec pairs are near-orthogonal -> cosines far below 0.99).
+    for i in range(6):
+        gid = f"dense-{i}"
+        g.upsert_gene(_make_gene(
+            f"wholly unrelated surface body {i} zzz qqq",
+            domains=["other"], gene_id=gid,
+        ))
+        _populate_v2(g, gid, hash_vec(f"vector for {gid}", 1024))
+
+
+def test_absurd_threshold_floor_on_dense_still_surfaces(floor_genome):
+    """ann threshold 0.99 (above every fake cosine): with the default floor
+    the dense leg still lands candidates in the retrieve() pool."""
+    g = floor_genome
+    _seed_corpus(g)
+    g._dense_codec = FakeBGEM3Codec(dim=1024)
+    g._ann_threshold = 0.99
+    assert g._dense_pool_floor_genes == 8  # default ON
+
+    out = g.query_docs_ann(
+        "completely different query wording xyzzy",
+        domains=["alpha"], entities=[], max_genes=12,
+    )
+    ids = [d.gene_id for d in out]
+    dense_ids = [i for i in ids if i.startswith("dense-")]
+    assert dense_ids, f"dense leg gated to zero despite floor; got {ids}"
+    # Fewer than 8 dense docs exist -> all 6 must be admitted.
+    assert set(dense_ids) == {f"dense-{i}" for i in range(6)}, ids
+    # Rescued block ordering follows the dense cosine order.
+    recall = dict(g.query_docs_dense_recall(
+        "completely different query wording xyzzy", k=500,
+    ))
+    cosines = [recall[i] for i in dense_ids]
+    assert cosines == sorted(cosines, reverse=True)
+
+
+def test_absurd_threshold_floor_zero_gates_dense_out(floor_genome):
+    """Same corpus, floor disabled: legacy behavior — the dense leg is gated
+    out of pool construction entirely (the #214 failure mode)."""
+    g = floor_genome
+    _seed_corpus(g)
+    g._dense_codec = FakeBGEM3Codec(dim=1024)
+    g._ann_threshold = 0.99
+    g._dense_pool_floor_genes = 0  # legacy gate-only
+
+    out = g.query_docs_ann(
+        "completely different query wording xyzzy",
+        domains=["alpha"], entities=[], max_genes=12,
+    )
+    ids = [d.gene_id for d in out]
+    assert not any(i.startswith("dense-") for i in ids), (
+        f"floor=0 must reproduce the legacy gate; got {ids}"
+    )
+    # min_genes floor (default 1) still returns the top lex pin.
+    assert len(out) >= 1


### PR DESCRIPTION
Closes #214. Evidence: the mu+3sigma random-pair calibrated threshold (0.779) sat above every real query-doc cosine (max ~0.713, golds 0.46-0.68) -> 0/5000 dense docs cleared pool construction; corroborated by 70.0% never-surfaced on the 480-question ERB headline run (#93), matching an independent 67.2% on a 125-question set (cc-exchange Experiment B). Pool membership is strictly upstream of fusion - no re-weight can recover a gold the gate never admits.

Fix A (runtime, surgical): [retrieval] dense_pool_floor_genes = 8 - the gate (KnowledgeStore.query_docs_ann step 5, factored into pure apply_ann_gate) now admits the top-N dense candidates by cosine whenever fewer than N survived the threshold but the dense leg had scored candidates. Degrades gracefully instead of dying; 0 restores the legacy gate-only path; per-shard in sharded mode with normal router dedup. Byte-identical when the gate is healthy (legacy cut reproduced exactly; floor only fires while dense is starving).

Fix B (root cause): scripts/calibrate_thresholds.py caps the random-pair bound at P05(true query-doc pairs) - 0.02 (--true-pairs, default 200; query = first ~12 content tokens, runtime codec; codec unavailable -> WARNING + legacy value). Both bounds + winner recorded in the TOML snippet, report JSON, and genome_calibration payload.

Tests: 21 new (gate units incl. byte-identical healthy path, config plumb, cap math, integration-lite at threshold 0.99 floor-on/off); 54 passed locally across floor+dense_recall+ann_threshold+config; 2197-test sandbox sweep clean (4 failures pre-existing on base). Acceptance: ERB strat-90 + full-480 rerun vs the 30.0% recall@10 baseline, posting to #214/#93.