### PR TITLE
#209 phase 2: hallucination-visibility telemetry completion + goal gates

### DIFF
--- a/deploy/otel/grafana/dashboards/helix-know-miss.json
+++ b/deploy/otel/grafana/dashboards/helix-know-miss.json
@@ -1,0 +1,248 @@
+{
+  "title": "Helix — Know/Miss (Hallucination Visibility)",
+  "uid": "helix-know-miss",
+  "description": "G1 visibility gate (docs/specs/2026-07-01-goal-gates-hallucination-visibility.md). Miss/abstain stream = the observable slice of the 10% hallucination budget; scored benches calibrate confidence→P(correct).",
+  "editable": true,
+  "schemaVersion": 39,
+  "time": {"from": "now-3h", "to": "now"},
+  "refresh": "10s",
+  "tags": ["helix", "know-miss", "hallucination", "telemetry"],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Know / Miss — the visible budget",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}
+    },
+    {
+      "type": "stat",
+      "title": "Non-know share of turns (miss + abstain, 15m)",
+      "description": "G2 budget: sustained > 10% means the budget is being spent on visible misses/abstains — retrieval, not honesty, is the bottleneck. Abstains are counted here as coverage loss, not hallucination.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 1},
+      "targets": [
+        {
+          "expr": "sum(rate(helix_know_decision_total{outcome=~\"miss|abstain\"}[15m])) / sum(rate(helix_know_decision_total[15m]))",
+          "legendFormat": "non-know share",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.05},
+              {"color": "red", "value": 0.1}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Miss rate by reason",
+      "description": "abstain | denatured | no_promoter_match | superseded | stale | cold | sparse — each reason has a different fix (see MissBlock escalate_to).",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 9, "x": 6, "y": 1},
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(helix_know_decision_total{outcome=~\"miss|abstain\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Know confidence — p10/p50/p90",
+      "description": "Know outcomes only. Mass hovering just above emit_floor (default 0.55) = borderline knows; recalibrate via scripts/calibrate_know_confidence.py.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 9, "x": 15, "y": 1},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.10, sum by (le) (rate(helix_know_confidence_bucket[15m])))",
+          "legendFormat": "p10",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(helix_know_confidence_bucket[15m])))",
+          "legendFormat": "p50",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(helix_know_confidence_bucket[15m])))",
+          "legendFormat": "p90",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "none", "min": 0, "max": 1}}
+    },
+    {
+      "type": "row",
+      "title": "Honesty mechanisms",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9}
+    },
+    {
+      "type": "timeseries",
+      "title": "Abstain fires by gate",
+      "description": "floor_and_ratio (additive) vs ratio_only (RRF). Abstains are not hallucinations — they buy the budget.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 10},
+      "targets": [
+        {
+          "expr": "sum by (gate, fusion_mode) (rate(helix_abstain_total[15m]))",
+          "legendFormat": "{{gate}} ({{fusion_mode}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Freshness demotions by status",
+      "description": "stale | missing | unknown | superseded — stale-answer suppression activity (Stage 7 gate). fresh is not emitted.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 10},
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(helix_freshness_demotion_total[15m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Balancing pair: splice ratio p50 vs abstain rate",
+      "description": "Roadmap §3c-5: tuning that raises compression but spikes abstains is a net loss. Watch these together while sweeping splice_aggressiveness.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 10},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, caller_model_class) (rate(helix_splice_ratio_bucket[15m])))",
+          "legendFormat": "splice ratio p50 {{caller_model_class}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(helix_abstain_total[15m]))",
+          "legendFormat": "abstain rate",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Retrieval calibration",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18}
+    },
+    {
+      "type": "timeseries",
+      "title": "Dense cosine — p10/p50/p90 by arm",
+      "description": "Calibration data for dense_additive_weight / dense_additive_min_cosine (hot floor 0.15) and cold_tier_min_cosine. Roadmap §3c-1.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 19},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.10, sum by (le, arm) (rate(helix_dense_cosine_bucket[15m])))",
+          "legendFormat": "p10 {{arm}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, arm) (rate(helix_dense_cosine_bucket[15m])))",
+          "legendFormat": "p50 {{arm}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum by (le, arm) (rate(helix_dense_cosine_bucket[15m])))",
+          "legendFormat": "p90 {{arm}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "none", "min": 0, "max": 1}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Shard fan-out + discrimination",
+      "description": "#165 router degeneracy, continuously monitored. Discrimination = routed/known healthy shards in [0,1]; 1.0 = router consulted everything (zero discrimination).",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 19},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, path) (rate(helix_shard_fanout_bucket[15m])))",
+          "legendFormat": "fanout p50 {{path}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(helix_shard_fanout_bucket[15m])))",
+          "legendFormat": "fanout p95 {{path}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(helix_shard_candidates_bucket[15m])))",
+          "legendFormat": "candidates p50",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Session elision savings",
+      "description": "Prices the ~40% multi-turn token-saving claim (CLAUDE.md). Decides whether session_delivery_enabled stays default-on.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 19},
+      "targets": [
+        {
+          "expr": "sum(rate(helix_session_elided_total[15m]))",
+          "legendFormat": "docs elided /s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(helix_session_tokens_saved_total[15m]))",
+          "legendFormat": "tokens saved /s",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Latency — annotate rig load before comparing days",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 27}
+    },
+    {
+      "type": "timeseries",
+      "title": "/context latency p50/p95",
+      "description": "Compare within a day, not across days, unless the rig-load annotation matches (see code-track-regression-log.md method notes, e.g. 2026-07-01 multi-tasking baseline). Do not decide latency-sensitive knobs on loaded-rig numbers.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 28},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(helix_context_latency_seconds_bucket[15m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(helix_context_latency_seconds_bucket[15m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    },
+    {
+      "type": "timeseries",
+      "title": "Pipeline stage p95 by stage",
+      "description": "helix_pipeline_stage_seconds — first panel anywhere for this instrument (roadmap §3a flagged it panel-less). Splice/assemble are the tuning targets.",
+      "datasource": "Prometheus",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 28},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(helix_pipeline_stage_seconds_bucket[15m])))",
+          "legendFormat": "p95 {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    }
+  ]
+}

--- a/docs/architecture/OBSERVABILITY.md
+++ b/docs/architecture/OBSERVABILITY.md
@@ -107,6 +107,17 @@ Two surfaces:
 | `helix_know_decision_total` | counter | `outcome` ∈ {know, miss, abstain}, `reason` | `decide_know_or_miss` (#209) |
 | `helix_session_tokens_saved_total` | counter | — | session working-set elision savings (#209) |
 | `helix_splice_ratio` | histogram | `caller_model_class` | assembled-window compression ratio (#209) |
+| `helix_know_confidence` | histogram | — | KnowBlock confidence, know outcomes only (#209 ph2) |
+| `helix_abstain_total` | counter | `gate` ∈ {floor_and_ratio, ratio_only}, `fusion_mode` | ABSTAIN gate in `pipeline/tier_logic.py` (#209 ph2) |
+| `helix_freshness_demotion_total` | counter | `status` ∈ {stale, missing, unknown, superseded} | freshness revalidation + supersession (#209 ph2) |
+| `helix_session_elided_total` | counter | — | elision-stub event count (#209 ph2) |
+| `helix_pki_candidates` | histogram | — | docs hit by ≥1 path_key_index pair per query (#209 ph2) |
+| `helix_pki_pairs_skipped_total` | counter | — | PKI pairs over the noise cutoff (#209 ph2) |
+| `helix_fingerprint_filtered_total` | counter | `cause` ∈ {floor, cap} | /fingerprint floor/cap outcomes (#209 ph2) |
+| `helix_ingest_vram_bytes` | gauge | — | CUDA memory per dense ingest batch (#209 ph2) |
+
+The #209 ph2 rows are the hallucination-visibility completion set — gates
+and alert queries in `docs/specs/2026-07-01-goal-gates-hallucination-visibility.md`.
 
 `/stats`-sourced gauges are refreshed each time `/stats` is hit.
 Prometheus scrapes every 15s — if nothing polls `/stats`, the gauges go
@@ -158,7 +169,7 @@ Query text is hashed by default — spans carry `query=<first-50-chars>[hash:<12
 
 ## Dashboards
 
-Five dashboards under `deploy/otel/grafana/dashboards/`. All use
+Six dashboards under `deploy/otel/grafana/dashboards/`. All use
 engineering vocabulary in panel titles; bio-domain legacy terms are
 referenced inline in panel descriptions. See `docs/ROSETTA.md` for the
 full bidirectional vocabulary table.
@@ -192,6 +203,15 @@ full bidirectional vocabulary table.
   signals (alignment, override, escalation) with party-id breakdown.
   Uses technical-term vocabulary (ellipticity, denatured) that is on
   ROSETTA's "STAYS" list.
+- **Helix — Know/Miss (Hallucination Visibility)** (`helix-know-miss.json`,
+  #209 phase 2) — the G1 visibility-gate view: non-know share vs the 10%
+  budget, miss rate by reason, know-confidence percentiles vs emit_floor,
+  abstain fires by gate, freshness demotions, splice-ratio/abstain
+  balancing pair, dense-cosine by arm, shard fan-out + discrimination,
+  session-elision savings, latency row with load-annotation discipline.
+  Overlaps helix-internals on the phase-1 series by design: internals is
+  the tuning view, this is the goal-gates view. Companion spec:
+  `docs/specs/2026-07-01-goal-gates-hallucination-visibility.md`.
 
 The native install (`tools/native-otel/`) auto-syncs dashboards from
 `deploy/otel/grafana/dashboards/` via

--- a/docs/benchmarks/2026-07-01-external-bench-run-plan.md
+++ b/docs/benchmarks/2026-07-01-external-bench-run-plan.md
@@ -1,0 +1,116 @@
+# External-bench run plan — 3 arms + pre-run gap closure
+
+**Date:** 2026-07-01 · **Executes:** council plan step 2
+(`docs/research/2026-07-01-next-bench-wave-consensus.md`) · **Leads:** Max + Claude
+**Inputs:** E1 repo verification + R1 web landscape refresh (2026-07-01, citations inline).
+
+## 0. Landscape deltas since the 2026-06-04 strategy doc (R1, verified)
+
+- **ContextBench:** leaderboard unchanged (Sonnet-4.5 Pass@1 53.0 / context-F1
+  0.344 top; only 4 foundation models) — our packet numbers still land against
+  the same field. **Harness got 2026-06-12 commits** (vendored Prometheus-agent
+  integration; Multi-SWE-bench JSONL loading fix) — **re-pin the scorer venv to
+  post-2026-06-12 HEAD** before any non-Python split.
+  [leaderboard](https://contextbench.github.io/) · [commits](https://github.com/EuniAI/ContextBench)
+  Dataset license **still unstated** on the HF card — keep results internal
+  until cleared for public claims. [HF card](https://huggingface.co/datasets/Contextbench/ContextBench)
+- **RACE-bench:** still arXiv-only, v1, zero artifact links — remains
+  metric-inspiration only (OverPrediction@RelevantFiles).
+  [arXiv 2603.26337](https://arxiv.org/abs/2603.26337)
+- **NEW — SWE-Explore** (submitted 2026-06-05): line-budgeted **ranked
+  retrieval** over repo+issue — 848 issues, 10 languages, 203 repos, line-level
+  gold, coverage/ranking/context-efficiency metrics, **code+data released**.
+  This is helix's exact operating mode (ranked regions under a token budget)
+  and its 10-language spread directly stresses our python-only symbol-ref
+  caveat. Candidate **arm-for-arm addition after the core 3-arm run**; check
+  repo/dataset license first.
+  [arXiv 2606.07297](https://arxiv.org/abs/2606.07297) ·
+  [code](https://github.com/Qiushao-E/SWE-Explore-Bench) ·
+  [data](https://huggingface.co/datasets/SWE-Explore-Bench/SWE-Explore-Bench)
+- **CodeRAG-Bench:** dormant since 2024-11; **repo has NO license set** — do
+  not publish CodeRAG-derived numbers externally until resolved (CC-BY-SA
+  applies to the data; the harness license is the gap).
+  [repo](https://github.com/code-rag-bench/code-rag-bench)
+- **RepoBench-R:** dormant (v1.1, data through Dec 2023); fine as a
+  low-effort corroboration arm, CC-BY-4.0. [repo](https://github.com/Leolty/repobench)
+- **Reading list before novelty claims:** LARGER — lexically-anchored
+  structural repo retrieval ([arXiv 2605.16352](https://arxiv.org/pdf/2605.16352),
+  unconfirmed) — methodological kin to lexical-first + symbol graph; and the
+  stale-repository-context diagnostic ([arXiv 2605.14478](https://arxiv.org/pdf/2605.14478),
+  unconfirmed) — external corroboration for the freshness-gate story.
+
+## 1. Pre-run gaps to close (E1 findings — all small)
+
+1. **`helix_probe_nosema.toml` is not in the tree.** The regression log's
+   method notes reference it; it exists (if anywhere) only untracked on the
+   rig. Action: locate on rig and **commit it** (bench configs must be
+   reproducible), or reconstruct: lexical config, SEMA off
+   (`[ingestion] sema_embed_on_ingest = false`), dense off, defaults otherwise.
+2. **AST-vs-regex path counter is absent** (Phase-0 observability; council
+   finding #10's sibling). `CodonChunker._chunk_code` silently falls back to
+   regex on `ImportError`/`ValueError`. Without it, "the AST path actually
+   fired" is an assumption, not an assertion. Apply this patch on the
+   cast-merge branch **before** the run (also emit once per ingest batch to the
+   log):
+
+   ```python
+   # fragments.py — in _chunk_code, at the AST-success and fallback branches:
+   try:
+       from ..telemetry import tier_fired_counter
+       tier_fired_counter().add(1, {"tier": "chunk_ast"})      # AST branch
+       # tier_fired_counter().add(1, {"tier": "chunk_regex"})  # fallback branch
+   except Exception:
+       pass
+   log.info("chunking path: %s for %s", "ast" | "regex", source_hint)
+   ```
+
+   Reuses the existing `helix_tier_fired_total` series (no new instrument);
+   the bench assertion is then `chunk_ast > 0 and chunk_regex == 0` for code
+   corpora, greppable from logs even with OTel off.
+3. **CLAUDE.md knob sync** (merge-gate; helix.toml + config.py already agree
+   on the WS branch — only CLAUDE.md lags). Add to the `[ingestion]` /
+   `[retrieval]` rows of the config table in the merge commit:
+   - `[ingestion] sema_embed_on_ingest` (default true; false = no MiniLM load
+     at ingest, TCM falls back to text)
+   - `[ingestion] symbol_graph` (default **false** — dark-shipped WS2)
+   - `[retrieval] symbol_expansion_cap` (default 8; 0 disables, <0 unbounded)
+4. **Arm-C config variant doesn't exist** — create `helix_probe_symbol.toml` =
+   arm-B TOML + `[ingestion] symbol_graph = true` +
+   `[retrieval] symbol_expansion_cap = 8`.
+
+## 2. The arms
+
+| Arm | Build | Config | What it answers |
+|---|---|---|---|
+| A — BM25 foil | frozen baseline | (hardcoded in harness) | the dump baseline |
+| B — cAST default | cast-merge (#228+#229) | `helix_probe_nosema.toml` | PRD Phase-1: does cAST beat BM25 on unseen corpora? |
+| C — symbol arm | ws3-pagerank (#230+#231) | `helix_probe_symbol.toml` (gap #4) | held-out evidence for the WS2/WS3 default decision |
+
+Runner (per regression-log method): `cb_helix_pred.py --tag <arm> --config
+<toml> --workers 3`, scored by the (re-pinned, §0) scorer venv over the
+common instance-id intersection. RepoBench-R / CodeRAG-Bench per their
+runbooks, same three arms.
+
+## 3. Run discipline
+
+- **OTel on for every arm** (`HELIX_OTEL_ENABLED=1`) — each run doubles as G1
+  capture + calibration data (dense-cosine, know-confidence, PKI series all
+  land in Grafana now).
+- **AST assertion** (gap #2) checked before scoring any arm-B/C run.
+- **Load annotation:** per the 2026-07-01 method note, record rig load with
+  every run; latency comparisons only within matching load profiles.
+- **Held-out discipline:** no knob changes between arms; the cap sweep
+  {4, 8, 16} runs only if arm C shows ≥ +1pp on either external bench, and on
+  a corpus not used for tuning.
+- **Decision rules** (unchanged from council): B ≤ BM25 → halt code-track
+  merges, re-open chunking. C ≥ +1pp → cap sweep + revisit default-on +
+  unlock scope-gap work. C regresses on both → WS2/WS3 stays dark permanently.
+
+## 4. After the core run
+
+- SWE-Explore arm (§0) if licenses clear — its context-efficiency metric is
+  the publishable form of our injected-tokens story.
+- Gate run per the judge protocol in
+  `docs/specs/2026-07-01-abstain-search-escalation.md` §4 (≥350 answered,
+  trinary cross-family judge, risk-coverage reporting) — first measured G2
+  datapoint.

--- a/docs/benchmarks/code-track-regression-log.md
+++ b/docs/benchmarks/code-track-regression-log.md
@@ -1,0 +1,61 @@
+# Code-track regression log + knob-impact map
+
+Living record of ContextBench Step-0 results by build/config, and which knobs
+move which arm/metric. All numbers: `gold_smoke_4repo.parquet` (26 tasks),
+official evaluator, lexical config, SEMA-off, micro-avg over the common task set.
+Headline metric = **packet line recall** (the production delivery path).
+
+## Results history (packet line recall unless noted)
+
+| build / config | packet line_R | fp@27k line_R | fp@8k line_R | notes |
+|---|---|---|---|---|
+| BM25:27k (foil) | 0.484 | — | 0.314@8k | reproduces frozen baseline exactly |
+| regex chunking (`m224`) | 0.655 | 0.549 | — | no tree-sitter; pre-AST |
+| greedy-AST | 0.662 | 0.626 | 0.134 | master tree_chunker (top-level greedy + char-cut) |
+| **cAST byte-exact** (#228) | **0.804** | 0.679 | 0.222 | recursive split-then-merge; Phase-1 win |
+| WS2 symbol_graph, **unbounded** (#230) | 0.825 | **0.538** | 0.212 | +packet, **−14pp fp@27k** (unranked expansion dumps into budget) |
+| **WS3 cap=8 (PageRank-ranked)** | **0.825** | **0.605** | 0.212 | holds packet, recovers +6.7pp fp@27k; **best sym_R 0.834**; precision recovered |
+
+Key transitions:
+- regex → cAST: **+15pp packet** (the chunking lever).
+- cAST → WS2-unbounded: **+2.1pp packet** but **−14pp fp@27k** (expansion helps curated assembly, hurts budget-fill).
+- WS2-unbounded → **WS3 cap=8: packet recall unchanged (0.825), symbol recall best-in-class (0.834), precision recovered (0.018→0.020), and fp@27k recovered +6.7pp (0.538→0.605).** Net improvement over unbounded; the cap + centrality ranking works.
+
+**Verdict (Phase 2a):** net win. The packet (production path) keeps its WS2 gain with better symbol recall + precision; the fingerprint budget-fill arm recovers most of its regression. Residual fp@27k gap to WS2-off (0.605 vs 0.679) is the budget-fill arm still paying a small expansion cost — addressable by Phase 2b (PageRank-ordered budget trim) **if the fingerprint arm matters**, but the production packet is fully won, so 2b stays deferred per the council. The cap (8) is a principled default; tune via a sweep on a **held-out** corpus, not this smoke set.
+
+## Knob → impact map
+
+| knob | default | primarily moves | neighboring impacts / cautions |
+|---|---|---|---|
+| `[ingestion] symbol_graph` | true | packet recall ↑; fp recall ↓ when unbounded | ingest time (edge emission), `symbol_defs`/`gene_relations` size |
+| `[retrieval] symbol_expansion_cap` | 8 | **fp regression lever**: ↑cap → recall↑ but budget-fill precision↓ (0 disables, <0 unbounded) | interacts with token budget; ranked by PageRank centrality |
+| `[ingestion] sema_embed_on_ingest` (#227) | true | — (off = no MiniLM load) | multi-worker bench OOM if true at scale; TCM uses text fallback when off |
+| cAST `max_chars` | 4000 | chunk granularity → recall/precision | larger → fewer, bigger chunks; below candidate size = no chunking |
+| PageRank `damping` (WS3) | 0.85 | centrality distribution | minor; rarely tuned |
+| PageRank personalization (query 10×, session 50×) | Aider values | which defs survive the cap | **overfit risk** — do not tune on the smoke set; validate held-out |
+| code-query gating (classifier) | on | confines symbol effects to code | prose non-regression depends on classifier accuracy |
+
+## Method notes (reproducibility)
+- Builds are isolated on one venv via `PYTHONPATH` override of the editable `.pth` (baseline) vs the WS branch (under test) — same deps, same config, only the code differs.
+- Bench: `cb_helix_pred.py --tag <build> --config helix_probe_nosema.toml --workers 3`; scored by `cb-step0` venv over the common instance-id intersection.
+- A worker OOM (`BrokenProcessPool`) yields a partial pred set; the common-id intersection keeps comparisons fair.
+- **2026-07-01 environment note:** rig is multi-tasking today (baseline ~14% CPU / 59% RAM / 24% GPU from concurrent sessions). Per-query latency captured today is load-annotated, not clean-room — fine for recall/precision comparisons, but do **not** decide latency-sensitive knobs (Wall-2 A/B #206, PageRank query-budget checks) on today's numbers without an idle-rig re-run. OTel latency histograms (`helix_context_latency_seconds`, `helix_pipeline_stage_seconds`) captured today inherit the caveat.
+
+## Council gating experiments (2026-06-28)
+
+**Ablation — PageRank vs in-degree (smoke, common 26):** PageRank packet 0.825 / fp@27k 0.605 vs in-degree 0.809 / 0.580 vs WS2-off 0.804. PageRank beats in-degree (+1.6pp packet, +2.5pp fp); in-degree captures only ~¼ of the gain. → **PageRank earns its place** (the "in-degree suffices" hypothesis is refuted).
+
+**Held-out — WS3-on vs WS2-off (sympy, unseen, common 20):** packet 0.598 vs 0.591 (**+0.7pp**, vs +2.1pp on the tuning smoke); fp@27k 0.461 vs 0.537 (**−7.6pp**). → **The symbol-graph gain is small and corpus-sensitive and does not robustly survive held-out**; it can regress the fingerprint on a new corpus.
+
+**Decision:** **dark-ship WS2/WS3** — `[ingestion] symbol_graph` default flipped to **false**. The feature stays fully available (opt-in) but is not an always-on production default, because the gain is marginal + inconsistent across corpora. cAST (WS1) + #227 remain default-on (cAST's +15pp is robust and corpus-independent). Revisit default-on only after a broader held-out sweep.
+
+## Scope & caveats (council review, 2026-06-28)
+- **Blob-mode only.** WS2/WS3 are not wired into the sharded router (`shard_router.py` walks only `harmonic_links`); `_emit_symbol_graph` no-ops on the sharded write adapter. All numbers here are single-genome/blob; sharded corpora get the cAST chunking gain but **no** symbol-graph gain.
+- **Python-only symbol refs.** cAST chunking covers 8 languages, but reference extraction (`_PY_REF_LANGS`) is python-only — JS/TS/Go/Java/Rust/C++ get definitions indexed but **zero SYMBOL_REF edges**, so WS2/WS3 are inert there.
+- **Existing genomes need re-ingest** to populate `symbol_defs` / `SYMBOL_REF` (`CREATE TABLE IF NOT EXISTS` adds the empty table; edges are written only on ingest).
+- **PageRank ≈ in-degree in production.** At retrieval the personalization is `query_symbol_nodes=cand_ids` (uniform — the 10×/50× weights are not wired through the live path), so the measured fp recovery is plausibly the **cap**, not centrality ordering. A `cap+PageRank` vs `cap+in-degree` ablation is the deciding test for keeping the module.
+- Validation is a single 26-task smoke (+2.1pp packet is sub-one-task); the held-out sweep is still owed before treating WS2/WS3 as load-bearing.
+
+## Cautions
+- The packet (max 32 genes) is the production path and the headline metric; the fingerprint arm is a diagnostic that stresses budget-fill behaviour (which is why it caught the unbounded-expansion regression).
+- Personalization weights and the cap should be validated on a held-out corpus, not tuned to maximize the 26-task smoke.

--- a/docs/research/2026-07-01-next-bench-wave-consensus.md
+++ b/docs/research/2026-07-01-next-bench-wave-consensus.md
@@ -1,0 +1,196 @@
+# Next benchmarking/tuning wave — swarm consensus (2026-07-01)
+
+**Decision:** After the fable-5 session, what is the next benchmarking/tuning wave?
+State: cAST (#228) + SEMA-gate (#227/#229) validated default-on (packet line recall
+0.804 vs BM25 0.484, ContextBench 26-task smoke), ready to merge. WS2 (#230) + WS3
+(#231) review-clean, dark-shipped opt-in (held-out sympy: +0.7pp packet / −7.6pp
+fp@27k). Constraints: single rig, runs are hours–days, smoke set is 26 tasks
+(overfit risk), production path = packet.
+
+**Options:**
+- **A** — broader held-out sweep to decide WS2/WS3 default
+- **B** — merge #228/#229 (+ tree-sitter packaging) → external benches RepoBench-R / CodeRAG-Bench post-cAST (PRD Phase-1 acceptance)
+- **C** — resume the idle 2026-06-10 prose/tuning roadmap (#202 plumb, #203 dense, #204 SPLADE, #205 profiles, SNOW-2)
+- **D** — ERB semantic re-test / ERB github-source content-type audit
+- **E** — close scope gaps (sharded-router wiring, multi-language symbol refs, live personalization)
+
+## Panel
+Pragmatic Engineer · Scale Architect · Operations Realist · Product Strategist ·
+Devil's Advocate. (IR/lexical-first lens intentionally lighter this round — those
+guards are already codified as tests and leak-guards from the 2026-06-28 councils.)
+
+## Independent positions
+
+**Pragmatic Engineer** — *Favors B.* Two validated, low-risk wins are sitting in
+worktrees accumulating drift against a stale master; merging is cheap and removes
+the biggest source of future integration pain. The packaging decision (tree-sitter
+extras-only → silent regex fallback) is small and is the difference between "the
+win exists" and "users get the win." Scores: **B 9**, A 6 (real, but can ride B's
+bench runs), C 5 (#202 plumb is cheap — background it), D 3, E 2 (YAGNI while
+dark). Changes mind on E if WS2/WS3 earns default-on.
+
+**Scale Architect** — *Favors A-rigor, delivered via B.* The open technical
+question is generalization: the smoke set already burned us once (sympy held-out
+flipped the WS2/WS3 verdict). But RepoBench-R and CodeRAG-Bench *are* unseen
+corpora — run them with `symbol_graph` off/on arms and they double as the broader
+held-out sweep. Insists: multi-corpus, no knob tuned on the smoke set, cap sweep
+only on held-out. Scores: A 8, **B 7** (conditional on the arms), E 5 (sharded gap
+is where scale lives, but gated), C 4 (the 28%@850K cliff is the R3 program, gated
+on the 500K fixture), D 4. Changes mind if external benches contradict the smoke
+ranking — then chunking, not expansion, gets re-opened.
+
+**Operations Realist** — *Favors B, with C's cheap unblockers early.* Four live
+worktrees + a stale local master is operational drift; runbooks for both external
+benches already exist; merged code makes every subsequent run reproducible from
+one branch. #202's knob plumb (byte-identical defaults) and the telemetry top-5
+are one-day items that make every later sweep produce calibration data instead of
+anecdotes. A full ERB 850K re-ingest would block the rig for days. Scores: **B 8**,
+C 6 (selective resume: plumb + telemetry only), A 6 (fold into B, don't build a
+bespoke sweep harness), D 3, E 3. Changes mind on D if the audit shows a large
+code-typed gold share in the github bucket.
+
+**Product Strategist** — *Favors B.* The PRD's stated goal is converting
+RepoBench-R parity into a citable win over BM25; the 0.804 number is an internal
+smoke on our own scorer. RepoBench-R `acc@k` and CodeRAG-Bench `NDCG@10` against
+published baselines are the credible external claim — and Phase-1 acceptance is
+literally defined on them. ERB's published baselines matter later, but the honest
+path above that line is the agentic arm (SNOW-2), not the encoder fight the
+2026-06-04 strategy doc already demoted. Scores: **B 9**, A 5, D 4, C 4, E 3.
+
+**Devil's Advocate** — *Favors B, but as falsification, not victory lap.* Four
+challenges: (1) "Held-out sweep first" is premature — WS2/WS3 is dark and safe;
+its default decision has no deadline. (2) Merging cAST without the packaging fix
+ships a dark path — the +15pp evaporates on a default install; packaging is the
+real gate of B, not a rider. (3) 26 tasks means 0.804 could be partly luck;
+external benches are the test that can *break* the claim — run them expecting
+failure. (4) The 2026-06-10 roadmap is three weeks stale; re-triage before
+executing its day-plan. On D: the question is malformed — nothing in the code
+path touches prose semantic (all changes gate on `content_type == "code"` +
+code-classified queries); only the github-bucket audit has information value.
+Scores: **B 8** (packaging as hard gate), A 5, C 5 (re-triage first), D 3, E 2.
+
+## Conflict map
+
+| Topic | Agrees | Disagrees | Confidence |
+|---|---|---|---|
+| B first (merge + external benches) | All 5 | — | **High** |
+| Packaging decision gates the merge | Pragmatic, Devil's (+2026-06-28 council #10) | — | **High** (cross-validated) |
+| Fold A into B (symbol_graph off/on arms on external benches) | Scale, Ops, Pragmatic | — | **High** |
+| Smoke-set overfit risk → no tuning on smoke | Scale, Devil's (+regression-log caution) | — | **High** (cross-validated) |
+| Full ERB semantic re-run now | — | All 5 against | **High (against)** |
+| Resume C wholesale | — | Ops, Devil's (re-triage; only plumb+telemetry now) | Medium |
+| Invest in E now | — | All (gated on WS2/WS3 earning default-on) | High (against) |
+
+**Blind spots:** no persona for downstream *generation* quality (SWE-bench e2e is
+Phase-2, untouched here); no end-user lens (Continue/MCP consumers of the packet);
+cross-file symbol resolution quality remains unrepresented (flagged 2026-06-28).
+
+## Consensus recommendation
+
+**Decision:** **Option B, with A folded in as bench arms** — merge, then externally
+validate, letting the external corpora double as the held-out evidence for the
+WS2/WS3 default decision. D reduces to a ~1-hour audit; C resumes selectively
+(cheap unblockers only); E stays gated.
+**Confidence:** High (5/5 first-choice B).
+**Unanimous:** Yes, with scoped dissent: Scale requires the off/on arms; Devil's
+requires packaging-as-gate and failure-expectation framing.
+
+### Sequenced plan
+
+1. **Merge wave (no rig time).** Land #228 + #229 on master. Hard gate: the
+   tree-sitter packaging decision — promote to core deps *or* loud ingest warning
+   on regex fallback (PRD Phase-0 / leak-guard 5; council finding #10). Sync
+   `helix.toml` + CLAUDE.md for the three new knobs. Keep #230/#231 dark-shipped
+   as-is (merge their branches only if rebase pain says otherwise).
+2. **External bench wave (PRD Phase-1 acceptance + held-out sweep in one).**
+   RepoBench-R `acc@k` and CodeRAG-Bench `NDCG@10` per existing runbooks, three
+   arms each: BM25 foil / cAST-default / cAST + `symbol_graph=on` (cap=8). cAST
+   arm must clear the BM25 bar (the parity-to-win conversion); the symbol arm is
+   pure held-out signal for the WS2/WS3 default decision. No knob changes between
+   arms; nothing tuned on the 26-task smoke.
+3. **Cap sweep (only if step 2's symbol arm shows signal ≥ +1pp on either bench):**
+   `symbol_expansion_cap ∈ {4, 8, 16}` on one held-out corpus. Otherwise WS2/WS3
+   stays dark indefinitely and E investment is cancelled.
+4. **ERB audit (~1 hour, parallel, no rig):** census file extensions under
+   `sources/github`, count gold `expected_doc_ids` resolving there, check the
+   fixture's stored content-type distribution. Outcome closes the lingering
+   question either way (see appendix).
+5. **Tuning-roadmap re-triage (background):** land #202 knob plumb (byte-identical
+   defaults + `precision_probe`/`ab_flag_sweep` regression) and the telemetry
+   top-5 so every subsequent run emits calibration data. Re-date the rest of the
+   2026-06-10 plan (#203–#205, SNOW-2) *after* the code track's merge+bench wave
+   completes — SNOW-2 remains the post-#205 acceptance bench, unchanged.
+
+### Mitigations for top concerns
+1. Dark AST path (cross-validated) → packaging decision is a merge *gate*, not a
+   follow-up; add the AST-vs-regex path counter assertion to the bench harness so
+   every external run proves the AST path fired.
+2. Smoke overfit (cross-validated) → external benches run with frozen config;
+   any surprise (cAST ≤ BM25) re-opens chunking before any new feature work.
+3. Rig contention (Ops) → order is merge (no rig) → external benches → optional
+   cap sweep; ERB audit is SQL/filesystem-only and runs anytime.
+4. Stale roadmap (Ops + Devil's) → step 5 re-dates rather than executes the June
+   day-plan.
+
+### Reversibility
+High. Merges are config-gated (`symbol_graph=false`, `sema_embed_on_ingest`
+revertible; cAST falls back to regex). Bench waves are read-only. The only
+low-reversibility item is the packaging decision — a core-dep promotion changes
+the wheel for all users; the loud-warning option is the reversible fallback.
+
+### Review triggers
+- cAST arm fails to beat BM25 on RepoBench-R or CodeRAG-Bench → halt merges of
+  further code-track features; re-open chunking (Phase-1 gate, PRD §3).
+- Symbol arm ≥ +1pp on either external bench → schedule cap sweep + revisit
+  default-on; also unlocks E (sharded wiring, multi-lang refs).
+- Symbol arm regresses on both → keep dark permanently; close #230/#231 follow-ups.
+- ERB audit shows >10% of gold in code-typed github files → schedule the one-shard
+  re-ingest A/B (below); else close the semantic re-test question.
+- GB10 encoder re-embed becomes available → *that* is the trigger for the ERB
+  semantic re-run, not the code-track changes.
+
+## Appendix — the lingering ERB question, resolved
+
+**Q: With the code-path improvements, is it worth re-testing semantic on ERB?**
+
+**A: No for the semantic bucket; a 1-hour audit for the github bucket.** Every
+code-path improvement is gated twice: at ingest (`content_type == "code"` →
+`CodonChunker._chunk_code`, fragments.py:78) and at retrieval (code-classified
+queries gate symbol expansion). ERB is prose-typed enterprise data; its semantic
+bucket (recall@10 = 2.4% @850K) is encoder-geometry-bound — the cheap routing fix
+was already smoke-refuted on 2026-06-04, re-implicating the encoder (~54% of the
+miss). The code changes are mechanically unreachable from that path; a re-run
+would re-measure the same encoder. Moreover the 2026-06-04 strategy doc's own
+gate — "if code-context wins without dense, the re-embed reframes to prose-only,
+defer" — has now *fired*: code won on lexical+structure with dense off. The code
+results strengthen the deprioritization; they don't argue for a re-test.
+
+**The one exception:** ERB's `sources/github` subtree. Fixtures were built
+~2026-05-20, pre-cAST; if that source contains real code files, they were chunked
+with the old path. If the audit (extension census + gold-share count) shows a
+material code-typed gold share, run a one-shard re-ingest A/B (re-chunk github
+source post-#224+cAST, re-run only github-bucket questions) — cheap, targeted,
+and it isolates the chunking effect from the encoder question.
+
+**Q: Do we have a file-type path for flagging code vs prose?**
+
+**Yes — extension-based, in two places (#224):**
+- `helix_context/cli/cmd_ingest.py:_content_type_for` — 26 code extensions →
+  `content_type="code"`, else `"text"`; `.md`/`.rst`/`.json` intentionally text.
+- `scripts/build_fixture_matrix.py:184,519` — same `ct = "code" if ext in
+  CODE_EXTS` logic in the fixture builder.
+- HTTP `/ingest` and `api.ingest()` take an explicit `content_type` (default
+  `"text"` — callers must set it); `mem_sync._infer_content_type` covers memory
+  files.
+
+**Known gaps:** extension-only (no content sniffing — a `.md` full of code fences
+stays prose, which is the intended PRD leak-guard-6 behavior); notebook/`.ipynb`
+and templated files (`.erb`, `.vue`, `.svelte`) are not in `CODE_EXTS`; the two
+extension lists (CLI vs fixture builder) should be unified into one shared
+constant to prevent drift.
+
+---
+> This analysis simulates multiple specialist perspectives to surface risks and
+> tradeoffs. It is not a substitute for input from actual domain experts. The
+> personas are heuristic models — real specialists may identify concerns not
+> captured here. Use it as a structured starting point, not a final verdict.

--- a/docs/specs/2026-07-01-abstain-search-escalation.md
+++ b/docs/specs/2026-07-01-abstain-search-escalation.md
@@ -1,0 +1,112 @@
+# Spec: abstain → search escalation (SNOW-2 arm E extension)
+
+**Date:** 2026-07-01 · **Status:** DRAFT (research-grounded; build after arm-E internal baseline)
+**Companions:** `docs/specs/2026-07-01-goal-gates-hallucination-visibility.md` (G2/G3 gates),
+2026-06-10 tuning roadmap §1 (SNOW-2 arm E) · **Leads:** Max + Claude
+**Research basis:** R2 web survey 2026-07-01 (citations inline; VERIFIED = read on page).
+
+## 1. Design
+
+On `miss{reason}` or `know.confidence < floor`, the packet already tells the agent
+what to do next (`escalate_to`, `refresh_targets`). The extension makes the
+escalation executable and persistent:
+
+1. **Abstain packet (search seed).** query + `miss.reason` + below-floor
+   candidate titles/fired-tiers/confidences + `refresh_targets`. Compact,
+   provenance-tagged, never delivered as context — it is the *reference doc*
+   for the search.
+2. **Reason-mapped actions** (CRAG's Correct/Incorrect/Ambiguous taxonomy mapped
+   onto our richer enum):
+   - `stale` / `superseded` / `cold` → internal refresh: re-read
+     `refresh_targets`, `/consolidate`, re-query. No external search.
+   - `sparse` / `no_promoter_match` → tiered external escalation.
+   - `abstain` (weak-and-flat) → query reformulation first (the packet's
+     below-floor titles seed the rewrite), then external tier.
+   - `denatured` → operator alert, no auto-search (corpus integrity issue).
+3. **Tiered `escalate_to`** (FrugalGPT cascade pattern): local corpus →
+   upstream RAG (`[headroom]` / configured upstream) → web search; each tier
+   has its own acceptance threshold before escalating further.
+4. **Round budget** (SIM-RAG): sufficiency check per escalation round, cap ≤3
+   rounds; every round's decision is the same calibrated gate, not a new
+   mechanism.
+5. **Write-back with provenance.** Accepted results are `/ingest`-ed with
+   `source_kind=escalation`, provenance carrying the trigger (query, reason,
+   tier) — so the next identical query is a `know` and the escalation cost is
+   amortized across future queries (Evolve's persistence pattern). Web content
+   enters **subject to the freshness gate and provenance tiers, never as
+   authoritative** — CRAG treats web as complementary, so do we.
+6. **Telemetry.** Rides the wiring landed today: `helix_know_decision_total`
+   (repair velocity = miss-rate decay per reason), plus a new
+   `helix_escalation_total{tier, reason, outcome}` when this ships.
+
+## 2. Prior-art grounding (why this shape)
+
+No published system combines all four pieces; each piece is separately
+validated:
+
+| Piece of our design | Closest precedent | Evidence |
+|---|---|---|
+| Calibrated-classifier abstain gate (no query-time LLM) | Kamath et al. 2020, selective QA calibrator | beats softmax: 56% vs 48% coverage @ 80% acc — [arXiv 2006.09462](https://arxiv.org/abs/2006.09462) VERIFIED |
+| Post-retrieval evaluator → web-search escalation | CRAG | lightweight trained evaluator, {Correct, Incorrect, Ambiguous} → refine / discard+web / blend — [arXiv 2401.15884](https://arxiv.org/abs/2401.15884) VERIFIED |
+| Cheap feature-based gate is competitive with LLM-uncertainty gates | LLM-Independent Adaptive RAG (27 external features, zero LLM calls at decision time) | matches LLM-based methods on 6 QA sets with large efficiency gains — [arXiv 2505.04253](https://arxiv.org/abs/2505.04253) VERIFIED; corroborated by the AdaRAGUE 35-method survey — [arXiv 2501.12835](https://arxiv.org/abs/2501.12835) VERIFIED |
+| Persistent write-back / corpus self-repair | Evolve (teacher-compiled store, usage-driven refresh; 2B model 20–33%→60–84% while halving teacher calls) | [arXiv 2604.23424](https://arxiv.org/abs/2604.23424) UNCONFIRMED (snippet) |
+| Auto-labeled trigger training (no annotation) | Adaptive-RAG (labels = which strategy sufficed) + SIM-RAG (self-practice rollouts labeled by final-answer correctness) | [arXiv 2403.14403](https://arxiv.org/abs/2403.14403), [arXiv 2505.02811](https://arxiv.org/abs/2505.02811) VERIFIED |
+
+**Explicitly rejected** (with reasons): Self-RAG reflection tokens (bespoke
+generator, breaks proxy transparency — [2310.11511](https://arxiv.org/abs/2310.11511));
+FLARE/DRAGIN logit triggers (need mid-decode logits we don't have upstream —
+[2305.06983](https://arxiv.org/abs/2305.06983)); SeaKR internal-state
+uncertainty (white-box only — [2406.19215](https://arxiv.org/abs/2406.19215));
+Rowen multi-sample consistency (2×+ LLM calls to detect what retrieval features
+already signal — [2402.10612](https://arxiv.org/abs/2402.10612)); trusting
+downstream self-abstention — AbstentionBench shows reasoning fine-tuning
+*degrades* abstention by ~24%, so the gate must stay ours —
+[2506.09038](https://arxiv.org/abs/2506.09038) VERIFIED.
+
+## 3. Trigger training loop (auto-labeling)
+
+Adopt Adaptive-RAG/SIM-RAG's trick against our own telemetry: each judged eval
+run yields (features, outcome) pairs — know-that-was-wrong = calibrator false
+positive; miss-that-search-repaired = correct escalation; miss-that-search
+didn't-repair = corpus gap. Re-fit `[know]` betas from these via
+`scripts/calibrate_know_confidence.py` (5-feature path fixed 2026-07-01). No
+human labels. The `helix_know_confidence` histogram + judged outcomes are the
+training stream.
+
+## 4. Judge protocol for the G2/G3 gates (the measurement half)
+
+- **Judge:** frontier-class model from a **different family than the answer
+  generator**, **reference-guided** (question + gold + answer in prompt);
+  cross-check a 10% subsample with a second judge family + human spot-audit,
+  require ≥0.8 agreement. Judge-bias basis: position/verbosity/self-enhancement
+  biases and mitigations — [arXiv 2306.05685](https://arxiv.org/abs/2306.05685) VERIFIED.
+- **Rubric:** single-answer trinary — CORRECT / INCORRECT / ABSTAINED.
+  Single-answer grading sidesteps pairwise position bias.
+- **Scoring:** hallucination = INCORRECT / (CORRECT + INCORRECT); abstains go
+  to **coverage** = answered/total. Report the (risk, coverage) pair and the
+  risk-coverage curve (Kamath framing). **Gate = risk ≤10% AND correctness
+  ≥90% among answered AND a coverage floor** — without the floor the gate is
+  gameable by abstaining on everything.
+- **Sample size** (two-proportion normal approx., computed): distinguishing
+  true 15% from claimed 10% needs **n≈316 answered** (two-sided α=0.05, power
+  0.8; n≈438 at power 0.9). At n=300, p̂=10% → 95% CI ±3.4pp. For the 5%-vs-10%
+  long-goal gate: n≈264 (power 0.9). **Standing recommendation: ≥350 answered
+  items per gate run (~500 queries at ~70% coverage), refreshed per release.**
+- **Auxiliary monitor:** MiniCheck-class CPU fact-checker
+  ([arXiv 2404.10774](https://arxiv.org/abs/2404.10774) UNCONFIRMED) or RAGAS
+  faithfulness ([docs](https://docs.ragas.io/en/stable/concepts/metrics/available_metrics/faithfulness/)
+  VERIFIED) as always-on groundedness telemetry — but **never the gate**:
+  groundedness ≠ correctness (a faithful answer to stale context still passes
+  groundedness; that error class is exactly what our freshness gate exists for).
+
+## 5. Sequencing
+
+1. SNOW-2 arm E **internal** escalation baseline first (fingerprint triage →
+   expand → gene_get) — otherwise external-search lift is unattributable.
+2. Then external tier + write-back behind a flag (`[escalation]` section:
+   enabled, max_rounds=3, tier order, acceptance thresholds).
+3. Gate runs per §4 with OTel on; betas re-fit per §3 after each run.
+
+> Research provenance: R2 agent survey 2026-07-01; VERIFIED/UNCONFIRMED tags
+> preserved from the agent's page-level verification. Statistics computed via
+> two-proportion normal approximation, not cited from literature.

--- a/docs/specs/2026-07-01-goal-gates-hallucination-visibility.md
+++ b/docs/specs/2026-07-01-goal-gates-hallucination-visibility.md
@@ -1,0 +1,135 @@
+# Goal gates: 90/10 → 95/5 + hallucination visibility
+
+**Date:** 2026-07-01 · **Companion:** `docs/research/2026-07-01-next-bench-wave-consensus.md`,
+2026-06-10 tuning roadmap §3 · **Status:** telemetry wired (this PR); gates defined below.
+
+## North-star goals
+
+| Horizon | Accuracy / correctness | Hallucination | Condition |
+|---|---|---|---|
+| **Near (G2)** | ≥ 90% avg across functions | ≤ 10% avg, **visible in telemetry** | all helix-context delivery paths |
+| **Long (G3)** | ≥ 95% code AND prose | ≤ 5% both tracks | + abstain triggers search with the abstain as reference doc |
+
+## Definitions (so the numbers mean one thing)
+
+- **Hallucination rate** = confidently-wrong / answered: responses judged incorrect
+  (bench rubric / LLM judge) among those where helix emitted `know` (not
+  miss/abstain). Abstains are NOT hallucinations — they are the mechanism that
+  buys the budget. Measured by scored benches; **not** directly observable at
+  runtime.
+- **Runtime proxy (the "visible" part)** = the know/miss/abstain event stream.
+  Every turn now lands on `helix_know_decision_total{outcome,reason}`; the
+  calibration mapping confidence → P(correct) (`scoring/know_calibration.py`,
+  `[know]` floors) converts the confidence histogram into an *expected*
+  hallucination bound. Scored bench runs recalibrate that mapping; Grafana
+  carries it between runs.
+- **Accuracy source of truth** = scored benches per track: prose = ERB 500-question
+  correctness (published baselines: BM25 68.8 / Vector 51.4 / Onyx+GPT-4 72.4);
+  code = ContextBench packet recall + (post-merge) RepoBench-R/CodeRAG-Bench;
+  navigation/agentic = SNOW-2 arms.
+
+## The instrument set (roadmap §3, landed in two phases)
+
+**#209 phase 1** (already on master before this spec): `helix_know_decision_total`
+{outcome ∈ know|miss|abstain, reason (= "none" for know)} in the
+`decide_know_or_miss` wrapper; `helix_dense_cosine` {arm ∈ hot|cold} at both
+computation sites; `helix_shard_fanout` + `helix_shard_discrimination`
+(routed/known ∈ [0,1]) in `shard_router.query_genes`;
+`helix_session_tokens_saved_total` and `helix_splice_ratio`
+{caller_model_class} in `_assemble`.
+
+**#209 phase 2** (this change):
+
+| Series | Labels | Emission site |
+|---|---|---|
+| `helix_know_confidence` | — | know branch of the `decide_know_or_miss` wrapper |
+| `helix_abstain_total` | gate (floor_and_ratio\|ratio_only), fusion_mode | `pipeline/tier_logic.py` ABSTAIN gate |
+| `helix_freshness_demotion_total` | status (stale\|missing\|unknown\|superseded) | `retrieval/freshness.py` |
+| `helix_session_elided_total` | — | `_assemble` elision branch (event count beside tokens-saved) |
+| `helix_pki_candidates` / `helix_pki_pairs_skipped_total` | — | `knowledge_store` PKI tier |
+| `helix_fingerprint_filtered_total` | cause (floor\|cap) | `server/routes_context.py` /fingerprint |
+| `helix_ingest_vram_bytes` | — | `backends/bgem3_codec.encode_batch` |
+
+All lazy-getter pattern, no-op when OTel is off, `try/except` guarded — zero
+hot-path risk. Tests: `tests/test_telemetry_wiring.py`.
+
+## Gates and their PromQL
+
+**G1 — visibility gate (precondition, closes now):** during any bench run or
+live session with `HELIX_OTEL_ENABLED=1`, these series exist and move:
+
+```promql
+# Non-know share of turns (the observable slice of the 10% budget;
+# outcome is know|miss|abstain — abstains count as coverage loss)
+sum(rate(helix_know_decision_total{outcome=~"miss|abstain"}[15m]))
+  / sum(rate(helix_know_decision_total[15m]))
+# Expected-correctness floor from calibrated confidence
+histogram_quantile(0.5, rate(helix_know_confidence_bucket[1h]))
+# Stale-answer suppression activity
+sum by (status) (rate(helix_freshness_demotion_total[1h]))
+```
+
+Alert sketch: miss-share > 0.10 sustained 1h → warn ("hallucination budget
+spent on visible misses — retrieval, not honesty, is the bottleneck");
+know-share with confidence < emit_floor+margin trending up → recalibrate.
+
+**G2 — 90/10 gate:** per track, scored run ≥ 90% correctness AND judged
+hallucination ≤ 10% AND G1 series captured during the run (the run must be
+observable, not just scored). Prose vehicle: ERB scored 500-q @500K fixture.
+Code vehicle: ContextBench packet + external benches per the council plan.
+
+**G3 — 95/5 gate:** same vehicles, both tracks, plus the abstain→search loop
+live (below). Do not tune abstain floors on the bench that grades the gate
+(held-out discipline, same rule as the cap sweep).
+
+## Abstain → search escalation (the G3 mechanism)
+
+Already in the tree: `MissBlock.reason` + `refresh_targets` +
+`escalate_to=_pick_escalation(query, reason)` — the packet already tells the
+agent *what to do next*. The extension:
+
+1. **Reference doc:** on miss/abstain, assemble a compact "abstain packet" —
+   query, miss.reason, top-k below-floor candidates (titles + fired tiers +
+   confidence), refresh_targets. This is the search *seed*, not delivered
+   context.
+2. **Escalation branch:** extend `_pick_escalation` with `web_search` /
+   `external_rag` targets; `/context/packet` carries an `escalation` block:
+   `{action: "search", seed: <abstain packet>, reason}`.
+3. **MCP surface:** `helix_search_escalate` tool (or client-side: Claude/agent
+   sees `miss{reason}` and calls its own search with the seed attached as the
+   reference doc).
+4. **Persistence loop:** search results get `/ingest`-ed with provenance →
+   next turn the same query lands `know` — the miss literally repairs the
+   corpus. `helix_know_decision_total{reason}` rates measure repair velocity.
+
+Sequencing: build as SNOW-2 **arm E extension** (the 2026-06-10 roadmap §1
+already specs miss-reason-driven escalation); wire external search only after
+arm E's internal escalation baseline exists — otherwise the search lift is
+unattributable.
+
+## The loop (standing cadence)
+
+1. **Status checks** — regression-log delta + branch/PR sweep + G1 dashboard
+   glance. Per session start.
+2. **Testing/tuning** — per merged change: targeted suites + the council
+   plan's bench arms; sweeps only on held-out corpora; every run with OTel on
+   so it doubles as calibration capture.
+3. **Telemetry completion** — remaining roadmap §3 items as they become
+   load-bearing: PKI counters, dense cold-arm, VRAM gauge, fingerprint
+   floor/truncation counters; Grafana panels for today's nine series; the
+   `genai_telemetry` docs-vs-code drift (OBSERVABILITY.md documents a module
+   that doesn't exist — land or strike).
+
+## Follow-ups / known gaps
+
+- Grafana dashboard JSON has no panels for the new series yet (add to
+  `deploy/otel/grafana/dashboards/helix-overview.json`; delete the dead
+  pipeline-observatory dashboard per roadmap §3a).
+- `helix_dense_cosine{arm="cold"}` not yet emitted (cold-tier peek site).
+- OBSERVABILITY.md needs the nine new series documented (fold into the
+  config-doc sync that gates the #228/#229 merge).
+- Pre-existing: `scripts/calibrate_know_confidence.py --smoke` fails
+  ("features must have length 5 per row") on this checkout — pre-dates this
+  change; verify on the rig and fix before the next know-floor calibration.
+- Session-elision savings assume estimate_tokens parity between spliced text
+  and stub — good enough for the ~40% claim's direction, not for billing.

--- a/helix_context/backends/bgem3_codec.py
+++ b/helix_context/backends/bgem3_codec.py
@@ -172,6 +172,16 @@ class BGEM3Codec:
                 ),
                 dtype=np.float32,
             )
+        # #209 phase 2 / roadmap §3b-9: sample VRAM once per ingest batch
+        # so dense-ingest memory pressure (the #176/#177 OOM class) is a
+        # Grafana series, not a post-mortem. No-op without torch/CUDA.
+        try:
+            from ..telemetry import ingest_vram_gauge
+            import torch  # type: ignore[import-not-found]
+            if torch.cuda.is_available():
+                ingest_vram_gauge().set(float(torch.cuda.memory_allocated()))
+        except Exception:  # pragma: no cover
+            pass
         # Matryoshka truncate + per-row L2 renormalise.
         mat = mat[:, : self.dim]
         norms = np.linalg.norm(mat, axis=1, keepdims=True)

--- a/helix_context/context_manager.py
+++ b/helix_context/context_manager.py
@@ -2662,6 +2662,13 @@ class HelixContextManager:
                 )
                 parts.append(stub)
                 _delivery_log_map[g.gene_id] = None  # no re-log on elision
+                # #209 phase 2: event-count companion of the tokens-saved
+                # counter below (docs elided vs tokens saved).
+                try:
+                    from .telemetry import session_elided_counter
+                    session_elided_counter().add(1)
+                except Exception:
+                    pass
                 # #209 phase 1: estimated tokens saved by eliding an
                 # already-delivered document — full spliced text minus the
                 # stub actually shipped (~4 chars/token; conservative, a

--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -1891,6 +1891,23 @@ class KnowledgeStore:
                         gene_scores[gid] = gene_scores.get(gid, 0) + capped
                         tier_contrib.setdefault(gid, {})["pki"] = capped
                         _pki_ranked.append((gid, capped))
+                # #209 phase 2 / roadmap §3b-1: PKI tier visibility —
+                # candidate count per query + noise-cutoff skips. Feeds
+                # the R@1 collision census (§4-E1). No-op when OTel off.
+                try:
+                    from .telemetry import (
+                        pki_candidates_histogram,
+                        pki_pairs_skipped_counter,
+                    )
+                    pki_candidates_histogram().record(len(gene_pairs))
+                    _n_skipped = sum(
+                        1 for _card in pair_count.values()
+                        if _card > PKI_NOISE_CUTOFF
+                    )
+                    if _n_skipped:
+                        pki_pairs_skipped_counter().add(_n_skipped)
+                except Exception:  # pragma: no cover
+                    pass
                 # Stage 3: feed PKI ranks into the Fuser regardless of
                 # fusion_mode — the Fuser is queried only when "rrf",
                 # so additive mode pays a tiny add_tier cost (~1µs per

--- a/helix_context/pipeline/tier_logic.py
+++ b/helix_context/pipeline/tier_logic.py
@@ -180,8 +180,15 @@ def apply_budget_tiers(
         and ratio_for_gate < ratio_gate_threshold
     ):
         try:
-            from ..telemetry import budget_tier_counter
+            from ..telemetry import abstain_counter, budget_tier_counter
             budget_tier_counter().add(1, attributes={"tier": "abstain"})
+            # Dedicated abstain series with trigger attribution (roadmap
+            # §3b-4): under RRF only the ratio gate runs; under additive
+            # both the absolute floor AND the ratio tripped.
+            abstain_counter().add(1, attributes={
+                "gate": "ratio_only" if skip_absolute_floors else "floor_and_ratio",
+                "fusion_mode": str(fusion_mode),
+            })
         except Exception:  # pragma: no cover
             pass
         result.abstain = True

--- a/helix_context/retrieval/freshness.py
+++ b/helix_context/retrieval/freshness.py
@@ -197,6 +197,14 @@ def revalidate_and_mark(
                 gene.gene_id,
                 exc_info=True,
             )
+    if status != "fresh":
+        # Roadmap §3b-7: demotion-relevant freshness verdicts, visible in
+        # Grafana. "fresh" is the common case and is not emitted (volume).
+        try:
+            from ..telemetry import freshness_demotion_counter
+            freshness_demotion_counter().add(1, {"status": str(status)})
+        except Exception:  # pragma: no cover
+            pass
     return status
 
 
@@ -251,6 +259,11 @@ def check_superseded(genome, gene: "Gene") -> Optional[str]:
 
     if not successor_source_id:
         return None
+    try:
+        from ..telemetry import freshness_demotion_counter
+        freshness_demotion_counter().add(1, {"status": "superseded"})
+    except Exception:  # pragma: no cover
+        pass
     return str(successor_source_id)
 
 

--- a/helix_context/scoring/know_decision.py
+++ b/helix_context/scoring/know_decision.py
@@ -500,18 +500,20 @@ def decide_know_or_miss(
     ``helix_know_decision_total`` increment labelled ``{outcome,
     reason}``: outcome is ``know`` | ``miss`` | ``abstain``; reason is
     ``"none"`` for know and the ``MissBlock.reason`` (a member of
-    ``schemas.MISS_REASONS``) otherwise. #209 phase 1. The counter is a
-    no-op when OTel is off; a telemetry failure never alters the
-    decision.
+    ``schemas.MISS_REASONS``) otherwise. #209 phase 1. Know outcomes
+    additionally record ``helix_know_confidence`` for [know] floor
+    calibration (#209 phase 2). Instruments are no-ops when OTel is
+    off; a telemetry failure never alters the decision.
     """
     block = _decide_know_or_miss_impl(window, **kwargs)
     try:
-        from ..telemetry import know_decision_counter
+        from ..telemetry import know_confidence_histogram, know_decision_counter
         if isinstance(block, MissBlock):
             outcome = "abstain" if block.reason == "abstain" else "miss"
             reason = str(block.reason)
         else:
             outcome, reason = "know", "none"
+            know_confidence_histogram().record(float(block.confidence))
         know_decision_counter().add(1, {"outcome": outcome, "reason": reason})
     except Exception:
         pass

--- a/helix_context/server/routes_context.py
+++ b/helix_context/server/routes_context.py
@@ -804,6 +804,21 @@ def setup_context_routes(app: FastAPI, helix, config, registry, **_kw) -> None:
         returned = len(truncated)
         filtered_by_floor = evaluated_total - above_floor_total
         truncated_by_cap = above_floor_total - returned
+        # #209 phase 2 / roadmap §3b-10: floor/cap outcomes as counters so
+        # score_floor / max_results tuning has a live distribution, not
+        # just the response_hint string.
+        try:
+            from ..telemetry import fingerprint_filtered_counter
+            if filtered_by_floor > 0:
+                fingerprint_filtered_counter().add(
+                    filtered_by_floor, {"cause": "floor"},
+                )
+            if truncated_by_cap > 0:
+                fingerprint_filtered_counter().add(
+                    truncated_by_cap, {"cause": "cap"},
+                )
+        except Exception:  # pragma: no cover
+            pass
 
         attribution_map: dict = {}
         if truncated:

--- a/helix_context/telemetry/otel.py
+++ b/helix_context/telemetry/otel.py
@@ -839,6 +839,129 @@ def splice_ratio_histogram():
     return _instruments["splice_ratio"]
 
 
+def know_confidence_histogram():
+    """Histogram of KnowBlock.confidence (know outcomes only).
+
+    #209 phase 2: pairs with helix_know_decision_total — the confidence
+    distribution calibrates [know] emit_floor per corpus, and judged eval
+    runs map it to P(correct) (goal-gates spec 2026-07-01).
+    """
+    if "know_confidence" not in _instruments:
+        _instruments["know_confidence"] = meter.create_histogram(
+            "helix_know_confidence",
+            unit="1",
+            description="KnowBlock confidence distribution, know outcomes only.",
+        )
+    return _instruments["know_confidence"]
+
+
+def abstain_counter():
+    """Counter of ABSTAIN gate fires with trigger attribution.
+
+    #209 phase 2: gate is floor_and_ratio (additive: both the absolute
+    floor and the ratio tripped) or ratio_only (RRF: absolute floors
+    bypassed). Balancing partner of helix_splice_ratio — tuning that
+    raises compression but spikes abstains is a net loss.
+    """
+    if "abstain" not in _instruments:
+        _instruments["abstain"] = meter.create_counter(
+            "helix_abstain_total",
+            description="ABSTAIN gate fires, labelled by gate "
+                        "(floor_and_ratio | ratio_only) and fusion_mode.",
+        )
+    return _instruments["abstain"]
+
+
+def freshness_demotion_counter():
+    """Counter of demotion-relevant freshness verdicts.
+
+    #209 phase 2: status ∈ {stale, missing, unknown, superseded};
+    "fresh" is the common case and is not emitted (volume). The
+    stale-answer-suppression activity behind MissBlock stale/superseded.
+    """
+    if "freshness_demotion" not in _instruments:
+        _instruments["freshness_demotion"] = meter.create_counter(
+            "helix_freshness_demotion_total",
+            description="Freshness demotion-relevant events, labelled by "
+                        "status (stale | missing | unknown | superseded).",
+        )
+    return _instruments["freshness_demotion"]
+
+
+def session_elided_counter():
+    """Counter of documents replaced by an elision stub.
+
+    #209 phase 2: the event-count companion of
+    helix_session_tokens_saved_total (docs elided vs tokens saved).
+    """
+    if "session_elided" not in _instruments:
+        _instruments["session_elided"] = meter.create_counter(
+            "helix_session_elided_total",
+            description="Documents elided by the session working-set register.",
+        )
+    return _instruments["session_elided"]
+
+
+def pki_candidates_histogram():
+    """Histogram of documents hit by >=1 path_key_index pair per query.
+
+    #209 phase 2 / roadmap §3b-1: input to the R@1 AND-route program's
+    collision census.
+    """
+    if "pki_candidates" not in _instruments:
+        _instruments["pki_candidates"] = meter.create_histogram(
+            "helix_pki_candidates",
+            unit="genes",
+            description="Documents hit by >=1 path_key_index pair per query.",
+        )
+    return _instruments["pki_candidates"]
+
+
+def pki_pairs_skipped_counter():
+    """Counter of PKI pairs skipped by the noise cutoff.
+
+    #209 phase 2: unique (path_token, kv_key) pairs with cardinality >
+    PKI_NOISE_CUTOFF per query. High values = the index doing inventory,
+    not pruning (the #165 lesson).
+    """
+    if "pki_pairs_skipped" not in _instruments:
+        _instruments["pki_pairs_skipped"] = meter.create_counter(
+            "helix_pki_pairs_skipped_total",
+            description="path_key_index pairs skipped by the noise cutoff.",
+        )
+    return _instruments["pki_pairs_skipped"]
+
+
+def fingerprint_filtered_counter():
+    """Counter of /fingerprint candidates dropped, labelled by cause.
+
+    #209 phase 2 / roadmap §3b-10: cause ∈ {floor, cap} — calibrates
+    score_floor / max_results for agentic navigation (SNOW-2 arms C/E).
+    """
+    if "fingerprint_filtered" not in _instruments:
+        _instruments["fingerprint_filtered"] = meter.create_counter(
+            "helix_fingerprint_filtered_total",
+            description="/fingerprint candidates dropped, labelled by cause "
+                        "(floor | cap).",
+        )
+    return _instruments["fingerprint_filtered"]
+
+
+def ingest_vram_gauge():
+    """Gauge of CUDA memory sampled once per dense ingest batch.
+
+    #209 phase 2 / roadmap §3b-9: tracks the #176/#177 OOM class live
+    instead of post-mortem. No-op without torch/CUDA.
+    """
+    if "ingest_vram" not in _instruments:
+        _instruments["ingest_vram"] = meter.create_gauge(
+            "helix_ingest_vram_bytes",
+            unit="By",
+            description="torch.cuda.memory_allocated per dense ingest batch.",
+        )
+    return _instruments["ingest_vram"]
+
+
 def _emit_snapshot_values(
     *,
     chrom_rows: list[tuple[Any, Any]],

--- a/scripts/audit_erb_github_bucket.py
+++ b/scripts/audit_erb_github_bucket.py
@@ -1,0 +1,158 @@
+"""ERB github-bucket audit (council plan 2026-07-01, step 4).
+
+Decides the lingering question "is a semantic/ERB re-test worth it after the
+code-path improvements?" with data instead of opinion. The code path only
+fires for ``content_type == "code"``; ERB is prose except (possibly) the
+``sources/github`` subtree, and the fixtures were built pre-cAST. This audit
+measures whether that exception is material.
+
+Decision rule (from docs/research/2026-07-01-next-bench-wave-consensus.md):
+  gold share in code-typed github files > 10%  → schedule a one-shard
+  re-ingest A/B (re-chunk github source post-#224+cAST, re-run only
+  github-bucket questions);
+  otherwise → close the semantic re-test question; the encoder re-embed
+  (GB10-gated) remains the only ERB-semantic lever.
+
+Usage (rig, no GPU, seconds):
+  python scripts/audit_erb_github_bucket.py \
+      --erb-root F:/Projects/EnterpriseRAG-Bench-main \
+      [--genome genomes/bench/enterprise_rag_onyx_full_2/main.db]
+
+Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+try:  # single source of truth when run from the repo
+    from helix_context.cli.cmd_ingest import _CODE_EXTENSIONS as CODE_EXTS
+except Exception:  # fallback copy (#224 list)
+    CODE_EXTS = frozenset({
+        ".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".java", ".c",
+        ".h", ".cc", ".cpp", ".hpp", ".hh", ".cs", ".rb", ".php", ".lua",
+        ".scala", ".kt", ".kts", ".swift", ".sh", ".bash", ".sql", ".m",
+        ".mm",
+    })
+
+
+def census_extensions(github_root: Path) -> tuple[collections.Counter, int, int]:
+    """Extension histogram under sources/github + code-typed file count."""
+    exts: collections.Counter = collections.Counter()
+    total = code = 0
+    for p in github_root.rglob("*"):
+        if not p.is_file():
+            continue
+        total += 1
+        suf = p.suffix.lower()
+        exts[suf or "<none>"] += 1
+        if suf in CODE_EXTS:
+            code += 1
+    return exts, total, code
+
+
+def load_uuid_index(gen_root: Path) -> dict[str, str]:
+    """uuid -> path map; tolerant of value shapes."""
+    idx_path = gen_root / "uuid_index.json"
+    if not idx_path.exists():
+        return {}
+    raw = json.loads(idx_path.read_text(encoding="utf-8", errors="replace"))
+    out: dict[str, str] = {}
+    for k, v in raw.items() if isinstance(raw, dict) else []:
+        if isinstance(v, str):
+            out[k] = v
+        elif isinstance(v, dict):
+            for key in ("path", "file", "source", "relative_path"):
+                if isinstance(v.get(key), str):
+                    out[k] = v[key]
+                    break
+    return out
+
+
+def gold_share(gen_root: Path, uuid_index: dict[str, str]) -> tuple[int, int, int]:
+    """(total gold ids, gold in github bucket, gold in github with code ext)."""
+    total = in_gh = in_gh_code = 0
+    for qfile in ("questions.jsonl", "extra_questions.jsonl"):
+        qpath = gen_root / qfile
+        if not qpath.exists():
+            continue
+        for line in qpath.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                q = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            for doc_id in q.get("expected_doc_ids") or []:
+                total += 1
+                path = uuid_index.get(str(doc_id), str(doc_id))
+                norm = str(path).replace("\\", "/").lower()
+                if "sources/github" in norm or "/github/" in norm:
+                    in_gh += 1
+                    if Path(norm).suffix.lower() in CODE_EXTS:
+                        in_gh_code += 1
+    return total, in_gh, in_gh_code
+
+
+def genome_census(db_path: Path) -> None:
+    """How the fixture actually stored github-source genes."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        n_total = conn.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+        n_gh = conn.execute(
+            "SELECT COUNT(*) FROM genes WHERE LOWER(source_id) LIKE '%github%'"
+        ).fetchone()[0]
+        print(f"genome: {n_total} genes, {n_gh} with github-ish source_id "
+              f"({100.0 * n_gh / max(n_total, 1):.1f}%)")
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--erb-root", default=os.environ.get(
+        "ERB_ROOT", "F:/Projects/EnterpriseRAG-Bench-main"))
+    ap.add_argument("--genome", default=None,
+                    help="optional fixture db for a stored-source census")
+    args = ap.parse_args()
+
+    gen_root = Path(args.erb_root) / "generated_data"
+    github_root = gen_root / "sources" / "github"
+    if not github_root.is_dir():
+        print(f"ERROR: {github_root} not found", file=sys.stderr)
+        return 2
+
+    exts, total, code = census_extensions(github_root)
+    print(f"sources/github: {total} files, {code} with code extensions "
+          f"({100.0 * code / max(total, 1):.1f}%)")
+    for ext, n in exts.most_common(12):
+        marker = "  <- code-typed (#224)" if ext in CODE_EXTS else ""
+        print(f"  {ext:>8}  {n}{marker}")
+
+    uuid_index = load_uuid_index(gen_root)
+    g_total, g_gh, g_gh_code = gold_share(gen_root, uuid_index)
+    if g_total:
+        print(f"\ngold: {g_total} expected_doc_ids | github bucket {g_gh} "
+              f"({100.0 * g_gh / g_total:.1f}%) | code-typed within github "
+              f"{g_gh_code} ({100.0 * g_gh_code / g_total:.1f}% of all gold)")
+        verdict = ("SCHEDULE one-shard re-ingest A/B (gold share above 10%)"
+                   if g_gh_code / g_total > 0.10 else
+                   "CLOSE the semantic re-test question (code-typed gold share <= 10%)")
+        print(f"verdict: {verdict}")
+    else:
+        print("\ngold: no questions.jsonl found — run with --erb-root pointing "
+              "at the upstream checkout")
+
+    if args.genome:
+        genome_census(Path(args.genome))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/calibrate_know_confidence.py
+++ b/scripts/calibrate_know_confidence.py
@@ -96,21 +96,27 @@ def _row_to_features(
       lexical_dense_agree   bool/int
       coordinate_confidence float in [0, 1]
       label                 0/1 (1 = ground-truth retrieval-success)
+      freshness_min         float in [0, 1], optional (Stage 7, feature 4)
 
-    # STAGE-7-EXT: also reads ``freshness_min`` when present and
-    # appends it to the feature vector.
+    Stage 7: the feature vector is always N_FEATURES (5) long. A missing
+    ``freshness_min`` contributes 0.0 — byte-matching
+    ``compute_confidence``'s None branch (no contribution to z), so
+    training rows and inference agree on legacy data.
     """
     top_score = float(row.get("top_score", 0.0))
     score_gap = float(row.get("score_gap", 0.0))
     agree = bool(row.get("lexical_dense_agree", False))
     coord = float(row.get("coordinate_confidence", 0.0))
     label = int(bool(row.get("label", 0)))
+    fresh_raw = row.get("freshness_min")
+    fresh = 0.0 if fresh_raw is None else max(0.0, min(1.0, float(fresh_raw)))
 
     feat = [
         math.tanh(top_score / s_ref),
         math.tanh(score_gap / g_ref),
         1.0 if agree else 0.0,
         max(0.0, min(1.0, coord)),
+        fresh,
     ]
     return feat, label
 
@@ -302,7 +308,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.smoke:
         # Synthesize a separable-by-design fixture. The two clusters
         # are linearly separable so any reasonable fitter recovers
-        # positive coefficients on all four features.
+        # positive coefficients on all N_FEATURES (5) features —
+        # Stage 7 added freshness_min as feature index 4.
         rows: list[dict] = []
         for i in range(40):
             rows.append({
@@ -310,6 +317,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 "score_gap": 0.8 + (i % 4) * 0.05,
                 "lexical_dense_agree": True,
                 "coordinate_confidence": 0.7 + (i % 3) * 0.05,
+                "freshness_min": 0.85 + (i % 3) * 0.05,
                 "label": 1,
             })
         for i in range(40):
@@ -318,6 +326,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 "score_gap": 0.005,
                 "lexical_dense_agree": False,
                 "coordinate_confidence": 0.0,
+                "freshness_min": 0.05,
                 "label": 0,
             })
         log.info("smoke: %d synthetic rows", len(rows))

--- a/tests/test_telemetry_wiring.py
+++ b/tests/test_telemetry_wiring.py
@@ -1,0 +1,269 @@
+"""Unit tests for the 2026-07-01 hallucination-visibility telemetry wiring.
+
+Covers the roadmap §3 instruments that make the know/miss + abstain +
+freshness-demotion surfaces visible (the sub-10% hallucination target's
+observability layer).
+
+Seam: pre-seed ``helix_context.telemetry.otel._instruments`` with fakes —
+the lazy getters return the seeded instrument instead of creating one, so
+emissions are captured without an OTel SDK or collector.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from helix_context.telemetry import otel
+
+
+class FakeInstrument:
+    def __init__(self):
+        self.calls = []
+
+    def add(self, value, attributes=None):
+        self.calls.append(("add", value, dict(attributes or {})))
+
+    def record(self, value, attributes=None):
+        self.calls.append(("record", value, dict(attributes or {})))
+
+    def set(self, value, attributes=None):
+        self.calls.append(("set", value, dict(attributes or {})))
+
+
+_SEED_KEYS = (
+    "know_decision", "know_confidence", "abstain", "freshness_demotion",
+    "session_elided", "session_tokens_saved", "splice_ratio",
+    "dense_cosine", "shard_fanout", "shard_discrimination", "budget_tier",
+)
+
+
+@pytest.fixture
+def fakes(monkeypatch):
+    seeded = {}
+    for key in _SEED_KEYS:
+        seeded[key] = FakeInstrument()
+        monkeypatch.setitem(otel._instruments, key, seeded[key])
+    return seeded
+
+
+def _window(status="abstain", genes=0):
+    return SimpleNamespace(
+        context_health=SimpleNamespace(status=status, genes_expressed=genes),
+        metadata={},
+    )
+
+
+# ── know/miss discriminator ──────────────────────────────────────────
+
+def test_miss_abstain_emits_counter(fakes):
+    from helix_context.scoring.know_decision import decide_know_or_miss
+
+    out = decide_know_or_miss(
+        _window("abstain"),
+        query="q",
+        top_score=1.0,
+        score_gap=0.0,
+        lexical_dense_agree=False,
+        coordinate_confidence=0.0,
+    )
+    assert out.reason == "abstain"
+    # #209 phase-1 convention: abstain is its own outcome, not a miss.
+    assert fakes["know_decision"].calls == [
+        ("add", 1, {"outcome": "abstain", "reason": "abstain"}),
+    ]
+    # Confidence histogram records know outcomes only.
+    assert fakes["know_confidence"].calls == []
+
+
+def test_no_promoter_match_emits_reason(fakes):
+    from helix_context.scoring.know_decision import decide_know_or_miss
+
+    out = decide_know_or_miss(
+        _window("healthy", genes=0),
+        query="q",
+        top_score=0.0,
+        score_gap=0.0,
+        lexical_dense_agree=False,
+        coordinate_confidence=0.0,
+    )
+    assert out.reason == "no_promoter_match"
+    assert fakes["know_decision"].calls == [
+        ("add", 1, {"outcome": "miss", "reason": "no_promoter_match"}),
+    ]
+
+
+def test_know_emits_confidence_histogram(fakes):
+    from helix_context.scoring.know_decision import (
+        KnowCalibration,
+        decide_know_or_miss,
+    )
+
+    out = decide_know_or_miss(
+        _window("healthy", genes=3),
+        query="what port does helix use",
+        top_score=10.0,
+        score_gap=5.0,
+        lexical_dense_agree=True,
+        coordinate_confidence=1.0,
+        calibration=KnowCalibration(emit_floor=0.0),
+    )
+    assert hasattr(out, "confidence"), f"expected KnowBlock, got {out!r}"
+    # #209 phase-1 convention: reason is "none" for know outcomes.
+    assert fakes["know_decision"].calls == [
+        ("add", 1, {"outcome": "know", "reason": "none"}),
+    ]
+    recs = fakes["know_confidence"].calls
+    assert len(recs) == 1
+    assert recs[0][0] == "record"
+    assert recs[0][1] == pytest.approx(out.confidence)
+
+
+# ── ABSTAIN gate trigger attribution ─────────────────────────────────
+
+def test_abstain_gate_additive_floor_and_ratio(fakes):
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+
+    genes = [SimpleNamespace(gene_id=f"g{i}") for i in range(6)]
+    scores = {f"g{i}": 1.0 for i in range(6)}  # flat + weak → abstain
+    res = apply_budget_tiers(
+        genes, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="additive",
+    )
+    assert res.abstain is True
+    assert fakes["abstain"].calls == [
+        ("add", 1, {"gate": "floor_and_ratio", "fusion_mode": "additive"}),
+    ]
+    # The legacy tier label still fires alongside.
+    assert ("add", 1, {"tier": "abstain"}) in fakes["budget_tier"].calls
+
+
+def test_abstain_gate_rrf_ratio_only(fakes):
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+
+    genes = [SimpleNamespace(gene_id=f"g{i}") for i in range(6)]
+    scores = {f"g{i}": 0.25 for i in range(6)}  # all tied → norm ratio 0
+    res = apply_budget_tiers(
+        genes, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="rrf",
+    )
+    assert res.abstain is True
+    assert fakes["abstain"].calls == [
+        ("add", 1, {"gate": "ratio_only", "fusion_mode": "rrf"}),
+    ]
+
+
+def test_no_abstain_no_emit(fakes):
+    from helix_context.config import AbstainClassFloors
+    from helix_context.pipeline.tier_logic import apply_budget_tiers
+
+    genes = [SimpleNamespace(gene_id=f"g{i}") for i in range(6)]
+    # Strong, separated top → no abstain.
+    scores = {"g0": 9.0, "g1": 1.0, "g2": 1.0, "g3": 1.0, "g4": 1.0, "g5": 1.0}
+    res = apply_budget_tiers(
+        genes, scores, AbstainClassFloors(),
+        abstain_enabled=True, fusion_mode="additive",
+    )
+    assert res.abstain is False
+    assert fakes["abstain"].calls == []
+
+
+# ── freshness demotions ──────────────────────────────────────────────
+
+def test_freshness_missing_emits(fakes, tmp_path):
+    from helix_context.retrieval.freshness import revalidate_and_mark
+
+    gene = SimpleNamespace(
+        gene_id="g1",
+        source_id=str(tmp_path / "does-not-exist.md"),
+        last_verified_at=123.0,
+    )
+    genome = SimpleNamespace(mark_verified=lambda *a, **k: None)
+    status = revalidate_and_mark(
+        genome, gene, mtime_cache={}, now_ts=1000.0, read_only=True,
+    )
+    assert status == "missing"
+    assert fakes["freshness_demotion"].calls == [
+        ("add", 1, {"status": "missing"}),
+    ]
+
+
+def test_freshness_fresh_not_emitted(fakes, tmp_path):
+    from helix_context.retrieval.freshness import revalidate_and_mark
+
+    src = tmp_path / "src.md"
+    src.write_text("content")
+    gene = SimpleNamespace(
+        gene_id="g1",
+        source_id=str(src),
+        last_verified_at=time.time() + 3600,  # verified after mtime → fresh
+    )
+    genome = SimpleNamespace(mark_verified=lambda *a, **k: None)
+    status = revalidate_and_mark(
+        genome, gene, mtime_cache={}, now_ts=time.time(), read_only=True,
+    )
+    assert status == "fresh"
+    assert fakes["freshness_demotion"].calls == []
+
+
+class _Cur:
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, sql, params):
+        return self
+
+    def fetchone(self):
+        return self._row
+
+
+class _Conn:
+    def __init__(self, row):
+        self._row = row
+
+    def cursor(self):
+        return _Cur(self._row)
+
+
+def test_superseded_emits(fakes):
+    from helix_context.retrieval.freshness import check_superseded
+
+    genome = SimpleNamespace(read_conn=_Conn(("g2", "src-2")))
+    out = check_superseded(genome, SimpleNamespace(gene_id="g1"))
+    assert out == "src-2"
+    assert fakes["freshness_demotion"].calls == [
+        ("add", 1, {"status": "superseded"}),
+    ]
+
+
+def test_not_superseded_no_emit(fakes):
+    from helix_context.retrieval.freshness import check_superseded
+
+    genome = SimpleNamespace(read_conn=_Conn(None))
+    out = check_superseded(genome, SimpleNamespace(gene_id="g1"))
+    assert out is None
+    assert fakes["freshness_demotion"].calls == []
+
+
+# ── getter registration smoke ────────────────────────────────────────
+
+def test_all_new_getters_resolve():
+    """Every new lazy getter returns an instrument (noop or real) and is
+    re-exported through helix_context.telemetry."""
+    import helix_context.telemetry as tel
+
+    for name in (
+        "know_decision_counter", "know_confidence_histogram",
+        "abstain_counter", "freshness_demotion_counter",
+        "session_elided_counter", "session_tokens_saved_counter",
+        "splice_ratio_histogram", "dense_cosine_histogram",
+        "shard_fanout_histogram", "shard_discrimination_histogram",
+        "pki_candidates_histogram", "pki_pairs_skipped_counter",
+        "fingerprint_filtered_counter", "ingest_vram_gauge",
+    ):
+        getter = getattr(tel, name)
+        inst = getter()
+        assert hasattr(inst, "add") or hasattr(inst, "record"), name


### PR DESCRIPTION
﻿Completes the roadmap sec-3 instrument set on top of #209 phase 1, and lands the 2026-07-01 planning wave.

## Code (88a3692)
- 8 new instruments: know_confidence, abstain{gate,fusion_mode}, freshness_demotion{status}, session_elided, pki_candidates, pki_pairs_skipped, fingerprint_filtered{cause}, ingest_vram_bytes
- Emissions at: know wrapper (confidence), tier_logic ABSTAIN gate, freshness revalidate/supersede, _assemble elision, PKI tier, /fingerprint floor/cap, bgem3 encode_batch
- fix: calibrate_know_confidence --smoke was emitting 4 features vs N_FEATURES=5 (broken on both fitter paths); 5th feature now matches compute_confidence None->0 semantics
- New dashboard helix-know-miss (goal-gates view) + OBSERVABILITY.md sync
- Tests: tests/test_telemetry_wiring.py (seeded-instrument seam); full battery 145 passed on-rig

## Docs (399a640)
- Council consensus: merge-then-external-validate, held-out arms folded into external benches
- Goal gates: G1 visibility -> G2 90/10 -> G3 95/5, PromQL + judge protocol (>=350 answered, trinary cross-family reference-guided, risk-coverage)
- Abstain->search escalation spec (Kamath/CRAG/Adaptive-RAG/Evolve grounding, cited)
- External-bench run plan (3 arms, pre-run gaps incl. probe TOML + arm-C TOML) + landscape refresh (ContextBench harness re-pin, SWE-Explore candidate, CodeRAG license caveat)
- ERB github-bucket audit script; regression log now tracked with the load-annotation method note

## Verification
- py_compile all touched files; dashboard JSON validated
- pytest: test_telemetry_wiring + know_miss_block + freshness_gate + session_delivery + shard_router = 145 passed (rig, Python 3.14)
- All emissions lazy-getter + try/except guarded; noop when OTel off

Part of #209 (phase 2). Remaining #209 scope after this merges: the genai_telemetry module (docs/dashboards reference it; not on master).
