### PR TITLE
perf(serving): lazy encoder loading - models load on first use, [hardware] lazy_encoders knob (#219 slice 2)

### DIFF
--- a/helix.toml
+++ b/helix.toml
@@ -67,6 +67,16 @@ batch_sizes = "auto"
 # the tray surfaces a one-time balloon. Set to 0 to disable.
 low_vram_threshold_gb = 4.0
 
+# Encoder lazy-loading (#219 slice 2). true (default) defers heavy encoder
+# construction (ΣĒMA MiniLM, DeBERTa rerank/splice) to first use, so an idle
+# serving process stays lean (an 829K-gene server measured 20.3 GB RSS with
+# the fully-eager stack; tray backend + bench server + build workers each
+# paid it — the #176/#191 3-CUDA-context incident class). false restores
+# eager warmup at boot: first-query latency paid up front. SPLADE / BGE-M3 /
+# spaCy load on first use either way. /admin/components shows
+# "idle (not loaded)" vs loaded per component.
+lazy_encoders = true
+
 [budget]
 ribosome_tokens = 3000                  # fixed decoder prompt
 expression_tokens = 7000                # ~7K expressions cap (BROAD tighten 2026-05-12, bench-gated #73). Code default matches since the 2026-06-12 default-honesty pass.

--- a/helix_context/backends/sema.py
+++ b/helix_context/backends/sema.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -256,3 +257,109 @@ class SemaCodec:
     @property
     def embed_dim(self) -> int:
         return self._embed_dim
+
+
+# ── Lazy construction (#219 slice 2) ─────────────────────────────────
+
+
+def sema_available() -> bool:
+    """Cheap availability probe: is sentence-transformers importable?
+
+    Uses ``find_spec`` so the probe itself never imports (or loads) the
+    package — a serving process that never touches a semantic path must
+    not pay the transformer import at boot.
+    """
+    try:
+        import importlib.util
+        return importlib.util.find_spec("sentence_transformers") is not None
+    except Exception:  # pragma: no cover - importlib metadata edge cases
+        return False
+
+
+class LazySemaCodec:
+    """Deferred-construction proxy around :class:`SemaCodec` (#219 slice 2).
+
+    Holds the construction args and builds the real codec — the
+    sentence-transformer model plus the 20-anchor projection — on the
+    first encoding call, behind a double-checked lock so concurrent first
+    users construct exactly once. Pure-math statics (``similarity`` /
+    ``nearest``) pass straight through without forcing a load.
+
+    ``loaded`` / ``peek()`` let GET /admin/components report
+    "idle (not loaded)" vs loaded without materializing the model.
+
+    A construction failure is cached and re-raised on subsequent calls.
+    Every sema call site already guards with try/except, so a broken
+    install degrades to "ΣĒMA disabled" exactly like the old eager path —
+    without re-attempting a model load on every call.
+    """
+
+    is_lazy_component = True
+
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        device: Optional[str] = None,
+    ):
+        self._model_name = model_name
+        self._device = device
+        self._codec: Optional[SemaCodec] = None
+        self._load_error: Optional[BaseException] = None
+        self._lock = threading.Lock()
+
+    @property
+    def loaded(self) -> bool:
+        """True once the underlying SemaCodec has been constructed."""
+        return self._codec is not None
+
+    def peek(self) -> Optional[SemaCodec]:
+        """The materialized codec, or None — never triggers a load."""
+        return self._codec
+
+    def warm(self) -> SemaCodec:
+        """Force construction now ([hardware] lazy_encoders = false)."""
+        return self._materialize()
+
+    def _materialize(self) -> SemaCodec:
+        codec = self._codec
+        if codec is not None:
+            return codec
+        with self._lock:
+            if self._codec is None:
+                if self._load_error is not None:
+                    raise self._load_error
+                try:
+                    # Module-global name lookup on purpose: tests monkeypatch
+                    # helix_context.backends.sema.SemaCodec with counting
+                    # fakes, and the eager ctor args are preserved verbatim.
+                    self._codec = SemaCodec(
+                        model_name=self._model_name, device=self._device,
+                    )
+                except BaseException as exc:
+                    self._load_error = exc
+                    raise
+            return self._codec
+
+    # Pure numpy — no model involved; never force a load for these.
+    similarity = staticmethod(SemaCodec.similarity)
+    nearest = staticmethod(SemaCodec.nearest)
+
+    def encode(self, text: str) -> List[float]:
+        return self._materialize().encode(text)
+
+    def encode_batch(self, texts: List[str], batch_size: int = 64) -> List[List[float]]:
+        return self._materialize().encode_batch(texts, batch_size=batch_size)
+
+    def signature(self, text: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        return self._materialize().signature(text, top_k=top_k)
+
+    def fingerprint(self, text: str) -> str:
+        return self._materialize().fingerprint(text)
+
+    @property
+    def projection_matrix(self) -> np.ndarray:
+        return self._materialize().projection_matrix
+
+    @property
+    def embed_dim(self) -> int:
+        return self._materialize().embed_dim

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -635,6 +635,12 @@ class Hardware:
     device: str = "auto"
     batch_sizes: Dict[str, int] = field(default_factory=dict)
     low_vram_threshold_gb: float = 4.0
+    # #219 slice 2: when true (default), heavy encoders (ΣĒMA MiniLM,
+    # DeBERTa rerank/splice) are armed lazily and load on FIRST USE; when
+    # false, restore the pre-slice eager warmup at manager init for
+    # operators who want first-query latency paid at boot. SPLADE /
+    # BGE-M3 / spaCy were already first-use-lazy and ignore this knob.
+    lazy_encoders: bool = True
 
 
 @dataclass
@@ -1123,6 +1129,7 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
         device=str(hardware_device),
         batch_sizes=bs,
         low_vram_threshold_gb=float(hw.get("low_vram_threshold_gb", 4.0)),
+        lazy_encoders=bool(hw.get("lazy_encoders", True)),
     )
 
     # Vault — Obsidian export (opt-in, off by default)

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -469,6 +469,87 @@ def _merge_subquery_candidates(
     )
 
 
+class LazyRibosome:
+    """Deferred-construction proxy for a heavy ribosome backend (#219 slice 2).
+
+    Wraps a zero-arg factory (e.g. the DeBERTa hybrid ribosome: two
+    DeBERTa-v3 models) and constructs it on first real use behind a
+    double-checked lock. Until then the serving process pays nothing for
+    it — part of the fix for the 20.3 GB-RSS-at-boot eager stack, where
+    every process (tray backend, bench server, build workers) loaded the
+    full encoder stack whether or not the workload touched it (the
+    #176/#191 3-CUDA-context incident class).
+
+    Any public attribute access (``re_rank``, ``splice``, ``encode``,
+    ``classify_relations``, ``backend``, …) materializes the real object
+    and forwards to it, so behavior after first use is identical to the
+    eager construction. Private/dunder lookups raise AttributeError
+    instead of forcing a load, so stdlib introspection (copy/pickle/repr
+    machinery) can never accidentally pull in a multi-GB model.
+
+    If the factory raises, the failure is logged once and the proxy
+    permanently falls back to ``fallback`` (the disabled ribosome) — the
+    same end state as the old eager try/except at manager init.
+
+    ``loaded`` / ``peek()`` / ``label`` are non-forcing introspection
+    hooks for GET /admin/components.
+    """
+
+    is_lazy_component = True
+
+    def __init__(self, factory, fallback, label: str = ""):
+        self._factory = factory
+        self._fallback = fallback
+        self._obj = None
+        self._lock = threading.Lock()
+        self._label = label
+
+    @property
+    def loaded(self) -> bool:
+        """True once the real ribosome (or its fallback) is resident."""
+        return self._obj is not None
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    def peek(self):
+        """The materialized ribosome, or None — never triggers a load."""
+        return self._obj
+
+    def warm(self):
+        """Force construction now ([hardware] lazy_encoders = false path)."""
+        return self._materialize()
+
+    def _materialize(self):
+        obj = self._obj
+        if obj is not None:
+            return obj
+        with self._lock:
+            if self._obj is None:
+                try:
+                    self._obj = self._factory()
+                    log.info(
+                        "Lazy %s ribosome materialized on first use",
+                        self._label or "backend",
+                    )
+                except Exception:
+                    log.warning(
+                        "%s backend failed to load, disabling ribosome",
+                        self._label or "lazy", exc_info=True,
+                    )
+                    self._obj = self._fallback
+            return self._obj
+
+    def __getattr__(self, name: str):
+        # Only reached when normal attribute lookup misses. Refuse
+        # private/dunder names so hasattr() probes on internals and
+        # stdlib introspection stay load-free.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._materialize(), name)
+
+
 class HelixContextManager:
     """
     Main orchestrator. Sits between the client and the upstream LLM.
@@ -509,15 +590,32 @@ class HelixContextManager:
             _metrics_path = _genome_path.parent / "metrics.json"
         self.token_counter: TokenCounter = TokenCounter(persist_path=_metrics_path)
 
-        # ΣĒMA codec (optional — loaded if sentence-transformers available)
+        # ΣĒMA codec (optional — requires sentence-transformers).
+        # #219 slice 2: armed lazily by default ([hardware] lazy_encoders).
+        # A serving process that never touches a semantic path no longer
+        # pays the MiniLM load at boot (part of the 20.3 GB-RSS eager
+        # stack); the first encode constructs the model under a
+        # double-checked lock. lazy_encoders = false restores the
+        # pre-slice eager warmup so first-query latency is paid at boot.
         self._sema_codec = None
+        self._lazy_encoders = bool(getattr(config.hardware, "lazy_encoders", True))
         try:
-            from .backends.sema import SemaCodec
-            self._sema_codec = SemaCodec()
-            log.info("ΣĒMA codec loaded — semantic retrieval enabled")
+            from .backends.sema import LazySemaCodec, sema_available
+            if sema_available():
+                self._sema_codec = LazySemaCodec()
+                if self._lazy_encoders:
+                    log.info(
+                        "ΣĒMA codec armed (lazy) — model loads on first semantic call"
+                    )
+                else:
+                    self._sema_codec.warm()
+                    log.info("ΣĒMA codec loaded — semantic retrieval enabled")
+            else:
+                log.info("sentence-transformers not installed — ΣĒMA disabled")
         except ImportError:
             log.info("sentence-transformers not installed — ΣĒMA disabled")
         except Exception:
+            self._sema_codec = None
             log.warning("ΣĒMA codec failed to load", exc_info=True)
 
         # BGE-M3 dense codec (Tier-0 PR-1, 2026-05-16). Lazy-loaded on the
@@ -646,34 +744,59 @@ class HelixContextManager:
             except Exception:
                 log.warning("LiteLLMBackend failed to load, disabling ribosome", exc_info=True)
         elif effective_backend == "deberta":
-            try:
+            def _build_deberta_ribosome(
+                _config: HelixConfig = config,
+                _encoder: CodonEncoder = self.encoder,
+            ):
+                """Construct the DeBERTa hybrid ribosome (two DeBERTa-v3 loads).
+
+                Construction args are byte-for-byte the old eager ones —
+                only the WHEN moves (#219 slice 2).
+                """
                 from .backends.deberta_backend import DeBERTaRibosome
                 ollama_backend = OllamaBackend(
-                    model=config.ribosome.model,
-                    base_url=config.ribosome.base_url,
-                    timeout=config.ribosome.timeout,
-                    keep_alive=config.ribosome.keep_alive,
-                    warmup=config.ribosome.warmup,
+                    model=_config.ribosome.model,
+                    base_url=_config.ribosome.base_url,
+                    timeout=_config.ribosome.timeout,
+                    keep_alive=_config.ribosome.keep_alive,
+                    warmup=_config.ribosome.warmup,
                 )
                 ollama_ribosome = Ribosome(
                     backend=ollama_backend,
-                    encoder=self.encoder,
-                    splice_aggressiveness=config.budget.splice_aggressiveness,
+                    encoder=_encoder,
+                    splice_aggressiveness=_config.budget.splice_aggressiveness,
                 )
-                self.ribosome = DeBERTaRibosome(
-                    rerank_model_path=config.ribosome.rerank_model_path,
-                    splice_model_path=config.ribosome.splice_model_path,
-                    nli_model_path=config.ribosome.nli_model_path,
+                return DeBERTaRibosome(
+                    rerank_model_path=_config.ribosome.rerank_model_path,
+                    splice_model_path=_config.ribosome.splice_model_path,
+                    nli_model_path=_config.ribosome.nli_model_path,
                     ollama_ribosome=ollama_ribosome,
-                    device=config.ribosome.device,
-                    splice_threshold=config.ribosome.splice_threshold,
-                    nli_splice_bonus=config.ribosome.nli_splice_bonus,
-                    nli_splice_penalty=config.ribosome.nli_splice_penalty,
-                    rerank_pretrained=config.ingestion.rerank_model,
+                    device=_config.ribosome.device,
+                    splice_threshold=_config.ribosome.splice_threshold,
+                    nli_splice_bonus=_config.ribosome.nli_splice_bonus,
+                    nli_splice_penalty=_config.ribosome.nli_splice_penalty,
+                    rerank_pretrained=_config.ingestion.rerank_model,
                 )
-                log.info("Using DeBERTa hybrid ribosome (re_rank + splice accelerated)")
-            except Exception:
-                log.warning("DeBERTa backend failed to load, disabling ribosome", exc_info=True)
+
+            if self._lazy_encoders:
+                # #219 slice 2: defer the two DeBERTa-v3 model loads to the
+                # first re_rank/splice/classify call. On load failure the
+                # proxy falls back to the disabled ribosome — same end state
+                # as the eager except-branch below.
+                self.ribosome = LazyRibosome(
+                    factory=_build_deberta_ribosome,
+                    fallback=self.ribosome,
+                    label="deberta",
+                )
+                log.info(
+                    "DeBERTa hybrid ribosome armed (lazy) — loads on first re_rank/splice"
+                )
+            else:
+                try:
+                    self.ribosome = _build_deberta_ribosome()
+                    log.info("Using DeBERTa hybrid ribosome (re_rank + splice accelerated)")
+                except Exception:
+                    log.warning("DeBERTa backend failed to load, disabling ribosome", exc_info=True)
         else:
             log.info(
                 "Ribosome disabled — only explicit LiteLLM or DeBERTa backends are honored "

--- a/helix_context/server/routes_admin.py
+++ b/helix_context/server/routes_admin.py
@@ -805,46 +805,117 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
 
     @app.get("/admin/components")
     async def admin_components():
-        """Return the list of active subsystems with running/idle status."""
+        """Return active subsystems with running/idle status + loaded-ness.
+
+        #219 slice 2: encoders may be armed lazily ([hardware]
+        lazy_encoders, default true), so a configured component is not
+        necessarily resident. This endpoint must NEVER force a lazy
+        component to materialize — loaded-ness is read through
+        non-forcing probes only (``peek()``/``loaded`` on lazy proxies,
+        the spaCy/SPLADE module globals, ``_model`` on the BGE-M3
+        codec). Components that are configured but not yet loaded report
+        ``status = "idle (not loaded)"`` and ``loaded = false``; loaded
+        components keep the running/idle activity semantics.
+        """
         import time as _time
         idle_threshold_s = 60.0
         age = _time.time() - getattr(helix, "_last_activity_ts", 0.0)
         active_status = "running" if age < idle_threshold_s else "idle"
-        ribosome_paused = id(helix.ribosome.backend) in _paused_ribosomes
-        ribosome_disabled = getattr(helix.ribosome.backend, "is_disabled_backend", False)
+
+        def _status(loaded: bool) -> str:
+            return active_status if loaded else "idle (not loaded)"
+
+        # ── ribosome (a LazyRibosome proxy when backend=deberta+lazy) ──
+        # type()-level probe: instance attribute access on the proxy
+        # would materialize the DeBERTa models.
+        rib = helix.ribosome
+        rib_is_lazy = bool(getattr(type(rib), "is_lazy_component", False))
+        rib_real = rib.peek() if rib_is_lazy else rib
+        rib_loaded = rib_real is not None
+        backend_obj = getattr(rib_real, "backend", None) if rib_loaded else None
+        ribosome_paused = backend_obj is not None and id(backend_obj) in _paused_ribosomes
+        ribosome_disabled = bool(getattr(backend_obj, "is_disabled_backend", False))
 
         components = []
 
         if not ribosome_paused and not ribosome_disabled:
-            ribosome_backend = "unknown"
-            if hasattr(helix.ribosome, "backend") and hasattr(helix.ribosome.backend, "model"):
-                ribosome_backend = helix.ribosome.backend.model
+            if rib_is_lazy:
+                ribosome_backend = rib.label or "unknown"
+            elif backend_obj is not None and hasattr(backend_obj, "model"):
+                ribosome_backend = backend_obj.model
+            else:
+                ribosome_backend = "unknown"
             components.append({
                 "name": "ribosome",
                 "kind": "decoder",
-                "status": active_status,
+                "status": _status(rib_loaded),
                 "backend": ribosome_backend,
+                "loaded": rib_loaded,
             })
 
-        if getattr(helix, "_sema_codec", None) is not None:
+        sema = getattr(helix, "_sema_codec", None)
+        if sema is not None:
+            # LazySemaCodec exposes ``loaded`` without touching the model;
+            # a plain (eager) SemaCodec has no such attr -> resident.
+            sema_loaded = bool(getattr(sema, "loaded", True))
             components.append({
                 "name": "sema",
                 "kind": "encoder",
-                "status": active_status,
+                "status": _status(sema_loaded),
+                "loaded": sema_loaded,
             })
 
         if getattr(helix, "_cpu_tagger", None) is not None:
+            # spaCy loads lazily inside tagger._get_nlp(); the module
+            # global reflects whether the pipeline is resident.
+            try:
+                from .. import tagger as _tagger_mod
+                tagger_loaded = getattr(_tagger_mod, "_nlp", None) is not None
+            except Exception:
+                tagger_loaded = False
             components.append({
                 "name": "cpu_tagger",
                 "kind": "encoder",
-                "status": active_status,
+                "status": _status(tagger_loaded),
+                "loaded": tagger_loaded,
             })
 
         if getattr(helix.genome, "_splade_enabled", False):
+            # splade_backend keeps its model in a module global, set on
+            # first encode (already first-use-lazy pre-#219).
+            try:
+                from ..backends import splade_backend as _splade_mod
+                splade_loaded = getattr(_splade_mod, "_model", None) is not None
+            except Exception:
+                splade_loaded = False
             components.append({
                 "name": "splade",
                 "kind": "encoder",
-                "status": active_status,
+                "status": _status(splade_loaded),
+                "loaded": splade_loaded,
+            })
+
+        # BGE-M3 dense codec — surfaced so operators can see whether the
+        # ~2 GB model is resident. Loaded when either holder (manager
+        # ingest-side, store query-side) has a materialized model; the
+        # codec wrapper itself is cheap and loads weights on first encode.
+        dense_enabled = bool(
+            getattr(helix.genome, "_dense_embedding_enabled", False)
+            or getattr(config.ingestion, "dense_embed_on_ingest", False)
+        )
+        if dense_enabled:
+            dense_loaded = any(
+                holder is not None and getattr(holder, "_model", None) is not None
+                for holder in (
+                    getattr(helix, "_dense_codec", None),
+                    getattr(helix.genome, "_dense_codec", None),
+                )
+            )
+            components.append({
+                "name": "dense_bgem3",
+                "kind": "encoder",
+                "status": _status(dense_loaded),
+                "loaded": dense_loaded,
             })
 
         if getattr(helix.genome, "_entity_graph_enabled", False):
@@ -852,6 +923,7 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
                 "name": "entity_graph",
                 "kind": "encoder",
                 "status": active_status,
+                "loaded": True,
             })
 
         try:
@@ -861,6 +933,7 @@ def setup_admin_routes(app: FastAPI, helix, config, registry, bridge, **_kw) -> 
                     "name": "headroom",
                     "kind": "decoder",
                     "status": active_status,
+                    "loaded": True,
                 })
         except Exception:
             pass

--- a/tests/test_lazy_encoders.py
+++ b/tests/test_lazy_encoders.py
@@ -1,0 +1,389 @@
+"""#219 slice 2 — lazy encoder loading (council Option-A rider).
+
+A serving process at 829K genes measured 20.3 GB RSS because the encoder
+stack loaded eagerly at manager init; every process (tray backend, bench
+server, build workers) paid the full stack whether or not the workload
+touched it — the #176/#191 3-CUDA-context incident class. This suite
+verifies the fix WITHOUT any real models: constructors are monkeypatched
+with counting (or raising) fakes.
+
+Covered:
+- HelixContextManager init constructs NO encoder (sema / spacy / splade /
+  bgem3 / deberta all untouched);
+- first use constructs exactly once; later uses reuse the instance;
+- concurrent first use constructs exactly once (double-checked lock);
+- [hardware] lazy_encoders = false restores eager construction at init;
+- GET /admin/components reports loaded-ness without forcing a load;
+- DeBERTa factory failure falls back to the disabled ribosome (the old
+  eager except-branch end state).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+from helix_context.backends import sema as sema_mod
+from helix_context.config import (
+    GenomeConfig,
+    Hardware,
+    HelixConfig,
+    RibosomeConfig,
+    ServerConfig,
+    load_config,
+)
+from helix_context.context_manager import HelixContextManager, LazyRibosome
+
+
+# ── fakes ────────────────────────────────────────────────────────────
+
+
+class CountingSemaCodec:
+    """Stands in for SemaCodec; records constructions and encodes."""
+
+    constructions = 0
+    construct_delay_s = 0.0
+
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2", device=None):
+        if type(self).construct_delay_s:
+            time.sleep(type(self).construct_delay_s)
+        type(self).constructions += 1
+        self.model_name = model_name
+        self.device = device
+
+    def encode(self, text):
+        return [0.0] * 20
+
+    def encode_batch(self, texts, batch_size: int = 64):
+        return [[0.0] * 20 for _ in texts]
+
+    def signature(self, text, top_k: int = 5):
+        return []
+
+    def fingerprint(self, text):
+        return ""
+
+    @property
+    def projection_matrix(self):
+        return None
+
+    @property
+    def embed_dim(self):
+        return 384
+
+
+@pytest.fixture
+def fake_sema(monkeypatch):
+    """Pretend sentence-transformers is installed; count SemaCodec builds."""
+
+    class _Fake(CountingSemaCodec):
+        constructions = 0
+        construct_delay_s = 0.0
+
+    monkeypatch.setattr(sema_mod, "sema_available", lambda: True)
+    monkeypatch.setattr(sema_mod, "SemaCodec", _Fake)
+    return _Fake
+
+
+@pytest.fixture
+def fake_deberta(monkeypatch):
+    """Inject a fake deberta_backend module (real one imports torch)."""
+
+    mod = types.ModuleType("helix_context.backends.deberta_backend")
+
+    class FakeDeBERTaRibosome:
+        constructions = 0
+
+        def __init__(self, **kwargs):
+            type(self).constructions += 1
+            self.kwargs = kwargs
+
+        def re_rank(self, query, candidates, k: int = 5):
+            return list(candidates)[:k]
+
+        def classify_relations(self, candidates):
+            return {}
+
+    mod.DeBERTaRibosome = FakeDeBERTaRibosome
+    monkeypatch.setitem(
+        sys.modules, "helix_context.backends.deberta_backend", mod
+    )
+    return FakeDeBERTaRibosome
+
+
+def _config(tmp_path, **hardware_kwargs) -> HelixConfig:
+    return HelixConfig(
+        genome=GenomeConfig(path=str(tmp_path / "genome.db"), cold_start_threshold=5),
+        server=ServerConfig(upstream="http://localhost:11434"),
+        hardware=Hardware(**hardware_kwargs),
+    )
+
+
+def _deberta_config(tmp_path, lazy: bool = True) -> HelixConfig:
+    return HelixConfig(
+        genome=GenomeConfig(path=str(tmp_path / "genome.db"), cold_start_threshold=5),
+        server=ServerConfig(upstream="http://localhost:11434"),
+        ribosome=RibosomeConfig(
+            enabled=True, backend="deberta", model="mock", warmup=False, timeout=2,
+        ),
+        hardware=Hardware(lazy_encoders=lazy),
+    )
+
+
+# ── init must not construct anything ─────────────────────────────────
+
+
+def test_manager_init_constructs_no_encoders(tmp_path, fake_sema, monkeypatch):
+    # spaCy: explode if anything tries to load it during init.
+    fake_spacy = types.ModuleType("spacy")
+
+    def _no_load(*args, **kwargs):
+        raise AssertionError("spacy.load called during manager init")
+
+    fake_spacy.load = _no_load
+    monkeypatch.setitem(sys.modules, "spacy", fake_spacy)
+
+    import helix_context.tagger as tagger_mod
+    from helix_context.backends import splade_backend
+
+    mgr = HelixContextManager(_config(tmp_path))
+
+    # SemaCodec deferred: proxy armed, model not constructed.
+    assert fake_sema.constructions == 0
+    assert isinstance(mgr._sema_codec, sema_mod.LazySemaCodec)
+    assert mgr._sema_codec.loaded is False
+    # The knowledge store received the same proxy, so the store-side
+    # tier-4 encode is the (single) load trigger.
+    assert mgr.genome._sema_codec is mgr._sema_codec
+    # Already-lazy components stayed unloaded too.
+    assert splade_backend._model is None
+    assert getattr(tagger_mod, "_nlp", None) is None
+    assert mgr._dense_codec is None
+    assert getattr(mgr.genome, "_dense_codec", None) is None
+
+
+def test_sema_disabled_when_dependency_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(sema_mod, "sema_available", lambda: False)
+    mgr = HelixContextManager(_config(tmp_path))
+    assert mgr._sema_codec is None
+
+
+# ── first use semantics ──────────────────────────────────────────────
+
+
+def test_first_use_constructs_exactly_once(tmp_path, fake_sema):
+    mgr = HelixContextManager(_config(tmp_path))
+    codec = mgr._sema_codec
+    assert fake_sema.constructions == 0
+
+    vec = codec.encode("what does the splice step do?")
+    assert vec == [0.0] * 20
+    assert fake_sema.constructions == 1
+    assert codec.loaded is True
+    assert codec.peek() is not None
+
+    codec.encode("again")
+    codec.encode_batch(["a", "b"])
+    assert fake_sema.constructions == 1
+
+
+def test_static_math_does_not_force_load(tmp_path, fake_sema):
+    mgr = HelixContextManager(_config(tmp_path))
+    codec = mgr._sema_codec
+    e0 = [1.0] + [0.0] * 19
+    assert codec.similarity(e0, e0) == pytest.approx(1.0)
+    nearest = codec.nearest(e0, [("g1", e0)], k=1)
+    assert nearest[0][0] == "g1"
+    assert fake_sema.constructions == 0
+    assert codec.loaded is False
+
+
+def test_concurrent_first_use_constructs_once(tmp_path, fake_sema):
+    fake_sema.construct_delay_s = 0.05
+    mgr = HelixContextManager(_config(tmp_path))
+    codec = mgr._sema_codec
+    errors = []
+    barrier = threading.Barrier(8)
+
+    def hit():
+        try:
+            barrier.wait(timeout=5)
+            codec.encode("race")
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hit) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    assert not errors
+    assert fake_sema.constructions == 1
+
+
+def test_sema_load_failure_cached_not_retried(tmp_path, fake_sema, monkeypatch):
+    boom_calls = []
+
+    class _Boom:
+        def __init__(self, **kwargs):
+            boom_calls.append(1)
+            raise RuntimeError("model download failed")
+
+    monkeypatch.setattr(sema_mod, "SemaCodec", _Boom)
+    mgr = HelixContextManager(_config(tmp_path))
+    codec = mgr._sema_codec
+    with pytest.raises(RuntimeError):
+        codec.encode("x")
+    with pytest.raises(RuntimeError):
+        codec.encode("y")
+    # Construction attempted exactly once; the failure is cached.
+    assert len(boom_calls) == 1
+    assert codec.loaded is False
+
+
+# ── the [hardware] lazy_encoders knob ────────────────────────────────
+
+
+def test_lazy_encoders_false_restores_eager(tmp_path, fake_sema):
+    mgr = HelixContextManager(_config(tmp_path, lazy_encoders=False))
+    assert fake_sema.constructions == 1
+    assert mgr._sema_codec is not None
+    assert mgr._sema_codec.loaded is True
+
+
+def test_lazy_encoders_knob_parses_from_toml(tmp_path):
+    p = tmp_path / "helix.toml"
+    p.write_text("[hardware]\nlazy_encoders = false\n", encoding="utf-8")
+    cfg = load_config(str(p))
+    assert cfg.hardware.lazy_encoders is False
+    # Default stays true (lazy).
+    assert HelixConfig().hardware.lazy_encoders is True
+    p2 = tmp_path / "helix2.toml"
+    p2.write_text("[hardware]\ndevice = \"cpu\"\n", encoding="utf-8")
+    assert load_config(str(p2)).hardware.lazy_encoders is True
+
+
+# ── DeBERTa ribosome ─────────────────────────────────────────────────
+
+
+def test_deberta_lazy_until_first_use(tmp_path, fake_deberta):
+    mgr = HelixContextManager(_deberta_config(tmp_path))
+    assert fake_deberta.constructions == 0
+    assert isinstance(mgr.ribosome, LazyRibosome)
+    assert mgr.ribosome.loaded is False
+    assert mgr.ribosome.peek() is None
+    assert mgr.ribosome.label == "deberta"
+
+    out = mgr.ribosome.re_rank("q", [], k=3)
+    assert out == []
+    assert fake_deberta.constructions == 1
+    assert mgr.ribosome.loaded is True
+
+    mgr.ribosome.re_rank("q2", [], k=3)
+    assert mgr.ribosome.classify_relations([]) == {}
+    assert fake_deberta.constructions == 1
+    # Exact construction args preserved from config.
+    built = mgr.ribosome.peek()
+    assert built.kwargs["rerank_model_path"] == "training/models/rerank"
+    assert built.kwargs["splice_threshold"] == 0.5
+
+
+def test_deberta_eager_when_knob_off(tmp_path, fake_deberta):
+    mgr = HelixContextManager(_deberta_config(tmp_path, lazy=False))
+    assert fake_deberta.constructions == 1
+    assert type(mgr.ribosome).__name__ == "FakeDeBERTaRibosome"
+
+
+def test_deberta_load_failure_falls_back_to_disabled(tmp_path, monkeypatch):
+    mod = types.ModuleType("helix_context.backends.deberta_backend")
+
+    class _Boom:
+        def __init__(self, **kwargs):
+            raise RuntimeError("no models on disk")
+
+    mod.DeBERTaRibosome = _Boom
+    monkeypatch.setitem(
+        sys.modules, "helix_context.backends.deberta_backend", mod
+    )
+    mgr = HelixContextManager(_deberta_config(tmp_path))
+    rib = mgr.ribosome
+    assert rib.loaded is False
+    # First use: factory raises -> permanent fallback to disabled ribosome.
+    assert getattr(rib.backend, "is_disabled_backend", False) is True
+    assert rib.loaded is True  # fallback is resident now
+    # hasattr probe used by Step 3.5 sees no classify_relations on fallback.
+    assert not hasattr(rib, "classify_relations")
+
+
+def test_lazy_ribosome_private_lookup_never_loads(tmp_path, fake_deberta):
+    mgr = HelixContextManager(_deberta_config(tmp_path))
+    rib = mgr.ribosome
+    # Introspection on private/dunder names must not materialize models.
+    assert not hasattr(rib, "_nli")
+    assert not hasattr(rib, "__wrapped__")
+    assert fake_deberta.constructions == 0
+    assert rib.loaded is False
+
+
+# ── /admin/components reports without forcing loads ──────────────────
+
+
+def test_admin_components_reports_unloaded_without_loading(tmp_path, fake_sema):
+    from fastapi.testclient import TestClient
+
+    from helix_context.server import create_app
+
+    app = create_app(_config(tmp_path))
+    client = TestClient(app)
+
+    resp = client.get("/admin/components")
+    assert resp.status_code == 200
+    data = resp.json()
+    by_name = {c["name"]: c for c in data["components"]}
+
+    assert "sema" in by_name
+    assert by_name["sema"]["loaded"] is False
+    assert by_name["sema"]["status"] == "idle (not loaded)"
+    # The probe itself must not have constructed the model.
+    assert fake_sema.constructions == 0
+    assert app.state.helix._sema_codec.loaded is False
+
+    # cpu_tagger configured (default backend "cpu") but spaCy not resident.
+    if "cpu_tagger" in by_name:
+        assert by_name["cpu_tagger"]["loaded"] is False
+        assert by_name["cpu_tagger"]["status"] == "idle (not loaded)"
+
+    # Default ribosome is disabled -> omitted, exactly as before.
+    assert "ribosome" not in by_name
+
+    # After first use the panel flips to loaded without further builds.
+    app.state.helix._sema_codec.encode("warm me up")
+    data2 = client.get("/admin/components").json()
+    by_name2 = {c["name"]: c for c in data2["components"]}
+    assert by_name2["sema"]["loaded"] is True
+    assert by_name2["sema"]["status"] in ("running", "idle")
+    assert fake_sema.constructions == 1
+
+
+def test_admin_components_lazy_deberta_listed_unloaded(tmp_path, fake_deberta, fake_sema):
+    from fastapi.testclient import TestClient
+
+    from helix_context.server import create_app
+
+    app = create_app(_deberta_config(tmp_path))
+    client = TestClient(app)
+    resp = client.get("/admin/components")
+    assert resp.status_code == 200
+    by_name = {c["name"]: c for c in resp.json()["components"]}
+    # Configured-but-unloaded deberta ribosome is listed (it is neither
+    # paused nor disabled) and reports its unloaded state.
+    assert "ribosome" in by_name
+    assert by_name["ribosome"]["loaded"] is False
+    assert by_name["ribosome"]["status"] == "idle (not loaded)"
+    assert by_name["ribosome"]["backend"] == "deberta"
+    # And the panel did not force the DeBERTa load.
+    assert fake_deberta.constructions == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -368,7 +368,10 @@ class TestAdminComponentsEndpoint:
             assert "kind" in c
             assert c["kind"] in ("encoder", "decoder")
             assert "status" in c
-            assert c["status"] in ("running", "idle")
+            # #219 slice 2: lazily-armed encoders report "idle (not loaded)"
+            # until their first use; "loaded" carries the explicit boolean.
+            assert c["status"] in ("running", "idle", "idle (not loaded)")
+            assert "loaded" in c
 
     def test_components_status_running_after_recent_activity(self, client):
         # /stats does NOT bump activity, but /context does.


### PR DESCRIPTION
Epic #219 slice 2 (council Option-A rider). A serving process at 829K genes ran 20.3 GB RSS with the encoder stack loaded eagerly per process (tray backend + bench server + workers each paying it - the #176/#191 3-CUDA-context incident class). Two eager sites found on the serving path and proxied: SemaCodec in HelixContextManager.__init__ (LazySemaCodec: find_spec probe, double-checked-lock first-use construction, failure degrades to SEMA-disabled exactly like the legacy except path) and DeBERTaRibosome (LazyRibosome, byte-identical ctor args on first re_rank/splice). Verified already-lazy and left alone: SPLADE, BGE-M3 shared codec, spaCy tagger, NLI. [hardware] lazy_encoders = true (false restores eager boot warmup). /admin/components now reports idle-(not-loaded) vs loaded via non-forcing probes and includes the dense codec. 14 new tests (counting-fake ctors: init builds nothing, first use builds once, 8-thread race builds once, knob-off eager, panel non-forcing); 103 passed locally across lazy+server+config; ~2,240 sandbox sweep clean (4 pre-existing env failures).