### PR TITLE
fix(#224): ingest CLI infers content_type so code is code-chunked, not prose

### DIFF
--- a/helix_context/cli/cmd_ingest.py
+++ b/helix_context/cli/cmd_ingest.py
@@ -11,6 +11,27 @@ from helix_context.api import open_session
 
 _DEFAULT_EXTENSIONS = (".txt", ".md", ".rst", ".py", ".ts", ".js", ".json", ".toml", ".yml", ".yaml")
 
+# Extensions whose contents should be chunked as CODE (AST/structure-aware via
+# the tree-sitter chunker) rather than prose paragraphs. Issue #224: the ingest
+# CLI previously never set content_type, so code was chunked as prose and the
+# AST/code chunker (encoding/tree_chunker.py + CodonChunker._chunk_code) was
+# never reached. Inferring content_type from the file extension activates it.
+_CODE_EXTENSIONS = frozenset({
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".java", ".c", ".h",
+    ".cc", ".cpp", ".hpp", ".hh", ".cs", ".rb", ".php", ".lua", ".scala",
+    ".kt", ".kts", ".swift", ".sh", ".bash", ".sql", ".m", ".mm",
+})
+
+
+def _content_type_for(path: Path) -> str:
+    """Infer ingest content_type from a file's extension (#224).
+
+    Code extensions route to the code chunker (function/class units via
+    tree-sitter when available, regex fallback otherwise); everything else
+    is chunked as text. Markup like .md/.rst/.json stays text on purpose.
+    """
+    return "code" if path.suffix.lower() in _CODE_EXTENSIONS else "text"
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -105,7 +126,13 @@ def run(argv: list[str]) -> int:
         # to propagate so Ctrl-C still works.
         try:
             content = f.read_text(encoding="utf-8", errors="replace")
-            result = sess.ingest(content)
+            # #224: infer content_type from extension (code vs text) and record
+            # the source path so retrieval can attribute + match gold by file.
+            result = sess.ingest(
+                content,
+                content_type=_content_type_for(f),
+                metadata={"path": str(f), "source_id": str(f)},
+            )
             all_gene_ids.extend(result.gene_ids)
             total_bytes += result.bytes_written
             files_processed += 1

--- a/tests/test_ingest_content_type.py
+++ b/tests/test_ingest_content_type.py
@@ -1,0 +1,33 @@
+"""#224: the ingest CLI must infer content_type from file extension so code
+files are routed to the code chunker (AST/regex) rather than the prose-text
+chunker. Regression guard for the 'code ingested as prose' bug."""
+from pathlib import Path
+
+from helix_context.cli.cmd_ingest import _content_type_for, _CODE_EXTENSIONS
+
+
+def test_code_extensions_route_to_code():
+    for ext in (".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".java",
+                ".c", ".cpp", ".hpp", ".cs", ".rb", ".php", ".lua", ".sh", ".sql"):
+        assert _content_type_for(Path("mod" + ext)) == "code", ext
+
+
+def test_text_and_markup_route_to_text():
+    for ext in (".md", ".rst", ".txt", ".json", ".toml", ".yml", ".yaml", ".csv"):
+        assert _content_type_for(Path("doc" + ext)) == "text", ext
+
+
+def test_extension_match_is_case_insensitive():
+    assert _content_type_for(Path("Mod.PY")) == "code"
+    assert _content_type_for(Path("README.MD")) == "text"
+
+
+def test_unknown_extension_defaults_to_text():
+    assert _content_type_for(Path("x.weirdext")) == "text"
+    assert _content_type_for(Path("noext")) == "text"
+
+
+def test_default_extensions_with_code_suffix_are_code():
+    # every code suffix listed in _CODE_EXTENSIONS resolves to "code"
+    for ext in _CODE_EXTENSIONS:
+        assert _content_type_for(Path("f" + ext)) == "code", ext


### PR DESCRIPTION
﻿## What
The ingest CLI never set `content_type`, so `helix ingest` chunked **code as prose paragraphs** -- the AST/regex code chunker (`CodonChunker._chunk_code`, gated on `content_type=="code"`) was unreachable. This infers `content_type` from the file extension and records the source path.

## Why (#224)
- `cmd_ingest.py` called `sess.ingest(content)` (no content_type -> default `"text"`).
- `encoding/fragments.py` routes to `_chunk_code` only when `content_type=="code"`; otherwise prose `_chunk_text`.
- Net: every code corpus (incl. the RepoBench-R BM25-parity run) used prose chunking on code.

## Change
- `_content_type_for(path)` maps code extensions (.py/.ts/.js/.rs/.go/.java/.c/.cpp/.rb/.lua/.sh/.sql/...) -> `"code"`, else `"text"`.
- `sess.ingest(..., content_type=_content_type_for(f), metadata={"path", "source_id"})` -- also fixes missing source attribution for CLI-ingested docs.
- `tests/test_ingest_content_type.py` (5 tests, passing).

## Verified
Ingesting `helix_context/*.py`: **552 chunks (text) -> 574 (code)**; `source_id` 100% populated.

## Out of scope (tracked separately)
- tree-sitter as a core dep (currently `ast`/`all` extras -> silent regex fallback on default installs).
- cAST recursive split-then-merge (code-structure PRD). Note: on this corpus AST ~= regex today; the cAST work is what unlocks AST's edge.


Closes #224
