### PR TITLE
fix(#227): gate ingest-time SEMA on [ingestion] sema_embed_on_ingest

### DIFF
--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -224,6 +224,14 @@ class IngestionConfig:
     # This is purely the WRITE path — retrieval still gates on
     # [retrieval] dense_embedding_enabled (default true).
     dense_embed_on_ingest: bool = True
+    # Issue #227: compute the 20D ΣĒMA embedding at ingest (feeds TCM / cymatics
+    # via gene.embedding). Default True preserves current behaviour. Set False to
+    # skip the ingest-time SEMA encode entirely — the MiniLM model is then never
+    # materialized (TCM falls back to its text-derived path, cymatics off), which
+    # is what a lexical-only config or a multi-worker bench wants. Without this,
+    # ingest always materialized the lazy SEMA codec (#220), loading MiniLM per
+    # worker and OOMing parallel bench runs even with dense/cymatics disabled.
+    sema_embed_on_ingest: bool = True
     # Issue #164 (size-aware SPLADE auto-toggle): SPLADE expansion's value
     # follows a corpus-regime curve -- the v2 EnterpriseRAG-Onyx storage
     # breakdown showed SPLADE at 21.1% of disk on the 850K-gene fixture
@@ -843,6 +851,9 @@ def load_config(path: Optional[str] = None) -> HelixConfig:
             entity_graph=i.get("entity_graph", cfg.ingestion.entity_graph),
             dense_embed_on_ingest=i.get(
                 "dense_embed_on_ingest", cfg.ingestion.dense_embed_on_ingest
+            ),
+            sema_embed_on_ingest=i.get(
+                "sema_embed_on_ingest", cfg.ingestion.sema_embed_on_ingest
             ),
             # Issue #164: size-aware SPLADE auto-toggle thresholds.
             splade_auto_enable_below_genes=int(i.get(

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -599,9 +599,16 @@ class HelixContextManager:
         # pre-slice eager warmup so first-query latency is paid at boot.
         self._sema_codec = None
         self._lazy_encoders = bool(getattr(config.hardware, "lazy_encoders", True))
+        # Issue #227: gate ingest-time SEMA on an explicit knob (default True).
+        # When false, the SEMA codec is never constructed, so MiniLM is not
+        # loaded (no per-worker OOM in lexical / multi-worker bench runs);
+        # gene.embedding stays unset and TCM uses its text-derived fallback.
+        self._sema_embed_on_ingest = bool(
+            getattr(config.ingestion, "sema_embed_on_ingest", True)
+        )
         try:
             from .backends.sema import LazySemaCodec, sema_available
-            if sema_available():
+            if self._sema_embed_on_ingest and sema_available():
                 self._sema_codec = LazySemaCodec()
                 if self._lazy_encoders:
                     log.info(
@@ -610,6 +617,8 @@ class HelixContextManager:
                 else:
                     self._sema_codec.warm()
                     log.info("ΣĒMA codec loaded — semantic retrieval enabled")
+            elif not self._sema_embed_on_ingest:
+                log.info("SEMA off — [ingestion] sema_embed_on_ingest=false (#227)")
             else:
                 log.info("sentence-transformers not installed — ΣĒMA disabled")
         except ImportError:

--- a/tests/test_sema_embed_knob.py
+++ b/tests/test_sema_embed_knob.py
@@ -1,0 +1,25 @@
+"""#227: [ingestion] sema_embed_on_ingest gates the ingest-time SEMA encode.
+
+Default True preserves prior behaviour; setting it False lets a lexical-only /
+multi-worker bench skip the MiniLM load entirely (the manager then never
+constructs the SEMA codec, so there is no per-worker OOM).
+"""
+from helix_context.config import IngestionConfig, load_config
+
+
+def test_default_is_true():
+    assert IngestionConfig().sema_embed_on_ingest is True
+
+
+def test_toml_can_disable(tmp_path):
+    p = tmp_path / "helix.toml"
+    p.write_text("[ingestion]\nsema_embed_on_ingest = false\n", encoding="utf-8")
+    cfg = load_config(str(p))
+    assert cfg.ingestion.sema_embed_on_ingest is False
+
+
+def test_toml_omitted_keeps_default_true(tmp_path):
+    p = tmp_path / "helix.toml"
+    p.write_text('[ingestion]\nbackend = "cpu"\n', encoding="utf-8")
+    cfg = load_config(str(p))
+    assert cfg.ingestion.sema_embed_on_ingest is True


### PR DESCRIPTION
## What

Add `[ingestion] sema_embed_on_ingest` (default **True**, behaviour-preserving). When false, the manager never constructs the ΣĒMA codec, so MiniLM is not loaded — `gene.embedding` stays unset and TCM uses its text-derived fallback (cymatics, when off, is unaffected).

Fixes #227.

## Why

`HelixContextManager` arms a `LazySemaCodec` whenever `sentence-transformers` is importable, and `ingest()` unconditionally calls `_sema_codec.encode_batch(...)` — which **materializes** the lazy codec on the first ingest. So even under a fully lexical config (dense / SPLADE / cymatics off), and even with #220 `lazy_encoders=true`, every worker loads MiniLM at first ingest. In a multi-worker bench (`ProcessPoolExecutor`) over large in-process genomes this OOMed a worker and cascaded `BrokenProcessPool` (observed: ContextBench Step-0, crash at task 17/26, 48 GB box; `--workers 1` was the only workaround).

The lazy proxy (#220) defers the *boot* load but not the ingest-time materialization, and SEMA is the *only* tier needed here — its consumers (TCM, cymatics) both degrade gracefully without it. An explicit ingest-time gate is the minimal, non-regressive fix.

## Changes

- `helix_context/config.py` — new `IngestionConfig.sema_embed_on_ingest: bool = True` + TOML parse.
- `helix_context/context_manager.py` — gate SEMA codec construction on the knob; when false, log and leave `_sema_codec = None` (the three ingest-time `if self._sema_codec is not None` sites then skip automatically).
- `tests/test_sema_embed_knob.py` — default-True, TOML-disable, TOML-omitted-defaults-True.

## Effect

A lexical-only / bench config sets `sema_embed_on_ingest = false` and runs multi-worker with no MiniLM load and no OOM. Default installs are unchanged (SEMA still computed at ingest, TCM still gets its 20D vectors).