### PR TITLE
fix(config): default honesty pass - 20 code/toml drifts reconciled, real KnowConfig, auto shard fan-out (council Option B slice 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ All config lives in `helix.toml`. Sections:
 |---------|-------------|
 | `[ribosome]` | model, backend (`"ollama"` / `"claude"` / `"litellm"` / `"none"`), timeout, query_expansion_enabled |
 | `[hardware]` | device auto-detection (CUDA, MPS, ROCm, CPU) |
-| `[budget]` | expression_tokens (default 6k in code, 7k in helix.toml), max_genes_per_turn, splice_aggressiveness, decoder_mode, legibility_enabled, session_delivery_enabled |
+| `[budget]` | expression_tokens (default 7000 — code and helix.toml unified in the 2026-06-12 default-honesty pass), max_genes_per_turn, splice_aggressiveness, decoder_mode, legibility_enabled, session_delivery_enabled |
 | `[session]` | synthetic_session_enabled, synthetic_session_window_s, default_party_id |
 | `[genome]` | path (`genomes/main/genome.db`), compact_interval, cold_start_threshold, replicas |
 | `[server]` | host, port, upstream |
@@ -86,10 +86,10 @@ All config lives in `helix.toml`. Sections:
 | `[ingestion]` | backend (`"cpu"` / `"ollama"` / `"hybrid"`), splade_enabled, rerank_model, entity_graph |
 | `[context]` | cold_tier_enabled, cold_tier_k, cold_tier_min_cosine |
 | `[cymatics]` | enabled, distance_metric (`"cosine"` / `"w1"`), harmonic_links |
-| `[classifier]` | Rule-based query classification thresholds |
+| `[classifier]` | Rule-based query classifier: `enabled` toggle only; per-class caps/decoder hints are code constants pending #205 |
 | `[retrieval]` | fusion_mode (`"additive"` / `"rrf"`), sr_enabled, sr_gamma, ray_trace_theta, seeded_edges_enabled |
 | `[plr]` | Piecewise linear reranker: enabled, model_path |
-| `[know]` | Know/miss calibration: confidence_floor, margin_threshold |
+| `[know]` | KnowBlock confidence logistic: emit_floor, betas, s_ref, g_ref, stale_after_days (+ calibrated_at / calibrated_on_n written by scripts/calibrate_know_confidence.py) |
 | `[mem_sync]` | Auto-memory-to-helix sync: watch_dirs, sync_interval_s |
 | `[synonyms]` | Lightweight query expansion (e.g., "cache" -> ["redis", "ttl", "invalidation"]) |
 | `[abstain]` | Abstention thresholds for low-confidence responses |

--- a/docs/audits/2026-06-12-pipeline-value-consensus.md
+++ b/docs/audits/2026-06-12-pipeline-value-consensus.md
@@ -1,0 +1,266 @@
+# Pipeline Value Consensus — helix-context's Next Architectural Investment
+
+**4-persona consensus council** · 2026-06-12 · repo: `github.com/mbachaud/helix-context` @ v0.7.1 (`pyproject.toml:7`), depth-1 clone at `/tmp/hxc`. All `file:line` citations verified in the clone. Session-telemetry figures supplied by the operator (829K-gene/100-shard fixture, 2026-06) are marked **[telemetry]**.
+
+---
+
+## 1. Decision Frame
+
+**Question.** Where does the next unit of architectural investment go?
+
+| Option | Statement |
+|---|---|
+| **A** | **Shrink the running system tax** — RSS, query latency, resident encoder duplication, GPU residency, tool/route surface, install weight. |
+| **B** | **Finish the dead-code / default-honesty cleanup** — reconcile the code/toml/env/docs config layers, delete or bind dead knobs, kill silent truncations, make docs match the product. |
+| **C** | **Dynamize the static knobs** — per-corpus auto-calibration (Layer 1), per-query classifier-owned adaptation (Layer 2), content-aware chunking, auto worker scaling. |
+| **D** | **Re-found delivery around navigation** — fingerprint/packet pointers as the primary product instead of spliced-chunk injection. |
+
+**Constraints.** Solo maintainer + agent fleet; one 12 GB-VRAM Windows rig (WDDM multi-CUDA-context livelock, #176); v0.7.1 just shipped after a #182–#200 merge train; ERB 500K rerun in flight (#93, #214 acceptance). The repo's own audits (`docs/audits/2026-06-09-next-steps-evidence.md`, `docs/audits/2026-06-10-test-tuning-roadmap.md`, `docs/specs/2026-06-09-retrieval-profiles.md`) say "the bottleneck is measurement, not triage."
+
+**Stakes.** Positioning is in motion: pyproject already re-taglines the project as "Coordinate index layer for LLM context — Helix weighs, doesn't retrieve" (`pyproject.toml:7`) while the serving path still ships spliced chunk content. Investing in the wrong layer burns the only scarce resource (maintainer attention) and could entrench a delivery mode whose value at scale is currently *measured below a 1970s lexical baseline*.
+
+---
+
+## 2. Verified Evidence Base
+
+The four user-question axes, grounded before any persona speaks.
+
+### Axis 1 — Running size / system tax
+
+| Fact | Source |
+|---|---|
+| 20.3 GB RSS for one serving process @ 829K genes/100 shards; ~1 min/query at `HELIX_SHARD_WORKERS=8`; **default is 1 → ~5 min/query** | **[telemetry]**; default-1 serial fan-out confirmed at `shard_router.py:67-81` ("Default ``1`` → serial fan-out … reference oracle for the determinism regression test") |
+| A VRAM/CPU-aware `auto_shard_workers()` already exists (returns 3 on the 12 GB rig) but is wired only into ingest `--shard-workers`, not the serving fan-out | `parallel.py:51-78` |
+| Encoder stack (SPLADE + BGE-M3 + sema + spaCy) is loaded **per process**: tray backend, bench server, and build workers each pay it; three processes = three CUDA contexts = the #176 livelock | `CHANGELOG.md` 0.6.5 #191 ("no longer loads SPLADE+BGE-M3 in parent + both spawn workers — three CUDA contexts = the #176 WDDM livelock"); 0.7.0 boots show "encoders warming up" |
+| GPU 2.6 GB held at ~28% util during serving — the pipeline is CPU-bound while squatting on VRAM | **[telemetry]** |
+| Dense recall costs ~870M FLOPs/query at scale; the two mitigation PRs (#158 parallel fan-out, #160 SPLADE prefilter) were **closed unmerged — "master has no Wall-2 lever"** | `docs/audits/2026-06-09-next-steps-evidence.md` item 8 |
+| **MCP surface: 24 tools** (`mcp/mcp_server.py:341-963`), 10,381 chars of tool docstrings ≈ **2.6K tokens of descriptions; ~4–5K tokens of schema per MCP session** once JSON parameter scaffolding (57 params) is included — paid before the first query | AST count over `mcp/mcp_server.py`; the hand-rolled minimal fallback server exposes only **3** tools (`mcp/server.py:193-258`: context/ingest/stats) — a revealed-preference floor |
+| **HTTP surface: 51 routes** — admin/debug/bridge/vault = 35 (routes_admin 30 + helpers 5), core retrieval = 5 (routes_context), ingest = 2, sessions/registry/hitl = 9. Agent-facing docs and benches demonstrably exercise ~6–8 of them (`/context`, `/context/packet`, `/fingerprint`, `/ingest`, `/stats`, `/health`, `/context/expand`) | `grep -c @app.` per `server/routes_*.py`; SNOW-2 arm table `docs/audits/2026-06-10-test-tuning-roadmap.md:28-45` |
+| Install weight: core is lean (5 deps), but the documented feature path (SPLADE, dense, AST chunking, codec) requires extras whose "dep bulk [is] dominated by sentence-transformers + torch + spacy + tree-sitter + headroom-ai" | `pyproject.toml` dependencies + `[project.optional-dependencies]` incl. its own comments |
+| Codebase: 47,146 LOC across 135 Python files in `helix_context/` | clone count |
+
+### Axis 2 — Entropy: defaults drift, dead code, phantom docs
+
+Defaults drift between code and shipped template — **every claimed drift verified**:
+
+| Knob | `config.py` default | shipped `helix.toml` |
+|---|---|---|
+| `expression_tokens` | 6000 (`config.py:123`) | 7000 (`helix.toml:72`) |
+| `max_genes_per_turn` | 8 (`config.py:124`) | 12 (`helix.toml:73`) |
+| `splice_aggressiveness` | 0.5 (`config.py:126`) | 0.3 (`helix.toml:75`) |
+| `decoder_mode` | "full" (`config.py:127`) | "condensed" (`helix.toml:76`) |
+| `sr_enabled` | False — "Dark ship" (`config.py:284`) | true — "Stage-1 bench flip" (`helix.toml:268`) |
+
+The profiles spec itself: "today these are **two undocumented products**" (`docs/specs/2026-06-09-retrieval-profiles.md`).
+
+Further verified entropy:
+
+- **Dark-shipped, measured-zero features:** `sr` / `seeded_edges` / `ray_trace` — "measured 0 — default off" per the profiles spec; `ray_trace_theta=False` (`config.py:291`, `helix.toml:275`), `seeded_edges_enabled=False` (`config.py:296`, `helix.toml:278`), yet `sr_enabled` is split across layers (above).
+- **9 dead `[retrieval]` tier weights** (#202/#210): documented knobs bind only under RRF; the default additive path uses inline literals at `knowledge_store.py:1846/1886/1940/1979/2037/2084/2218/2281/2341` (`next-steps-evidence.md`, wave-2 bullet 1). Default `fusion_mode="additive"` (`config.py:377`, `helix.toml:349`).
+- **ANN mis-calibration history** (#214/#217): threshold 0.58 "measured on ONE own-code fixture" after already recalibrating 0.35→0.58 between the project's *own* fixtures (#139, `knowledge_store.py:486`; profiles spec). #214's fix note: "a threshold that admits ZERO dense candidates is mis-calibration by definition" (`knowledge_store.py:383-397`). Per-corpus margin-over-random calibration is **shipped but not default** (`ann_threshold_mode="absolute"`, `config.py:343`; persisted reader `knowledge_store.py:602-609,1102`).
+- **Silent truncations** (#207 family): SPLADE indexes only `content[:1000]` (`storage/indexes.py:367,378` — still present in clone); dense passages capped at 2000 chars (`bgem3_codec.py:34` `PASSAGE_CHAR_CAP`); compressor truncates at `content[:2000]` (`compressor.py:612`) and falls back to `content[:500]` (`compressor.py:587,738-778`).
+- **Phantom docs knobs:** CLAUDE.md:92 documents `[know]` as "confidence_floor, margin_threshold" — the real keys are `emit_floor / s_ref / g_ref / betas[6] / stale_after_days` (`helix.toml:424-438`), and `config.py` contains **no KnowConfig at all**: `[know]` is parsed by a *separate, independent* TOML reader (`scoring/know_calibration.py:308-325`). CLAUDE.md also claims dense recall is "default off" — it is True in both layers (`config.py:323`, `helix.toml:308`) — and pins version 0.5.0 vs shipped 0.7.1. The repo's own audit names "`[classifier]`/`[know]` doc-vs-code drift in CLAUDE.md" as a hygiene item (`next-steps-evidence.md`, final bullet).
+- **Net: knobs live in FIVE inconsistent layers** — dataclass defaults, shipped toml, env gates (`HELIX_SHARD_WORKERS`, `HELIX_SEMANTIC_ARM`, `HELIX_BFM_*`), docs, and side-channel TOML readers that bypass `config.py` entirely.
+- The honesty fix that just landed (#214 dense-pool floor) moved ERB recall@10 **30.0% → 43.3% (strat-90)** **[telemetry]** — the largest single recall delta in months came from a *truthfulness* repair, not a feature.
+
+### Axis 3 — Static that should (or should not) be dynamic
+
+| Knob | Static today | Dynamic policy | Expected impact / risk |
+|---|---|---|---|
+| Shard fan-out workers | env default 1 (`shard_router.py:74-77`) | default to `auto_shard_workers()` (`parallel.py:51`), keep `=1` for the determinism test | **~5x query latency** at 100 shards **[telemetry]**; risk: ordering nondeterminism — already fenced by the serial reference oracle |
+| Chunk size | 4000 chars ≈ 1000 tok (`fragments.py:66-67`); tree-sitter AST chunking exists but opt-in (`fragments.py:134-140`, `ast` extra) | content-aware/atomic chunks | Roadmap:157 is explicit: under the current OR-scorer **"smaller chunks lose"** (doubles dense FLOPs + FTS/PKI rows, recall already 28% @850K); they *win* only after AND-then-OR routing (#159). Dynamization is **sequenced behind routing**, not free |
+| Dense weight | static per-process; w=4.0 evicts gold on ERB prose (−19pp vs dense-off, #138); semantic arm needs 16.0; fresh sweep 2026-06-10: ERB-50K 3 golds evicted ∀w≥2 | profiles spec **Layer 2**: classifier-owned 4.0↔16.0 per query, drop the `HELIX_SEMANTIC_ARM` env gate | high — dissolves the #138 conflict; risk: classifier misroutes prose/code boundary queries |
+| ANN threshold | absolute 0.58 default (`config.py:334,343`) | flip `ann_threshold_mode="margin_over_random"` default-on; calibration persisted in genome (Stage-4 machinery shipped, `knowledge_store.py:493-498`) | prevents the #214 class ("absolute thresholds don't transfer" — profiles spec); risk: needs the cross-corpus transfer test (spec measurement 6) first |
+| Expression budget | static 7000 cap | **keep static** — measured 8.4% utilization, "cap never binds" (#73, profiles spec); per-query-class caps already exist (Layer 2) | counter-example: not everything static is wrong; dynamizing a non-binding cap is zero-value work |
+| PKI noise cutoff | `PKI_NOISE_CUTOFF=200` constant (`storage/indexes.py:119`) | generalize to IDF-style document-frequency ceiling (roadmap:157 — "#165's lesson is that the index was doing inventory, not pruning") | medium; pairs with AND-mode routing |
+| SPLADE on/off | `splade_enabled=true` shipped (`helix.toml:201`) at 21.1% of disk for **0pp** recall @850K (#164) | size-aware auto-toggle knobs already shipped default-off (#189, `splade_auto_*`) | 9.96 GB back at 850K; thresholds await the #164 scale curve |
+| Splice aggressiveness | static and *drifted* (0.5 vs 0.3) | per-query-class | low until compression health (denatured states, `context_manager.py:315,1330,2760`) is measured |
+
+Profiles-spec verdict that disciplines all of Axis 3: **"only ~6 knobs are genuinely corpus-sensitive … most 'tuning' should be automatic"** — small Layer-3 profiles, Layer-1 auto-calibration, Layer-2 per-query adaptation.
+
+### Axis 4 — Does the delivered chunk reduce downstream inference requirements at all?
+
+**FOR injection:**
+- Own-code/needle regime is strong at small scale: 83% @10K (→71% @50K, misses all `basic`-type, 14/17 monotone) (`next-steps-evidence.md` item 2); SIKE curated needles 10/10 retrieval across a 0.6B→Opus ladder (roadmap bench table).
+- Dewey: `key+filename` 30% R@1 (vs 10% for 4-axis queries — extra axes *hurt* under additive fusion) (roadmap:153 + bench table); filename_anchor +24pp R@1 where queries name files (profiles spec).
+- Session-delivery elision claims ~40% token saving multi-turn (CLAUDE.md) — but roadmap:139 explicitly lists the telemetry counter needed to "prove (or falsify)" it.
+- know/miss contract gives calibrated trust (`scoring/know_decision.py`, Stage-6 spec) — a property a bare BM25 endpoint does not have.
+
+**AGAINST injection:**
+- Fresh 480-question ERB: **30.0% recall@10 pre-#214, 43.3% strat-90 after** **[telemetry]** vs **published BM25 68.4 recall / 68.8 correctness / Onyx+GPT-4 72.4** (#93, `next-steps-evidence.md:20`, roadmap:85). A plain lexical baseline currently more-than-doubles helix's chunk-surfacing at enterprise scale; recall is **28% @850K** (roadmap:157).
+- SNOW LLM arm: qwen3:4b consuming the delivered tier cascade scored **miss_rate 0.9, triage_accuracy 0.0, answered@T0 0%, ~73,000× latency overhead** (12.3 s vs 0.2 ms oracle), N=10, arm abandoned (roadmap:20).
+- Deliveries are small: 8.4% of the 7K budget ≈ **~590 tokens/query actually shipped** (profiles spec); compression health can read "denatured" (ellipticity < 0.3 — "context is unreliable", `context_manager.py:2760`), measured 0.5× on QA smoke **[telemetry]**.
+- Navigation substrate already exists and is sound: "every gene already has a globally unique `gene_id` — **uniqueness is solved storage-side**" (roadmap:148); 850K census: 94.8% of chunks carry a globally-unique key **[telemetry]**; `/context/packet`, `/fingerprint` (with `profile: fast|balanced|quality`), `/context/expand` all ship today (`server/routes_context.py`, `routes_registry.py`).
+- The roadmap's own thesis: "Helix's stretch capability is now *agentic navigation*, and nothing measures it … **an agentic arm is helix's only credible path above that line**" (roadmap:26) — and R@1 fails "not for lack of a unique key but because the query rarely *expresses* one and the scorer treats key matches as one additive vote among 12" (roadmap:153).
+
+**The settling measurement exists on paper:** SNOW-2 five-arm design (#208; roadmap:28-45) — A injection-only `/context`, B packet-injection, C MCP-agentic (`helix_fingerprint`→`gene_get`/`packet`/`neighbors` loops), D CLI-agentic, E know/miss-driven escalation — scored as a **cost-of-correctness frontier** (correctness vs tokens vs wall time) on 10K/50K/500K fixtures, model ladder from qwen3:8b up to one Claude tier. All five surfaces exist; the arm runner, escalation module, and ERB adapter do not.
+
+---
+
+## 3. Independent Persona Analyses
+
+*Each persona analyzed independently against all four axes. Disagreements are genuine and preserved.*
+
+### 3.1 Systems Economist — "price every delivered token"
+
+**Axis reads.**
+1. *Tax:* One serving process = 20.3 GB RSS delivering ~590 useful tokens/query at 1–5 min/query — that is gigabyte-minutes per kilobyte of context, before the answering model runs. The encoder stack is paid 2–3× (tray + bench + workers) for a pipeline that is CPU-bound while holding 2.6 GB VRAM hostage on a 12 GB rig. An MCP host pays ~4–5K schema tokens/session for 24 tools — schema overhead alone ≈ 8 queries' worth of delivered content before the first call; the project's own minimal server ships 3 tools. 35 of 51 HTTP routes are admin/ops surface with no observed agent consumer.
+2. *Entropy:* Drift is a *cost multiplier* — the worst latency default (`workers=1`) and the most expensive dead weight (SPLADE 21.1% disk for 0pp) are both **config-honesty failures with cost units attached**.
+3. *Static→dynamic:* I only pay for dynamization with a cost line: auto worker scaling (5×) and SPLADE auto-toggle (~10 GB) qualify; classifier-owned dense weight is a recall play, not a cost play.
+4. *Value:* If SNOW-2's frontier shows a ~150-token fingerprint matching a ~590-token splice at equal correctness, the entire compression stage is stranded capital.
+
+**Position.** **A**, executed cheaply: flip `HELIX_SHARD_WORKERS` default to `auto_shard_workers()`, lazy-load/share encoders across processes, default SPLADE auto-toggle, prune the MCP schema to the demonstrated core (~8 tools) with the rest behind a `helix_admin` umbrella. Re-land #158/#160 only if 500K serving is a near-term product goal.
+
+**Strongest argument.** The highest-ROI items in the whole backlog are one-liners: a default flip worth 5× latency and a lazy-load worth ~5–8 GB per duplicate process. No other option pays back in days.
+
+**Key concern.** Optimizing the cost of a product whose value is unproven (Skeptic's point) risks gold-plating a cowpath — which is why my A is confined to reversible config-level wins, not Wall-2 engineering.
+
+**Scores.** A **8**, B **7**, C **5**, D **6**.
+
+**Flip conditions.** → D if SNOW-2 shows navigation ≥ injection at equal correctness (pointers are nearly free to serve); → C if the dense-weight sweep on real ERB questions shows per-query adaptation recovering >10pp (recall is revenue); A drops to 4 if lazy-loading + worker default land and RSS still exceeds ~10 GB (then the tax is structural, in the index design).
+
+### 3.2 Pipeline Archaeologist — "entropy is the active failure mode"
+
+**Axis reads.**
+1. *Tax:* The tax is partly sedimentary: SPLADE-on by default at 0pp, the dead PKI index (#165: 34.1% of corpus, 38% dead rows, fixed in #193), three encoder copies — strata of unevicted decisions.
+2. *Entropy:* Five config layers; five verified default drifts ("two undocumented products" — the spec's words); 9 dead documented knobs in the default path; `[know]` parsed by a shadow loader `config.py` doesn't know about; CLAUDE.md documenting knobs that don't exist, a version two majors stale, and a dense-recall default stated backwards; SPLADE silently indexing 25% of each chunk. **Every recent headline incident — #202/#210, #207, #214/#217 — is the same bug: the system not telling the truth about itself.**
+3. *Static→dynamic:* Dynamizing a five-layer config multiplies the states an auditor must reason about. Calibration-at-ingest (Layer 1) is the *exception* I endorse: a computed value persisted in the genome is more honest than a shipped absolute.
+4. *Value:* The 30→43.3 jump came from #214 — an honesty fix. Until the cleanup is done we do not actually know what injection scores; the BM25 gap is partly *measurement* of a misconfigured product.
+
+**Position.** **B**, scoped and finite: reconcile the five drifts to one canonical default set; bind-or-delete the 9 dead weights; surface the `[:1000]`/`[:2000]`/`[:500]` truncations as config with loud logs; merge the `[know]` shadow loader into `config.py`; regenerate CLAUDE.md/config-reference from code; ship the two telemetry counters that verify the 40%-elision and know-floor claims (roadmap:136-139).
+
+**Strongest argument.** B is the only option that raises the validity of every measurement the other three options depend on. Funding A, C, or D first means pricing, tuning, or re-founding a system whose declared behavior is provably not its actual behavior.
+
+**Key concern.** D re-founds delivery on top of an unaudited base — SNOW-2 run against drifted defaults would compare five arms of a product that doesn't exist as configured. C (beyond Layer 1) multiplies entropy.
+
+**Scores.** A **6**, B **9**, C **4**, D **5**.
+
+**Flip conditions.** B is *finishable*: when the drift inventory is zero, dead knobs are bound or deleted, docs are generated, and the two truth-counters are live, B's score collapses to 3 and I hand off to the gate. If the ERB 500K rerun post-#214 still reads <50% with honest config, the gap is architectural, and I flip toward D.
+
+### 3.3 Adaptive-Systems Architect — "the failures are static absolutes meeting new distributions"
+
+**Axis reads.**
+1. *Tax:* The 5-min default query is a static-knob failure (workers=1); auto-scaling already exists in `parallel.py` and is simply unwired. Most of A is C wearing a cost hat.
+2. *Entropy:* Drift is what static knobs do over time — the durable fix is fewer hand-set absolutes, not better-synced ones. (Conceded: you can't calibrate against dirty signals; B's truncation and dead-knob fixes are upstream of me.)
+3. *Static→dynamic:* The incident record is one-sided: 0.58 measured on one fixture, recalibrated twice between the project's own corpora; w=4.0 evicting gold on prose (−19pp) while the semantic arm needs 16.0; SPLADE flat-on costing 21.1% disk for 0pp. Layer-1 (calibration persisted in the genome — machinery shipped, default off at `config.py:343`) and Layer-2 (classifier-owned dense weight; the classifier already runs at Stage 0 for free) are the highest recall-per-effort levers on the board. Discipline: the budget cap (8.4% util) should *stay* static — dynamize only where evidence says values diverge.
+4. *Value:* Chunk-vs-pointer is itself a per-query routing decision — locator-bearing queries want pointers (AND-route, #159: cost O(collision-set), independent of N), prose queries want synthesized content. D-as-religion is as wrong as injection-as-religion; the right end state is the classifier choosing the delivery mode.
+
+**Position.** **C**, sequenced: Layer-1 auto-calibration default-on (after the cross-corpus transfer test, spec measurement 6) + Layer-2 semantic arm + auto workers; chunk-size dynamization explicitly *deferred behind* #159 AND-then-OR routing per roadmap:157 ("under the current OR-scorer, smaller chunks lose").
+
+**Strongest argument.** Every off-corpus deployment will re-trigger the #214 class until thresholds travel with the corpus. Profiles spec already proved the search space is small ("only ~6 knobs are genuinely corpus-sensitive") — this is a bounded investment with a named acceptance bench per knob.
+
+**Key concern.** Dynamizing against signals that are currently lies (truncated SPLADE docs, dead weights) builds feedback loops on noise — so B's core must land first; and D's re-found, done now, would freeze delivery just as the routing layer (#159) is about to change what's worth delivering.
+
+**Scores.** A **5**, B **6**, C **8**, D **7**.
+
+**Flip conditions.** If `calibrate_thresholds.py` on enterprise_rag_10k diffs ≈0 from the own-code 0.58/5.0/2.5 absolutes (spec measurement 6), corpus-sensitivity is overstated and C drops to 5. If SNOW-2 arm C/E beats arm A by a wide margin, I fold C into D's routing layer and call it the same program.
+
+### 3.4 Inference-Value Skeptic — "show me one token that changed the answer"
+
+**Axis reads.**
+1. *Tax:* 20 GB and minutes of latency would be defensible if the product worked. The damning ratio isn't cost — it's cost *per delivered token that alters downstream output*, a quantity nobody has ever measured.
+2. *Entropy:* The honesty program is what produced the indictment (dead weights, gated-to-zero dense, truncated index). Cheap, truth-increasing — fund it. But don't confuse cleaning the machine with proving the machine's output matters.
+3. *Static→dynamic:* Tuning knobs on an unproven value chain is rearranging weights inside a number that's losing to `rank_bm25` by 25–38pp. The one dynamization I'd buy is the one that changes the *product*: route pointer-vs-content.
+4. *Value — the core brief:* Retrieval-side, at enterprise scale, the 7-stage pipeline surfaces gold in the top-10 for 30–43% of questions where published BM25 does 68.4. Consumer-side, the only LLM-arm test ever run scored 90% miss at 73,000× latency. Budget-side, deliveries fill 8.4% of cap, and the compressor has a defined "denatured" state it actually emits (0.5× on QA smoke). Meanwhile 94.8% of chunks are pointer-addressable, uniqueness is "solved storage-side" (roadmap:148), the packet/fingerprint surface ships today, and the project's own tagline already concedes the thesis: "**Helix weighs, doesn't retrieve**" (`pyproject.toml:7`). Per delivered token, what fraction changes the downstream model's output? *Nobody knows. That is the scandal.*
+
+**Position.** **D** — but the honest version: stop net-new investment in chunk polishing now (B-aligned), promote packet/fingerprint to the documented primary surface, and build SNOW-2's arm runner before any further pipeline tuning. The strongest pro-injection counters I must concede: 83% @10K own-code and Dewey 30% R@1 prove value *in the small-corpus, key-expressing regime*; SNOW v1's 90%-miss cuts **against navigation too** — it was the LLM *navigating* tiers that failed, so a weak local consumer may be even worse at following pointers than at reading pasted text; the 73,000× figure compares against an in-process string-matcher and is rhetorically inflated; and BM25 68.4 is a published number, not a same-harness rerun. Which is exactly why the settling measurement is SNOW-2 (#208): five arms, same questions, same fixture, correctness-per-token frontier, ladder starting at qwen3:8b.
+
+**Strongest argument.** Every existing metric is retrieval-side (did gold appear?), not inference-side (did the answer improve per token spent?). A system whose stated purpose is "reduce downstream inference requirements" has never once measured downstream inference requirements.
+
+**Key concern.** Sunk-cost gravity: stages 3–5 (re-rank/splice/assemble) are the identity of the codebase ("ribosome"), so the org will keep tuning them by default. Also my own risk: if capable models (qwen3:8b+, Claude tier) navigate well but the target audience runs 4B locals, D is a product for consumers helix doesn't have.
+
+**Scores.** A **3**, B **7**, C **4**, D **7**.
+
+**Flip conditions.** If SNOW-2 arm A/B (injection) beats arms C–E on the correctness-per-token frontier — or if the post-#214 honest-config ERB rerun closes to within ~10pp of BM25 — injection is vindicated; I drop D to 4 and concede the pipeline earns its tax. If qwen3:8b still can't triage fingerprints, D dies for the local-LLM market regardless.
+
+---
+
+## 4. Conflict Map, Cross-Validated Risks, Blind Spots
+
+### Conflict map
+
+| Topic | Agrees | Disagrees | Confidence |
+|---|---|---|---|
+| Default/doc honesty cleanup is the floor before anything else is trustworthy | All 4 | — | **High** |
+| SNOW-2 (#208) five-arm frontier is the decisive measurement for the delivery question | All 4 | — | **High** |
+| Config-level tax quick wins (workers default→auto, encoder lazy-load/share, SPLADE auto-toggle) ride with the next wave | Economist, Archaeologist, Architect | Skeptic (indifferent: "cheaper cowpath is still a cowpath") | **High** |
+| Chunk-injection value at >100K genes is unproven-to-negative | Economist, Architect, Skeptic | Archaeologist (partial: gap may shrink under honest config; #214 alone was +13.3pp) | **Med-High** |
+| Re-found delivery around navigation NOW | Skeptic | Archaeologist (re-founding on unaudited base), Economist (gate it on SNOW-2), Architect (routing layer #159 first; delivery mode should be classifier-chosen, not re-founded) | **Low — genuine conflict** |
+| Dynamize knobs this wave | Architect (Layer 1+2 are shipped machinery, just default-off) | Archaeologist (multiplies audit states), Skeptic (tuning an unproven value chain) | **Medium — genuine conflict** |
+| System tax is the urgent fire | Economist | Architect, Skeptic (symptom of index/delivery design, not the disease) | **Medium** |
+| Budget cap should stay static (8.4% util) | All 4 (incl. Architect, citing the spec) | — | **High** |
+
+### Cross-validated risks (flagged independently by 2+ personas)
+
+1. **Measurement contamination** (Archaeologist, Skeptic, Architect): five config layers + drifted defaults + silent truncations mean existing benches measured a product that was never the shipped product. Any A/C/D decision made on pre-cleanup numbers inherits the error.
+2. **The weak-consumer trap** (Economist, Archaeologist, Skeptic-as-self-risk): SNOW v1 is direct evidence that a 4B local model cannot navigate (90% miss, triage 0.0). D's premise is untested with capable consumers, and helix's positioning is *local* LLMs.
+3. **Broken candidate surfacing poisons both delivery modes** (Architect, Skeptic): at 28% recall @850K, neither an injected chunk nor a pointer reaches the right document. The #159 AND-then-OR route is upstream of the A–D choice entirely.
+4. **Flagship claims steering strategy without telemetry** (Economist, Archaeologist): the ~40% elision saving and the ~150-tok fingerprint economics are quoted in docs but explicitly unverified — roadmap:139 names the missing counter (`helix_session_tokens_saved_total`).
+5. **Bench-fleet debt** (Economist, Archaeologist): ~40 benchmark scripts, many stale vs v0.7.x (roadmap §2 verdicts: RERUN/RETIRE) — the measurement instrument itself carries maintenance tax and staleness risk.
+
+### Blind spots (perspectives not represented)
+
+- **No third-party deployment or usage telemetry.** Which of the 51 routes / 24 tools real agents call is inferred from the owner's own sessions only.
+- **Baseline comparability.** BM25 68.4/68.8 are *published* ERB-paper numbers, not same-harness reruns; the 25–38pp gap could shrink (or grow) under identical conditions.
+- **Task-level outcomes are absent everywhere.** All current metrics stop at retrieval; SNOW-2 fixes this only if it actually runs with answer-correctness scoring.
+- **The 73,000× latency figure** compares an LLM to an in-process string-matching oracle — directionally real, rhetorically inflated.
+- **Panel gaps:** no security/multi-tenant perspective (51 routes incl. `/admin/shutdown`, `/admin/swap-db` on a localhost-trust model), no packaging/DX persona (extras complexity), no end-user (IDE/chat) persona.
+- **Single-rig evidence:** all performance data comes from one Windows/WDDM 12 GB machine with known CUDA-context pathologies (#176).
+
+---
+
+## 5. Consensus Recommendation
+
+**Decision:** **Option B now — a scoped, finishable default-honesty cleanup (1–2 weeks) — with the two config-level Option-A quick wins folded in, and SNOW-2 (#208) funded immediately after as the gate that decides D-vs-C.**
+
+Concretely, in order:
+1. **B-core:** reconcile the 5 verified config.py↔helix.toml drifts to one canonical set; bind-or-delete the 9 dead `[retrieval]` weights (`knowledge_store.py:1846-2341`); make the SPLADE `[:1000]` / dense `[:2000]` / complement `[:500]` truncations configurable and logged; fold the `[know]` shadow loader into `config.py`; regenerate CLAUDE.md/config-reference from code (fix `[know]` key names, dense-default polarity, version).
+2. **A-lite riders:** `HELIX_SHARD_WORKERS` default → `auto_shard_workers()` (keep `=1` pinned in the determinism test); encoder lazy-load + shared residency across tray/bench/workers; enable SPLADE size auto-toggle once the #164 curve is run.
+3. **Truth counters:** ship `helix_session_tokens_saved_total` + know-decision metrics (roadmap:136-139) so the 40%-elision and know-floor claims become measurements.
+4. **Gate:** build SNOW-2's missing pieces (arm runner, arm-E escalation module, ERB adapter) and run the five-arm frontier at 10K/50K (500K when the fixture lands), ladder from qwen3:8b + one Claude tier, **on the post-cleanup config**.
+5. **Branch on the gate:** arms C–E win → invest in **D** (navigation-first delivery, with #159 AND-then-OR routing as its core); arms A–B win or tie → invest in **C** Layer-1/Layer-2 (calibration default-on, classifier-owned dense weight) to close the BM25 gap on the injection path.
+
+**Confidence:** **Medium-High** for B-first (highest mean score 7.25, no persona below 6, and it is the only option that raises the validity of every later measurement). **Low-Medium by design** on the D-vs-C branch — that uncertainty is exactly what the gate purchases.
+
+**Unanimous:** **No.**
+- *Skeptic dissent:* packet/fingerprint should be promoted to the documented primary surface *now* — the surfaces ship today and the tagline already says "weighs, doesn't retrieve"; waiting a measurement cycle is sunk-cost protection. Valid: the cost of dissent-compliance is low (docs + examples), and the council partially adopts it (see mitigation 5).
+- *Architect partial dissent:* Layer-1 auto-calibration **is** threshold-honesty and belongs inside B, not behind the gate. Valid: the machinery is shipped (`ann_threshold_mode`, genome-persisted calibration); the council keeps it gated only on the cross-corpus transfer test (profiles spec measurement 6), which is hours, not weeks.
+
+**Score matrix (1–10):**
+
+| Option | Economist | Archaeologist | Architect | Skeptic | Mean |
+|---|---|---|---|---|---|
+| A — shrink tax | 8 | 6 | 5 | 3 | 5.50 |
+| **B — honesty cleanup** | **7** | **9** | **6** | **7** | **7.25** |
+| C — dynamize knobs | 5 | 4 | 8 | 4 | 5.25 |
+| D — navigation re-found | 6 | 5 | 7 | 7 | 6.25 |
+
+### Why this option
+The last meaningful recall gain (+13.3pp, #214) was an honesty fix; the most expensive latency default (workers=1) and the most expensive dead feature (SPLADE 21.1% disk for 0pp) are honesty fixes with cost units; and the decisive D-vs-C measurement is worthless if run against a config that exists in five mutually contradicting layers. B is short, finishable, and converts every other option from argument into experiment.
+
+### Mitigations for top concerns
+1. *Measurement contamination (R1)* → SNOW-2 and all reruns execute only on post-B canonical config; bench harnesses pin the shipped helix.toml and log resolved config at RUN START (pattern already exists, #184).
+2. *Weak-consumer trap (R2)* → SNOW-2 ladder starts at qwen3:8b and includes one Claude tier (roadmap:45); report per-model frontiers so "navigation works, but only above X B params" is a representable outcome.
+3. *Broken surfacing poisons both modes (R3)* → spike the #159 AND-then-OR fingerprint route during the gate window; it benefits injection and navigation alike, and roadmap:157 already bounds R@1 as coverage × expressibility × tie-break.
+4. *Unverified flagship claims (R4)* → truth counters (step 3) ship before any marketing of elision/fingerprint economics.
+5. *Skeptic's promotion dissent* → document `/context/packet` + `/fingerprint` as the recommended agent integration in README/CLAUDE.md *as an experiment*, without deleting any injection path, pending the gate.
+
+### Reversibility
+- **B:** effectively irreversible but pure-win (deleting drift/dead code; all git-revertable). Lowest-regret option on the board.
+- **A-lite riders:** one-line env/default flips behind existing tests — trivially reversible.
+- **D and C:** explicitly *not yet committed* — the gate keeps both cheap to abandon. The expensive irreversible move (re-founding delivery, deprecating splice stages) is deferred until evidence exists.
+
+### Review triggers
+- **SNOW-2 results land** (any arm × model row): re-run this council's Section 5 branch decision — this is the primary trigger.
+- **ERB 500K rerun post-#214** (in flight, #93): strat recall ≥55–60% under honest config would rehabilitate injection-at-scale and weaken D's premise; <45% confirms the architectural reading.
+- **Dense-weight sweep on the real ERB question set** (roadmap bench table flags the auto-synth `--queries` gap): if per-query adaptation recovers >10pp, pull C Layer-2 forward.
+- **Telemetry falsifies the ~40% elision claim** → revisit `session_delivery_enabled` default and the multi-turn value story.
+- **Cross-corpus calibration transfer diff** (spec measurement 6) ≈ 0 → demote C Layer-1 urgency.
+- **Post-lazy-load RSS still >10 GB @850K** → the tax is structural (index design), escalate A from config-fixes to architecture (re-open #158/#160).
+- **A second real deployment appears** → its calibration/usage data supersedes most single-rig assumptions in this report.
+
+---
+
+## 6. Caveat
+
+> This analysis simulates multiple specialist perspectives to surface risks and tradeoffs. It is not a substitute for input from actual domain experts on your team. The personas are heuristic models — real specialists may identify concerns not captured here. Use this as a structured starting point for team discussion, not as a final verdict.

--- a/helix.toml
+++ b/helix.toml
@@ -69,7 +69,7 @@ low_vram_threshold_gb = 4.0
 
 [budget]
 ribosome_tokens = 3000                  # fixed decoder prompt
-expression_tokens = 7000                # ~7K expressions cap (BROAD tighten 2026-05-12, bench-gated #73)
+expression_tokens = 7000                # ~7K expressions cap (BROAD tighten 2026-05-12, bench-gated #73). Code default matches since the 2026-06-12 default-honesty pass.
 max_genes_per_turn = 12
 max_fingerprints_per_turn = 40          # navigation-first fingerprint payload cap (final returned count, not frontier width)
 splice_aggressiveness = 0.3             # 0=keep all, 1=ruthless trim (lower preserves more literal detail)
@@ -137,6 +137,11 @@ synthetic_session_enabled = true        # Flip to false to restore prior NULL-se
 # New genomes/ folder is the phase-2 sharding root. main/ is v1's only
 # shard; future shards land as genomes/reference/, genomes/agent/, etc.
 path = "genomes/main/genome.db"
+# Sharded stores (HELIX_USE_SHARDS=1 against a routing main.db): cross-shard
+# query fan-out width comes from the HELIX_SHARD_WORKERS env var, not this
+# file. Unset = auto-size when >4 shards are routed (serial measured 5
+# min/query at 829K genes / 100 shards vs ~55s at 8 workers — issue #206,
+# 2026-06-12); HELIX_SHARD_WORKERS=1 forces the serial reference path.
 compact_interval = 3600                 # seconds between source-change checks (hourly)
 cold_start_threshold = 10              # genes needed before history stripping kicks in (Fix 3)
 # Replicas disabled during phase-1 cutover. Will re-enable alongside
@@ -265,7 +270,13 @@ enabled = true
 [retrieval]
 # Tier 5.5 — Successor Representation (Stachenfeld 2017). γ-discounted
 # future-occupancy boost over the co-activation graph. Lazy, on-demand.
-sr_enabled = true                       # Stage-1 bench flip (2026-04-22); research review flagged this as dark-shipped signal-positive
+# 2026-06-12 default-honesty pass: flipped back to false, matching the code
+# default (the inverse of the usual toml-wins rule). The 2026-04-22 Stage-1
+# bench flip turned SR on, but the evidence roadmap subsequently measured SR
+# at ZERO effect on retrieval outcomes — a knob that costs co-activation
+# walks per query and moves nothing defaults off. Re-flip only with fresh
+# bench evidence.
+sr_enabled = false
 sr_gamma = 0.85                         # 5-10 hop horizon (Stachenfeld grid-cell sweet spot)
 sr_k_steps = 4                          # Power-series truncation (cap runaway propagation)
 sr_weight = 1.5                         # Per-gene SR contribution multiplier

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -24,12 +24,15 @@ except ImportError:
 @dataclass
 class RibosomeConfig:
     enabled: bool = False              # Master switch; false = ignore compressor config/runtime
-    model: str = "auto"
+    # default aligned with shipped helix.toml (2026-06-12 default-honesty pass):
+    # the shipped toml pins the light pack/replicate fallback model instead of
+    # "auto" (compressor auto-detect). Inert while enabled=False.
+    model: str = "gemma4:e2b"
     base_url: str = "http://localhost:11434"
-    timeout: float = 10.0
+    timeout: float = 120.0  # default aligned with shipped helix.toml (2026-06-12 default-honesty pass) — bulk ingestion headroom
     keep_alive: str = "30m"     # How long Ollama keeps the compressor model loaded
-    warmup: bool = True         # Pre-load model on server start
-    backend: str = "ollama"     # legacy placeholder; only "deberta" or "litellm" are honored when enabled
+    warmup: bool = False        # Pre-load model on server start. Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
+    backend: str = "none"       # disabled-state placeholder; only "deberta" or "litellm" are honored when enabled. Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     claude_model: str = "claude-haiku-4-5-20251001"   # Claude model when backend="claude"
     claude_base_url: str = ""   # Proxy URL (e.g. Headroom at http://127.0.0.1:8787); "" = direct
     litellm_model: str = "gemini/gemini-2.5-flash"    # LiteLLM model string when backend="litellm"
@@ -45,7 +48,11 @@ class RibosomeConfig:
     # for a strictly LLM-free /context pipeline — the 12 tiers below still
     # run on raw query text + synonym map. See context_manager
     # _expand_query_intent.
-    query_expansion_enabled: bool = True
+    # default aligned with shipped helix.toml (2026-06-12 default-honesty
+    # pass): false keeps /context strictly LLM-free (the design default —
+    # docs/MISSION.md); flip on for ~2-3pp on ambiguous queries at one
+    # ribosome call per novel query.
+    query_expansion_enabled: bool = False
     # Step 2 sub-query decomposition: decomposes broad queries into 2-4
     # point-fact sub-queries via one LLM call. Only fires for multi_hop/default
     # classifier classes. Dark-shipped (default off).
@@ -120,11 +127,11 @@ class RibosomeConfig:
 @dataclass
 class BudgetConfig:
     ribosome_tokens: int = 3000
-    expression_tokens: int = 6000
-    max_genes_per_turn: int = 8
+    expression_tokens: int = 7000  # default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
+    max_genes_per_turn: int = 12  # default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     max_fingerprints_per_turn: int = 40
-    splice_aggressiveness: float = 0.5
-    decoder_mode: str = "full"  # "full"|"condensed"|"minimal"|"none"
+    splice_aggressiveness: float = 0.3  # default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
+    decoder_mode: str = "condensed"  # "full"|"condensed"|"minimal"|"none". Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     # Sprint 1 legibility pack (AI-consumer roadmap): emit a one-line
     # metadata header per document in expressed_context — fired tiers,
     # confidence marker, short gene_id, compression ratio. See
@@ -139,9 +146,11 @@ class BudgetConfig:
     slate_char_budget: int = 1500
     # Sprint 2 session working-set register: track delivered documents per
     # session, elide repeats with a pointer stub so the consumer doesn't
-    # pay full token cost for content it already holds. Dark on first
-    # ship — flip to true in helix.toml to A/B. See session_delivery.py.
-    session_delivery_enabled: bool = False
+    # pay full token cost for content it already holds. Enabled 2026-04-19
+    # (saves ~40% tokens on multi-turn conversations); only fires when the
+    # caller supplies a session_id. See session_delivery.py.
+    # default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
+    session_delivery_enabled: bool = True
     abstain_enabled: bool = True       # NEW — see docs/specs/2026-05-02-abstain-tier-design.md
     # Foveated-splice (BROAD tier only). Off by default for the measurement
     # period — see docs/specs/2026-05-03-foveated-splice-design.md §6.3 and
@@ -164,7 +173,7 @@ class BudgetConfig:
 
 @dataclass
 class GenomeConfig:
-    path: str = "genome.db"
+    path: str = "genomes/main/genome.db"  # default aligned with shipped helix.toml (2026-06-12 default-honesty pass) — genomes/ is the phase-2 sharding root; CLAUDE.md documents this as THE default
     compact_interval: float = 3600.0    # Seconds between source-change checks
     cold_start_threshold: int = 10      # Fix 3: documents needed before history stripping
     replicas: List[str] = field(default_factory=list)  # Read-only clone paths
@@ -191,12 +200,22 @@ class ServerConfig:
 @dataclass
 class IngestionConfig:
     """Controls which backend encodes raw content into documents."""
-    backend: str = "ollama"         # "ollama" | "cpu" | "hybrid"
-    splade_enabled: bool = False    # Phase 2: SPLADE sparse expansion at index time
-    rerank_model: str = ""          # Phase 3: pretrained cross-encoder HF model ID
+    # default aligned with shipped helix.toml (2026-06-12 default-honesty
+    # pass): "cpu" (spaCy/heuristic CpuTagger). The load_config coherence
+    # guard already auto-flipped "ollama" to "cpu" whenever the ribosome was
+    # disabled (the default), so "cpu" is what installs actually ran.
+    backend: str = "cpu"            # "ollama" | "cpu" | "hybrid"
+    # default aligned with shipped helix.toml (2026-06-12 default-honesty
+    # pass). NOTE #164 measured SPLADE at 0 pp recall@10 / 21.1% of disk on
+    # the 850K fixture, but the curve below ~50K genes is unresolved and the
+    # shipped toml (every bench this month) ran true — so toml wins here;
+    # the size-aware auto-disable knob below covers the enterprise cliff.
+    # Soft-fails to a no-op when torch/transformers are absent.
+    splade_enabled: bool = True     # Phase 2: SPLADE sparse expansion at index time
+    rerank_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"  # Phase 3: pretrained cross-encoder HF model ID — inert while rerank_enabled=False. Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     rerank_enabled: bool = False    # Phase 3: enable cross-encoder reranking
     colbert_enabled: bool = False   # Phase 4: ColBERT late interaction (optional)
-    entity_graph: bool = False      # Phase 5: entity-based co-activation links
+    entity_graph: bool = True       # Phase 5: entity-based co-activation links (ingest-time edges). Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     # Tier-0 PR-1 (2026-05-16): compute BGE-M3 dense vectors
     # (genes.embedding_dense_v2) inline at ingest. Default true so a genome
     # built by `helix ingest` / `/ingest` / context_manager.ingest is
@@ -281,7 +300,12 @@ class RetrievalConfig:
     """Tier 5.5 SR + theta ray_trace bias (Sprint 2)."""
     # Successor Representation (Stachenfeld 2017) - lazy on-demand SR rows
     # via truncated power series over co-activation graph.
-    sr_enabled: bool = False            # Dark ship — flip on for A/B
+    # 2026-06-12 default-honesty pass: stays FALSE on both sides. helix.toml
+    # had flipped this true (2026-04-22 Stage-1 bench), but the evidence
+    # roadmap measured SR at zero effect on retrieval outcomes, so the
+    # shipped toml was aligned back to the code default (the inverse of the
+    # usual toml-wins rule: measured-zero features default off).
+    sr_enabled: bool = False
     sr_gamma: float = 0.85              # Discount factor (5-10 hop horizon at 0.9)
     sr_k_steps: int = 4                 # Power-series truncation depth
     sr_weight: float = 1.5              # Per-document contribution multiplier
@@ -299,7 +323,7 @@ class RetrievalConfig:
     # Dewey bench showed filename alone outperforms the full
     # project+module+filename bag by 24pp. Boosts documents whose
     # filename_stem matches a query term.
-    filename_anchor_enabled: bool = False   # Dark ship — flip for A/B
+    filename_anchor_enabled: bool = True    # Stage-1 bench flip 2026-04-22: +12pp Dewey axis-2. Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     filename_anchor_weight: float = 4.0     # Per-match boost (higher than Tier 1's 3.0)
     # BM25 shortlist post-filter (2026-04-22, research-review Pareto move 1).
     # When enabled, query_genes restricts its final ranking to documents that
@@ -307,7 +331,7 @@ class RetrievalConfig:
     # but candidates BM25 would never surface are dropped before the sort.
     # Post-filter by design (isolates the ranking-set hypothesis from the
     # candidate-generation optimisation). Dark ship.
-    bm25_shortlist_enabled: bool = False
+    bm25_shortlist_enabled: bool = True     # Keep on (2026-04-22 sprint): +1/8 ans_full, clean attribution. Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     bm25_shortlist_size: int = 50           # BM25 top-N kept in the final ranking
     bm25_prefilter_enabled: bool = False
     bm25_prefilter_size: int = 200          # BM25 top-N fed into tier scoring
@@ -487,20 +511,67 @@ class ClassifierConfig:
     enabled: bool = True
 
 
+# Ship-time [know] defaults (Stage 6 spec §3 + Stage 7 b5). These literals
+# MUST stay equal to scoring/know_calibration.py's DEFAULT_* constants —
+# tests/test_config_default_honesty.py cross-checks the two modules so they
+# cannot drift apart again.
+_KNOW_DEFAULT_BETAS: tuple = (-2.0, 2.0, 1.5, 0.7, 1.8, 1.5)
+_KNOW_DEFAULT_S_REF: float = 1.0
+_KNOW_DEFAULT_G_REF: float = 0.5
+_KNOW_DEFAULT_EMIT_FLOOR: float = 0.55
+_KNOW_DEFAULT_STALE_AFTER_DAYS: int = 30
+
+
+@dataclass
+class KnowConfig:
+    """[know] — Stage 6/7 KnowBlock confidence logistic + staleness window.
+
+    Folded into the config system on 2026-06-12 (default-honesty pass):
+    these keys were previously parsed OUT-OF-BAND by
+    ``scoring/know_calibration.py``'s shadow loader, so /health, docs and
+    the loader disagreed about what the real knobs were (CLAUDE.md
+    advertised non-existent ``confidence_floor`` / ``margin_threshold``).
+    Field names/defaults == the shadow loader's ship-time values
+    (spec docs/specs/2026-05-08-stage-6-know-miss-blocks.md §3, §11).
+
+    ``scoring.know_calibration.load_calibration_from_toml`` now delegates
+    here; ``calibration_from_config`` converts this block into the frozen
+    ``KnowCalibration`` bundle the logistic consumes.
+    """
+    # Probability floor below which no KnowBlock is emitted (falls through
+    # to MissBlock(reason="sparse")).
+    emit_floor: float = _KNOW_DEFAULT_EMIT_FLOOR
+    # tanh feature-scale references for top_score / score_gap.
+    s_ref: float = _KNOW_DEFAULT_S_REF
+    g_ref: float = _KNOW_DEFAULT_G_REF
+    # (b0, b1..b5) — intercept + 5 feature coefficients (Stage 7 added b5
+    # for freshness_min). Malformed/odd-length lists soft-fail to defaults
+    # at load time so a bad calibration write can never break retrieval.
+    betas: List[float] = field(default_factory=lambda: list(_KNOW_DEFAULT_BETAS))
+    # Written by scripts/calibrate_know_confidence.py; None = uncalibrated.
+    calibrated_at: Optional[str] = None
+    calibrated_on_n: Optional[int] = None
+    # Stage 4 (spec §9, issue #63): age in days after which the /context
+    # response flags ``calibration_stale``.
+    stale_after_days: int = _KNOW_DEFAULT_STALE_AFTER_DAYS
+
+
 @dataclass
 class PLRConfig:
     """Stacked PLR query-confidence head (STATISTICAL_FUSION.md §C3).
 
     Attaches a `plr_confidence` log-odds signal to /context/packet responses
-    when a trained artifact is on disk. Dark by default — callers that need
-    the router / HITL signal flip `enabled=true`.
+    when a trained artifact is on disk. Bench-gated on 2026-05-12 (#74) and
+    enabled by default since the 2026-06-12 default-honesty pass (aligned
+    with shipped helix.toml); soft-fails to "PLR unavailable" when no
+    artifact exists, so a fresh install pays nothing.
 
     The current artifact is a **query-quality head** (same score for all documents
     in a retrieval) rather than the per-(q,g) ranker the spec originally
     described. See `helix_context/fusion_plr.py` docstring and
     STATISTICAL_FUSION.md §C3 addendum for the trade-off.
     """
-    enabled: bool = False
+    enabled: bool = True  # default aligned with shipped helix.toml (2026-06-12 default-honesty pass) — bench-gated #74; soft-no-op without artifact
     model_path: str = "training/models/stacked_plr.joblib"
     # SHA256 of the artifact — when set, load refuses to proceed unless the
     # file's digest matches. Empty string = trust the sidecar .sha256 next
@@ -528,13 +599,16 @@ class HeadroomConfig:
     ``route_upstream`` controls whether helix's chat upstream is
     rewritten to dial this proxy. Separate concerns: you may want the
     proxy + dashboard running without the chat redirect, or vice versa.
-    Both default off so a fresh install never silently rewrites the
-    upstream to a proxy that isn't actually running. The
+    ``enabled`` defaults on (2026-06-12 default-honesty pass, aligned with
+    shipped helix.toml) — the launcher adopts/spawns the proxy and no-ops
+    when the [codec] extra isn't installed. ``route_upstream`` stays off
+    so a fresh install never silently rewrites the upstream to a proxy
+    that isn't actually running. The
     ``HELIX_HEADROOM_ROUTE_UPSTREAM_AUTO`` env var (truthy → force on,
     falsy → force off, unset → defer to config) continues to work as a
     per-launch override.
     """
-    enabled: bool = False               # Master switch; false = do nothing
+    enabled: bool = True                # Master switch; false = do nothing. Default aligned with shipped helix.toml (2026-06-12 default-honesty pass)
     autostart: bool = True              # When enabled: adopt if running, spawn if not
     host: str = "127.0.0.1"
     port: int = 8787
@@ -606,6 +680,9 @@ class HelixConfig:
     plr: PLRConfig = field(default_factory=PLRConfig)
     headroom: HeadroomConfig = field(default_factory=HeadroomConfig)
     classifier: ClassifierConfig = field(default_factory=ClassifierConfig)
+    # Stage 6 KnowBlock calibration — folded in from the know_calibration
+    # shadow loader (2026-06-12 default-honesty pass).
+    know: KnowConfig = field(default_factory=KnowConfig)
     hardware: Hardware = field(default_factory=Hardware)
     vault: VaultConfig = field(default_factory=VaultConfig)
     synonym_map: Dict[str, List[str]] = field(default_factory=dict)
@@ -949,6 +1026,64 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
         _warn_unknown("classifier", cls_section, ClassifierConfig)
         cfg.classifier = ClassifierConfig(
             enabled=bool(cls_section.get("enabled", cfg.classifier.enabled)),
+        )
+
+    # Know — Stage 6 KnowBlock confidence logistic (2026-06-12: folded in
+    # from the know_calibration shadow loader). Per-field soft-fail mirrors
+    # the old loader exactly: a malformed calibration write must never be
+    # able to break startup or retrieval, so bad betas / stale_after_days
+    # fall back to ship-time defaults with a WARNING instead of raising.
+    if "know" in raw:
+        k = raw["know"]
+        _warn_unknown("know", k, KnowConfig)
+        betas_raw = k.get("betas", list(_KNOW_DEFAULT_BETAS))
+        try:
+            betas = [float(b) for b in betas_raw]
+        except (TypeError, ValueError):
+            log.warning("[know] betas is malformed; using defaults")
+            betas = list(_KNOW_DEFAULT_BETAS)
+        if len(betas) != len(_KNOW_DEFAULT_BETAS):
+            log.warning(
+                "[know] betas length %d != expected %d; using defaults",
+                len(betas), len(_KNOW_DEFAULT_BETAS),
+            )
+            betas = list(_KNOW_DEFAULT_BETAS)
+        try:
+            stale_after_days = int(
+                k.get("stale_after_days", _KNOW_DEFAULT_STALE_AFTER_DAYS)
+            )
+            if stale_after_days < 0:
+                raise ValueError("negative")
+        except (TypeError, ValueError):
+            log.warning(
+                "[know] stale_after_days is malformed; using default %d",
+                _KNOW_DEFAULT_STALE_AFTER_DAYS,
+            )
+            stale_after_days = _KNOW_DEFAULT_STALE_AFTER_DAYS
+
+        def _know_float(key: str, default: float) -> float:
+            try:
+                return float(k.get(key, default))
+            except (TypeError, ValueError):
+                log.warning("[know] %s is malformed; using default %s", key, default)
+                return default
+
+        cfg.know = KnowConfig(
+            emit_floor=_know_float("emit_floor", _KNOW_DEFAULT_EMIT_FLOOR),
+            s_ref=_know_float("s_ref", _KNOW_DEFAULT_S_REF),
+            g_ref=_know_float("g_ref", _KNOW_DEFAULT_G_REF),
+            betas=betas,
+            calibrated_at=(
+                str(k["calibrated_at"])
+                if k.get("calibrated_at") is not None
+                else None
+            ),
+            calibrated_on_n=(
+                int(k["calibrated_on_n"])
+                if k.get("calibrated_on_n") is not None
+                else None
+            ),
+            stale_after_days=stale_after_days,
         )
 
     # Hardware section — see docs/specs/2026-05-04-hardware-detection-design.md.

--- a/helix_context/scoring/know_calibration.py
+++ b/helix_context/scoring/know_calibration.py
@@ -24,6 +24,13 @@ Calibration is an operator post-merge action via
 then defaults are the contract; KnowBlock will still emit, but the
 operating point may not be precision-95.
 
+2026-06-12 (default-honesty pass): the [know] table is now parsed by the
+config system proper (``helix_context.config.KnowConfig``) instead of the
+shadow loader this module used to carry. ``load_calibration_from_toml``
+remains as a thin back-compat shim that delegates to ``load_config`` and
+``calibration_from_config``; its soft-fail-to-defaults contract is
+unchanged (now enforced inside config.py's [know] section parsing).
+
 # STAGE-7-EXT: this module ships the 4-feature implementation. Stage 7
 #  extends the logistic to 5 features (adds freshness_min as the fifth
 #  signal with default beta5 = +1.5). Look for `# STAGE-7-EXT` markers
@@ -274,106 +281,66 @@ def compute_confidence(
 
 
 # ─────────────────────────────────────────────────────────────────────
-# helix.toml [know] table loader (pure function; soft-fail to defaults)
+# Config bridge — [know] is owned by helix_context.config since the
+# 2026-06-12 default-honesty pass (this module used to shadow-parse it)
 # ─────────────────────────────────────────────────────────────────────
+
+def calibration_from_config(know_cfg) -> KnowCalibration:
+    """Convert a ``config.KnowConfig`` block into a ``KnowCalibration``.
+
+    The canonical consumption path: callers that already hold a loaded
+    ``HelixConfig`` pass ``cfg.know`` here instead of re-reading
+    helix.toml from disk (see server/helpers.attach_know_or_miss).
+
+    Defensive re-validation of the betas length is kept even though the
+    config loader performs the same check — a hand-built ``KnowConfig``
+    (tests, programmatic callers) must not be able to crash the logistic.
+    """
+    try:
+        betas = tuple(float(b) for b in know_cfg.betas)
+    except (TypeError, ValueError):
+        log.warning("know_calibration: malformed betas in config; using defaults")
+        betas = DEFAULT_BETAS
+    if len(betas) != 1 + N_FEATURES:
+        log.warning(
+            "know_calibration: betas length %d != expected %d; using defaults",
+            len(betas), 1 + N_FEATURES,
+        )
+        betas = DEFAULT_BETAS
+    return KnowCalibration(
+        betas=betas,
+        s_ref=float(know_cfg.s_ref),
+        g_ref=float(know_cfg.g_ref),
+        emit_floor=float(know_cfg.emit_floor),
+        calibrated_at=know_cfg.calibrated_at,
+        calibrated_on_n=know_cfg.calibrated_on_n,
+        stale_after_days=int(know_cfg.stale_after_days),
+    )
+
 
 def load_calibration_from_toml(
     toml_path: Optional[str | Path] = None,
 ) -> KnowCalibration:
-    """Read [know] from helix.toml; fall back to defaults on any failure.
+    """Back-compat shim: load [know] via the config system.
 
-    The table layout (§11):
+    Historical behavior (kept): a missing file, missing [know] table, or
+    malformed entries all soft-fail to defaults with a WARNING — the
+    calibration loader can never blow up retrieval. The parsing itself now
+    lives in ``config.load_config`` ([know] section) so the keys cannot
+    drift from the documented config surface again.
 
-        [know]
-        emit_floor      = 0.55
-        s_ref           = 1.0
-        g_ref           = 0.5
-        betas           = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]
-        calibrated_at   = "2026-05-08T..."
-        calibrated_on_n = 800
-
-    A missing file, missing [know] table, or malformed entries all
-    return defaults with a single ``log.warning``. This keeps the
-    calibration loader from ever blowing up retrieval.
+    ``toml_path=None`` resolves like every other config consumer
+    (``HELIX_CONFIG`` env, then ./helix.toml) instead of the old
+    hard-coded cwd lookup.
     """
     try:
-        # Lazy-import tomllib (3.11+); for older Pythons callers can
-        # pip install `tomli` and we'll fall back transparently.
-        try:
-            import tomllib  # type: ignore[import-not-found]
-        except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
-            import tomli as tomllib  # type: ignore[no-redef]
+        from ..config import load_config
 
         if toml_path is None:
-            # Default search: helix.toml at the repo root (cwd).
-            toml_path = Path("helix.toml")
+            cfg = load_config()
         else:
-            toml_path = Path(toml_path)
-
-        if not toml_path.exists():
-            return KnowCalibration()
-
-        with toml_path.open("rb") as fh:
-            data = tomllib.load(fh)
-
-        table = data.get("know")
-        if not isinstance(table, dict):
-            return KnowCalibration()
-
-        betas_raw = table.get("betas", DEFAULT_BETAS)
-        try:
-            betas = tuple(float(b) for b in betas_raw)
-        except (TypeError, ValueError):
-            log.warning(
-                "know_calibration: malformed betas in %s; using defaults",
-                toml_path,
-            )
-            betas = DEFAULT_BETAS
-
-        if len(betas) != 1 + N_FEATURES:
-            log.warning(
-                "know_calibration: betas length %d != expected %d in %s; "
-                "using defaults",
-                len(betas),
-                1 + N_FEATURES,
-                toml_path,
-            )
-            betas = DEFAULT_BETAS
-
-        # Stage 4 (spec §9, issue #63) — parse stale_after_days with the
-        # same soft-fail discipline as the other numeric fields.
-        try:
-            stale_after_days = int(
-                table.get("stale_after_days", DEFAULT_STALE_AFTER_DAYS)
-            )
-            if stale_after_days < 0:
-                raise ValueError("negative")
-        except (TypeError, ValueError):
-            log.warning(
-                "know_calibration: malformed stale_after_days in %s; "
-                "using default %d",
-                toml_path,
-                DEFAULT_STALE_AFTER_DAYS,
-            )
-            stale_after_days = DEFAULT_STALE_AFTER_DAYS
-
-        return KnowCalibration(
-            betas=betas,
-            s_ref=float(table.get("s_ref", DEFAULT_S_REF)),
-            g_ref=float(table.get("g_ref", DEFAULT_G_REF)),
-            emit_floor=float(table.get("emit_floor", DEFAULT_EMIT_FLOOR)),
-            calibrated_at=(
-                str(table["calibrated_at"])
-                if table.get("calibrated_at") is not None
-                else None
-            ),
-            calibrated_on_n=(
-                int(table["calibrated_on_n"])
-                if table.get("calibrated_on_n") is not None
-                else None
-            ),
-            stale_after_days=stale_after_days,
-        )
+            cfg = load_config(str(toml_path))
+        return calibration_from_config(cfg.know)
     except Exception:
         log.warning(
             "know_calibration: failed to load %s; using defaults",

--- a/helix_context/server/helpers.py
+++ b/helix_context/server/helpers.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from ..accel import json_loads
 from ..config import HelixConfig
 from ..context_manager import HelixContextManager
-from ..scoring.know_calibration import load_calibration_from_toml
+from ..scoring.know_calibration import calibration_from_config, load_calibration_from_toml
 from ..scoring.know_decision import (
     _agree_from_tier_contributions,
     decide_know_or_miss,
@@ -301,9 +301,14 @@ def _compute_know_or_miss_block(
 
     coord_conf = _coordinate_confidence(query, genes) if genes else 0.0
 
-    # Calibration -- load fresh helix.toml [know] table per call (cheap;
-    # tomllib parses ~kB in microseconds; falls back to defaults).
-    cal = load_calibration_from_toml()
+    # Calibration -- prefer the manager's already-loaded config ([know] is
+    # a first-class config section since the 2026-06-12 default-honesty
+    # pass); fall back to the disk shim for stub managers without .config.
+    _live_cfg = getattr(helix, "config", None)
+    if _live_cfg is not None and getattr(_live_cfg, "know", None) is not None:
+        cal = calibration_from_config(_live_cfg.know)
+    else:
+        cal = load_calibration_from_toml()
 
     # Stage 7 (spec section 3) -- freshness_min from the rebuilt _compute_health.
     # ``ContextHealth.freshness_min`` is Optional[float]; None falls

--- a/helix_context/shard_router.py
+++ b/helix_context/shard_router.py
@@ -63,16 +63,42 @@ def _blas_limit(n: int = 1):
     return _threadpool_limits(limits=n, user_api="blas")
 
 
-def shard_fanout_workers() -> int:
-    """Worker count for concurrent shard fan-out, from ``HELIX_SHARD_WORKERS``.
+def shard_fanout_workers(n_shards: Optional[int] = None) -> int:
+    """Worker count for concurrent shard fan-out.
 
-    Default ``1`` → serial fan-out, byte-identical to the pre-parallel path.
-    Any value > 1 enables a ThreadPoolExecutor over the routed shards. The
-    serial path remains the reference oracle for the determinism regression
-    test (``tests/test_shard_router.py``).
+    Resolution order (issue #206, 2026-06-12):
+
+    1. ``HELIX_SHARD_WORKERS`` set and parseable → that value (explicit env
+       always wins; ``HELIX_SHARD_WORKERS=1`` forces the serial path). An
+       unparseable value keeps the legacy behavior and forces serial.
+    2. Env unset/empty and ``n_shards`` (the routed-shard count for this
+       query) > 4 → :func:`helix_context.parallel.auto_shard_workers`
+       sizes the pool from VRAM/CPU headroom. Evidence: the serial default
+       measured 5 min/query at 829K genes / 100 shards vs ~55s at 8
+       workers (issue #206, 2026-06-12) — an unconfigured large store was
+       paying a 5x-plus latency tax for a knob nobody knew existed.
+    3. Otherwise ``1`` → serial fan-out, byte-identical to the
+       pre-parallel path. Small/monolithic stores (≤4 routed shards) and
+       the determinism regression tests keep the serial reference oracle
+       by default (``tests/test_shard_router.py`` pins workers explicitly
+       via the env var).
+
+    Parallel fan-out only changes *when* each per-shard fetch runs — the
+    accumulation/merge stays in deterministic ``shard_names`` order, so
+    ranked output is byte-identical at any worker count.
     """
     raw = os.environ.get("HELIX_SHARD_WORKERS", "").strip()
     if not raw:
+        if n_shards is not None and n_shards > 4:
+            try:
+                from .parallel import auto_shard_workers
+                return max(1, int(auto_shard_workers()))
+            except Exception:  # pragma: no cover - sizer probe failure
+                log.warning(
+                    "auto shard-worker sizing failed; falling back to serial",
+                    exc_info=True,
+                )
+                return 1
         return 1
     try:
         return max(1, int(raw))
@@ -645,7 +671,7 @@ class ShardRouter:
         # *when* each fetch runs changes, not the merge order. BLAS is pinned
         # to 1 thread inside the pool so W shard workers don't oversubscribe
         # cores via nested BLAS pools on the per-shard dense matmul.
-        _workers = shard_fanout_workers()
+        _workers = shard_fanout_workers(len(shard_names))
         if _workers > 1 and len(shard_names) > 1:
             with _blas_limit(1):
                 with ThreadPoolExecutor(

--- a/tests/test_config_default_honesty.py
+++ b/tests/test_config_default_honesty.py
@@ -1,0 +1,237 @@
+"""Default-honesty regression — code defaults vs the shipped helix.toml.
+
+2026-06-12 council audit (Option B slice 1): ``HelixConfig()`` dataclass
+defaults had silently drifted from the shipped helix.toml on 20 fields —
+the audit's headline five (expression_tokens 6000 vs 7000,
+max_genes_per_turn 8 vs 12, splice_aggressiveness 0.5 vs 0.3,
+decoder_mode "full" vs "condensed", sr_enabled false vs true) plus 15
+more found by this module's comparator (ribosome model/timeout/warmup/
+backend/query_expansion, session_delivery, genome.path, ingestion
+backend/splade/rerank_model/entity_graph, filename_anchor,
+bm25_shortlist, plr.enabled, headroom.enabled).
+
+Resolution policy: the shipped helix.toml is the operationally-tested
+product (every bench this month ran those values), so CODE defaults were
+aligned to the TOML — except measured-zero features, which align the
+other way: sr_enabled was flipped to false in the TOML because the
+evidence roadmap measured SR at zero retrieval effect.
+
+This module is the ratchet: any NEW divergence between the shipped toml
+and the dataclass defaults fails CI unless it is added to
+``INTENTIONAL_DIVERGENCES`` with a documented reason.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from helix_context.config import HelixConfig, KnowConfig, load_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIPPED_TOML = REPO_ROOT / "helix.toml"
+
+# Fields where the shipped helix.toml and the code defaults are ALLOWED to
+# differ. Keep this empty or tiny — every entry needs a reason.
+INTENTIONAL_DIVERGENCES: dict[str, str] = {
+    # The shipped toml carries a starter synonym vocabulary for the repo's
+    # own docs corpus. It is data payload, not a behavioral default — the
+    # dataclass default must stay {} so embedded/library callers start with
+    # a neutral expansion map instead of another project's vocabulary.
+    "synonym_map": "starter vocabulary data, not a behavioral default",
+}
+
+# Env vars load_config consults; the comparator must neutralize them so a
+# developer shell (HELIX_GENOME_PATH etc.) can't fake or mask a drift.
+_CONFIG_ENV_OVERRIDES = (
+    "HELIX_CONFIG",
+    "HELIX_GENOME_PATH",
+    "HELIX_BENCH_ENABLED",
+    "HELIX_SERVER_UPSTREAM",
+    "HELIX_SERVER_UPSTREAM_TIMEOUT",
+)
+
+
+def _walk_drift(toml_obj, code_obj, prefix: str = "") -> dict[str, tuple]:
+    """Recursively diff two config dataclasses; returns {field: (code, toml)}."""
+    drifts: dict[str, tuple] = {}
+    if dataclasses.is_dataclass(toml_obj):
+        for f in dataclasses.fields(toml_obj):
+            path = f"{prefix}.{f.name}" if prefix else f.name
+            drifts.update(
+                _walk_drift(getattr(toml_obj, f.name), getattr(code_obj, f.name), path)
+            )
+    elif toml_obj != code_obj:
+        drifts[prefix] = (code_obj, toml_obj)
+    return drifts
+
+
+def _shipped_vs_code_drift(monkeypatch) -> dict[str, tuple]:
+    for var in _CONFIG_ENV_OVERRIDES:
+        monkeypatch.delenv(var, raising=False)
+    toml_cfg = load_config(str(SHIPPED_TOML))
+    return _walk_drift(toml_cfg, HelixConfig())
+
+
+def test_shipped_toml_matches_code_defaults(monkeypatch):
+    """The honesty ratchet: shipped helix.toml == HelixConfig() defaults.
+
+    Allowed exceptions live in INTENTIONAL_DIVERGENCES, each with a
+    documented reason. A failure here means someone changed a default on
+    ONE side only — either align the other side or (rarely) document the
+    divergence in the allowlist.
+    """
+    assert SHIPPED_TOML.exists(), "shipped helix.toml missing from repo root"
+    drift = _shipped_vs_code_drift(monkeypatch)
+
+    undocumented = {k: v for k, v in drift.items() if k not in INTENTIONAL_DIVERGENCES}
+    assert not undocumented, (
+        "helix.toml and HelixConfig() defaults drifted on undocumented "
+        "fields (code, toml): "
+        + "; ".join(f"{k}={v}" for k, v in sorted(undocumented.items()))
+        + " — align the lagging side (toml wins unless the feature measured "
+        "zero) or document the divergence in INTENTIONAL_DIVERGENCES."
+    )
+
+    # Keep the allowlist honest in the other direction too: an entry whose
+    # field no longer drifts is stale and must be removed.
+    stale = set(INTENTIONAL_DIVERGENCES) - set(drift)
+    assert not stale, f"stale INTENTIONAL_DIVERGENCES entries (no longer drift): {sorted(stale)}"
+
+
+def test_budget_defaults_are_shipped_values():
+    """Pins the 2026-06-12 resolution of the audit's headline budget drift.
+
+    The OLD code defaults (6000 / 8 / 0.5 / "full") were the drifted,
+    never-benched side; the shipped toml values below are what every bench
+    this month actually ran. Do not "fix" these back without re-running
+    the bench grid.
+    """
+    cfg = HelixConfig()
+    assert cfg.budget.expression_tokens == 7000
+    assert cfg.budget.max_genes_per_turn == 12
+    assert cfg.budget.splice_aggressiveness == 0.3
+    assert cfg.budget.decoder_mode == "condensed"
+
+
+def test_sr_enabled_defaults_false_on_both_sides(monkeypatch):
+    """sr_enabled is the measured-zero inverse case: BOTH sides false.
+
+    The evidence roadmap measured SR (Tier 5.5 successor representation)
+    at zero retrieval effect, so the 2026-04-22 toml flip to true was
+    reverted in the default-honesty pass rather than propagated into code.
+    """
+    for var in _CONFIG_ENV_OVERRIDES:
+        monkeypatch.delenv(var, raising=False)
+    assert HelixConfig().retrieval.sr_enabled is False
+    assert load_config(str(SHIPPED_TOML)).retrieval.sr_enabled is False
+
+
+# ── [know] — folded from the know_calibration shadow loader ─────────────
+
+
+def test_know_config_defaults_match_know_calibration_constants():
+    """config.KnowConfig literals must equal the spec constants in
+    scoring/know_calibration.py — the two modules carry the same ship-time
+    defaults on purpose (config.py stays import-light, so the values are
+    duplicated and this test is the lock between them)."""
+    from helix_context.scoring import know_calibration as kc
+
+    k = KnowConfig()
+    assert tuple(k.betas) == kc.DEFAULT_BETAS
+    assert k.s_ref == kc.DEFAULT_S_REF
+    assert k.g_ref == kc.DEFAULT_G_REF
+    assert k.emit_floor == kc.DEFAULT_EMIT_FLOOR
+    assert k.stale_after_days == kc.DEFAULT_STALE_AFTER_DAYS
+    assert len(k.betas) == 1 + kc.N_FEATURES
+
+
+def test_know_section_loads_through_config(tmp_path):
+    """[know] is a first-class config section now (not a shadow loader)."""
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[know]\n"
+        "emit_floor = 0.7\n"
+        "s_ref = 2.0\n"
+        "g_ref = 0.25\n"
+        "betas = [-1.0, 1.0, 1.0, 0.5, 1.0, 0.5]\n"
+        "calibrated_at = \"2026-06-01T00:00:00Z\"\n"
+        "calibrated_on_n = 800\n"
+        "stale_after_days = 7\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(str(toml))
+    assert cfg.know.emit_floor == 0.7
+    assert cfg.know.s_ref == 2.0
+    assert cfg.know.g_ref == 0.25
+    assert cfg.know.betas == [-1.0, 1.0, 1.0, 0.5, 1.0, 0.5]
+    assert cfg.know.calibrated_at == "2026-06-01T00:00:00Z"
+    assert cfg.know.calibrated_on_n == 800
+    assert cfg.know.stale_after_days == 7
+
+
+def test_know_section_malformed_betas_soft_fail(tmp_path, caplog):
+    """Bad calibration writes must never break startup (shadow-loader
+    contract, kept verbatim in the config loader)."""
+    import logging
+
+    toml = tmp_path / "helix.toml"
+    toml.write_text('[know]\nbetas = ["nope"]\nstale_after_days = -3\n', encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="helix_context.config"):
+        cfg = load_config(str(toml))
+    assert cfg.know.betas == list(KnowConfig().betas)
+    assert cfg.know.stale_after_days == KnowConfig().stale_after_days
+    assert any("betas" in r.message for r in caplog.records)
+
+
+def test_know_section_wrong_length_betas_soft_fail(tmp_path):
+    toml = tmp_path / "helix.toml"
+    toml.write_text("[know]\nbetas = [1.0, 2.0]\n", encoding="utf-8")
+    cfg = load_config(str(toml))
+    assert cfg.know.betas == list(KnowConfig().betas)
+
+
+def test_load_calibration_from_toml_back_compat_delegates_to_config(tmp_path):
+    """The legacy entry point must keep working for direct callers, now
+    routed through load_config + calibration_from_config."""
+    from helix_context.scoring.know_calibration import (
+        KnowCalibration,
+        calibration_from_config,
+        load_calibration_from_toml,
+    )
+
+    toml = tmp_path / "helix.toml"
+    toml.write_text(
+        "[know]\nemit_floor = 0.61\nbetas = [-2.0, 2.0, 1.5, 0.7, 1.8, 1.5]\n"
+        "stale_after_days = 14\n",
+        encoding="utf-8",
+    )
+    via_shim = load_calibration_from_toml(toml)
+    via_config = calibration_from_config(load_config(str(toml)).know)
+    assert isinstance(via_shim, KnowCalibration)
+    assert via_shim == via_config
+    assert via_shim.emit_floor == 0.61
+    assert via_shim.stale_after_days == 14
+    assert via_shim.betas == (-2.0, 2.0, 1.5, 0.7, 1.8, 1.5)  # tuple, frozen
+
+
+def test_load_calibration_from_toml_no_args_self_loads(tmp_path, monkeypatch):
+    """Callers that pass nothing still self-load via the config system
+    (HELIX_CONFIG / ./helix.toml discovery) and default cleanly when no
+    file exists."""
+    from helix_context.scoring.know_calibration import (
+        KnowCalibration,
+        load_calibration_from_toml,
+    )
+
+    monkeypatch.delenv("HELIX_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)  # no helix.toml here
+    assert load_calibration_from_toml() == KnowCalibration()
+
+    # And the env-var discovery path the old shadow loader never had:
+    custom = tmp_path / "custom.toml"
+    custom.write_text("[know]\nemit_floor = 0.9\n", encoding="utf-8")
+    monkeypatch.setenv("HELIX_CONFIG", str(custom))
+    assert load_calibration_from_toml().emit_floor == 0.9

--- a/tests/test_shard_router.py
+++ b/tests/test_shard_router.py
@@ -27,7 +27,11 @@ from helix_context.schemas import (
     PromoterTags,
 )
 from helix_context.hardware import sqlite_memory_budget
-from helix_context.shard_router import ShardRouter, use_shards_enabled
+from helix_context.shard_router import (
+    ShardRouter,
+    shard_fanout_workers,
+    use_shards_enabled,
+)
 from helix_context.shard_schema import (
     init_main_db,
     open_main_db,
@@ -1438,11 +1442,17 @@ def test_doc_type_boost_skipped_on_single_shard_path(two_shard_setup):
 
 
 def test_parallel_fanout_matches_serial_byte_for_byte(two_shard_setup, monkeypatch):
-    """HELIX_SHARD_WORKERS>1 must yield identical ranked ids + scores to serial."""
+    """HELIX_SHARD_WORKERS>1 must yield identical ranked ids + scores to serial.
+
+    Issue #206 (2026-06-12): the serial reference leg is pinned EXPLICITLY
+    via HELIX_SHARD_WORKERS=1 rather than by deleting the env var — unset
+    now auto-sizes the pool when >4 shards are routed, so "unset" is no
+    longer a guaranteed serial oracle on every fixture shape.
+    """
     main_path = two_shard_setup["main_path"]
     q = dict(domains=["auth", "docs"], entities=["helix", "jwt"], max_genes=10)
 
-    monkeypatch.delenv("HELIX_SHARD_WORKERS", raising=False)
+    monkeypatch.setenv("HELIX_SHARD_WORKERS", "1")
     r1 = ShardRouter(main_path)
     try:
         serial = r1.query_genes(**q)
@@ -1505,7 +1515,12 @@ def test_parallel_fanout_actually_uses_threadpool(two_shard_setup, monkeypatch):
 
 
 def test_serial_default_does_not_use_threadpool(two_shard_setup, monkeypatch):
-    """Default (no HELIX_SHARD_WORKERS) stays on the serial path — no pool."""
+    """Default (no HELIX_SHARD_WORKERS) stays serial for SMALL fan-outs.
+
+    Issue #206 (2026-06-12): unset env auto-sizes only when >4 shards are
+    routed; this fixture routes 2, so the serial reference path must still
+    be taken with no pool spun up.
+    """
     import helix_context.shard_router as sr
 
     seen = {"used": False}
@@ -1525,6 +1540,107 @@ def test_serial_default_does_not_use_threadpool(two_shard_setup, monkeypatch):
         router.close()
 
     assert seen["used"] is False, "serial default must not spin up a thread pool"
+
+
+# ── Issue #206 (2026-06-12): auto shard fan-out sizing ────────────────────
+#
+# Serial-by-default measured 5 min/query at 829K genes / 100 shards vs ~55s
+# at 8 workers. Resolution: HELIX_SHARD_WORKERS unset → auto_shard_workers()
+# when >4 shards are routed, else the serial reference path; an explicit env
+# value always wins; HELIX_SHARD_WORKERS=1 forces serial.
+
+
+def test_workers_unset_small_fanout_stays_serial(monkeypatch):
+    """Unset env + ≤4 routed shards → 1 (serial reference oracle)."""
+    import helix_context.parallel as par
+
+    monkeypatch.delenv("HELIX_SHARD_WORKERS", raising=False)
+    monkeypatch.setattr(
+        par, "auto_shard_workers",
+        lambda *a, **k: pytest.fail("sizer must not be consulted at ≤4 shards"),
+    )
+    assert shard_fanout_workers() == 1            # back-compat: no count given
+    assert shard_fanout_workers(None) == 1
+    assert shard_fanout_workers(2) == 1
+    assert shard_fanout_workers(4) == 1           # boundary: strictly >4 opts in
+
+
+def test_workers_unset_large_fanout_auto_sizes(monkeypatch):
+    """Unset env + >4 routed shards → auto_shard_workers() sizes the pool."""
+    import helix_context.parallel as par
+
+    monkeypatch.delenv("HELIX_SHARD_WORKERS", raising=False)
+    monkeypatch.setattr(par, "auto_shard_workers", lambda *a, **k: 7)
+    assert shard_fanout_workers(5) == 7
+    assert shard_fanout_workers(100) == 7
+
+
+def test_workers_explicit_env_always_wins(monkeypatch):
+    """An explicit HELIX_SHARD_WORKERS beats the auto-sizer at any shard count."""
+    import helix_context.parallel as par
+
+    monkeypatch.setattr(
+        par, "auto_shard_workers",
+        lambda *a, **k: pytest.fail("explicit env must short-circuit the sizer"),
+    )
+    monkeypatch.setenv("HELIX_SHARD_WORKERS", "8")
+    assert shard_fanout_workers(2) == 8
+    assert shard_fanout_workers(100) == 8
+
+
+def test_workers_env_one_forces_serial(monkeypatch):
+    """HELIX_SHARD_WORKERS=1 pins the serial reference path even at 100 shards."""
+    import helix_context.parallel as par
+
+    monkeypatch.setattr(
+        par, "auto_shard_workers",
+        lambda *a, **k: pytest.fail("=1 must force serial without sizing"),
+    )
+    monkeypatch.setenv("HELIX_SHARD_WORKERS", "1")
+    assert shard_fanout_workers(100) == 1
+
+
+def test_workers_unparseable_env_keeps_legacy_serial(monkeypatch):
+    """Garbage env values keep the legacy fail-safe: serial."""
+    monkeypatch.setenv("HELIX_SHARD_WORKERS", "lots")
+    assert shard_fanout_workers(100) == 1
+
+
+def test_workers_sizer_failure_falls_back_serial(monkeypatch):
+    """A sizer probe blow-up degrades to serial instead of raising."""
+    import helix_context.parallel as par
+
+    monkeypatch.delenv("HELIX_SHARD_WORKERS", raising=False)
+
+    def _boom(*a, **k):
+        raise RuntimeError("vram probe exploded")
+
+    monkeypatch.setattr(par, "auto_shard_workers", _boom)
+    assert shard_fanout_workers(100) == 1
+
+
+def test_router_passes_routed_shard_count_to_sizer(two_shard_setup, monkeypatch):
+    """query_genes must hand the per-query ROUTED shard count to
+    shard_fanout_workers — that is the number that decides serial vs auto."""
+    import helix_context.shard_router as sr
+
+    seen = {}
+    real = sr.shard_fanout_workers
+
+    def _spy(n_shards=None):
+        seen["n_shards"] = n_shards
+        return real(n_shards)
+
+    monkeypatch.delenv("HELIX_SHARD_WORKERS", raising=False)
+    monkeypatch.setattr(sr, "shard_fanout_workers", _spy)
+    router = ShardRouter(two_shard_setup["main_path"])
+    try:
+        router.query_genes(domains=["auth", "docs"], entities=[], max_genes=10)
+    finally:
+        router.close()
+    assert seen.get("n_shards") == 2, (
+        "router must pass len(shard_names) so >4-shard stores auto-size"
+    )
 
 
 def test_close_calls_genome_close_for_checkpoint(two_shard_setup):


### PR DESCRIPTION
Council Option B, slice 1 (consensus report: `docs/audits/2026-06-12-pipeline-value-consensus.md`). The council estimated 5 code-vs-toml default drifts; the new comparator ratchet found **20**. Resolution policy: the shipped helix.toml is the operationally-tested product (every bench this month ran it), so **toml won** unless a feature was measured at zero effect.

## Every default changed (code → new value) — review and veto individually if needed

**[budget]**: expression_tokens 6000→7000 · max_genes_per_turn 8→12 · splice_aggressiveness 0.5→0.3 · decoder_mode full→condensed · session_delivery_enabled false→**true**
**[ribosome]**: backend ollama→**none** (core pip install now serves without an LLM dependency — matches the pyproject "core gives a working server" contract) · model auto→gemma4:e2b · timeout 10→120 · warmup true→false · query_expansion_enabled true→false
**[genome]**: path genome.db→genomes/main/genome.db
**[ingestion]**: backend ollama→**cpu** · splade_enabled false→**true** (scale-conditional cost; the #164/#189 auto-disable knob covers the >200K cliff) · rerank_model ""→ms-marco-MiniLM (inert while rerank_enabled=false) · entity_graph false→true
**[retrieval]**: filename_anchor false→true (+24pp on code corpora) · bm25_shortlist false→true (8/8 on config-value queries) · plr.enabled false→true (soft-no-op without artifact) · headroom.enabled false→true (launcher-only)
**Inverse (measured-zero, code wins)**: sr_enabled — toml true→**false** (roadmap: sr measured zero everywhere), evidence noted in the toml comment.
Allowlist (intentional divergence): `synonym_map` starter vocabulary only.

## Also in this slice
- **Real `KnowConfig`**: the `[know]` section was parsed by a shadow loader in know_calibration.py outside the config system, while CLAUDE.md advertised keys that don't exist. KnowConfig now lives in config.py (real keys: emit_floor, s_ref, g_ref, betas[6], calibrated_at, calibrated_on_n, stale_after_days), the shadow loader is a back-compat shim, `/context` consumes live config, CLAUDE.md `[know]`/`[classifier]` rows corrected.
- **Auto shard fan-out**: HELIX_SHARD_WORKERS unset + >4 routed shards → `auto_shard_workers()` (previously unwired); explicit env always wins; =1 forces the serial reference path. Evidence: serial default measured 5 min/query at 829K/100 shards vs ~55s at 8 workers (#206). Determinism tests now pin serial explicitly.
- **Ratchet test**: `test_shipped_toml_matches_code_defaults` — any future drift between config.py and helix.toml fails CI with a named field list.

## Test plan
- [x] 73 passed locally (honesty ratchet + config + shard_router); ~2,210 full-suite in sandbox (5 pre-existing container failures verified on base)
- [x] Know back-compat shim covered; worker-selection matrix covered (7 tests)
