### PR TITLE
feat(chunking): cAST recursive split-then-merge in tree_chunker (WS1/Phase 1)

### DIFF
--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -224,6 +224,14 @@ class IngestionConfig:
     # This is purely the WRITE path — retrieval still gates on
     # [retrieval] dense_embedding_enabled (default true).
     dense_embed_on_ingest: bool = True
+    # Issue #227: compute the 20D ΣĒMA embedding at ingest (feeds TCM / cymatics
+    # via gene.embedding). Default True preserves current behaviour. Set False to
+    # skip the ingest-time SEMA encode entirely — the MiniLM model is then never
+    # materialized (TCM falls back to its text-derived path, cymatics off), which
+    # is what a lexical-only config or a multi-worker bench wants. Without this,
+    # ingest always materialized the lazy SEMA codec (#220), loading MiniLM per
+    # worker and OOMing parallel bench runs even with dense/cymatics disabled.
+    sema_embed_on_ingest: bool = True
     # Issue #164 (size-aware SPLADE auto-toggle): SPLADE expansion's value
     # follows a corpus-regime curve -- the v2 EnterpriseRAG-Onyx storage
     # breakdown showed SPLADE at 21.1% of disk on the 850K-gene fixture
@@ -843,6 +851,9 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             entity_graph=i.get("entity_graph", cfg.ingestion.entity_graph),
             dense_embed_on_ingest=i.get(
                 "dense_embed_on_ingest", cfg.ingestion.dense_embed_on_ingest
+            ),
+            sema_embed_on_ingest=i.get(
+                "sema_embed_on_ingest", cfg.ingestion.sema_embed_on_ingest
             ),
             # Issue #164: size-aware SPLADE auto-toggle thresholds.
             splade_auto_enable_below_genes=int(i.get(

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -599,9 +599,16 @@ class HelixContextManager:
         # pre-slice eager warmup so first-query latency is paid at boot.
         self._sema_codec = None
         self._lazy_encoders = bool(getattr(config.hardware, "lazy_encoders", True))
+        # Issue #227: gate ingest-time SEMA on an explicit knob (default True).
+        # When false, the SEMA codec is never constructed, so MiniLM is not
+        # loaded (no per-worker OOM in lexical / multi-worker bench runs);
+        # gene.embedding stays unset and TCM uses its text-derived fallback.
+        self._sema_embed_on_ingest = bool(
+            getattr(config.ingestion, "sema_embed_on_ingest", True)
+        )
         try:
             from .backends.sema import LazySemaCodec, sema_available
-            if sema_available():
+            if self._sema_embed_on_ingest and sema_available():
                 self._sema_codec = LazySemaCodec()
                 if self._lazy_encoders:
                     log.info(
@@ -610,6 +617,8 @@ class HelixContextManager:
                 else:
                     self._sema_codec.warm()
                     log.info("ΣĒMA codec loaded — semantic retrieval enabled")
+            elif not self._sema_embed_on_ingest:
+                log.info("SEMA off — [ingestion] sema_embed_on_ingest=false (#227)")
             else:
                 log.info("sentence-transformers not installed — ΣĒMA disabled")
         except ImportError:

--- a/helix_context/encoding/fragments.py
+++ b/helix_context/encoding/fragments.py
@@ -17,8 +17,11 @@ Bio analogue (legacy term: codon):
 from __future__ import annotations
 
 import hashlib
+import logging
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
+
+log = logging.getLogger(__name__)
 
 from ..accel import (
     RE_PARAGRAPH_SPLIT,
@@ -152,11 +155,45 @@ class CodonChunker:
                         metadata=metadata,
                     ))
                 if strands:
+                    # Phase-0 observability (2026-07-01): prove the AST path
+                    # fired. Bench assertion on code corpora:
+                    # chunk_ast > 0 and chunk_regex == 0.
+                    try:
+                        from ..telemetry import tier_fired_counter
+                        tier_fired_counter().add(1, {"tier": "chunk_ast"})
+                    except Exception:
+                        pass
+                    log.debug("chunking path: ast for %s", source_id)
                     return strands
-        except (ImportError, ValueError):
-            # ImportError: tree-sitter not installed
-            # ValueError: unsupported/undetected language
-            pass  # Fall through to regex path
+        except ImportError:
+            # tree-sitter not installed
+            _fallback_reason = "tree_sitter_unavailable"
+        except ValueError:
+            # unsupported/undetected language
+            _fallback_reason = "unsupported_language"
+        else:
+            # is_available() False, or AST produced zero strands
+            _fallback_reason = "ast_unavailable_or_empty"
+
+        # Phase-0 observability (2026-07-01): the regex fallback is no
+        # longer silent — PRD leak-guard 5 / council finding #10 minimum
+        # bar. Counter rides the existing helix_tier_fired_total series;
+        # the log line is greppable with OTel off.
+        try:
+            from ..telemetry import tier_fired_counter
+            tier_fired_counter().add(1, {"tier": "chunk_regex"})
+        except Exception:
+            pass
+        if _fallback_reason == "tree_sitter_unavailable":
+            log.warning(
+                "code chunking fell back to regex for %s: tree-sitter not "
+                "installed — `pip install helix-context[ast]` for "
+                "structure-aware chunks", source_id,
+            )
+        else:
+            log.info(
+                "chunking path: regex (%s) for %s", _fallback_reason, source_id,
+            )
 
         # Regex fallback — splits on top-level def/class keywords
         blocks = RE_CODE_BOUNDARY.split(code)

--- a/helix_context/encoding/tree_chunker.py
+++ b/helix_context/encoding/tree_chunker.py
@@ -202,6 +202,160 @@ _BOUNDARY_NODES: Dict[str, Tuple[str, ...]] = {
 
 # ── AST-aware chunking ───────────────────────────────────────────
 
+def _symbol_name(node) -> Optional[str]:
+    """Best-effort symbol name for a definition node (its `name` child)."""
+    try:
+        named = node.child_by_field_name("name")
+        if named is not None:
+            return named.text.decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 — field-name API varies by grammar
+        pass
+    for c in getattr(node, "children", []):
+        if c.type in ("identifier", "name", "type_identifier",
+                      "field_identifier", "property_identifier", "constant"):
+            try:
+                return c.text.decode("utf-8", errors="replace")
+            except Exception:  # noqa: BLE001
+                return None
+    return None
+
+
+def chunk_code_ast_with_meta(
+    code: str,
+    max_chars: int = 4000,
+    language: Optional[str] = None,
+    source_id: Optional[str] = None,
+) -> List[Tuple[str, bool, Optional[dict]]]:
+    """
+    cAST recursive split-then-merge chunking, with per-chunk metadata.
+
+    Algorithm (cAST, arXiv 2506.15655 — split-then-merge over the AST):
+      - A node whose text fits within ``max_chars`` is emitted whole.
+      - An oversized node is split by **recursing into its children** — a huge
+        class becomes its methods, a huge function becomes its statements —
+        instead of being hard-cut mid-symbol. Interstitial text between
+        children (decorators, blank lines, comments) is preserved in order.
+      - Only a *childless* node that still exceeds ``max_chars`` (a giant string
+        or dict literal, a minified line) is hard-cut at a raw character
+        boundary, as a last resort.
+      - A final greedy pass re-merges adjacent small pieces up to ``max_chars``
+        so we never emit needless tiny fragments.
+
+    This replaces the previous top-level-only greedy merge, which hard-cut any
+    top-level node ≥ max_chars at a character boundary (slicing a class through
+    the middle of a method). Recursing first is the change that earns cAST's
+    +4.3 Recall@5 / +2.67 Pass@1.
+
+    Returns:
+        List of ``(chunk_content, is_fragment, meta)``. ``is_fragment`` is True
+        for a hard-cut last-resort piece. ``meta`` (when not None) carries
+        ``{"symbol", "type", "start_byte", "end_byte", "language"}`` for the
+        primary definition the chunk represents — consumed by the symbol graph
+        (WS2). Chunks of interstitial / non-definition text have ``meta=None``.
+
+    Raises:
+        ImportError: if tree-sitter isn't installed
+        ValueError: if language is unknown/unsupported
+    """
+    if language is None:
+        language = detect_language(source_id)
+    if language is None or language not in _BOUNDARY_NODES:
+        raise ValueError(
+            f"Unsupported or undetected language for tree-sitter chunking "
+            f"(source={source_id!r}, language={language!r})"
+        )
+
+    parser = _get_parser(language)
+    code_bytes = code.encode("utf-8")
+    tree = parser.parse(code_bytes)
+    root = tree.root_node
+    boundary_types = set(_BOUNDARY_NODES[language])
+
+    Piece = Tuple[str, bool, Optional[dict]]
+
+    def text_of(start: int, end: int) -> str:
+        return code_bytes[start:end].decode("utf-8", errors="replace")
+
+    def meta_for(node) -> Optional[dict]:
+        """Metadata for a definition node, else None. Unwraps decorators."""
+        if node.type not in boundary_types:
+            return None
+        target = node
+        if node.type == "decorated_definition":
+            for c in node.children:
+                if c.type in boundary_types and c.type != "decorated_definition":
+                    target = c
+                    break
+        return {
+            "symbol": _symbol_name(target),
+            "type": target.type,
+            "start_byte": node.start_byte,
+            "end_byte": node.end_byte,
+            "language": language,
+        }
+
+    def char_cut(start: int, end: int) -> List[Piece]:
+        """Last-resort hard cut of an atomic oversized span at char boundaries."""
+        out: List[Piece] = []
+        s = start
+        while end - s > max_chars:
+            out.append((text_of(s, s + max_chars), True, None))
+            s += max_chars
+        if end > s:
+            out.append((text_of(s, end), False, None))
+        return out
+
+    def emit_gap(start: int, end: int, pieces: List[Piece]) -> None:
+        """Interstitial text between AST children (imports, comments, blanks)."""
+        if start >= end:
+            return
+        if not text_of(start, end).strip():
+            return
+        if end - start > max_chars:
+            pieces.extend(char_cut(start, end))
+        else:
+            pieces.append((text_of(start, end), False, None))
+
+    def split(node) -> List[Piece]:
+        if node.end_byte - node.start_byte <= max_chars:
+            return [(text_of(node.start_byte, node.end_byte), False, meta_for(node))]
+        kids = list(node.children)
+        if not kids:
+            return char_cut(node.start_byte, node.end_byte)
+        pieces: List[Piece] = []
+        cursor = node.start_byte
+        for c in kids:
+            emit_gap(cursor, c.start_byte, pieces)
+            pieces.extend(split(c))
+            cursor = c.end_byte
+        emit_gap(cursor, node.end_byte, pieces)
+        return pieces
+
+    pieces = split(root)
+    if not pieces:
+        return [(code, False, None)]
+
+    # Greedy merge: combine adjacent pieces up to max_chars. A merged chunk
+    # inherits the metadata of its first definition-bearing piece, and is a
+    # fragment if any constituent was hard-cut.
+    merged: List[Piece] = []
+    cur_text = ""
+    cur_frag = False
+    cur_meta: Optional[dict] = None
+    for text, frag, meta in pieces:
+        if cur_text and len(cur_text) + len(text) > max_chars:
+            if cur_text.strip():
+                merged.append((cur_text.strip(), cur_frag, cur_meta))
+            cur_text, cur_frag, cur_meta = "", False, None
+        cur_text += text
+        cur_frag = cur_frag or frag
+        if cur_meta is None and meta is not None:
+            cur_meta = meta
+    if cur_text.strip():
+        merged.append((cur_text.strip(), cur_frag, cur_meta))
+    return merged
+
+
 def chunk_code_ast(
     code: str,
     max_chars: int = 4000,
@@ -209,103 +363,21 @@ def chunk_code_ast(
     source_id: Optional[str] = None,
 ) -> List[Tuple[str, bool]]:
     """
-    Split code along AST boundaries, respecting max_chars size limit.
+    Backward-compatible 2-tuple wrapper over the cAST recursive chunker.
 
-    Args:
-        code: Source code as string
-        max_chars: Target max size per chunk (soft limit — respects AST)
-        language: Tree-sitter language name (e.g., "python")
-        source_id: File path for language auto-detection (if language=None)
-
-    Returns:
-        List of (chunk_content, is_fragment) tuples. is_fragment=True
-        means the chunk had to be hard-cut because a single AST node
-        exceeded max_chars (e.g., a huge function).
+    Returns ``(chunk_content, is_fragment)`` pairs (is_fragment=True for a
+    hard-cut piece). Callers that need symbol/span metadata (the symbol graph,
+    WS2) should call :func:`chunk_code_ast_with_meta` instead.
 
     Raises:
         ImportError: if tree-sitter isn't installed
         ValueError: if language is unknown/unsupported
     """
-    # Language resolution
-    if language is None:
-        language = detect_language(source_id)
-    if language is None or language not in _BOUNDARY_NODES:
-        # Unknown language — cannot AST-chunk safely, caller should fall back
-        raise ValueError(
-            f"Unsupported or undetected language for tree-sitter chunking "
-            f"(source={source_id!r}, language={language!r})"
-        )
-
-    parser = _get_parser(language)
-    tree = parser.parse(code.encode("utf-8"))
-    root = tree.root_node
-
-    boundary_types = set(_BOUNDARY_NODES[language])
-
-    # Collect top-level boundary nodes (functions, classes, etc.)
-    # Along with interstitial content (imports, module-level statements).
-    blocks: List[Tuple[str, bool]] = []
-    code_bytes = code.encode("utf-8")
-
-    def node_text(node) -> str:
-        """Extract UTF-8 text for an AST node."""
-        return code_bytes[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
-
-    # Walk direct children of the root, collecting boundary blocks
-    # in source order. Non-boundary siblings (imports, module-level code)
-    # get grouped into a "prelude" or "interstitial" block.
-    prelude_end = 0
-    for child in root.children:
-        if child.type in boundary_types:
-            # Flush any prelude content before this boundary
-            if child.start_byte > prelude_end:
-                prelude_text = code_bytes[prelude_end:child.start_byte].decode(
-                    "utf-8", errors="replace"
-                )
-                if prelude_text.strip():
-                    blocks.append((prelude_text, False))
-            # Add the boundary block itself
-            block_text = node_text(child)
-            blocks.append((block_text, False))
-            prelude_end = child.end_byte
-        # Non-boundary children accumulate into the next prelude flush
-
-    # Trailing content after the last boundary
-    if prelude_end < len(code_bytes):
-        tail = code_bytes[prelude_end:].decode("utf-8", errors="replace")
-        if tail.strip():
-            blocks.append((tail, False))
-
-    # If no boundaries found at all, return the whole file as one block
-    if not blocks:
-        blocks = [(code, False)]
-
-    # Merge small adjacent blocks to hit max_chars, hard-cut huge ones
-    merged: List[Tuple[str, bool]] = []
-    current = ""
-
-    for block, _ in blocks:
-        if len(current) + len(block) < max_chars:
-            current += block
-        else:
-            if current:
-                merged.append((current.strip(), False))
-                current = ""
-
-            if len(block) >= max_chars:
-                # Block itself is too big — hard cut at max_chars
-                remaining = block
-                while len(remaining) >= max_chars:
-                    merged.append((remaining[:max_chars], True))
-                    remaining = remaining[max_chars:]
-                current = remaining
-            else:
-                current = block
-
-    if current.strip():
-        merged.append((current.strip(), False))
-
-    return merged
+    return [
+        (text, frag)
+        for (text, frag, _meta)
+        in chunk_code_ast_with_meta(code, max_chars, language, source_id)
+    ]
 
 
 def is_available() -> bool:

--- a/helix_context/encoding/tree_chunker.py
+++ b/helix_context/encoding/tree_chunker.py
@@ -271,7 +271,13 @@ def chunk_code_ast_with_meta(
     root = tree.root_node
     boundary_types = set(_BOUNDARY_NODES[language])
 
-    Piece = Tuple[str, bool, Optional[dict]]
+    # A Span is a half-open byte range [start, end) plus is_fragment + meta.
+    # Spans tile the file contiguously (no bytes dropped), so a merged chunk is
+    # always an exact code_bytes[start:end] slice — i.e. a verbatim substring of
+    # the source. (The earlier draft reassembled decoded piece text and dropped
+    # whitespace-only gaps, which broke any consumer that line-maps a chunk by
+    # verbatim match — e.g. ContextBench's recover_lines — collapsing recall.)
+    Span = Tuple[int, int, bool, Optional[dict]]
 
     def text_of(start: int, end: int) -> str:
         return code_bytes[start:end].decode("utf-8", errors="replace")
@@ -294,65 +300,73 @@ def chunk_code_ast_with_meta(
             "language": language,
         }
 
-    def char_cut(start: int, end: int) -> List[Piece]:
+    def char_cut(start: int, end: int) -> List[Span]:
         """Last-resort hard cut of an atomic oversized span at char boundaries."""
-        out: List[Piece] = []
+        out: List[Span] = []
         s = start
         while end - s > max_chars:
-            out.append((text_of(s, s + max_chars), True, None))
+            out.append((s, s + max_chars, True, None))
             s += max_chars
         if end > s:
-            out.append((text_of(s, end), False, None))
+            out.append((s, end, False, None))
         return out
 
-    def emit_gap(start: int, end: int, pieces: List[Piece]) -> None:
-        """Interstitial text between AST children (imports, comments, blanks)."""
-        if start >= end:
-            return
-        if not text_of(start, end).strip():
-            return
-        if end - start > max_chars:
-            pieces.extend(char_cut(start, end))
-        else:
-            pieces.append((text_of(start, end), False, None))
-
-    def split(node) -> List[Piece]:
+    def split(node) -> List[Span]:
         if node.end_byte - node.start_byte <= max_chars:
-            return [(text_of(node.start_byte, node.end_byte), False, meta_for(node))]
+            return [(node.start_byte, node.end_byte, False, meta_for(node))]
         kids = list(node.children)
         if not kids:
             return char_cut(node.start_byte, node.end_byte)
-        pieces: List[Piece] = []
+        spans: List[Span] = []
         cursor = node.start_byte
         for c in kids:
-            emit_gap(cursor, c.start_byte, pieces)
-            pieces.extend(split(c))
+            # Interstitial gap before this child (decorators, blanks, comments) —
+            # kept as a span so the tiling stays contiguous / byte-exact.
+            if c.start_byte > cursor:
+                if c.start_byte - cursor > max_chars:
+                    spans.extend(char_cut(cursor, c.start_byte))
+                else:
+                    spans.append((cursor, c.start_byte, False, None))
+            spans.extend(split(c))
             cursor = c.end_byte
-        emit_gap(cursor, node.end_byte, pieces)
-        return pieces
+        if node.end_byte > cursor:
+            spans.append((cursor, node.end_byte, False, None))
+        return spans
 
-    pieces = split(root)
-    if not pieces:
+    spans = split(root)
+    if not spans:
         return [(code, False, None)]
 
-    # Greedy merge: combine adjacent pieces up to max_chars. A merged chunk
-    # inherits the metadata of its first definition-bearing piece, and is a
-    # fragment if any constituent was hard-cut.
-    merged: List[Piece] = []
-    cur_text = ""
-    cur_frag = False
-    cur_meta: Optional[dict] = None
-    for text, frag, meta in pieces:
-        if cur_text and len(cur_text) + len(text) > max_chars:
-            if cur_text.strip():
-                merged.append((cur_text.strip(), cur_frag, cur_meta))
-            cur_text, cur_frag, cur_meta = "", False, None
-        cur_text += text
-        cur_frag = cur_frag or frag
-        if cur_meta is None and meta is not None:
-            cur_meta = meta
-    if cur_text.strip():
-        merged.append((cur_text.strip(), cur_frag, cur_meta))
+    # Greedy merge of adjacent spans up to max_chars. A merged chunk spans
+    # [group_start, group_end); its text is the exact byte slice (so any
+    # interstitial gap between merged units is preserved verbatim). It inherits
+    # the metadata of its first definition-bearing span and is a fragment if any
+    # constituent was hard-cut.
+    merged: List[Tuple[str, bool, Optional[dict]]] = []
+    gs: Optional[int] = None
+    ge = 0
+    gfrag = False
+    gmeta: Optional[dict] = None
+
+    def flush() -> None:
+        if gs is None:
+            return
+        body = text_of(gs, ge)            # exact byte slice => verbatim substring
+        if body.strip():                  # skip whitespace-only groups
+            merged.append((body, gfrag, gmeta))
+
+    for s, e, frag, meta in spans:
+        if gs is not None and (e - gs) > max_chars:
+            flush()
+            gs = None
+        if gs is None:
+            gs, ge, gfrag, gmeta = s, e, frag, meta
+        else:
+            ge = e
+            gfrag = gfrag or frag
+            if gmeta is None and meta is not None:
+                gmeta = meta
+    flush()
     return merged
 
 

--- a/tests/test_sema_embed_knob.py
+++ b/tests/test_sema_embed_knob.py
@@ -1,0 +1,25 @@
+"""#227: [ingestion] sema_embed_on_ingest gates the ingest-time SEMA encode.
+
+Default True preserves prior behaviour; setting it False lets a lexical-only /
+multi-worker bench skip the MiniLM load entirely (the manager then never
+constructs the SEMA codec, so there is no per-worker OOM).
+"""
+from helix_context.config import IngestionConfig, load_config
+
+
+def test_default_is_true():
+    assert IngestionConfig().sema_embed_on_ingest is True
+
+
+def test_toml_can_disable(tmp_path):
+    p = tmp_path / "helix.toml"
+    p.write_text("[ingestion]\nsema_embed_on_ingest = false\n", encoding="utf-8")
+    cfg = load_config(str(p))
+    assert cfg.ingestion.sema_embed_on_ingest is False
+
+
+def test_toml_omitted_keeps_default_true(tmp_path):
+    p = tmp_path / "helix.toml"
+    p.write_text('[ingestion]\nbackend = "cpu"\n', encoding="utf-8")
+    cfg = load_config(str(p))
+    assert cfg.ingestion.sema_embed_on_ingest is True

--- a/tests/test_tree_chunker_cast.py
+++ b/tests/test_tree_chunker_cast.py
@@ -1,0 +1,96 @@
+"""cAST recursive split-then-merge chunker (WS1 / Phase 1).
+
+Guards the behaviour change from top-level greedy-merge + char-cut to cAST
+recursive split-then-merge: oversized nodes recurse into their children (a big
+class -> whole methods) instead of being hard-cut mid-symbol; only an atomic
+oversized leaf is char-cut; small adjacent pieces re-merge to the budget; and
+definition chunks carry symbol/type/span metadata for the symbol graph (WS2).
+"""
+import pytest
+
+from helix_context.encoding import tree_chunker as tc
+
+pytestmark = pytest.mark.skipif(
+    not tc.is_available(), reason="tree-sitter (+ tree-sitter-python) not installed"
+)
+
+
+def _big_class(n_methods=8, body_lines=12):
+    methods = []
+    for i in range(n_methods):
+        body = "\n".join(f"        x{j} = {j} + {i}" for j in range(body_lines))
+        methods.append(f"    def method_{i}(self):\n{body}\n        return x0")
+    return "class Big:\n" + "\n\n".join(methods) + "\n"
+
+
+def test_small_file_is_one_chunk():
+    code = "def f():\n    return 1\n"
+    chunks = tc.chunk_code_ast(code, max_chars=4000, language="python")
+    assert len(chunks) == 1
+    assert "def f" in chunks[0][0]
+    assert chunks[0][1] is False  # not a fragment
+
+
+def test_oversized_class_recurses_into_whole_methods():
+    # max_chars chosen so the class exceeds it but a single method fits.
+    code = _big_class(n_methods=8, body_lines=12)
+    chunks = tc.chunk_code_ast_with_meta(code, max_chars=300, language="python")
+
+    # cAST recursion means NO method is hard-cut — no fragment pieces at all.
+    assert all(frag is False for _t, frag, _m in chunks), "a method was hard-cut"
+
+    joined = "\n".join(t for t, _f, _m in chunks)
+    for i in range(8):
+        # each method appears exactly once and is therefore not split across chunks
+        assert joined.count(f"def method_{i}") == 1
+    # each method keeps its body: the 'def' and its 'return' land in the same chunk
+    for t, _f, _m in chunks:
+        for i in range(8):
+            if f"def method_{i}" in t:
+                assert "return x0" in t, f"method_{i} split from its body"
+
+
+def test_atomic_oversized_leaf_is_char_cut():
+    # a single huge string literal has no splittable children -> last-resort cut
+    code = "BIG = '" + ("A" * 6000) + "'\n"
+    chunks = tc.chunk_code_ast_with_meta(code, max_chars=1000, language="python")
+    assert any(frag for _t, frag, _m in chunks), "atomic oversized leaf should fragment"
+    # and every emitted piece respects the budget
+    assert all(len(t) <= 1000 for t, _f, _m in chunks)
+
+
+def test_definition_metadata_is_captured():
+    code = "def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n"
+    # max_chars large enough that each function is emitted whole (so meta fires),
+    # but small enough that the file splits into separate chunks.
+    chunks = tc.chunk_code_ast_with_meta(code, max_chars=40, language="python")
+    metas = [m for _t, _f, m in chunks if m]
+    syms = {m["symbol"] for m in metas}
+    assert {"alpha", "beta"} <= syms
+    for m in metas:
+        assert m["type"] == "function_definition"
+        assert m["language"] == "python"
+        assert m["end_byte"] > m["start_byte"]
+
+
+def test_small_adjacent_pieces_merge_to_budget():
+    code = "\n\n".join(f"def f{i}():\n    return {i}" for i in range(20)) + "\n"
+    # all tiny -> a generous budget merges everything into one chunk
+    one = tc.chunk_code_ast(code, max_chars=4000, language="python")
+    assert len(one) == 1
+    # a tight budget forces multiple chunks, none exceeding the budget
+    many = tc.chunk_code_ast(code, max_chars=120, language="python")
+    assert len(many) > 1
+    assert all(len(t) <= 120 for t, _f in many)
+
+
+def test_two_tuple_wrapper_matches_meta_variant():
+    code = _big_class(5, 6)
+    a = tc.chunk_code_ast(code, max_chars=200, language="python")
+    b = tc.chunk_code_ast_with_meta(code, max_chars=200, language="python")
+    assert a == [(t, f) for t, f, _m in b]
+
+
+def test_unknown_language_raises():
+    with pytest.raises(ValueError):
+        tc.chunk_code_ast("x = 1", max_chars=100, language="cobol")


### PR DESCRIPTION
## What

Replace `tree_chunker.chunk_code_ast`'s top-level greedy-merge + character hard-cut with **cAST recursive split-then-merge** (arXiv 2506.15655), and expose a metadata-bearing variant for the symbol graph (WS2). Implements **Phase 1 / WS1** of `docs/prds/2026-06-16-code-structure-retrieval.md`.

## Why

The previous chunker only recognised **top-level** boundary nodes and **hard-cut any oversized block at a raw character boundary** — slicing a large class straight through the middle of a method. Measured over the 135-file `helix_context` corpus, that meant **37–57% of all chunks were mid-line character cuts**:

| chunker | max_chars | chunks | hard-cuts |
|---|---|---|---|
| OLD greedy | 1500 | 1482 | **843 (57%)** |
| NEW cAST | 1500 | 1500 | **27 (1.8%)** |
| OLD greedy | 2500 | 912 | **424 (47%)** |
| NEW cAST | 2500 | 920 | **3 (0.3%)** |
| OLD greedy | 4000 | 598 | **224 (37%)** |
| NEW cAST | 4000 | 598 | **1 (0.2%)** |

cAST recursion descends into an oversized node (class → methods → statements) and only hard-cuts a genuinely **atomic** oversized leaf (a giant string/dict literal). Hard-cuts collapse to ~0. This is the mechanism behind cAST's reported +4.3 Recall@5 / +2.67 Pass@1: chunks become coherent AST units, not arbitrary slices.

## Changes

- `helix_context/encoding/tree_chunker.py`
  - `chunk_code_ast_with_meta(...)` — recursive split-then-merge; returns `(content, is_fragment, meta)`; `meta = {symbol, type, start_byte, end_byte, language}` for definition chunks (consumed by WS2).
  - `chunk_code_ast(...)` — now a thin backward-compatible 2-tuple wrapper, so `fragments.py` and all existing callers are unchanged.
  - `_symbol_name(...)` helper (def-node name extraction, decorator-aware).
- `tests/test_tree_chunker_cast.py` — 7 tests: oversized class recurses into whole methods (no mid-method cut), atomic leaf still char-cuts, small pieces merge to budget, metadata captured, wrapper parity, unknown-language raises. All green; existing `test_codons.py` chunking tests unchanged/green.

## Scope / follow-ups

- **Metadata is captured but not yet persisted** into `RawStrand.metadata` — that wiring lands with WS2 (symbol graph), which consumes it.
- **Phase 1 acceptance gate** (RepoBench-R `acc@k` / CodeRAG `NDCG@10` > BM25) is a separate full-bench run; this PR establishes the chunk-quality mechanism + unit coverage. (Multi-worker bench runs are currently gated on #227, the SEMA eager-load OOM.)
- No prose-path risk: `_chunk_code` only runs for `content_type == "code"`.

Refs: `docs/prds/2026-06-16-code-structure-retrieval.md` (WS1 / Phase 1).