### PR TITLE
feat(bench): commit the external-bench harness suite + session docs (salvage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,15 @@ tools/native-otel/configs/*.yml
 # Deep-review working notes — local analysis artifacts (Tier-0 plan,
 # deep-review notes, PR-5 handoff). Not part of the tracked codebase.
 docs/reviews/2026-05-16-deep-review/
+
+# Local data / tool caches (2026-07-01 housekeeping)
+.serena/
+.tmp.driveupload/
+.worktrees/
+runs/
+s2b_*/
+benchmarks/aider_polyglot/
+benchmarks/contextbench/
+*.db-wal
+*.db-shm
+google_doc.*

--- a/benchmarks/bench_shard_recall.py
+++ b/benchmarks/bench_shard_recall.py
@@ -1,0 +1,430 @@
+"""bench_shard_recall.py -- Shard × dense recall A/B harness.
+
+Reads gold needles from build_shard_gold.py, issues POST /fingerprint per
+query, finds the first gold-path hit in the ranked list, and computes:
+
+  recall@1, recall@3, recall@5, recall@10
+  MRR (Mean Reciprocal Rank)
+
+All metrics are broken out by needle type (within / cross) and written to
+benchmarks/results/shard_recall_<label>_<ts>.json.
+
+Conventions match coderag_bench_helix.py and bench_claude_matrix.py:
+  - urllib (no third-party deps)
+  - /fingerprint endpoint, max_results=10, score_floor=0, profile="fast"
+  - path normalisation: forward-slash, lowercase, substring containment
+    (same rule as bench_claude_matrix.retrieval_probe and test_bench_needles.py)
+  - results/ JSON + printed table
+
+GOLD-PATH MATCH RULE
+--------------------
+A fingerprint source S matches a gold_path G when:
+    normalise(G) is a substring of normalise(S)
+    OR
+    normalise(S) is a substring of normalise(G)
+
+where normalise(x) = x.replace("\\\\", "/").lower().strip()
+
+This is the same bidirectional substring rule used by the existing needle
+harnesses.  It means gold_paths are project-relative substrings like
+"helix-context/helix_context/pipeline/stages.py".
+
+CLI
+---
+python benchmarks/bench_shard_recall.py \\
+    --needles benchmarks/results/shard_gold.jsonl \\
+    --helix-url http://127.0.0.1:11437 \\
+    --label sharded_medium
+
+python benchmarks/bench_shard_recall.py \\
+    --needles benchmarks/results/shard_gold.jsonl \\
+    --helix-url http://127.0.0.1:11438 \\
+    --label unsharded_medium_dense
+
+RUN SEQUENCE (4 genome modes)
+------------------------------
+# 1. SHARDED / dense-disabled server (medium corpus)
+python benchmarks/bench_shard_recall.py \\
+    --needles benchmarks/results/shard_gold_medium.jsonl \\
+    --helix-url http://127.0.0.1:11437 \\
+    --label medium_sharded
+
+# 2. UNSHARDED / dense-ON + backfilled server (medium corpus)
+python benchmarks/bench_shard_recall.py \\
+    --needles benchmarks/results/shard_gold_medium.jsonl \\
+    --helix-url http://127.0.0.1:11438 \\
+    --label medium_unsharded_dense
+
+# 3. SHARDED / dense-disabled server (xl corpus)
+python benchmarks/bench_shard_recall.py \\
+    --needles benchmarks/results/shard_gold_xl.jsonl \\
+    --helix-url http://127.0.0.1:11437 \\
+    --label xl_sharded
+
+# 4. UNSHARDED / dense-ON + backfilled server (xl corpus)
+python benchmarks/bench_shard_recall.py \\
+    --needles benchmarks/results/shard_gold_xl.jsonl \\
+    --helix-url http://127.0.0.1:11438 \\
+    --label xl_unsharded_dense
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+KS = (1, 3, 5, 10)
+
+
+# ---------------------------------------------------------------------------
+# Path normalisation (matches bench_claude_matrix / test_bench_needles)
+# ---------------------------------------------------------------------------
+
+def _norm(path: str) -> str:
+    return str(path or "").replace("\\", "/").lower().strip()
+
+
+def _gold_hit(source: str, gold_paths: list[str]) -> bool:
+    """Return True if source matches any gold path (bidirectional substring)."""
+    sn = _norm(source)
+    for gp in gold_paths:
+        gn = _norm(gp)
+        if gn and (gn in sn or sn in gn):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Metric helpers
+# ---------------------------------------------------------------------------
+
+def _recall_at(rank1: int | None, k: int) -> float:
+    """1.0 if rank (1-based) <= k else 0.0.  None means not retrieved."""
+    if rank1 is None:
+        return 0.0
+    return 1.0 if rank1 <= k else 0.0
+
+
+def _rr(rank1: int | None) -> float:
+    """Reciprocal rank.  None (not retrieved) scores 0."""
+    if rank1 is None:
+        return 0.0
+    return 1.0 / rank1
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * pct / 100
+    lo, hi = int(k), min(int(k) + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+# ---------------------------------------------------------------------------
+# /fingerprint HTTP call
+# ---------------------------------------------------------------------------
+
+def fingerprint(
+    helix_url: str,
+    query: str,
+    max_results: int = 10,
+    timeout_s: float = 30.0,
+) -> tuple[list[dict], float]:
+    """POST /fingerprint; return (fingerprints_list, latency_ms)."""
+    url = helix_url.rstrip("/") + "/fingerprint"
+    payload = json.dumps({
+        "query": query,
+        "max_results": max_results,
+        "score_floor": 0,
+        "profile": "fast",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+        body = json.loads(resp.read())
+    latency_ms = (time.time() - t0) * 1000.0
+    return body.get("fingerprints", []), latency_ms
+
+
+# ---------------------------------------------------------------------------
+# Scoring loop
+# ---------------------------------------------------------------------------
+
+def _zero_agg() -> dict:
+    a: dict = {"n": 0, "err": 0, "rr": 0.0, "latency_ms": []}
+    for k in KS:
+        a["recall@{}".format(k)] = 0.0
+    return a
+
+
+def score_needles(
+    needles: list[dict],
+    helix_url: str,
+    max_results: int = 10,
+    timeout_s: float = 30.0,
+) -> tuple[dict, list[dict]]:
+    """Run /fingerprint per needle; return (agg_by_type, per_needle_rows)."""
+    # Aggregates keyed by needle type: "within", "cross", "all"
+    agg: dict[str, dict] = collections.defaultdict(_zero_agg)
+    per_rows: list[dict] = []
+    n_total = len(needles)
+
+    for qi, nd in enumerate(needles):
+        ntype = nd.get("type", "within")
+        if (qi + 1) % 25 == 0 or qi == 0:
+            print("[shard_recall] {}/{} ...".format(qi + 1, n_total), flush=True)
+
+        gold_paths = nd.get("gold_paths", [])
+
+        try:
+            fps, lat_ms = fingerprint(helix_url, nd["question"], max_results, timeout_s)
+        except Exception as exc:
+            for key in (ntype, "all"):
+                agg[key]["err"] += 1
+            per_rows.append({
+                "id": nd.get("id"),
+                "project": nd.get("project"),
+                "type": ntype,
+                "question": nd.get("question", "")[:120],
+                "gold_paths": gold_paths,
+                "rank": None,
+                "error": repr(exc),
+            })
+            continue
+
+        # Find rank of first gold-path hit (1-based; None if not retrieved).
+        rank1: int | None = None
+        for i, fp in enumerate(fps):
+            src = fp.get("source") or fp.get("path") or ""
+            if _gold_hit(src, gold_paths):
+                rank1 = i + 1
+                break
+
+        for key in (ntype, "all"):
+            a = agg[key]
+            a["n"] += 1
+            a["rr"] += _rr(rank1)
+            for k in KS:
+                a["recall@{}".format(k)] += _recall_at(rank1, k)
+            a["latency_ms"].append(lat_ms)
+
+        per_rows.append({
+            "id": nd.get("id"),
+            "project": nd.get("project"),
+            "type": ntype,
+            "file_type": nd.get("file_type"),
+            "question": nd.get("question", "")[:120],
+            "gold_paths": gold_paths,
+            "rank": rank1,
+            "latency_ms": round(lat_ms, 1),
+            "n_returned": len(fps),
+        })
+
+    # Finalise.
+    summary: dict = {}
+    for key, a in sorted(agg.items()):
+        n = a["n"]
+        if n == 0:
+            continue
+        row: dict = {
+            "n": n,
+            "err": a["err"],
+            "mrr": round(a["rr"] / n, 4),
+            "latency": {
+                "median_ms": round(_percentile(a["latency_ms"], 50), 1),
+                "p90_ms": round(_percentile(a["latency_ms"], 90), 1),
+            },
+        }
+        for k in KS:
+            row["recall@{}".format(k)] = round(a["recall@{}".format(k)] / n, 4)
+        summary[key] = row
+
+    return summary, per_rows
+
+
+# ---------------------------------------------------------------------------
+# Pretty table
+# ---------------------------------------------------------------------------
+
+def _print_table(label: str, summary: dict) -> None:
+    hdr = (
+        "{:<8}  {:>5}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>8}  {:>8}".format(
+            "type", "n", "MRR", "R@1", "R@3", "R@5", "R@10",
+            "med_ms", "p90_ms",
+        )
+    )
+    print()
+    print("Shard recall A/B -- {}".format(label))
+    print(hdr)
+    print("-" * len(hdr))
+    for key in ("all", "within", "cross"):
+        if key not in summary:
+            continue
+        s = summary[key]
+        lat = s.get("latency", {})
+        print(
+            "{:<8}  {:>5}  {:>7.4f}  {:>7.4f}  {:>7.4f}  {:>7.4f}  {:>7.4f}"
+            "  {:>8.1f}  {:>8.1f}".format(
+                key, s["n"],
+                s["mrr"],
+                s.get("recall@1", 0.0),
+                s.get("recall@3", 0.0),
+                s.get("recall@5", 0.0),
+                s.get("recall@10", 0.0),
+                lat.get("median_ms", 0.0),
+                lat.get("p90_ms", 0.0),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Shard × dense recall A/B harness. "
+            "Issues POST /fingerprint per needle, computes recall@k + MRR "
+            "broken out by type (within / cross), writes results JSON."
+        )
+    )
+    ap.add_argument(
+        "--needles",
+        default=str(RESULTS_DIR / "shard_gold.jsonl"),
+        help="Path to JSONL needle file produced by build_shard_gold.py.",
+    )
+    ap.add_argument(
+        "--helix-url",
+        default="http://127.0.0.1:11437",
+        dest="helix_url",
+        help="Base URL of the Helix server (default: http://127.0.0.1:11437).",
+    )
+    ap.add_argument(
+        "--label",
+        default="unlabeled",
+        help="Run label for the results filename, e.g. 'medium_sharded'.",
+    )
+    ap.add_argument(
+        "--max-results",
+        type=int,
+        default=10,
+        dest="max_results",
+        help="max_results for /fingerprint (default 10; recall@10 saturates here).",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap total needles to score (0 = all).",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Per-request HTTP timeout in seconds (default 30).",
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Override output JSON path.",
+    )
+    args = ap.parse_args(argv)
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    # Load needles.
+    needles_path = Path(args.needles)
+    if not needles_path.exists():
+        print(
+            "ERROR: needles file not found: {}\n"
+            "  Run: python benchmarks/build_shard_gold.py --out {}".format(
+                needles_path, needles_path
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    needles: list[dict] = []
+    with needles_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                needles.append(json.loads(line))
+
+    if args.limit:
+        needles = needles[: args.limit]
+
+    print("[shard_recall] {} needles from {}".format(len(needles), needles_path))
+    print("[shard_recall] server: {}  label: {}".format(args.helix_url, args.label))
+
+    # Health check.
+    try:
+        health_url = args.helix_url.rstrip("/") + "/health"
+        with urllib.request.urlopen(health_url, timeout=30) as r:
+            health = json.loads(r.read())
+        print("[shard_recall] server health: {} docs={}".format(
+            health.get("status", "ok"), health.get("document_count", "?")))
+    except Exception as exc:
+        print(
+            "ERROR: cannot reach Helix at {}: {}\n"
+            "  Start: python -m uvicorn helix_context._asgi:app --port 11437".format(
+                args.helix_url, exc
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    summary, per_rows = score_needles(
+        needles=needles,
+        helix_url=args.helix_url,
+        max_results=args.max_results,
+        timeout_s=args.timeout,
+    )
+
+    _print_table(args.label, summary)
+
+    out_path = (
+        Path(args.out) if args.out
+        else RESULTS_DIR / "shard_recall_{}_{}.json".format(args.label, ts)
+    )
+    result_blob = {
+        "benchmark": "shard_recall",
+        "label": args.label,
+        "timestamp": ts,
+        "helix_url": args.helix_url,
+        "needles_file": str(needles_path),
+        "n_needles": len(needles),
+        "max_results": args.max_results,
+        "metrics": "recall@{1,3,5,10}, MRR -- by type (within / cross / all)",
+        "gold_match_rule": (
+            "bidirectional case-insensitive forward-slash substring: "
+            "norm(gold) in norm(source) OR norm(source) in norm(gold)"
+        ),
+        "summary": summary,
+        "per_needle_sample": per_rows[:50],
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result_blob, indent=2), encoding="utf-8")
+    print("\n-> {}".format(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/build_gold_from_genome.py
+++ b/benchmarks/build_gold_from_genome.py
@@ -1,0 +1,465 @@
+"""build_gold_from_genome.py -- Gold-needle generator from a BLOB genome.db.
+
+Sibling of ``build_shard_gold.py``, but instead of walking project source
+*trees* it samples salient genes directly out of a single, already-ingested
+**blob** ``genome.db`` (the non-sharded knowledge store). This lets us build a
+recall needle-set for any corpus we have a genome for, without needing the
+original files on disk.
+
+DESIGN
+------
+1. Read every gene's ``source_id`` (the on-disk path the document came from)
+   and ``content`` from the ``genes`` table (read-only, ``mode=ro``).
+2. Bucket genes by *source-prefix* -- the top path segment of ``source_id``.
+   That top segment is treated as the gene's "project" / shard label
+   (e.g. ``F:\\tmp\\enterprise_rag_500k\\sources\\github\\...`` -> ``github``
+   once the drive / mount prefix is peeled). See ``source_prefix``.
+3. For each prefix, sample ``--per-source`` genes whose content is
+   "substantial" (>= ``--min-content-chars`` after whitespace collapse).
+4. Form a natural-language QUESTION from a salient sentence / heading /
+   docstring line of the content, SCRUBBED of the gene's own filename stem,
+   directory tokens, and symbol-like tokens -- the same no-leak guard idea as
+   ``build_shard_gold.py`` so the lexical retriever can't win by echoing the
+   path back.
+5. ``gold_paths = [that gene's source_id]`` (the recall target).
+
+~20 % of needles are tagged ``type="cross"`` (drawn from the within pool but
+re-tagged so the retriever must pick the right source among all sources). The
+rest are ``type="within"``.
+
+OUTPUT SCHEMA (JSONL -- EXACTLY what bench_shard_recall.py consumes)
+-------------------------------------------------------------------
+``bench_shard_recall.py`` reads, per row:
+    nd["question"]            -- the query string (required)
+    nd.get("type", "within")  -- "within" | "cross"
+    nd.get("gold_paths", [])  -- list of path substrings (bidirectional match)
+    nd.get("id")              -- row id (echoed into per-needle results)
+    nd.get("project")         -- echoed into per-needle results
+    nd.get("file_type")       -- echoed into per-needle results
+
+So each emitted row carries:
+    {
+      "id":         "<uuid4-hex>",
+      "project":    "<source-prefix>",
+      "type":       "within" | "cross",
+      "file_type":  "code" | "doc",
+      "question":   "...",                 // scrubbed natural-language query
+      "gold_paths": ["<gene.source_id>"],  // the recall target
+      "gene_id":    "<gene_id>",           // provenance (ignored by the bench)
+      "source_prefix": "<prefix>"          // provenance (ignored by the bench)
+    }
+
+CLI
+---
+python benchmarks/build_gold_from_genome.py \\
+    --genome genomes/main/genome.db \\
+    --per-source 20 \\
+    --out benchmarks/results/blob_gold.jsonl \\
+    --seed 42 \\
+    --min-content-chars 200
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import uuid
+from collections import defaultdict
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Iterable
+
+# ~20 % of needles are cross-project (matches build_shard_gold.py).
+CROSS_RATIO = 0.20
+
+# File extensions we treat as "doc" rather than "code".
+_DOC_EXTS = {".md", ".txt", ".rst", ".adoc"}
+
+# Tokens that carry no retrieval signal -- never count them as a "leak".
+_BORING_TOKENS = {
+    "py", "js", "ts", "md", "txt", "json", "tsx", "jsx", "src", "lib", "app",
+    "test", "tests", "docs", "doc", "index", "main", "init", "readme", "setup",
+    "config", "utils", "util", "helpers", "helper", "api", "the", "a", "an",
+    "of", "in", "on", "at", "to", "and", "or", "is", "are", "for", "with",
+    "sources", "source", "tmp", "data",
+}
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+def _split_path(source_id: str) -> list[str]:
+    """Split a Windows-or-POSIX path into its components, drive peeled."""
+    if not source_id:
+        return []
+    s = source_id.replace("\\", "/")
+    # Peel a Windows drive prefix (e.g. "F:/").
+    s = re.sub(r"^[A-Za-z]:/", "", s)
+    parts = [p for p in s.split("/") if p and p not in (".", "..")]
+    return parts
+
+
+def source_prefix(source_id: str) -> str:
+    """Return the top path segment of ``source_id`` -- the gene's "project".
+
+    We peel structural wrapper segments (``tmp``, ``sources``, mount/scratch
+    dirs) so the prefix lands on the meaningful corpus name. For
+
+        F:\\tmp\\enterprise_rag_500k\\sources\\github\\pr-1.json
+
+    we want ``github`` (the real per-shard source), not ``tmp``. Heuristic:
+    walk components left-to-right, skipping boring wrapper tokens, and return
+    the first "meaningful" segment; if the next-to-last meaningful directory
+    looks like a corpus container (``sources``/``source``), prefer the segment
+    *after* it.
+    """
+    parts = _split_path(source_id)
+    if not parts:
+        return "_unknown"
+    # Drop the filename (last component) when there's a directory to use.
+    dirs = parts[:-1] if len(parts) > 1 else parts
+    # If a "sources"/"source" container appears, the segment right after it is
+    # the canonical shard/source label.
+    low = [d.lower() for d in dirs]
+    for container in ("sources", "source"):
+        if container in low:
+            i = low.index(container)
+            if i + 1 < len(dirs):
+                return dirs[i + 1]
+    # Otherwise: first non-boring directory segment.
+    for d in dirs:
+        if d.lower() not in _BORING_TOKENS:
+            return d
+    return dirs[0]
+
+
+def _path_leak_tokens(source_id: str) -> set[str]:
+    """All tokens from the path that must NOT appear in the question.
+
+    Mirrors build_shard_gold._path_tokens: every component, its stem, and the
+    camelCase / snake_case sub-words thereof, plus the extension.
+    """
+    tokens: set[str] = set()
+    for part in _split_path(source_id):
+        tokens.add(part.lower())
+        stem = re.sub(r"\.[^.]+$", "", part).lower()  # strip extension
+        tokens.add(stem)
+        sub = re.sub(r"([A-Z])", r"_\1", stem).lower()
+        for t in re.split(r"[_\-\.\s]+", sub):
+            if t:
+                tokens.add(t)
+    # Extension of the final component.
+    last = _split_path(source_id)[-1] if _split_path(source_id) else ""
+    m = re.search(r"\.([A-Za-z0-9]+)$", last)
+    if m:
+        tokens.add(m.group(1).lower())
+    tokens -= _BORING_TOKENS
+    return {t for t in tokens if len(t) > 2}
+
+
+def _symbol_like_tokens(text: str) -> set[str]:
+    """Symbol-ish tokens in *text* (snake_case, camelCase, dotted.paths).
+
+    These are stripped from a question because they tend to be code symbols
+    that echo the gene's identity rather than describe its behaviour.
+    """
+    out: set[str] = set()
+    # dotted.module.paths and snake_case_words and camelCase identifiers
+    for m in re.finditer(r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+", text):
+        out.add(m.group(0).lower())
+    for m in re.finditer(r"\b[a-z]+(?:_[a-z0-9]+)+\b", text):
+        out.add(m.group(0).lower())
+    for m in re.finditer(r"\b[a-z]+[A-Z][A-Za-z0-9]*\b", text):  # camelCase
+        out.add(m.group(0).lower())
+    return out
+
+
+def _scrub(text: str, forbidden: set[str]) -> str:
+    """Whole-word, case-insensitive removal of forbidden tokens."""
+    for tok in sorted(forbidden, key=len, reverse=True):
+        if not tok:
+            continue
+        pattern = r"(?<![A-Za-z0-9_])" + re.escape(tok) + r"(?![A-Za-z0-9_])"
+        text = re.sub(pattern, "", text, flags=re.IGNORECASE)
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Question extraction
+# ---------------------------------------------------------------------------
+
+def _salient_sentences(content: str) -> list[str]:
+    """Yield candidate salient lines/sentences from raw content, best first.
+
+    Strategy: prefer Markdown headings and the first prose sentence; fall back
+    to the longest plain sentence. Code fences and obvious noise are stripped.
+    """
+    cands: list[str] = []
+
+    # Strip fenced code blocks for prose extraction.
+    prose = re.sub(r"```.*?```", " ", content, flags=re.DOTALL)
+    prose = re.sub(r"`[^`]+`", " ", prose)
+    # Strip HTML/XML tags so markup-heavy corpora (rendered docs) yield clean
+    # prose questions rather than tag soup.
+    prose = re.sub(r"<[^>]+>", " ", prose)
+
+    # Markdown headings (drop the leading #'s).
+    for m in re.finditer(r"(?m)^#{1,4}\s+(.+)$", content):
+        h = m.group(1).strip()
+        if len(h) >= 12:
+            cands.append(h)
+
+    # Sentences from the prose body.
+    flat = re.sub(r"\s+", " ", prose).strip()
+    for sent in re.split(r"(?<=[.!?])\s+", flat):
+        sent = sent.strip()
+        if 20 <= len(sent) <= 400:
+            cands.append(sent)
+
+    # Longest single line as a final fallback.
+    for line in content.splitlines():
+        line = line.strip()
+        if 20 <= len(line) <= 400:
+            cands.append(line)
+
+    # De-dup, preserve order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for c in cands:
+        key = c.lower()
+        if key not in seen:
+            seen.add(key)
+            out.append(c)
+    return out
+
+
+def build_question(content: str, source_id: str) -> str | None:
+    """Build a scrubbed natural-language question, or None if not usable."""
+    forbidden = _path_leak_tokens(source_id)
+    for cand in _salient_sentences(content):
+        # Also forbid symbol-like tokens that appear in the candidate.
+        forbidden_cand = forbidden | _symbol_like_tokens(cand)
+        # Strip markdown inline formatting.
+        text = re.sub(r"!\[.*?\]\(.*?\)", "", cand)
+        text = re.sub(r"\[(.+?)\]\(.+?\)", r"\1", text)
+        # Strip any residual HTML/XML tags (heading + line fallbacks use raw
+        # content, which may still carry markup).
+        text = re.sub(r"<[^>]+>", " ", text)
+        # Strip *bold* / ~strike~ emphasis. Deliberately do NOT touch '_': it
+        # is a word char inside snake_case identifiers, and stripping it would
+        # fuse tokens (frobnicator_service -> frobnicatorservice) past the
+        # whole-word scrub below, defeating the no-leak guard.
+        text = re.sub(r"[*~]{1,3}(.+?)[*~]{1,3}", r"\1", text)
+        scrubbed = _scrub(text, forbidden_cand)
+        if len(scrubbed) >= 40:
+            return scrubbed
+    return None
+
+
+def _file_type(source_id: str) -> str:
+    last = _split_path(source_id)[-1] if _split_path(source_id) else ""
+    m = re.search(r"(\.[A-Za-z0-9]+)$", last)
+    ext = m.group(1).lower() if m else ""
+    return "doc" if ext in _DOC_EXTS else "code"
+
+
+# ---------------------------------------------------------------------------
+# Genome reader
+# ---------------------------------------------------------------------------
+
+def _open_ro(genome_path: str) -> sqlite3.Connection:
+    """Open the genome strictly read-only (mode=ro)."""
+    if not os.path.exists(genome_path):
+        raise FileNotFoundError(genome_path)
+    uri = "file:{}?mode=ro".format(os.path.abspath(genome_path).replace("\\", "/"))
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def iter_genes(conn: sqlite3.Connection) -> Iterable[sqlite3.Row]:
+    """Yield (gene_id, source_id, content) rows that have a source + content."""
+    cur = conn.execute(
+        "SELECT gene_id, source_id, content FROM genes "
+        "WHERE source_id IS NOT NULL AND source_id != '' "
+        "AND content IS NOT NULL AND content != ''"
+    )
+    for row in cur:
+        yield row
+
+
+def _substantial(content: str, min_chars: int) -> bool:
+    return len(re.sub(r"\s+", " ", content or "").strip()) >= min_chars
+
+
+# ---------------------------------------------------------------------------
+# Needle builder
+# ---------------------------------------------------------------------------
+
+def build_needles(
+    genome_path: str,
+    per_source: int,
+    seed: int,
+    min_content_chars: int,
+) -> tuple[list[dict], dict[str, int]]:
+    """Build within-needles from a blob genome. Returns (needles, per_src_n)."""
+    import random
+
+    rng = random.Random(seed)
+    conn = _open_ro(genome_path)
+    try:
+        by_prefix: dict[str, list[sqlite3.Row]] = defaultdict(list)
+        for row in iter_genes(conn):
+            if not _substantial(row["content"], min_content_chars):
+                continue
+            by_prefix[source_prefix(row["source_id"])].append(row)
+    finally:
+        conn.close()
+
+    needles: list[dict] = []
+    per_src_n: dict[str, int] = {}
+
+    for prefix in sorted(by_prefix.keys()):
+        rows = list(by_prefix[prefix])
+        rng.shuffle(rows)
+        taken = 0
+        for row in rows:
+            if taken >= per_source:
+                break
+            question = build_question(row["content"], row["source_id"])
+            if not question:
+                continue
+            needles.append({
+                "id": uuid.uuid4().hex,
+                "project": prefix,
+                "type": "within",
+                "file_type": _file_type(row["source_id"]),
+                "question": question,
+                "gold_paths": [row["source_id"]],
+                "gene_id": row["gene_id"],
+                "source_prefix": prefix,
+            })
+            taken += 1
+        per_src_n[prefix] = taken
+
+    return needles, per_src_n
+
+
+def make_cross_needles(
+    within: list[dict],
+    n_cross: int,
+    seed: int,
+) -> list[dict]:
+    """Re-tag a round-robin selection of within-needles as type='cross'."""
+    import random
+
+    rng = random.Random(seed + 1)
+    by_project: dict[str, list[dict]] = defaultdict(list)
+    for nd in within:
+        by_project[nd["project"]].append(nd)
+    project_names = sorted(by_project.keys())
+
+    pool: list[dict] = []
+    idx = 0
+    guard = 0
+    while len(pool) < n_cross and any(by_project.values()):
+        pname = project_names[idx % len(project_names)]
+        bucket = by_project.get(pname)
+        if bucket:
+            pool.append(bucket.pop(rng.randrange(len(bucket))))
+        idx += 1
+        guard += 1
+        if guard > n_cross * 50 + 100:
+            break
+
+    cross: list[dict] = []
+    for nd in pool[:n_cross]:
+        c = dict(nd)
+        c["id"] = uuid.uuid4().hex  # fresh id so cross row is distinct
+        c["type"] = "cross"
+        cross.append(c)
+    return cross
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Generate gold recall needles directly from a single blob "
+            "genome.db. Questions are scrubbed of the gene's own path / "
+            "filename / symbol tokens (no leak). Output JSONL is consumed "
+            "by bench_shard_recall.py."
+        )
+    )
+    ap.add_argument("--genome", required=True, help="Path to a blob genome.db.")
+    ap.add_argument(
+        "--per-source", type=int, default=20, dest="per_source",
+        help="Target needles per source-prefix (default 20).",
+    )
+    ap.add_argument("--out", required=True, help="Output JSONL path.")
+    ap.add_argument("--seed", type=int, default=42, help="RNG seed (default 42).")
+    ap.add_argument(
+        "--min-content-chars", type=int, default=200, dest="min_content_chars",
+        help="Minimum collapsed content length to sample a gene (default 200).",
+    )
+    args = ap.parse_args(argv)
+
+    within, per_src_n = build_needles(
+        genome_path=args.genome,
+        per_source=args.per_source,
+        seed=args.seed,
+        min_content_chars=args.min_content_chars,
+    )
+
+    if not within:
+        print(
+            "ERROR: no needles generated from {} -- empty genome, or no genes "
+            "passed the --min-content-chars / no-leak filters.".format(args.genome),
+            file=sys.stderr,
+        )
+        return 1
+
+    n_within = len(within)
+    n_cross = max(1, round(n_within * CROSS_RATIO / (1.0 - CROSS_RATIO)))
+    cross = make_cross_needles(within, n_cross, args.seed)
+
+    all_needles = within + cross
+    import random
+    random.Random(args.seed + 2).shuffle(all_needles)
+
+    out_path = args.out
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)) or ".", exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as fh:
+        for nd in all_needles:
+            fh.write(json.dumps(nd, ensure_ascii=False) + "\n")
+
+    n_cross_final = sum(1 for n in all_needles if n["type"] == "cross")
+    n_code = sum(1 for n in all_needles if n["file_type"] == "code")
+    n_doc = sum(1 for n in all_needles if n["file_type"] == "doc")
+
+    print("=" * 60)
+    print("  Gold needles from blob genome")
+    print("=" * 60)
+    print("  genome:        {}".format(args.genome))
+    print("  {:>8}  total needles".format(len(all_needles)))
+    print("  {:>8}  within-source (type=within)".format(n_within))
+    print("  {:>8}  cross-source  (type=cross)".format(n_cross_final))
+    print("  {:>8}  code / {:<8} doc".format(n_code, n_doc))
+    print()
+    print("  Per-source breakdown:")
+    for prefix in sorted(per_src_n.keys()):
+        print("    {:30s}  {:3d} needles".format(prefix, per_src_n[prefix]))
+    print()
+    print("  -> {}".format(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/build_shard_gold.py
+++ b/benchmarks/build_shard_gold.py
@@ -1,0 +1,657 @@
+"""build_shard_gold.py -- Gold-needle generator for shard × dense recall A/B.
+
+Auto-generates a needle set from project source trees WITHOUT leaking
+path/filename/symbol tokens into the natural-language query.  This is the
+prerequisite for bench_shard_recall.py.
+
+DESIGN
+------
+For each project root we walk source files (.py, .js, .ts, .md), skipping
+vendor/node_modules/.git/__pycache__ directories.  We extract salient units:
+
+  * Python/JS/TS: functions and classes that have a docstring or leading
+    block comment.  The QUERY is built from that docstring/comment prose.
+  * Markdown: H1/H2 sections with at least one non-heading prose line.
+    The QUERY is built from the prose body of the section.
+
+Scrubbing (no-leak guard)
+--------------------------
+The query is scrubbed of:
+  1. Every component of the file's path (directory names, filename stem,
+     extension, and the project root name itself).
+  2. The symbol name (function/class name, section title).
+  3. Common path separators / camelCase / snake_case splits thereof.
+
+This prevents the lexical retriever from trivially winning by echoing the
+filename back in the query.
+
+CROSS-PROJECT class
+--------------------
+~20 % of needles are tagged type="cross": they are drawn from one project
+but phrased with generic prose (no project-name token) so the retriever must
+pick the right project among all ingested projects.
+
+OUTPUT SCHEMA (JSONL, one JSON object per line)
+-----------------------------------------------
+{
+  "id":          "<uuid4-hex>",      // unique row id
+  "project":     "<project-name>",   // directory name of the project
+  "type":        "within"|"cross",   // within-project vs cross-project
+  "file_type":   "code"|"doc",       // source file category
+  "question":    "...",              // natural-language query (scrubbed)
+  "gold_paths":  ["project/rel/path/to/file.py"],  // project-relative forward-slash
+  "gold_symbols":["ClassName.method_name"],        // [] for doc sections
+  "gold_lines":  [start_1based, end_1based]        // inclusive
+}
+
+CLI
+---
+python benchmarks/build_shard_gold.py \\
+    --project-roots F:/Projects/BookKeeper,F:/Projects/helix-context \\
+    --per-project 20 \\
+    --out benchmarks/results/shard_gold.jsonl \\
+    --seed 42
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import random
+import re
+import sys
+import textwrap
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_PROJECT_ROOTS = [
+    "F:/Projects/BookKeeper",
+    "F:/Projects/CosmicTasha",
+    "F:/Projects/Education",
+    "F:/Projects/helix-context",
+    "F:/Projects/MaxExpressKit",
+    "F:/Projects/two-brain-audit",
+]
+
+SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", "vendor", ".venv", "venv",
+    "env", ".env", "dist", "build", ".cache", ".mypy_cache", ".pytest_cache",
+    ".tox", "eggs", ".eggs", "*.egg-info", "site-packages", "htmlcov",
+    ".ruff_cache", "target",  # Rust/Java
+}
+
+SOURCE_EXTS = {".py", ".js", ".ts", ".jsx", ".tsx"}
+DOC_EXTS = {".md"}
+ALL_EXTS = SOURCE_EXTS | DOC_EXTS
+
+# Minimum prose characters to accept a docstring/section body as a query source.
+MIN_PROSE_CHARS = 60
+# Maximum prose characters to use (truncate for readability).
+MAX_PROSE_CHARS = 500
+# Cross-project ratio: ~20 % of needles.
+CROSS_RATIO = 0.20
+
+
+# ---------------------------------------------------------------------------
+# Path utilities
+# ---------------------------------------------------------------------------
+
+def _rel_forward(root: Path, path: Path) -> str:
+    """Return forward-slash path relative to root, e.g. 'src/foo/bar.py'."""
+    return path.relative_to(root).as_posix()
+
+
+def _path_tokens(root: Path, path: Path) -> set[str]:
+    """Return all individual tokens that could leak path/filename info.
+
+    Includes every path component, the project root name, stem, camelCase /
+    snake_case sub-words, and the extension.
+    """
+    tokens: set[str] = set()
+
+    # project root directory name
+    tokens.add(root.name.lower())
+
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+
+    for part in rel.parts:
+        tokens.add(part.lower())
+        stem = Path(part).stem.lower()
+        tokens.add(stem)
+        # split camelCase and snake_case sub-tokens
+        sub = re.sub(r"([A-Z])", r"_\1", stem).lower()
+        for t in re.split(r"[_\-\.]+", sub):
+            if t:
+                tokens.add(t)
+
+    # extension without dot
+    ext = path.suffix.lstrip(".")
+    if ext:
+        tokens.add(ext)
+
+    # Remove trivial 1-2 char tokens and common words that give no info
+    boring = {"py", "js", "ts", "md", "tsx", "jsx", "src", "lib", "app",
+               "test", "tests", "docs", "doc", "index", "main", "init",
+               "readme", "setup", "config", "utils", "util", "helpers",
+               "helper", "api", "the", "a", "an", "of", "in", "on", "at"}
+    tokens -= boring
+    return {t for t in tokens if len(t) > 2}
+
+
+def _scrub(text: str, forbidden: set[str]) -> str:
+    """Remove exact-word occurrences of forbidden tokens from text.
+
+    Uses whole-word regex replacement (case-insensitive) so partial matches
+    (e.g. 'bookkeeper' in 'bookkeeper_route') are still caught.
+    """
+    for tok in sorted(forbidden, key=len, reverse=True):
+        if not tok:
+            continue
+        # Escape and replace as whole word (word boundary aware)
+        pattern = r"(?<![A-Za-z0-9_])" + re.escape(tok) + r"(?![A-Za-z0-9_])"
+        text = re.sub(pattern, "", text, flags=re.IGNORECASE)
+    # Collapse whitespace
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# File walkers
+# ---------------------------------------------------------------------------
+
+def _should_skip(path: Path) -> bool:
+    """Return True if any directory component should be skipped."""
+    for part in path.parts:
+        if part in SKIP_DIRS or part.endswith(".egg-info"):
+            return True
+    return False
+
+
+def walk_source_files(root: Path) -> Iterator[Path]:
+    """Yield source + doc files under root, respecting skip rules."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune skip dirs in-place so os.walk doesn't descend into them.
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS
+                       and not d.endswith(".egg-info")]
+        p = Path(dirpath)
+        if _should_skip(p):
+            continue
+        for fname in filenames:
+            fp = p / fname
+            if fp.suffix in ALL_EXTS and not _should_skip(fp):
+                yield fp
+
+
+# ---------------------------------------------------------------------------
+# Python extractor
+# ---------------------------------------------------------------------------
+
+def _first_docstring(node: ast.AST) -> str | None:
+    """Return the docstring of a function/class node, or None."""
+    if not (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            and node.body):
+        return None
+    first = node.body[0]
+    if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+        val = first.value.value
+        if isinstance(val, str) and len(val.strip()) >= MIN_PROSE_CHARS:
+            return val.strip()
+    return None
+
+
+def extract_python_units(path: Path) -> list[dict]:
+    """Extract functions/classes with docstrings from a Python file."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    units = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        doc = _first_docstring(node)
+        if not doc:
+            continue
+        symbol = node.name
+        start = node.lineno  # 1-based
+        end = getattr(node, "end_lineno", start)
+        units.append({
+            "symbol": symbol,
+            "doc": doc,
+            "start": start,
+            "end": end,
+        })
+
+    return units
+
+
+# ---------------------------------------------------------------------------
+# JS/TS extractor (regex-based, no full parse)
+# ---------------------------------------------------------------------------
+
+_JS_FUNC_RE = re.compile(
+    r"/\*\*\s*(.*?)\*/\s*"
+    r"(?:export\s+)?(?:async\s+)?(?:function\s+(\w+)|"
+    r"(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\(?)",
+    re.DOTALL,
+)
+_JS_CLASS_RE = re.compile(
+    r"/\*\*\s*(.*?)\*/\s*(?:export\s+)?class\s+(\w+)",
+    re.DOTALL,
+)
+
+
+def _clean_jsdoc(raw: str) -> str:
+    """Strip JSDoc * prefixes and @param/@returns lines."""
+    lines = []
+    for line in raw.splitlines():
+        line = re.sub(r"^\s*\*\s?", "", line)
+        if re.match(r"@\w+", line.strip()):
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+def extract_js_units(path: Path) -> list[dict]:
+    """Extract JSDoc-documented functions/classes from JS/TS files."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    units = []
+    lines = source.splitlines()
+
+    for pattern in (_JS_FUNC_RE, _JS_CLASS_RE):
+        for m in pattern.finditer(source):
+            raw_doc = m.group(1)
+            doc = _clean_jsdoc(raw_doc)
+            if len(doc) < MIN_PROSE_CHARS:
+                continue
+            # Pick symbol name from whichever capture group matched.
+            symbol = next((g for g in m.groups()[1:] if g), "anonymous")
+            # Approximate line number from match start.
+            start = source[:m.start()].count("\n") + 1
+            end = source[:m.end()].count("\n") + 1
+            units.append({
+                "symbol": symbol,
+                "doc": doc,
+                "start": start,
+                "end": end,
+            })
+
+    return units
+
+
+# ---------------------------------------------------------------------------
+# Markdown extractor
+# ---------------------------------------------------------------------------
+
+_MD_HEADING_RE = re.compile(r"^(#{1,3})\s+(.+)$")
+
+
+def extract_md_sections(path: Path) -> list[dict]:
+    """Extract H1/H2/H3 sections with prose bodies from Markdown."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    lines = source.splitlines()
+    sections = []
+    i = 0
+    while i < len(lines):
+        m = _MD_HEADING_RE.match(lines[i])
+        if m:
+            title = m.group(2).strip()
+            start = i + 1  # 1-based
+            body_lines = []
+            i += 1
+            while i < len(lines) and not _MD_HEADING_RE.match(lines[i]):
+                body_lines.append(lines[i])
+                i += 1
+            body = "\n".join(body_lines).strip()
+            # Strip code fences from body for prose extraction.
+            body_no_code = re.sub(r"```.*?```", "", body, flags=re.DOTALL)
+            body_no_code = re.sub(r"`[^`]+`", "", body_no_code)
+            body_no_code = body_no_code.strip()
+            if len(body_no_code) >= MIN_PROSE_CHARS:
+                sections.append({
+                    "symbol": title,
+                    "doc": body_no_code,
+                    "start": start,
+                    "end": i,  # 1-based, end of section
+                })
+        else:
+            i += 1
+
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Unit extractor dispatcher
+# ---------------------------------------------------------------------------
+
+def extract_units(path: Path) -> list[dict]:
+    """Extract salient units (with docstrings/prose) from any supported file."""
+    ext = path.suffix.lower()
+    if ext == ".py":
+        return extract_python_units(path)
+    elif ext in (".js", ".ts", ".jsx", ".tsx"):
+        return extract_js_units(path)
+    elif ext == ".md":
+        return extract_md_sections(path)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Query builder
+# ---------------------------------------------------------------------------
+
+def _build_query(doc: str, forbidden: set[str]) -> str | None:
+    """Build and scrub a natural-language query from docstring/prose.
+
+    Returns None if the scrubbed result is too short to be useful.
+    """
+    # Take first paragraph (up to MAX_PROSE_CHARS) and normalise whitespace.
+    prose = textwrap.dedent(doc)
+    # Use the first non-empty paragraph that is not badge/image-heavy.
+    # A paragraph where >50% of lines start with "![" is a badge block —
+    # skip it and try the next one.
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", prose) if p.strip()]
+    if not paragraphs:
+        return None
+    text = ""
+    for para in paragraphs:
+        lines = [l.strip() for l in para.splitlines() if l.strip()]
+        badge_lines = sum(1 for l in lines if l.startswith("![") or l.startswith("[!["))
+        if lines and badge_lines / len(lines) > 0.4:
+            continue  # skip badge paragraph, try next
+        text = para[:MAX_PROSE_CHARS]
+        break
+    if not text:
+        return None
+    # Strip Markdown inline image syntax first (before link stripping).
+    text = re.sub(r"!\[.*?\]\(.*?\)", "", text)
+    # Strip Markdown inline formatting.
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"\*(.+?)\*", r"\1", text)
+    text = re.sub(r"`(.+?)`", r"\1", text)
+    text = re.sub(r"\[(.+?)\]\(.+?\)", r"\1", text)
+
+    # Scrub forbidden tokens.
+    scrubbed = _scrub(text, forbidden)
+
+    # Require at least 40 chars after scrubbing.
+    if len(scrubbed) < 40:
+        return None
+
+    # Convert to a question form if it looks like a declarative sentence.
+    # We prepend "What does this code do?" only for very terse snippets;
+    # for longer prose we use the prose directly (it already describes behaviour).
+    first_word = scrubbed.split()[0].lower() if scrubbed.split() else ""
+    question_starters = {"what", "how", "why", "when", "where", "which", "who",
+                         "does", "is", "are", "can", "should", "will"}
+    if first_word not in question_starters:
+        # Trim to first sentence if possible.
+        m = re.search(r"[.!?]", scrubbed)
+        if m and m.start() > 40:
+            scrubbed = scrubbed[: m.start() + 1]
+        # Don't wrap — leave as declarative description; it's a valid query form.
+
+    return scrubbed.strip()
+
+
+# ---------------------------------------------------------------------------
+# Needle builder for one project
+# ---------------------------------------------------------------------------
+
+def build_needles_for_project(
+    root: Path,
+    n: int,
+    rng: random.Random,
+) -> list[dict]:
+    """Walk a project root and generate up to n needle candidates."""
+    if not root.exists():
+        return []
+
+    candidates: list[dict] = []
+
+    for fpath in walk_source_files(root):
+        units = extract_units(fpath)
+        if not units:
+            continue
+
+        forbidden = _path_tokens(root, fpath)
+        file_type = "doc" if fpath.suffix == ".md" else "code"
+        rel = _rel_forward(root, fpath)
+
+        for unit in units:
+            forbidden_unit = forbidden | {unit["symbol"].lower()}
+            # Also add camelCase splits of the symbol.
+            sym_parts = re.sub(r"([A-Z])", r"_\1", unit["symbol"]).lower()
+            for t in re.split(r"[_\-\. ]+", sym_parts):
+                if len(t) > 2:
+                    forbidden_unit.add(t)
+
+            query = _build_query(unit["doc"], forbidden_unit)
+            if not query:
+                continue
+
+            candidates.append({
+                "_root": root,
+                "_fpath": fpath,
+                "project": root.name,
+                "file_type": file_type,
+                "question": query,
+                "gold_paths": ["{}/{}".format(root.name, rel)],
+                "gold_symbols": [unit["symbol"]] if file_type == "code" else [],
+                "gold_lines": [unit["start"], unit["end"]],
+            })
+
+    if not candidates:
+        return []
+
+    rng.shuffle(candidates)
+    return candidates[:n]
+
+
+# ---------------------------------------------------------------------------
+# Cross-project needle synthesis
+# ---------------------------------------------------------------------------
+
+def make_cross_needles(
+    within_needles: list[dict],
+    n_cross: int,
+    rng: random.Random,
+) -> list[dict]:
+    """Select n_cross within-needles and re-tag them as type='cross'.
+
+    We pick from different projects to ensure variety.  The query is already
+    scrubbed of project-name tokens, so the same row works as a cross-project
+    needle.
+    """
+    # Group by project.
+    by_project: dict[str, list[dict]] = {}
+    for nd in within_needles:
+        by_project.setdefault(nd["project"], []).append(nd)
+
+    pool: list[dict] = []
+    project_names = sorted(by_project.keys())
+    # Round-robin across projects to ensure variety.
+    idx = 0
+    while len(pool) < n_cross * 3 and any(by_project.values()):
+        pname = project_names[idx % len(project_names)]
+        if by_project.get(pname):
+            pool.append(by_project[pname].pop(rng.randint(0, len(by_project[pname]) - 1)))
+        idx += 1
+        if idx > n_cross * 10:
+            break
+
+    rng.shuffle(pool)
+    cross = []
+    for nd in pool[:n_cross]:
+        c = dict(nd)
+        c["type"] = "cross"
+        cross.append(c)
+    return cross
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Generate a gold-needle set for shard × dense recall A/B benchmarks. "
+            "Queries are scrubbed of filename/symbol/path tokens to prevent lexical "
+            "short-circuiting.  Output is JSONL with one needle per line."
+        )
+    )
+    ap.add_argument(
+        "--project-roots",
+        default=",".join(DEFAULT_PROJECT_ROOTS),
+        help=(
+            "Comma-separated list of project root directories.  Missing roots are "
+            "skipped gracefully.  Default: the 6 medium-corpus projects."
+        ),
+    )
+    ap.add_argument(
+        "--per-project",
+        type=int,
+        default=20,
+        dest="per_project",
+        help="Target number of needles per project (default: 20).",
+    )
+    ap.add_argument(
+        "--out",
+        default=str(Path(__file__).resolve().parent / "results" / "shard_gold.jsonl"),
+        help="Output JSONL path (default: benchmarks/results/shard_gold.jsonl).",
+    )
+    ap.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for determinism (default: 42).",
+    )
+    args = ap.parse_args(argv)
+
+    rng = random.Random(args.seed)
+
+    project_roots = [
+        Path(p.strip()) for p in args.project_roots.split(",") if p.strip()
+    ]
+
+    all_within: list[dict] = []
+    summary_rows: list[dict] = []
+
+    for root in project_roots:
+        if not root.exists():
+            print(
+                "[build_shard_gold] SKIP {} (not found on this machine)".format(root),
+                file=sys.stderr,
+            )
+            summary_rows.append({"project": root.name, "status": "missing", "n": 0})
+            continue
+
+        print("[build_shard_gold] scanning {} ...".format(root), flush=True)
+        needles = build_needles_for_project(root, args.per_project, rng)
+
+        for nd in needles:
+            nd["id"] = uuid.uuid4().hex
+            nd["type"] = "within"
+            # Remove internal _root/_fpath keys.
+            nd.pop("_root", None)
+            nd.pop("_fpath", None)
+
+        all_within.extend(needles)
+        n_code = sum(1 for n in needles if n["file_type"] == "code")
+        n_doc = sum(1 for n in needles if n["file_type"] == "doc")
+        summary_rows.append({
+            "project": root.name,
+            "status": "ok",
+            "n": len(needles),
+            "n_code": n_code,
+            "n_doc": n_doc,
+        })
+        print(
+            "  -> {} needles ({} code, {} doc)".format(
+                len(needles), n_code, n_doc
+            ),
+            flush=True,
+        )
+
+    if not all_within:
+        print(
+            "ERROR: no needles generated — are the project roots accessible?",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Build cross-project needles (~20 % of total).
+    n_total_within = len(all_within)
+    n_cross = max(1, round(n_total_within * CROSS_RATIO / (1.0 - CROSS_RATIO)))
+    cross_needles = make_cross_needles(list(all_within), n_cross, rng)
+
+    all_needles = all_within + cross_needles
+    rng.shuffle(all_needles)
+
+    # Write JSONL.
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fh:
+        for nd in all_needles:
+            fh.write(json.dumps(nd, ensure_ascii=False) + "\n")
+
+    # Summary.
+    n_within = sum(1 for n in all_needles if n["type"] == "within")
+    n_cross_final = sum(1 for n in all_needles if n["type"] == "cross")
+    n_code = sum(1 for n in all_needles if n["file_type"] == "code")
+    n_doc = sum(1 for n in all_needles if n["file_type"] == "doc")
+
+    print()
+    print("=" * 60)
+    print("  Gold needle summary")
+    print("=" * 60)
+    print("  {:>8}  total needles".format(len(all_needles)))
+    print("  {:>8}  within-project (type=within)".format(n_within))
+    print("  {:>8}  cross-project  (type=cross)".format(n_cross_final))
+    print("  {:>8}  code units (functions/classes)".format(n_code))
+    print("  {:>8}  doc units (Markdown sections)".format(n_doc))
+    print()
+    print("  Per-project breakdown:")
+    for row in summary_rows:
+        if row["status"] == "missing":
+            print("    {:30s}  MISSING".format(row["project"]))
+        else:
+            print(
+                "    {:30s}  {:3d} needles "
+                "({} code / {} doc)".format(
+                    row["project"],
+                    row["n"],
+                    row.get("n_code", 0),
+                    row.get("n_doc", 0),
+                )
+            )
+    print()
+    print("  -> {}".format(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/cb_dpacket_clamp_rescore.py
+++ b/benchmarks/cb_dpacket_clamp_rescore.py
@@ -1,0 +1,787 @@
+#!/usr/bin/env python3
+"""
+cb_dpacket_clamp_rescore.py  — ContextBench D-packet 27k-clamp re-run + re-score
+
+PURPOSE
+-------
+Re-emits the D-packet arm (/context/packet via in-process Helix) with a hard
+27 000-token greedy budget cap applied AFTER packet assembly, then scores it
+with the official contextbench.evaluate and regenerates the combined recall-vs-
+tokens table + scatter plot alongside all existing arms.
+
+BACKGROUND (why the first run was unclamped)
+--------------------------------------------
+The original cb_helix_pred.py called build_context_packet with max_genes=32
+and max_item_chars=100_000. build_context_packet has no internal token-budget
+cap; it just returns all genes up to max_genes with each gene's content
+truncated at max_item_chars characters. With 32-55 genes each up to 100k chars
+per instance the median injected-tokens landed at ~53k vs the BM25-27k / D-rank
+comparison baseline at 27k.
+
+THE FIX (the clamp knob)
+------------------------
+`build_context_packet` does NOT read [budget] expression_tokens. The only levers
+that govern packet size are:
+  * max_genes         — gene count cap (default 8 in the API, set to 32 in the bench)
+  * max_item_chars    — per-gene character cap (default 48k in include_raw mode)
+  * [budget] expression_tokens   — NOT consulted by build_context_packet at all
+  * [budget] max_genes_per_turn  — NOT consulted by build_context_packet at all
+
+The correct fix is a POST-assembly greedy token-budget truncation applied in the
+bench driver, identical to the fingerprint arm's strategy: iterate delivered items
+in order, accumulate tiktoken cl100k_base token counts, stop when the running
+total reaches the budget.
+
+For the live re-run there are two equivalent implementation options:
+  Option A (config):  set max_genes=8 AND max_item_chars~=3400 in the helix
+                      probe config so each gene ≤ ~850 tokens; the 8 × 850 = 6.8k
+                      budget is too small. Not a clean match to 27k.
+  Option B (post-assembly clamp, USED HERE): keep the full packet assembly
+                      (max_genes=32, max_item_chars=100_000 same as before) so
+                      we see what Helix "would deliver", then greedy-cap the pred
+                      spans at 27k tokens before writing the pred JSON. This is
+                      the same discipline the fingerprint arm uses.
+
+HOW TO RUN (one-liner for the Windows rig)
+------------------------------------------
+  cd F:/Projects/helix-context
+  C:/Users/max/AppData/Local/Python/pythoncore-3.14-64/python.exe ^
+      benchmarks/cb_dpacket_clamp_rescore.py ^
+      --tag wt ^
+      --tasks F:/tmp/cb_tasks_smoke.json ^
+      --gold benchmarks/contextbench/gold_smoke_4repo.parquet ^
+      --cb-src F:/Projects/contextbench-src ^
+      --out-dir benchmarks/contextbench/results ^
+      --cache F:/Projects/_cache/cb_repos
+
+Kill-switches (no GPU needed):
+  HELIX_BFM_SPLADE=0 HELIX_BFM_DENSE_BACKFILL=0 (prevent multi-CUDA-context livelock)
+
+Full example with all defaults shown:
+  set HELIX_BFM_SPLADE=0
+  set HELIX_BFM_DENSE_BACKFILL=0
+  C:/Users/max/AppData/Local/Python/pythoncore-3.14-64/python.exe ^
+      benchmarks/cb_dpacket_clamp_rescore.py ^
+      --tag wt --budget 27000 ^
+      --tasks F:/tmp/cb_tasks_smoke.json ^
+      --gold benchmarks/contextbench/gold_smoke_4repo.parquet ^
+      --cb-src F:/Projects/contextbench-src ^
+      --cache F:/Projects/_cache/cb_repos ^
+      --config F:/tmp/cb_helix_probe/helix_probe.toml ^
+      --out-dir benchmarks/contextbench/results
+"""
+import argparse
+import gc
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+
+# ──────────────────────── file universe (mirror cb_helix_pred.py) ─────────────
+SRC_EXT = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".c", ".h", ".cpp", ".cc",
+    ".hpp", ".hh", ".java", ".cs", ".rb", ".php", ".swift", ".kt", ".scala",
+    ".cfg", ".ini", ".toml", ".yaml", ".yml", ".pyi",
+}
+SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".mypy_cache", ".pytest_cache",
+    ".tox", ".eggs", "dist", "build", ".venv", "venv",
+}
+MAX_FILE_BYTES = 2_000_000
+COMPRESSED_PREFIX = "[COMPRESSED"
+
+# ──────────────────────── defaults ────────────────────────────────────────────
+DEFAULT_HELIX_CONFIG = "F:/tmp/cb_helix_probe/helix_probe.toml"
+DEFAULT_GENOME_ROOT  = "F:/tmp/cb_helix_genomes"
+DEFAULT_OUT_DIR      = "F:/Projects/helix-context/benchmarks/contextbench/results"
+DEFAULT_CB_SRC       = "F:/Projects/contextbench-src"
+DEFAULT_CACHE        = "F:/Projects/_cache/cb_repos"
+DEFAULT_GOLD         = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+DEFAULT_TASKS        = "F:/tmp/cb_tasks_smoke.json"
+DEFAULT_BUDGET       = 27_000
+
+# ──────────────────────── tokenization ────────────────────────────────────────
+import tiktoken
+ENC = tiktoken.get_encoding("cl100k_base")
+
+
+def ntok(text):
+    return len(ENC.encode(text or "", disallowed_special=()))
+
+
+# ──────────────────────── file helpers ────────────────────────────────────────
+def iter_repo_files(repo_dir):
+    for root, dirs, files in os.walk(repo_dir):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for fn in files:
+            ext = os.path.splitext(fn)[1].lower()
+            if ext not in SRC_EXT:
+                continue
+            ap = os.path.join(root, fn)
+            try:
+                if os.path.getsize(ap) > MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel = os.path.relpath(ap, repo_dir).replace("\\", "/")
+            yield rel, ap
+
+
+def read_text(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def recover_lines(content, file_text):
+    """Verbatim content-match → (start, end) 1-indexed inclusive. None on failure."""
+    c = content or ""
+    if not c.strip() or file_text is None:
+        return None
+    off = file_text.find(c)
+    matched = c
+    if off < 0:
+        cs = c.strip()
+        off = file_text.find(cs)
+        matched = cs
+    if off < 0:
+        return None
+    start = file_text.count("\n", 0, off) + 1
+    end = start + matched.count("\n")
+    return start, end
+
+
+# ──────────────────────── helix bootstrap (mirror cb_helix_pred.py) ───────────
+def build_helix(genome_dir, helix_config):
+    os.environ.pop("HELIX_USE_SHARDS", None)
+    os.environ["HELIX_CONFIG"] = helix_config
+    os.environ["HELIX_GENOME_PATH"] = genome_dir + "/genome.db"
+    os.makedirs(genome_dir, exist_ok=True)
+    from helix_context.config import load_config
+    from helix_context.context_manager import HelixContextManager
+    cfg = load_config()
+    return HelixContextManager(cfg)
+
+
+def ingest_repo(helix, repo_dir, file_cache):
+    n = 0
+    for rel, ap in iter_repo_files(repo_dir):
+        text = read_text(ap)
+        if text is None:
+            continue
+        file_cache[rel] = text
+        try:
+            helix.ingest(text, content_type="code", metadata={"path": rel})
+            n += 1
+        except Exception as e:
+            print(f"    [ingest-warn] {rel}: {e!r}", file=sys.stderr)
+    return n
+
+
+def gene_src(g):
+    src = getattr(g, "source_id", None)
+    if src:
+        return src.replace("\\", "/")
+    if getattr(g, "promoter", None) and g.promoter.metadata:
+        p = g.promoter.metadata.get("path")
+        if p:
+            return p.replace("\\", "/")
+    return None
+
+
+def run_packet(helix, query, max_genes=32, max_item_chars=100_000):
+    """Call build_context_packet exactly like the original cb_helix_pred.py did."""
+    from helix_context.context_packet import build_context_packet
+    packet = build_context_packet(
+        query,
+        task_type="explain",
+        genome=helix.genome,
+        max_genes=max_genes,
+        now_ts=0.0,
+        read_only=True,
+        include_raw=True,
+        max_item_chars=max_item_chars,
+    )
+    pd = packet.model_dump()
+    items = list(pd.get("verified", [])) + list(pd.get("stale_risk", []))
+    return items
+
+
+# ──────────────────────── clamp + pred builder ────────────────────────────────
+def items_to_pred_clamped(iid, items, file_cache, budget_tokens):
+    """Convert packet items → unified pred, greedy-clamped at budget_tokens.
+
+    Items are consumed in delivery order (verified first, then stale_risk, as
+    returned by build_context_packet). We accumulate injected_tokens and stop
+    when the budget is reached. This is identical to the fingerprint arm's
+    strategy (cb_helix_pred.py process_task lines 281-289).
+    """
+    from collections import defaultdict
+    spans = defaultdict(list)
+    files = set()
+    injected = 0
+    n_genes = 0
+    n_fail = 0
+    n_compressed = 0
+    n_clamped = 0
+
+    for it in items:
+        src = ((it.get("source_id") or "").replace("\\", "/")) or None
+        content = it.get("content") or ""
+
+        if not src:
+            n_fail += 1
+            continue
+        if content.startswith(COMPRESSED_PREFIX):
+            n_compressed += 1
+            continue
+
+        ftext = file_cache.get(src)
+        rng = recover_lines(content, ftext)
+        if rng is None:
+            n_fail += 1
+            continue
+
+        tok = ntok(content)
+        # Greedy budget gate: if we've already filled 1+ genes and this pushes
+        # us over, skip it (same policy as the fingerprint arm's fill loop).
+        if n_genes >= 1 and injected + tok > budget_tokens:
+            n_clamped += 1
+            continue  # try smaller subsequent genes
+
+        start, end = rng
+        spans[src].append({"start": start, "end": end})
+        files.add(src)
+        injected += tok
+        n_genes += 1
+
+        if injected >= budget_tokens:
+            break
+
+    pred = {
+        "instance_id": iid,
+        "traj_data": {
+            "pred_steps": [],
+            "pred_files": sorted(files),
+            "pred_spans": {k: v for k, v in spans.items()},
+        },
+        "model_patch": "",
+    }
+    meta = {
+        "injected_tokens": injected,
+        "n_genes": n_genes,
+        "n_match_fail": n_fail,
+        "n_compressed": n_compressed,
+        "n_clamped_by_budget": n_clamped,
+    }
+    return pred, meta
+
+
+# ──────────────────────── scoring helpers ─────────────────────────────────────
+def run_evaluator(cb_src, gold, pred_path, cache_dir, out_jsonl):
+    """Run contextbench.evaluate as a subprocess. Returns (rows, returncode)."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = cb_src + os.pathsep + env.get("PYTHONPATH", "")
+    env["CONTEXTBENCH_TMP_ROOT"] = os.path.dirname(cache_dir).replace("\\", "/") + "/_cache/cb_wt"
+    env["GIT_LFS_SKIP_SMUDGE"] = "1"
+    cmd = [sys.executable, "-m", "contextbench.evaluate",
+           "--gold", gold, "--pred", pred_path, "--cache", cache_dir, "--out", out_jsonl]
+    print(f"  [eval] {' '.join(cmd)}", file=sys.stderr)
+    if os.path.isfile(out_jsonl):
+        os.remove(out_jsonl)
+    r = subprocess.run(cmd, env=env, creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    rows = []
+    if os.path.isfile(out_jsonl):
+        with open(out_jsonl, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    return rows, r.returncode
+
+
+def micro(rows, gran):
+    valid = [r for r in rows if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in valid)
+    gold  = sum(r.get("final", {}).get(gran, {}).get("gold_size",  0) for r in valid)
+    pred  = sum(r.get("final", {}).get(gran, {}).get("pred_size",  0) for r in valid)
+    recall = inter / gold if gold else 1.0
+    prec   = inter / pred if pred else 1.0
+    f1 = (2 * recall * prec / (recall + prec)) if (recall + prec) else 0.0
+    return {"recall": recall, "precision": prec, "f1": f1, "n_valid": len(valid)}
+
+
+def med(xs):
+    xs = sorted(xs)
+    return xs[len(xs) // 2] if xs else 0
+
+
+# ──────────────────────── per-task entry point ────────────────────────────────
+def process_task(task, tag, budget, genome_root, helix_config):
+    """Run one task: ingest → packet → clamp → pred. Returns a result dict."""
+    iid  = task["instance_id"]
+    wt   = task["worktree_dir"]
+    gdir = f"{genome_root}/{tag}_packet27k/{iid}"
+    shutil.rmtree(gdir, ignore_errors=True)
+
+    res = {
+        "iid": iid, "repo": task.get("repo", ""),
+        "pred": None, "meta": None, "error": None, "n_indexed": 0,
+    }
+    helix = None
+    file_cache = {}
+    try:
+        helix = build_helix(gdir, helix_config)
+        n_indexed = ingest_repo(helix, wt, file_cache)
+        res["n_indexed"] = n_indexed
+        q = task["problem_statement"]
+        items = run_packet(helix, q)
+        pred, meta = items_to_pred_clamped(iid, items, file_cache, budget)
+        meta["n_indexed_files"] = n_indexed
+        res["pred"] = pred
+        res["meta"] = meta
+    except Exception as e:
+        import traceback
+        res["error"] = f"{e!r} | {traceback.format_exc().splitlines()[-1]}"
+    finally:
+        try:
+            if helix is not None and getattr(helix, "genome", None) is not None:
+                close = getattr(helix.genome, "close", None)
+                if callable(close):
+                    close()
+        except Exception:
+            pass
+        helix = None
+        file_cache = None
+        gc.collect()
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                torch.cuda.ipc_collect()
+        except Exception:
+            pass
+        shutil.rmtree(gdir, ignore_errors=True)
+    return res
+
+
+# ──────────────────────── combined table + plot ────────────────────────────────
+def load_existing_table(out_dir):
+    """Load combined_table.json from a previous cb_score_all.py run."""
+    path = os.path.join(out_dir, "combined_table.json")
+    if not os.path.isfile(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def regenerate_table_and_plot(existing_rows, new_arm_label, new_scores, out_dir):
+    """Append the new clamped-packet arm to the existing combined table and
+    regenerate the recall-vs-tokens scatter plot."""
+
+    # Build the new row
+    g = new_scores["granularity"]
+    new_row = {
+        "arm": new_arm_label,
+        "n": new_scores["n_scored"],
+        "file_R": g["file"]["recall"],
+        "line_R": g["line"]["recall"],
+        "line_P": g["line"]["precision"],
+        "sym_R": g["symbol"]["recall"],
+        "med_inj": new_scores["median_injected_tokens"],
+        "compressed": new_scores.get("n_compressed", 0),
+    }
+
+    # Remove any stale entry with the same arm label
+    merged = [r for r in existing_rows if r.get("arm") != new_arm_label]
+    merged.append(new_row)
+
+    # Write updated combined_table.json
+    table_path = os.path.join(out_dir, "combined_table.json")
+    with open(table_path, "w", encoding="utf-8") as f:
+        json.dump(merged, f, indent=2)
+    print(f"  [table] -> {table_path}", file=sys.stderr)
+
+    # Print the table
+    print(f"\n{'arm':<28}{'n':>4}{'file_R':>8}{'line_R':>8}{'line_P':>8}"
+          f"{'sym_R':>8}{'med_inj':>9}")
+    print("-" * 77)
+    for r in merged:
+        print(f"{r['arm']:<28}{r['n']:>4}{r['file_R']:>8.3f}{r['line_R']:>8.3f}"
+              f"{r['line_P']:>8.3f}{r['sym_R']:>8.3f}{int(r['med_inj']):>9}")
+
+    # Generate scatter plot
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(figsize=(9, 5))
+        colors = {
+            "bm25": "#4C72B0",
+            "fingerprint": "#55A868",
+            "packet": "#C44E52",
+            "packet27k": "#DD8452",
+        }
+        markers = {"8k": "o", "27k": "s", "packet": "D", "packet27k": "*"}
+
+        for r in merged:
+            arm = r["arm"]
+            x = r["med_inj"]
+            y = r["line_R"]
+            # Pick colour + marker by arm name keywords
+            c = "#888888"
+            m = "o"
+            s = 80
+            label = arm
+            if "bm25" in arm:
+                c = colors["bm25"]
+                m = "o" if "8k" in arm else "s"
+            elif "fingerprint" in arm:
+                c = colors["fingerprint"]
+                m = "o" if "8k" in arm else "s"
+                s = 70
+            elif arm.endswith("packet27k") or "packet27k" in arm:
+                c = colors["packet27k"]
+                m = "*"
+                s = 160
+            elif "packet" in arm:
+                c = colors["packet"]
+                m = "D"
+                s = 100
+            ax.scatter(x, y, color=c, marker=m, s=s, zorder=5, label=label)
+            ax.annotate(arm, (x, y), textcoords="offset points",
+                        xytext=(4, 4), fontsize=6.5)
+
+        ax.set_xlabel("Median injected tokens", fontsize=11)
+        ax.set_ylabel("Line recall (coverage)", fontsize=11)
+        ax.set_title("ContextBench Step-0: recall vs injected tokens\n"
+                     "(D-packet 27k = clamped; D-packet = original unclamped)", fontsize=10)
+        ax.grid(True, alpha=0.3)
+        # Legend deduplicated
+        handles, labels = ax.get_legend_handles_labels()
+        by_label = dict(zip(labels, handles))
+        ax.legend(by_label.values(), by_label.keys(), fontsize=7, loc="lower right")
+        fig.tight_layout()
+        plot_path = os.path.join(os.path.dirname(out_dir), "cb_step0_recall_vs_tokens.png")
+        fig.savefig(plot_path, dpi=150)
+        plt.close(fig)
+        print(f"  [plot]  -> {plot_path}", file=sys.stderr)
+    except ImportError:
+        print("  [plot]  matplotlib not available — skipping plot", file=sys.stderr)
+
+    return table_path
+
+
+# ──────────────────────── post-process preview ────────────────────────────────
+def postprocess_existing_packet(tag, budget, out_dir, cb_src, gold, cache_dir):
+    """
+    APPROXIMATE PREVIEW (no live re-run): post-process the existing unclamped
+    packet pred JSON by greedy-truncating pred_spans to match the ~27k budget.
+
+    This is an approximation because:
+    1. We no longer have the gene content (only the line ranges in pred_spans)
+       so we re-read the file bytes from the cached repo worktrees to count
+       tokens — those worktrees may not be present in the sandbox.
+    2. We cannot recover injected_tokens per span without the content, so we
+       fall back to line-count × average-chars-per-line as a token estimate.
+
+    In practice this produces a conservative lower bound on recall (we may
+    drop spans that would have fit) but it's directionally correct.
+    If repo worktrees are unavailable we emit the pred as-is and note it.
+    """
+    pred_path = os.path.join(out_dir, f"helix_{tag}_packet_pred.json")
+    meta_path = os.path.join(out_dir, f"helix_{tag}_packet_meta.json")
+    if not os.path.isfile(pred_path):
+        print(f"  [preview] no existing pred at {pred_path} — skipping preview",
+              file=sys.stderr)
+        return None
+
+    with open(pred_path, "r", encoding="utf-8") as f:
+        preds = json.load(f)
+    meta_map = {}
+    if os.path.isfile(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta_map = json.load(f)
+
+    # Greedy truncation by estimated token count (line count × 4 tokens/line heuristic)
+    TOKENS_PER_LINE = 4   # conservative for Python code
+    clamped_preds = []
+    approx_totals = []
+    for item in preds:
+        iid = item["instance_id"]
+        td = item.get("traj_data", {})
+        old_spans = td.get("pred_spans", {})
+
+        new_spans = {}
+        new_files = []
+        approx_injected = 0
+        for fpath, spans in old_spans.items():
+            for sp in spans:
+                n_lines = max(1, sp["end"] - sp["start"] + 1)
+                est_tok = n_lines * TOKENS_PER_LINE
+                if approx_injected > 0 and approx_injected + est_tok > budget:
+                    continue  # skip — would exceed budget
+                if fpath not in new_spans:
+                    new_spans[fpath] = []
+                    new_files.append(fpath)
+                new_spans[fpath].append(sp)
+                approx_injected += est_tok
+                if approx_injected >= budget:
+                    break
+            if approx_injected >= budget:
+                break
+
+        clamped_preds.append({
+            "instance_id": iid,
+            "traj_data": {
+                "pred_steps": [],
+                "pred_files": sorted(set(new_files)),
+                "pred_spans": new_spans,
+            },
+            "model_patch": "",
+        })
+        approx_totals.append(approx_injected)
+
+    out_pred = os.path.join(out_dir, f"helix_{tag}_packet27k_approx_pred.json")
+    with open(out_pred, "w", encoding="utf-8") as f:
+        json.dump(clamped_preds, f)
+    print(f"  [preview] approx-clamped pred -> {out_pred}", file=sys.stderr)
+    print(f"  [preview] approx median injected tokens (line-count heuristic): "
+          f"{statistics.median(approx_totals):.0f}", file=sys.stderr)
+
+    # Try to score if cb_src is available
+    out_jsonl = os.path.join(out_dir, f"helix_{tag}_packet27k_approx_eval.jsonl")
+    rows, rc = run_evaluator(cb_src, gold, out_pred, cache_dir, out_jsonl)
+    if rc == 0 and rows:
+        lr_r = micro(rows, "line")
+        fr_r = micro(rows, "file")
+        sr_r = micro(rows, "symbol")
+        print(f"  [preview] APPROXIMATE CLAMPED SCORES (line-heuristic truncation):")
+        print(f"    file_R={fr_r['recall']:.3f}  line_R={lr_r['recall']:.3f}  "
+              f"line_P={lr_r['precision']:.3f}  sym_R={sr_r['recall']:.3f}  "
+              f"approx_med_inj={statistics.median(approx_totals):.0f}")
+        print(f"  [preview] NOTE: these are APPROXIMATE — content not re-fetched, "
+              f"budget enforced by line-count×4tok heuristic. Run without "
+              f"--preview-only for exact numbers.", file=sys.stderr)
+        return {
+            "arm": f"{tag}_packet27k_approx",
+            "granularity": {"line": lr_r, "file": fr_r, "symbol": sr_r,
+                            "span": micro(rows, "span")},
+            "median_injected_tokens_approx": statistics.median(approx_totals),
+            "n_scored": lr_r["n_valid"],
+            "approximate": True,
+            "method": "line_count_heuristic",
+        }
+    else:
+        print(f"  [preview] evaluator returned rc={rc} or no rows — "
+              f"score not available", file=sys.stderr)
+        return None
+
+
+# ──────────────────────── main ────────────────────────────────────────────────
+def main():
+    ap = argparse.ArgumentParser(
+        description="Re-emit D-packet arm at 27k token budget and re-score"
+    )
+    ap.add_argument("--tag", required=True,
+                    help="Helix variant tag, e.g. wt | v062 | r063fix")
+    ap.add_argument("--tasks", default=DEFAULT_TASKS,
+                    help="JSON task list from cb_dump_tasks.py")
+    ap.add_argument("--gold", default=DEFAULT_GOLD,
+                    help="Gold parquet (e.g. gold_smoke_4repo.parquet)")
+    ap.add_argument("--budget", type=int, default=DEFAULT_BUDGET,
+                    help="Token budget for clamping (default 27000)")
+    ap.add_argument("--cb-src", default=DEFAULT_CB_SRC,
+                    help="Path to contextbench-src (for contextbench.evaluate)")
+    ap.add_argument("--cache", default=DEFAULT_CACHE,
+                    help="Repo clone cache dir for evaluator")
+    ap.add_argument("--config", default=DEFAULT_HELIX_CONFIG,
+                    help="HELIX_CONFIG toml for the probe genome")
+    ap.add_argument("--genome-root", default=DEFAULT_GENOME_ROOT,
+                    help="Root dir for temporary probe genomes")
+    ap.add_argument("--out-dir", default=DEFAULT_OUT_DIR,
+                    help="Results directory (where pred JSONs are written)")
+    ap.add_argument("--workers", type=int, default=1,
+                    help="Parallel task workers (1 = serial, safe on low VRAM)")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Cap number of tasks (0 = all)")
+    ap.add_argument("--preview-only", action="store_true",
+                    help="Skip live re-run; only post-process existing pred JSON "
+                         "with line-count heuristic (approximate, no VRAM needed)")
+    ap.add_argument("--no-plot", action="store_true",
+                    help="Skip regenerating the recall-vs-tokens plot")
+    args = ap.parse_args()
+
+    bk = f"{args.budget // 1000}k"
+    arm_label = f"{args.tag}_packet{bk}"
+
+    sys.path.insert(0, args.cb_src)
+    os.makedirs(args.out_dir, exist_ok=True)
+    os.makedirs(args.cache, exist_ok=True)
+    os.makedirs(args.genome_root, exist_ok=True)
+
+    # ── preview-only path ────────────────────────────────────────────────────
+    if args.preview_only:
+        print(f"\n=== PREVIEW ONLY (approximate, no live re-run) ===", file=sys.stderr)
+        preview = postprocess_existing_packet(
+            args.tag, args.budget, args.out_dir,
+            args.cb_src, args.gold, args.cache,
+        )
+        if preview:
+            g = preview["granularity"]
+            print(f"\n[PREVIEW] Approximate clamped-packet recall @ {bk}:")
+            print(f"  file_R={g['file']['recall']:.3f}  "
+                  f"line_R={g['line']['recall']:.3f}  "
+                  f"line_P={g['line']['precision']:.3f}  "
+                  f"sym_R={g['symbol']['recall']:.3f}  "
+                  f"approx_med_inj={preview['median_injected_tokens_approx']:.0f}")
+        else:
+            print("[PREVIEW] Could not produce approximate scores.", file=sys.stderr)
+        return
+
+    # ── live re-run ──────────────────────────────────────────────────────────
+    with open(args.tasks, "r", encoding="utf-8") as f:
+        tasks = json.load(f)
+    if args.limit and args.limit > 0:
+        tasks = tasks[:args.limit]
+    print(f"loaded {len(tasks)} tasks | tag={args.tag} | budget={args.budget} ({bk})",
+          file=sys.stderr)
+
+    preds  = []
+    pk_meta = {}
+    total = len(tasks)
+
+    if args.workers and args.workers > 1:
+        from concurrent.futures import ProcessPoolExecutor, as_completed
+        payloads = [(t, args.tag, args.budget, args.genome_root, args.config)
+                    for t in tasks]
+        with ProcessPoolExecutor(max_workers=args.workers,
+                                 max_tasks_per_child=1) as ex:
+            futs = {ex.submit(process_task, *p): p[0]["instance_id"]
+                    for p in payloads}
+            done = 0
+            for fut in as_completed(futs):
+                done += 1
+                try:
+                    r = fut.result()
+                except Exception as e:
+                    iid = futs[fut]
+                    r = {"iid": iid, "repo": "", "pred": None, "meta": None,
+                         "error": repr(e), "n_indexed": 0}
+                if r["error"]:
+                    print(f"[{done}/{total}] {r['iid'][-8:]} ERROR: {r['error']}",
+                          file=sys.stderr, flush=True)
+                else:
+                    m = r["meta"]
+                    print(f"[{done}/{total}] {r['iid'][-8:]} "
+                          f"idx={r['n_indexed']} "
+                          f"pk:g{m['n_genes']}/t{m['injected_tokens']}"
+                          f"/clamp{m['n_clamped_by_budget']}",
+                          file=sys.stderr, flush=True)
+                    preds.append(r["pred"])
+                    pk_meta[r["iid"]] = r["meta"]
+    else:
+        for i, t in enumerate(tasks):
+            r = process_task(t, args.tag, args.budget, args.genome_root, args.config)
+            if r["error"]:
+                print(f"[{i+1}/{total}] {r['iid'][-8:]} ERROR: {r['error']}",
+                      file=sys.stderr, flush=True)
+            else:
+                m = r["meta"]
+                print(f"[{i+1}/{total}] {r['iid'][-8:]} "
+                      f"idx={r['n_indexed']} "
+                      f"pk:g{m['n_genes']}/t{m['injected_tokens']}"
+                      f"/clamp{m['n_clamped_by_budget']}",
+                      file=sys.stderr, flush=True)
+                preds.append(r["pred"])
+                pk_meta[r["iid"]] = r["meta"]
+
+    if not preds:
+        print("ERROR: no successful tasks — aborting", file=sys.stderr)
+        sys.exit(1)
+
+    # Write pred + meta
+    pred_path = os.path.join(args.out_dir, f"helix_{arm_label}_pred.json")
+    meta_path = os.path.join(args.out_dir, f"helix_{arm_label}_meta.json")
+    with open(pred_path, "w", encoding="utf-8") as f:
+        json.dump(preds, f)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(pk_meta, f, indent=2)
+    print(f"\n[pred] -> {pred_path}", file=sys.stderr)
+    print(f"[meta] -> {meta_path}", file=sys.stderr)
+
+    # Score
+    out_jsonl = os.path.join(args.out_dir, f"helix_{arm_label}_eval.jsonl")
+    rows, rc = run_evaluator(args.cb_src, args.gold, pred_path, args.cache, out_jsonl)
+    n_scored = sum(1 for r in rows if "error" not in r)
+
+    if rc != 0 or n_scored == 0:
+        print(f"ERROR: evaluator returned rc={rc}, n_scored={n_scored} — check logs",
+              file=sys.stderr)
+        sys.exit(1)
+
+    inj = [pk_meta.get(r["instance_id"], {}).get("injected_tokens", 0)
+           for r in rows if "error" not in r]
+    n_clamped_total = sum(pk_meta.get(r["instance_id"], {}).get("n_clamped_by_budget", 0)
+                          for r in rows if "error" not in r)
+    gran = {g: micro(rows, g) for g in ("file", "symbol", "span", "line")}
+    med_inj = statistics.median(inj) if inj else 0
+    p90_inj = sorted(inj)[int(0.9 * (len(inj) - 1))] if inj else 0
+    line_recall = gran["line"]["recall"]
+    rec_per_1k  = (line_recall / (med_inj / 1000.0)) if med_inj else 0.0
+    n_comp = sum(pk_meta.get(r["instance_id"], {}).get("n_compressed", 0)
+                 for r in rows if "error" not in r)
+
+    new_scores = {
+        "arm_label": arm_label,
+        "n_scored": n_scored,
+        "granularity": gran,
+        "median_injected_tokens": med_inj,
+        "p90_injected_tokens": p90_inj,
+        "recall_per_1k_tokens": rec_per_1k,
+        "n_clamped_by_budget_total": n_clamped_total,
+        "n_compressed": n_comp,
+    }
+
+    print(f"\n{'='*72}")
+    print(f"ARM: {arm_label}")
+    print(f"  n_scored      = {n_scored}")
+    print(f"  file_R        = {gran['file']['recall']:.4f}")
+    print(f"  line_R        = {line_recall:.4f}  (line_P={gran['line']['precision']:.4f}  "
+          f"F1={gran['line']['f1']:.4f})")
+    print(f"  sym_R         = {gran['symbol']['recall']:.4f}")
+    print(f"  med_inj       = {med_inj:.0f} tokens")
+    print(f"  p90_inj       = {p90_inj:.0f} tokens")
+    print(f"  R/1k          = {rec_per_1k:.4f}")
+    print(f"  n_clamped     = {n_clamped_total} genes dropped by budget across all tasks")
+    print(f"{'='*72}")
+
+    # Regenerate combined table + plot
+    existing = load_existing_table(args.out_dir)
+    if not args.no_plot:
+        regenerate_table_and_plot(existing, arm_label, new_scores, args.out_dir)
+
+    # Also run the approximate preview on top, to compare with real scores
+    print(f"\n=== Running approximate preview (line-count heuristic) for comparison ===",
+          file=sys.stderr)
+    preview = postprocess_existing_packet(
+        args.tag, args.budget, args.out_dir,
+        args.cb_src, args.gold, args.cache,
+    )
+    if preview:
+        g = preview["granularity"]
+        print(f"\n[PREVIEW vs REAL comparison]")
+        print(f"  Approx (line heuristic) line_R = {g['line']['recall']:.3f}")
+        print(f"  Real   (live re-run)    line_R = {line_recall:.3f}")
+        print(f"  Delta  = {line_recall - g['line']['recall']:+.3f}")
+
+    print(f"\nDone. Key output: {pred_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cb_dump_tasks.py
+++ b/benchmarks/cb_dump_tasks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""ContextBench Step-0 arm-D: dump tasks (checkout worktrees) for the smoke gold set.
+
+Run with the cb-step0 venv (has contextbench via PYTHONPATH, pyarrow).
+Emits F:/tmp/cb_tasks_smoke.json = list of
+  {instance_id, repo, repo_url, base_commit, problem_statement, worktree_dir}
+Worktrees are already cloned/warm; checkout() returns the existing worktree fast.
+Any checkout returning None is skipped and recorded (printed at the end).
+Read-only on contextbench source.
+"""
+import json
+import os
+import sys
+
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+CACHE = "F:/Projects/_cache/cb_repos"
+OUT = "F:/tmp/cb_tasks_smoke.json"
+CONTEXTBENCH_SRC = os.environ.get("CONTEXTBENCH_SRC", "F:/Projects/contextbench-src")
+
+os.environ["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
+sys.path.insert(0, CONTEXTBENCH_SRC)
+
+from contextbench.core import checkout  # noqa: E402
+import pyarrow.dataset as ds  # noqa: E402
+
+
+def main():
+    rows = ds.dataset(GOLD, format="parquet").to_table().to_pylist()
+    print(f"loaded {len(rows)} gold rows from {GOLD}", file=sys.stderr)
+
+    tasks = []
+    checkout_errors = {}
+    for i, r in enumerate(rows):
+        iid = r["instance_id"]
+        repo_url = r.get("repo_url")
+        base_commit = r.get("base_commit")
+        try:
+            gc = json.loads(r["gold_context"]) if r.get("gold_context") else []
+        except Exception:  # noqa: BLE001
+            gc = []
+        gold_files = sorted({(e.get("file") or "").replace("\\", "/").lstrip("/")
+                             for e in gc if e.get("file")})
+        print(f"[checkout {i+1}/{len(rows)}] {iid} {r.get('repo')}@{(base_commit or '')[:10]}",
+              file=sys.stderr)
+        try:
+            wt = checkout(repo_url, base_commit, CACHE)
+        except Exception as e:  # noqa: BLE001
+            wt = None
+            checkout_errors[iid] = repr(e)
+        if not wt or not os.path.isdir(wt):
+            checkout_errors[iid] = checkout_errors.get(iid, "checkout_returned_none")
+            print(f"  CHECKOUT FAILED: {checkout_errors[iid]}", file=sys.stderr)
+            continue
+        tasks.append({
+            "instance_id": iid,
+            "repo": r.get("repo"),
+            "repo_url": repo_url,
+            "base_commit": base_commit,
+            "problem_statement": r.get("problem_statement") or "",
+            "worktree_dir": wt.replace("\\", "/"),
+            "gold_files": gold_files,
+        })
+        print(f"  ok -> {wt}", file=sys.stderr)
+
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    with open(OUT, "w", encoding="utf-8") as f:
+        json.dump(tasks, f, indent=2)
+    print(f"\nwrote {len(tasks)} tasks -> {OUT}", file=sys.stderr)
+    if checkout_errors:
+        print(f"checkout_errors ({len(checkout_errors)}): {json.dumps(checkout_errors, indent=2)}",
+              file=sys.stderr)
+    else:
+        print("checkout_errors: none", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cb_helix_pred.py
+++ b/benchmarks/cb_helix_pred.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""ContextBench Step-0 arm-D: in-process Helix retrieval -> unified-format preds.
+
+Run TWICE:
+  helix062 venv  -> --tag v062   (shipped helix-context 0.6.2)
+  bgem3   venv   -> --tag wt      (vibrant-easley perf worktree)
+
+Per task: fresh isolated genome under F:/tmp/cb_helix_genomes/<tag>/<iid>/, ingest the
+worktree's indexable files (same file-universe constants as the BM25 arm), run the
+LLM-free fingerprint + packet recipe, recover 1-indexed line ranges by VERBATIM
+content-match (no fabrication — failures are recorded and skipped), tally injected
+tokens with cl100k_base (same tokenizer as BM25). rmtree the genome after each task.
+
+Emits per (mode,budget) a unified-format pred list:
+  helix_<tag>_fingerprint_8k_pred.json, ..._fingerprint_27k_pred.json, ..._packet_pred.json
+plus a meta sidecar ..._meta.json = {iid: {injected_tokens, n_genes, n_match_fail, n_indexed_files}}.
+
+Read-only on helix + contextbench source. No server / no ports touched (in-process).
+HARMLESS: torch "hardware candidate cuda failed" tracebacks on helix062 are CPU-fallback noise.
+"""
+import argparse
+import json
+import os
+import shutil
+import sys
+
+# ---- file universe (MUST match contextbench_step0.py exactly) ----------------
+# Code + core docs only. High-volume non-code (.po/.html/.json/.css/.xml...) is dropped:
+# Helix's per-file spaCy ingest chokes on django's thousands of .po files, and they are
+# never code gold. Kept symmetric with the BM25 arm. The gold-file warn flags any drop.
+SRC_EXT = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".c", ".h", ".cpp", ".cc",
+    ".hpp", ".hh", ".java", ".cs", ".rb", ".php", ".swift", ".kt", ".scala",
+    ".cfg", ".ini", ".toml", ".yaml", ".yml", ".pyi",
+}
+# Helix compacts large genes -> content becomes "[COMPRESSED:euchromatin] source=...".
+# Such genes cannot be line-mapped; they hit large DOCS prose (.txt/.rst/.md), never .py code
+# gold, so docs are dropped above. This guard skips any residual compressed gene (never mis-mapped).
+COMPRESSED_PREFIX = "[COMPRESSED"
+SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".mypy_cache", ".pytest_cache",
+    ".tox", ".eggs", "dist", "build", ".venv", "venv",
+}
+MAX_FILE_BYTES = 2_000_000
+
+HELIX_CONFIG = "F:/tmp/cb_helix_probe/helix_probe.toml"
+GENOME_ROOT = "F:/tmp/cb_helix_genomes"
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+
+import tiktoken  # noqa: E402
+ENC = tiktoken.get_encoding("cl100k_base")
+
+
+def ntok(text):
+    return len(ENC.encode(text or "", disallowed_special=()))
+
+
+def iter_repo_files(repo_dir):
+    """Yield (rel_path forward-slashed, abs_path) for indexable files. Mirrors BM25 arm."""
+    for root, dirs, files in os.walk(repo_dir):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for fn in files:
+            ext = os.path.splitext(fn)[1].lower()
+            if ext not in SRC_EXT:
+                continue
+            ap = os.path.join(root, fn)
+            try:
+                if os.path.getsize(ap) > MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel = os.path.relpath(ap, repo_dir).replace("\\", "/")
+            yield rel, ap
+
+
+def read_text(abs_path):
+    try:
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def recover_lines(content, file_text):
+    """Return (start, end) 1-indexed inclusive by verbatim content-match, or None on failure."""
+    c = content or ""
+    if not c.strip() or file_text is None:
+        return None
+    off = file_text.find(c)
+    matched = c
+    if off < 0:
+        cs = c.strip()
+        off = file_text.find(cs)
+        matched = cs
+    if off < 0:
+        return None
+    start = file_text.count("\n", 0, off) + 1
+    end = start + matched.count("\n")
+    return start, end
+
+
+def load_gold_files(tasks):
+    """{iid: list(gold rel files)} from the tasks JSON (emitted by cb_dump_tasks.py).
+    Used only for the 3-task retrieval sanity check."""
+    return {t["instance_id"]: t.get("gold_files", []) for t in tasks}
+
+
+def _patch_dense_gpu():
+    """Move the BGE-M3 dense codec to CUDA. Results are IDENTICAL to CPU (same model,
+    same vectors) — only faster. v0.6.2/worktree build BGEM3Codec(dim=...) with no device
+    arg, defaulting to cpu; this subclass forces cuda. (SPLADE already uses get_hardware().device.)"""
+    try:
+        from helix_context.backends import bgem3_codec as _bc
+    except Exception:  # noqa: BLE001
+        return
+    if getattr(_bc, "_cb_gpu_patched", False):
+        return
+    _Orig = _bc.BGEM3Codec
+
+    class _GpuBGEM3(_Orig):  # noqa: N801
+        def __init__(self, dim=1024, device="cpu", model_name="BAAI/bge-m3"):
+            super().__init__(dim=dim, device="cuda", model_name=model_name)
+
+    _bc.BGEM3Codec = _GpuBGEM3
+    _bc._cb_gpu_patched = True
+
+
+def build_helix(genome_dir):
+    """Fresh in-process Helix on an isolated genome. Imports helix AFTER env is set."""
+    os.environ.pop("HELIX_USE_SHARDS", None)
+    os.environ.setdefault("HELIX_CONFIG", HELIX_CONFIG)  # main sets the real path; fallback only
+    os.environ["HELIX_GENOME_PATH"] = genome_dir + "/genome.db"
+    os.makedirs(genome_dir, exist_ok=True)
+    if os.environ.get("CB_DENSE_DEVICE", "cpu").strip().lower() == "cuda":
+        _patch_dense_gpu()
+    from helix_context.config import load_config
+    from helix_context.context_manager import HelixContextManager
+    cfg = load_config()
+    return HelixContextManager(cfg)
+
+
+# Release CUDA caching-allocator memory every N ingested files. helix.ingest() dense-encodes
+# each file, and torch caches a distinct block size-class per input shape; over a large repo
+# (~1k+ files of varying size) those size-classes accumulate and VRAM climbs to the card
+# ceiling even on ONE worker (measured: 11.7GB/95% on a 12GB 3080 Ti; expandable_segments
+# alone only got the *start* down to 7.7GB, it still climbed within a single task). A periodic
+# empty_cache() inside the loop bounds the within-task peak. This is a STOP-GAP for the bench;
+# the real fix belongs in helix's dense ingest path (see issue). Off unless dense on cuda.
+VRAM_RELEASE_EVERY = int(os.environ.get("CB_VRAM_RELEASE_EVERY", "100"))
+
+
+def _release_vram():
+    if os.environ.get("CB_DENSE_DEVICE", "cpu").strip().lower() != "cuda":
+        return
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def ingest_repo(helix, repo_dir, file_cache):
+    """Ingest every indexable file as whole-file code blobs. Populates file_cache[rel]=text.
+    Returns n_indexed_files."""
+    n = 0
+    for rel, ap in iter_repo_files(repo_dir):
+        text = read_text(ap)
+        if text is None:
+            continue
+        file_cache[rel] = text
+        try:
+            helix.ingest(text, content_type="code", metadata={"path": rel})
+            n += 1
+            if n % VRAM_RELEASE_EVERY == 0:
+                _release_vram()
+        except Exception as e:  # noqa: BLE001
+            print(f"    [ingest-warn] {rel}: {e!r}", file=sys.stderr)
+    return n
+
+
+def gene_src(g):
+    """rel path for a gene: source_id (== metadata path) preferred, fall back to promoter meta."""
+    src = getattr(g, "source_id", None)
+    if src:
+        return src.replace("\\", "/")
+    if getattr(g, "promoter", None) and g.promoter.metadata:
+        p = g.promoter.metadata.get("path")
+        if p:
+            return p.replace("\\", "/")
+    return None
+
+
+def run_fingerprint(helix, q, max_results=400):
+    """LLM-free fingerprint. Returns ranked list of genes (by last_query_scores desc)."""
+    eq, dom, ent = helix._prepare_query_signals(q, session_context=None, expand_query=False)
+    cands = helix._retrieve(dom, ent, max_results, query_text=q, include_cold=None,
+                            party_id="default", use_harmonic=False, use_sr=False)
+    cands, contrib = helix._apply_candidate_refiners(
+        q, cands, max_results, use_cymatics=False, use_harmonic_bin=False,
+        use_tcm=True, allow_rerank=False)
+    scores = dict(helix.genome.last_query_scores or {})
+    ranked = sorted(cands, key=lambda g: scores.get(g.gene_id, 0.0), reverse=True)
+    return ranked
+
+
+def run_packet(helix, q):
+    """Delivered packet items (verified + stale_risk). Each dict has gene_id, content, source_id."""
+    from helix_context.context_packet import build_context_packet
+    packet = build_context_packet(q, task_type="explain", genome=helix.genome, max_genes=32,
+                                  now_ts=0.0, read_only=True, include_raw=True,
+                                  max_item_chars=100000)
+    pd = packet.model_dump()
+    return list(pd.get("verified", [])) + list(pd.get("stale_risk", []))
+
+
+def genes_to_pred(iid, items, file_cache):
+    """items: list of (src, content). Build unified pred + (injected_tokens, n_genes, n_match_fail).
+    Lines recovered by verbatim content-match; failures recorded+skipped (never fabricated)."""
+    from collections import defaultdict
+    spans = defaultdict(list)
+    files = set()
+    injected = 0
+    n_genes = 0
+    n_fail = 0
+    n_compressed = 0
+    for src, content in items:
+        if not src:
+            n_fail += 1
+            continue
+        if (content or "").startswith(COMPRESSED_PREFIX):
+            n_compressed += 1  # Helix-compacted gene: not line-mappable (separate from a real fail)
+            continue
+        ftext = file_cache.get(src)
+        rng = recover_lines(content, ftext)
+        if rng is None:
+            n_fail += 1
+            continue
+        start, end = rng
+        spans[src].append({"start": start, "end": end})
+        files.add(src)
+        injected += ntok(content)
+        n_genes += 1
+    pred = {
+        "instance_id": iid,
+        "traj_data": {"pred_steps": [], "pred_files": sorted(files),
+                      "pred_spans": {k: v for k, v in spans.items()}},
+        "model_patch": "",
+    }
+    meta = {"injected_tokens": injected, "n_genes": n_genes,
+            "n_match_fail": n_fail, "n_compressed": n_compressed}
+    return pred, meta
+
+
+def process_task(payload):
+    """Run one task end-to-end in an isolated process (fresh genome). Returns a result dict.
+    Top-level + picklable so it works under ProcessPoolExecutor (spawn) on Windows."""
+    task, tag, budgets, modes, gold_files = payload
+    iid = task["instance_id"]
+    wt = task["worktree_dir"]
+    gdir = f"{GENOME_ROOT}/{tag}/{iid}"
+    shutil.rmtree(gdir, ignore_errors=True)
+    res = {"iid": iid, "repo": task.get("repo", ""), "fp": {}, "packet": None, "error": None,
+           "n_indexed": 0, "n_ranked": 0, "gold_in_ranked": 0, "n_gold": len(gold_files or [])}
+    do_fp = "fingerprint" in modes
+    do_pk = "packet" in modes
+    helix = None
+    file_cache = {}
+    try:
+        helix = build_helix(gdir)
+        n_indexed = ingest_repo(helix, wt, file_cache)
+        res["n_indexed"] = n_indexed
+        q = task["problem_statement"]
+        ranked = run_fingerprint(helix, q, max_results=400) if do_fp else []
+        ranked_items = [(gene_src(g), (g.content or "")) for g in ranked]
+        res["n_ranked"] = len(ranked_items)
+        gset = set(gold_files or [])
+        res["gold_in_ranked"] = len(gset & {s for s, _ in ranked_items if s})
+        if do_fp:
+            for b in budgets:
+                sel = []
+                inj = 0
+                for s, c in ranked_items:
+                    if s is None or not (c or "").strip() or c.startswith(COMPRESSED_PREFIX):
+                        continue
+                    sel.append((s, c))
+                    inj += ntok(c)
+                    if inj >= b:
+                        break
+                pred, meta = genes_to_pred(iid, sel, file_cache)
+                meta["n_indexed_files"] = n_indexed
+                res["fp"][b] = (pred, meta)
+        if do_pk:
+            items = [(((it.get("source_id") or "").replace("\\", "/")) or None, it.get("content") or "")
+                     for it in run_packet(helix, q)]
+            pred, meta = genes_to_pred(iid, items, file_cache)
+            meta["n_indexed_files"] = n_indexed
+            res["packet"] = (pred, meta)
+    except Exception as e:  # noqa: BLE001
+        import traceback
+        res["error"] = f"{e!r} | {traceback.format_exc().splitlines()[-1]}"
+    finally:
+        try:
+            if helix is not None and getattr(helix, "genome", None) is not None:
+                close = getattr(helix.genome, "close", None)
+                if callable(close):
+                    close()
+        except Exception:  # noqa: BLE001
+            pass
+        helix = None
+        file_cache = None
+        import gc as _gc
+        _gc.collect()
+        # Serial (--workers 1) reuses one process across all tasks, so torch's CUDA caching
+        # allocator accumulates to the largest-task peak and holds it (medium repos -> ~12GB,
+        # 95% of a 12GB card). Release cached VRAM back to the OS after each task so the next
+        # task starts near baseline instead of stacking. (Pool path already gets a fresh proc.)
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                torch.cuda.ipc_collect()
+        except Exception:  # noqa: BLE001
+            pass
+        shutil.rmtree(gdir, ignore_errors=True)
+    return res
+
+
+def _print_result(n, total, r):
+    if r["error"]:
+        print(f"[{n}/{total}] {r['iid'][-8:]} {r['repo']} ERROR: {r['error']}", file=sys.stderr, flush=True)
+        return
+    fp = " ".join(f"fp{b//1000}k:g{m['n_genes']}/t{m['injected_tokens']}/cz{m['n_compressed']}"
+                  for b, (p, m) in sorted(r["fp"].items()))
+    pk = r["packet"][1] if r["packet"] else None
+    pkinfo = f"pk:g{pk['n_genes']}/t{pk['injected_tokens']}/cz{pk['n_compressed']}" if pk else ""
+    print(f"[{n}/{total}] {r['iid'][-8:]} {r['repo']:<22} idx={r['n_indexed']} "
+          f"gold_in_rank={r['gold_in_ranked']}/{r['n_gold']} {fp} {pkinfo}", file=sys.stderr, flush=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="ContextBench Step-0 Helix arm-D predictor")
+    ap.add_argument("--tasks", default="F:/tmp/cb_tasks_smoke.json")
+    ap.add_argument("--tag", required=True, help="v062 | wt")
+    ap.add_argument("--out-dir", default="F:/Projects/helix-context/benchmarks/contextbench/results")
+    ap.add_argument("--budgets", default="8000,27000")
+    ap.add_argument("--modes", default="fingerprint,packet")
+    ap.add_argument("--validate-only", action="store_true", help="only first 3 tasks; don't write preds")
+    ap.add_argument("--workers", type=int, default=1, help="parallel task workers (one process+genome each)")
+    ap.add_argument("--config", default=HELIX_CONFIG, help="HELIX_CONFIG toml (v1=lexical, v2=dense+splade)")
+    ap.add_argument("--dense-device", default="cpu", choices=["cpu", "cuda"],
+                    help="device for BGE-M3 dense codec (cuda = results-identical speedup)")
+    args = ap.parse_args()
+
+    # Set before spawning workers so they inherit (Windows spawn copies os.environ).
+    os.environ["HELIX_CONFIG"] = args.config
+    os.environ["CB_DENSE_DEVICE"] = args.dense_device
+
+    budgets = [int(b) for b in args.budgets.split(",") if b.strip()]
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    with open(args.tasks, "r", encoding="utf-8") as f:
+        tasks = json.load(f)
+    gold_map = load_gold_files(tasks)
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    # accumulators: (mode,budget) -> list of preds; meta sidecars per output
+    fp_preds = {b: [] for b in budgets}          # fingerprint @ budget
+    fp_meta = {b: {} for b in budgets}
+    pk_preds = []                                # packet
+    pk_meta = {}
+    do_fp = "fingerprint" in modes
+    do_pk = "packet" in modes
+
+    if args.validate_only:
+        tasks = tasks[:3]
+    payloads = [(t, args.tag, budgets, modes, gold_map.get(t["instance_id"], [])) for t in tasks]
+    total = len(payloads)
+    results = []
+    if args.workers and args.workers > 1:
+        from concurrent.futures import ProcessPoolExecutor, as_completed
+        print(f"running {total} tasks with {args.workers} workers (tag={args.tag})",
+              file=sys.stderr, flush=True)
+        with ProcessPoolExecutor(max_workers=args.workers, max_tasks_per_child=1) as ex:
+            futs = {ex.submit(process_task, p): p[0]["instance_id"] for p in payloads}
+            done = 0
+            for fut in as_completed(futs):
+                done += 1
+                try:
+                    r = fut.result()
+                except Exception as e:  # noqa: BLE001
+                    r = {"iid": futs[fut], "repo": "", "fp": {}, "packet": None,
+                         "error": repr(e), "n_indexed": 0, "n_ranked": 0,
+                         "gold_in_ranked": 0, "n_gold": 0}
+                results.append(r)
+                _print_result(done, total, r)
+    else:
+        for i, p in enumerate(payloads):
+            r = process_task(p)
+            results.append(r)
+            _print_result(i + 1, total, r)
+
+    # aggregate into output accumulators
+    n_err = 0
+    for r in results:
+        if r["error"]:
+            n_err += 1
+            continue
+        for b, (pred, meta) in r["fp"].items():
+            fp_preds[b].append(pred)
+            fp_meta[b][r["iid"]] = meta
+        if r["packet"]:
+            pred, meta = r["packet"]
+            pk_preds.append(pred)
+            pk_meta[r["iid"]] = meta
+    print(f"\naggregated {total - n_err}/{total} tasks ({n_err} errored)", file=sys.stderr, flush=True)
+
+    # ---- write outputs (skip when validate-only so we don't ship partial preds) ----
+    if args.validate_only:
+        print("[validate-only] not writing pred files.", file=sys.stderr, flush=True)
+        return
+
+    written = []
+
+    def dump(name_preds, name_meta, preds, meta):
+        p1 = os.path.join(args.out_dir, name_preds)
+        p2 = os.path.join(args.out_dir, name_meta)
+        with open(p1, "w", encoding="utf-8") as f:
+            json.dump(preds, f)
+        with open(p2, "w", encoding="utf-8") as f:
+            json.dump(meta, f, indent=2)
+        written.extend([p1, p2])
+
+    if do_fp:
+        for b in budgets:
+            bk = f"{b // 1000}k"
+            dump(f"helix_{args.tag}_fingerprint_{bk}_pred.json",
+                 f"helix_{args.tag}_fingerprint_{bk}_meta.json", fp_preds[b], fp_meta[b])
+    if do_pk:
+        dump(f"helix_{args.tag}_packet_pred.json",
+             f"helix_{args.tag}_packet_meta.json", pk_preds, pk_meta)
+
+    print(f"\nwrote {len(written)} files:", file=sys.stderr)
+    for w in written:
+        print(f"  {w}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cb_score_all.py
+++ b/benchmarks/cb_score_all.py
@@ -1,0 +1,73 @@
+"""Score all arms on the ContextBench smoke gold (official evaluator) -> one combined table.
+BM25 pulled from step0_summary.json; every helix_*_pred.json scored fresh. cb-step0 venv."""
+import glob, json, os, subprocess, sys
+
+CB_SRC = "F:/Projects/contextbench-src"
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+RES = "F:/Projects/helix-context/benchmarks/contextbench/results"
+CACHE = "F:/Projects/_cache/cb_repos"
+
+env = os.environ.copy()
+env["PYTHONPATH"] = CB_SRC + os.pathsep + env.get("PYTHONPATH", "")
+env["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+env["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+
+def run_eval(pred, out):
+    if os.path.isfile(out):
+        os.remove(out)
+    r = subprocess.run([sys.executable, "-m", "contextbench.evaluate", "--gold", GOLD,
+                        "--pred", pred, "--cache", CACHE, "--out", out], env=env,
+                       creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    rows = [json.loads(l) for l in open(out, encoding="utf-8") if l.strip()] if os.path.isfile(out) else []
+    return rows, r.returncode
+
+
+def micro(rows, gran):
+    v = [r for r in rows if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in v)
+    gold = sum(r.get("final", {}).get(gran, {}).get("gold_size", 0) for r in v)
+    pred = sum(r.get("final", {}).get(gran, {}).get("pred_size", 0) for r in v)
+    return (inter / gold if gold else 1.0), (inter / pred if pred else 1.0), len(v)
+
+
+def med(xs):
+    xs = sorted(xs)
+    return xs[len(xs) // 2] if xs else 0
+
+
+rows_out = []  # (arm, n, file_R, line_R, line_P, sym_R, med_inj, comp)
+
+# BM25 from summary
+summ = os.path.join(RES, "step0_summary.json")
+if os.path.isfile(summ):
+    s = json.load(open(summ, encoding="utf-8"))
+    for arm, d in s.get("arms", {}).items():
+        if "granularity" in d:
+            g = d["granularity"]
+            rows_out.append((arm, d["n_scored"], g["file"]["recall"], g["line"]["recall"],
+                             g["line"]["precision"], g["symbol"]["recall"], d["median_injected_tokens"], 0))
+
+# every helix pred
+for pred in sorted(glob.glob(os.path.join(RES, "helix_*_pred.json"))):
+    name = os.path.basename(pred).replace("_pred.json", "")
+    metaf = pred.replace("_pred.json", "_meta.json")
+    rows, rc = run_eval(pred, os.path.join(RES, name + "_eval.jsonl"))
+    fr, _, _ = micro(rows, "file")
+    lr, lp, n = micro(rows, "line")
+    sr, _, _ = micro(rows, "symbol")
+    inj, comp = [], 0
+    if os.path.isfile(metaf):
+        m = json.load(open(metaf, encoding="utf-8"))
+        inj = [v.get("injected_tokens", 0) for v in m.values()]
+        comp = sum(v.get("n_compressed", 0) for v in m.values())
+    rows_out.append((name.replace("helix_", ""), n, fr, lr, lp, sr, med(inj), comp))
+
+print(f"\n{'arm':<26}{'n':>3}{'file_R':>8}{'line_R':>8}{'line_P':>8}{'sym_R':>8}{'med_inj':>9}{'cmprsd':>7}")
+print("-" * 77)
+for a, n, fr, lr, lp, sr, mi, cz in rows_out:
+    print(f"{a:<26}{n:>3}{fr:>8.3f}{lr:>8.3f}{lp:>8.3f}{sr:>8.3f}{int(mi):>9}{cz:>7}")
+json.dump([dict(zip(["arm", "n", "file_R", "line_R", "line_P", "sym_R", "med_inj", "compressed"], r))
+           for r in rows_out], open(os.path.join(RES, "combined_table.json"), "w"), indent=2)
+print("\n-> combined_table.json")

--- a/benchmarks/cb_score_compare.py
+++ b/benchmarks/cb_score_compare.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""ContextBench Step-0 arm-D: score Helix preds with the OFFICIAL evaluator + compare to BM25.
+
+Run with the cb-step0 venv. For each Helix pred JSON: run `python -m contextbench.evaluate`
+(same convention as the BM25 harness), parse the per-instance JSONL, micro-average file/symbol/
+line EXACTLY like the evaluator (cov=inter/gold if gold else 1.0; prec=inter/pred if pred else 1.0),
+join injected_tokens (median) from the meta sidecar. Load existing BM25 numbers from step0_summary.json.
+Print ONE combined 8-row table and write a combined summary JSON.
+
+Read-only on contextbench source; never mutates repos.
+"""
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+
+CONTEXTBENCH_SRC = os.environ.get("CONTEXTBENCH_SRC", "F:/Projects/contextbench-src")
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+CACHE = "F:/Projects/_cache/cb_repos"
+RESULTS = "F:/Projects/helix-context/benchmarks/contextbench/results"
+BM25_SUMMARY = os.path.join(RESULTS, "step0_summary.json")
+
+
+def micro(results, gran):
+    """Micro-average exactly like the official evaluator aggregate (and the BM25 harness)."""
+    valid = [r for r in results if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in valid)
+    gold = sum(r.get("final", {}).get(gran, {}).get("gold_size", 0) for r in valid)
+    pred = sum(r.get("final", {}).get(gran, {}).get("pred_size", 0) for r in valid)
+    cov = inter / gold if gold else 1.0
+    prec = inter / pred if pred else 1.0
+    f1 = (2 * cov * prec / (cov + prec)) if (cov + prec) else 0.0
+    return {"recall": cov, "precision": prec, "f1": f1,
+            "inter": inter, "gold": gold, "pred": pred, "n_valid": len(valid)}
+
+
+def run_evaluator(pred_path, out_jsonl, env):
+    """Run the official evaluator; delete stale --out first (crash != real empty result)."""
+    cmd = [sys.executable, "-m", "contextbench.evaluate",
+           "--gold", GOLD, "--pred", pred_path, "--cache", CACHE, "--out", out_jsonl]
+    print(f"  [eval] {' '.join(cmd)}", file=sys.stderr)
+    if os.path.isfile(out_jsonl):
+        os.remove(out_jsonl)
+    r = subprocess.run(cmd, env=env, creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    rows = []
+    if os.path.isfile(out_jsonl):
+        with open(out_jsonl, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    if r.returncode != 0 or not rows:
+        print(f"  [eval] ERROR rc={r.returncode} rows={len(rows)} -- UNTRUSTWORTHY",
+              file=sys.stderr)
+    return rows, r.returncode
+
+
+def score_helix_pred(label, pred_path, meta_path, env):
+    """Returns a summary dict for one Helix arm (or not_measured)."""
+    out_jsonl = os.path.join(RESULTS, os.path.basename(pred_path).replace("_pred.json", "_eval.jsonl"))
+    rows, rc = run_evaluator(pred_path, out_jsonl, env)
+    n_scored = sum(1 for r in rows if "error" not in r)
+    if rc != 0 or n_scored == 0:
+        return {"not_measured": True, "returncode": rc, "n_scored": n_scored,
+                "pred_path": pred_path, "eval_jsonl": out_jsonl}, out_jsonl
+
+    meta = {}
+    if os.path.isfile(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+    inj = [meta.get(r["instance_id"], {}).get("injected_tokens", 0)
+           for r in rows if "error" not in r]
+    match_fail = sum(meta.get(r["instance_id"], {}).get("n_match_fail", 0)
+                     for r in rows if "error" not in r)
+    gran = {g: micro(rows, g) for g in ("file", "symbol", "span", "line")}
+    med_inj = statistics.median(inj) if inj else 0
+    p90_inj = sorted(inj)[int(0.9 * (len(inj) - 1))] if inj else 0
+    line_recall = gran["line"]["recall"]
+    rec_per_1k = (line_recall / (med_inj / 1000.0)) if med_inj else 0.0
+    return {
+        "n_scored": n_scored, "granularity": gran,
+        "median_injected_tokens": med_inj, "p90_injected_tokens": p90_inj,
+        "recall_per_1k_tokens": rec_per_1k, "match_fail": match_fail,
+        "pred_path": pred_path, "eval_jsonl": out_jsonl,
+    }, out_jsonl
+
+
+def bm25_row(bm, label_in):
+    """Pull a BM25 arm from the existing step0_summary into our common row shape."""
+    a = bm["arms"][label_in]
+    g = a["granularity"]
+    return {
+        "n_scored": a["n_scored"], "granularity": g,
+        "median_injected_tokens": a["median_injected_tokens"],
+        "p90_injected_tokens": a["p90_injected_tokens"],
+        "recall_per_1k_tokens": a["recall_per_1k_tokens"],
+        "match_fail": 0,
+        "pred_path": a.get("pred_path"), "eval_jsonl": a.get("eval_jsonl"),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Score Helix arm-D + compare to BM25")
+    ap.add_argument("--tags", default="v062,wt")
+    ap.add_argument("--out", default=os.path.join(RESULTS, "step0_helix_compare_summary.json"))
+    args = ap.parse_args()
+
+    os.environ["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+    os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = CONTEXTBENCH_SRC + os.pathsep + env.get("PYTHONPATH", "")
+    env["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+    env["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+    with open(BM25_SUMMARY, "r", encoding="utf-8") as f:
+        bm = json.load(f)
+
+    # row order: bm25:8k, bm25:27k, then helix arms per tag
+    rows = {}
+    rows["bm25:8k"] = bm25_row(bm, "bm25:8k")
+    rows["bm25:27k"] = bm25_row(bm, "bm25:27k")
+
+    tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+    helix_specs = []  # (row_label, pred_basename, meta_basename)
+    for tag in tags:
+        helix_specs += [
+            (f"helix_{tag}_fingerprint_8k", f"helix_{tag}_fingerprint_8k_pred.json",
+             f"helix_{tag}_fingerprint_8k_meta.json"),
+            (f"helix_{tag}_fingerprint_27k", f"helix_{tag}_fingerprint_27k_pred.json",
+             f"helix_{tag}_fingerprint_27k_meta.json"),
+            (f"helix_{tag}_packet", f"helix_{tag}_packet_pred.json",
+             f"helix_{tag}_packet_meta.json"),
+        ]
+
+    for label, predb, metab in helix_specs:
+        pred_path = os.path.join(RESULTS, predb)
+        meta_path = os.path.join(RESULTS, metab)
+        if not os.path.isfile(pred_path):
+            print(f"  [skip] {label}: pred not found ({pred_path})", file=sys.stderr)
+            rows[label] = {"not_measured": True, "reason": "pred_missing"}
+            continue
+        print(f"\n===== SCORE {label} =====", file=sys.stderr)
+        row, _ = score_helix_pred(label, pred_path, meta_path, env)
+        rows[label] = row
+
+    # ---- combined table ----
+    print("\n" + "=" * 104)
+    hdr = ["arm", "scored", "file_R", "line_R", "line_P", "sym_R", "med_inj_tok", "R/1k", "match_fail"]
+    print(("{:<26}" + "{:>9}" * (len(hdr) - 1)).format(*hdr))
+    print("-" * 104)
+    for label, a in rows.items():
+        if "granularity" not in a:
+            print(f"{label:<26}  (not_measured: {a.get('reason') or a.get('returncode')})")
+            continue
+        g = a["granularity"]
+        print(("{:<26}" + "{:>9}" * 8).format(
+            label, a["n_scored"],
+            f"{g['file']['recall']:.3f}", f"{g['line']['recall']:.3f}",
+            f"{g['line']['precision']:.3f}", f"{g['symbol']['recall']:.3f}",
+            f"{a['median_injected_tokens']:.0f}", f"{a['recall_per_1k_tokens']:.4f}",
+            a.get("match_fail", 0)))
+    print("=" * 104)
+    print("Headline: line_R (recall) vs med_inj_tok — high recall at low tokens wins. "
+          "R/1k = line_R per 1k median injected tokens.")
+
+    summary = {"gold": GOLD, "bm25_source": BM25_SUMMARY, "arms": rows}
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    print(f"\nsummary -> {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cb_score_sklearn2.py
+++ b/benchmarks/cb_score_sklearn2.py
@@ -1,0 +1,80 @@
+"""SPLADE gate scorer on sklearn-2 (the GPU matched isolation set).
+densefix (dense-only, cap-lifted) vs +SPLADE on the SAME 2 sklearn tasks, official evaluator.
+Plus BM25 and v063 lexical (filtered to the 2 sklearn iids) as references. cb-step0 venv."""
+import json, os, subprocess, sys
+
+CB_SRC = "F:/Projects/contextbench-src"
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+RES = "F:/Projects/helix-context/benchmarks/contextbench/results"
+CACHE = "F:/Projects/_cache/cb_repos"
+VAL = "F:/tmp/cb_val"; os.makedirs(VAL, exist_ok=True)
+IIDS = {"4f130690", "5900c195"}  # sklearn-2
+
+env = os.environ.copy()
+env["PYTHONPATH"] = CB_SRC + os.pathsep + env.get("PYTHONPATH", "")
+env["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+env["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+
+def _m(iid):
+    return any(iid.endswith(s) or iid == s for s in IIDS)
+
+
+def evalrows(pred, out):
+    if os.path.isfile(out):
+        os.remove(out)
+    subprocess.run([sys.executable, "-m", "contextbench.evaluate", "--gold", GOLD, "--pred", pred,
+                    "--cache", CACHE, "--out", out], env=env,
+                   creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    rows = [json.loads(l) for l in open(out, encoding="utf-8") if l.strip()] if os.path.isfile(out) else []
+    return [r for r in rows if _m(r.get("instance_id", ""))]
+
+
+def micro(rows, gran):
+    v = [r for r in rows if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in v)
+    gold = sum(r.get("final", {}).get(gran, {}).get("gold_size", 0) for r in v)
+    pred = sum(r.get("final", {}).get(gran, {}).get("pred_size", 0) for r in v)
+    return (inter / gold if gold else 1.0), (inter / pred if pred else 1.0), len(v)
+
+
+def inj(metaf, fixed=None):
+    if fixed:
+        return fixed
+    if not os.path.isfile(metaf):
+        return 0
+    m = json.load(open(metaf, encoding="utf-8"))
+    xs = [m[i]["injected_tokens"] for i in m if _m(i)]
+    return sum(xs) // len(xs) if xs else 0
+
+
+arms = [
+    ("BM25 @8k", "bm25_8k_pred.json", None, 8000),
+    ("BM25 @27k", "bm25_27k_pred.json", None, 27000),
+    ("v063 lexical @8k", "helix_v063lex_fingerprint_8k_pred.json", "helix_v063lex_fingerprint_8k_meta.json", None),
+    ("v063 lexical @27k", "helix_v063lex_fingerprint_27k_pred.json", "helix_v063lex_fingerprint_27k_meta.json", None),
+    ("s063 DENSEFIX @8k", "helix_s063fix_fingerprint_8k_pred.json", "helix_s063fix_fingerprint_8k_meta.json", None),
+    ("s063 DENSEFIX @27k", "helix_s063fix_fingerprint_27k_pred.json", "helix_s063fix_fingerprint_27k_meta.json", None),
+    ("s063 +SPLADE @8k", "helix_s063splade_fingerprint_8k_pred.json", "helix_s063splade_fingerprint_8k_meta.json", None),
+    ("s063 +SPLADE @27k", "helix_s063splade_fingerprint_27k_pred.json", "helix_s063splade_fingerprint_27k_meta.json", None),
+    ("v063 lexical packet", "helix_v063lex_packet_pred.json", "helix_v063lex_packet_meta.json", None),
+    ("s063 DENSEFIX packet", "helix_s063fix_packet_pred.json", "helix_s063fix_packet_meta.json", None),
+    ("s063 +SPLADE packet", "helix_s063splade_packet_pred.json", "helix_s063splade_packet_meta.json", None),
+]
+
+print(f"\nsklearn-2 GPU isolation set = {sorted(IIDS)} (N=2)")
+print(f"{'arm':<24}{'n':>3}{'file_R':>8}{'line_R':>8}{'sym_R':>8}{'inj':>9}")
+print("-" * 60)
+for label, pf, mf, fixed in arms:
+    pp = os.path.join(RES, pf)
+    if not os.path.isfile(pp):
+        print(f"{label:<24}{'(missing pred)':>20}")
+        continue
+    rows = evalrows(pp, os.path.join(VAL, "sk2_" + pf.replace(".json", ".jsonl")))
+    fr, _, _ = micro(rows, "file")
+    lr, _, n = micro(rows, "line")
+    sr, _, _ = micro(rows, "symbol")
+    it = inj(os.path.join(RES, mf) if mf else "", fixed)
+    print(f"{label:<24}{n:>3}{fr:>8.3f}{lr:>8.3f}{sr:>8.3f}{int(it):>9}")
+print("\n(DENSEFIX vs +SPLADE @27k = the clean SPLADE contribution on a medium code repo)")

--- a/benchmarks/cb_score_splade.py
+++ b/benchmarks/cb_score_splade.py
@@ -1,0 +1,86 @@
+"""SPLADE gate scorer: isolate SPLADE's contribution on the requests subset.
+Same 2 requests tasks, official evaluator. The ONLY config delta between densefix and
+SPLADE is splade_enabled -> this table is the clean +SPLADE-on-code measurement.
+Run in cb-step0 venv (contextbench via PYTHONPATH, tree-sitter 0.20.4)."""
+import json, os, subprocess, sys
+
+CB_SRC = "F:/Projects/contextbench-src"
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+RES = "F:/Projects/helix-context/benchmarks/contextbench/results"
+CACHE = "F:/Projects/_cache/cb_repos"
+VAL = "F:/tmp/cb_val"; os.makedirs(VAL, exist_ok=True)
+
+# the 2 requests tasks (the clean dense isolation set)
+IIDS = {"88e1ffd3", "e989ba2d"}  # short forms; match on suffix
+
+env = os.environ.copy()
+env["PYTHONPATH"] = CB_SRC + os.pathsep + env.get("PYTHONPATH", "")
+env["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+env["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+
+def _match(iid):
+    return any(iid.endswith(s) or iid == s for s in IIDS)
+
+
+def evalrows(pred, out):
+    if os.path.isfile(out):
+        os.remove(out)
+    rc = subprocess.run([sys.executable, "-m", "contextbench.evaluate", "--gold", GOLD,
+                         "--pred", pred, "--cache", CACHE, "--out", out], env=env,
+                        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
+    rows = [json.loads(l) for l in open(out, encoding="utf-8") if l.strip()] if os.path.isfile(out) else []
+    return [r for r in rows if _match(r.get("instance_id", ""))]
+
+
+def micro(rows, gran):
+    v = [r for r in rows if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in v)
+    gold = sum(r.get("final", {}).get(gran, {}).get("gold_size", 0) for r in v)
+    pred = sum(r.get("final", {}).get(gran, {}).get("pred_size", 0) for r in v)
+    return (inter / gold if gold else 1.0), (inter / pred if pred else 1.0), len(v)
+
+
+def inj(metaf, fixed=None):
+    if fixed:
+        return fixed
+    if not os.path.isfile(metaf):
+        return 0
+    m = json.load(open(metaf, encoding="utf-8"))
+    xs = [m[i]["injected_tokens"] for i in m if _match(i)]
+    return sum(xs) // len(xs) if xs else 0
+
+
+# (label, pred_file, meta_file_or_None, fixed_tok_or_None)
+arms = [
+    ("BM25 @8k", "bm25_8k_pred.json", None, 8000),
+    ("BM25 @27k", "bm25_27k_pred.json", None, 27000),
+    ("v063 lexical @8k", "helix_v063lex_fingerprint_8k_pred.json", "helix_v063lex_fingerprint_8k_meta.json", None),
+    ("v063 lexical @27k", "helix_v063lex_fingerprint_27k_pred.json", "helix_v063lex_fingerprint_27k_meta.json", None),
+    ("r063 SHIP dense(cap12) @8k", "helix_r063ship_fingerprint_8k_pred.json", "helix_r063ship_fingerprint_8k_meta.json", None),
+    ("r063 SHIP dense(cap12) @27k", "helix_r063ship_fingerprint_27k_pred.json", "helix_r063ship_fingerprint_27k_meta.json", None),
+    ("r063 DENSEFIX(cap500) @8k", "helix_r063fix_fingerprint_8k_pred.json", "helix_r063fix_fingerprint_8k_meta.json", None),
+    ("r063 DENSEFIX(cap500) @27k", "helix_r063fix_fingerprint_27k_pred.json", "helix_r063fix_fingerprint_27k_meta.json", None),
+    ("r063 +SPLADE @8k", "helix_r063splade_fingerprint_8k_pred.json", "helix_r063splade_fingerprint_8k_meta.json", None),
+    ("r063 +SPLADE @27k", "helix_r063splade_fingerprint_27k_pred.json", "helix_r063splade_fingerprint_27k_meta.json", None),
+    ("v063 lexical packet", "helix_v063lex_packet_pred.json", "helix_v063lex_packet_meta.json", None),
+    ("r063 DENSEFIX packet", "helix_r063fix_packet_pred.json", "helix_r063fix_packet_meta.json", None),
+    ("r063 +SPLADE packet", "helix_r063splade_packet_pred.json", "helix_r063splade_packet_meta.json", None),
+]
+
+print(f"\nrequests isolation subset = {sorted(IIDS)} (N=2)")
+print(f"{'arm':<30}{'n':>3}{'file_R':>8}{'line_R':>8}{'sym_R':>8}{'inj':>9}")
+print("-" * 66)
+for label, pf, mf, fixed in arms:
+    pp = os.path.join(RES, pf)
+    if not os.path.isfile(pp):
+        print(f"{label:<30}{'(missing pred)':>20}")
+        continue
+    rows = evalrows(pp, os.path.join(VAL, "spl_" + pf.replace(".json", ".jsonl")))
+    fr, _, _ = micro(rows, "file")
+    lr, _, n = micro(rows, "line")
+    sr, _, _ = micro(rows, "symbol")
+    it = inj(os.path.join(RES, mf) if mf else "", fixed)
+    print(f"{label:<30}{n:>3}{fr:>8.3f}{lr:>8.3f}{sr:>8.3f}{int(it):>9}")
+print("\n(densefix vs +SPLADE @27k = the clean SPLADE contribution; same dense, same cap)")

--- a/benchmarks/cb_score_sub8.py
+++ b/benchmarks/cb_score_sub8.py
@@ -1,0 +1,84 @@
+"""Score the v0.6.3 dense matrix on the 8-task subset (official evaluator, matched tasks).
+Arms: BM25 / v0.6.3 lexical / v0.6.3 shipped-dense(cap12) / v0.6.3 densefix(cap500). cb-step0 venv."""
+import json, os, subprocess, sys
+
+CB_SRC = "F:/Projects/contextbench-src"
+GOLD = "F:/Projects/helix-context/benchmarks/contextbench/gold_smoke_4repo.parquet"
+RES = "F:/Projects/helix-context/benchmarks/contextbench/results"
+CACHE = "F:/Projects/_cache/cb_repos"
+VAL = "F:/tmp/cb_val"; os.makedirs(VAL, exist_ok=True)
+
+iids = {t["instance_id"] for t in json.load(open("F:/tmp/cb_tasks_sub8.json", encoding="utf-8"))}
+env = os.environ.copy()
+env["PYTHONPATH"] = CB_SRC + os.pathsep + env.get("PYTHONPATH", "")
+env["CONTEXTBENCH_TMP_ROOT"] = "F:/Projects/_cache/cb_wt"
+env["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+
+def evalrows(pred, out):
+    if os.path.isfile(out):
+        os.remove(out)
+    subprocess.run([sys.executable, "-m", "contextbench.evaluate", "--gold", GOLD, "--pred", pred,
+                    "--cache", CACHE, "--out", out], env=env,
+                   creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    rows = [json.loads(l) for l in open(out, encoding="utf-8") if l.strip()] if os.path.isfile(out) else []
+    return [r for r in rows if r.get("instance_id") in iids]
+
+
+def micro(rows, gran):
+    v = [r for r in rows if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in v)
+    gold = sum(r.get("final", {}).get(gran, {}).get("gold_size", 0) for r in v)
+    pred = sum(r.get("final", {}).get(gran, {}).get("pred_size", 0) for r in v)
+    return (inter / gold if gold else 1.0), (inter / pred if pred else 1.0), len(v)
+
+
+def medtok(metaf, fixed=None):
+    if fixed:
+        return fixed
+    if not os.path.isfile(metaf):
+        return 0
+    m = json.load(open(metaf, encoding="utf-8"))
+    xs = sorted(m[i]["injected_tokens"] for i in m if i in iids)
+    return xs[len(xs) // 2] if xs else 0
+
+
+# (label, pred_file, meta_file_or_None, fixed_tok_or_None)
+arms = [
+    ("BM25 @8k", "bm25_8k_pred.json", None, 8000),
+    ("BM25 @27k", "bm25_27k_pred.json", None, 27000),
+    ("v063 lexical @8k", "helix_v063lex_fingerprint_8k_pred.json", "helix_v063lex_fingerprint_8k_meta.json", None),
+    ("v063 lexical @27k", "helix_v063lex_fingerprint_27k_pred.json", "helix_v063lex_fingerprint_27k_meta.json", None),
+    ("v063 lexical packet", "helix_v063lex_packet_pred.json", "helix_v063lex_packet_meta.json", None),
+    ("v063 SHIP dense @8k", "helix_v063ship8_fingerprint_8k_pred.json", "helix_v063ship8_fingerprint_8k_meta.json", None),
+    ("v063 SHIP dense @27k", "helix_v063ship8_fingerprint_27k_pred.json", "helix_v063ship8_fingerprint_27k_meta.json", None),
+    ("v063 SHIP dense packet", "helix_v063ship8_packet_pred.json", "helix_v063ship8_packet_meta.json", None),
+    ("v063 DENSEFIX @8k", "helix_v063fix8_fingerprint_8k_pred.json", "helix_v063fix8_fingerprint_8k_meta.json", None),
+    ("v063 DENSEFIX @27k", "helix_v063fix8_fingerprint_27k_pred.json", "helix_v063fix8_fingerprint_27k_meta.json", None),
+    ("v063 DENSEFIX packet", "helix_v063fix8_packet_pred.json", "helix_v063fix8_packet_meta.json", None),
+]
+
+print(f"\nSubset = {len(iids)} tasks (2 each django/sympy/sklearn/requests)")
+print(f"{'arm':<24}{'n':>3}{'file_R':>8}{'line_R':>8}{'sym_R':>8}{'med_inj':>9}{'cmprsd':>7}")
+print("-" * 67)
+out_rows = []
+for label, pf, mf, fixed in arms:
+    pp = os.path.join(RES, pf)
+    if not os.path.isfile(pp):
+        print(f"{label:<24}{'(missing pred)':>20}")
+        continue
+    rows = evalrows(pp, os.path.join(VAL, "s8_" + pf.replace(".json", ".jsonl")))
+    fr, _, _ = micro(rows, "file")
+    lr, _, n = micro(rows, "line")
+    sr, _, _ = micro(rows, "symbol")
+    mt = medtok(os.path.join(RES, mf) if mf else "", fixed)
+    cz = 0
+    if mf and os.path.isfile(os.path.join(RES, mf)):
+        m = json.load(open(os.path.join(RES, mf), encoding="utf-8"))
+        cz = sum(m[i].get("n_compressed", 0) for i in m if i in iids)
+    print(f"{label:<24}{n:>3}{fr:>8.3f}{lr:>8.3f}{sr:>8.3f}{int(mt):>9}{cz:>7}")
+    out_rows.append(dict(zip(["arm", "n", "file_R", "line_R", "sym_R", "med_inj", "compressed"],
+                            [label, n, fr, lr, sr, int(mt), cz])))
+json.dump(out_rows, open(os.path.join(RES, "sub8_table.json"), "w"), indent=2)
+print("\n-> sub8_table.json")

--- a/benchmarks/coderag_bench.py
+++ b/benchmarks/coderag_bench.py
@@ -1,0 +1,473 @@
+"""CodeRAG-Bench (Step-2) foils: random floor + BM25 baseline over the
+programming-solutions corpus.
+
+CodeRAG-Bench (arXiv 2406.14497, NAACL'25 Findings) native retrieval track.
+8 datasets; this file covers the two canonical-solution datasets that share ONE
+corpus (programming-solutions) and have the simplest gold-matching semantics:
+
+  HumanEval (164 q) : query=prompt (signature+docstring) -> gold = its solution.
+                       Gold shares surface tokens with query -> LEXICALLY FRIENDLY.
+  MBPP     (~974 q)  : query=NL text (no signature)       -> gold = its solution.
+                       Pure NL->code -> more SEMANTIC, the harder contrast.
+
+Corpus = code-rag-bench/programming-solutions (text + meta{task_id,task_name}).
+One gold/query. IDCG=1 for all queries, so NDCG@k = 1/log2(rank+1) if gold in
+top-k else 0.
+
+METRICS (primary = NDCG@10):
+  - NDCG@10   -- primary metric per the CodeRAG-Bench paper
+  - Recall@k  -- hit rate: 1 if gold in top-k else 0 (k=1,5,10)
+  - Precision@k -- same as recall for a single-gold query: hit/k (= recall/k)
+
+EFFICIENCY LAYER (injected-token cost estimate):
+  - median / p90 of token_estimate (whitespace-split words * 1.3, rounded).
+  - Measures how many tokens the top-10 results would inject into context.
+  - This is the cheap-vs-7B-dense efficiency argument from the strategy doc.
+
+ARMS:
+  A -- random floor (deterministic per-query hash)
+  B -- BM25 (floored-IDF Okapi, same identifier tokenizer; the classic foil)
+
+Writes:
+  benchmarks/results/coderag_foils_{timestamp}.json   -- summary
+  benchmarks/results/coderag_queries_{timestamp}.json -- per-query dump for
+    the Helix arm (coderag_bench_helix.py) to consume with the same examples.
+
+License: CC-BY-SA-4.0 (ShareAlike copyleft, internal measurement OK; verify
+before any redistributed/public claim on processed data).
+
+LLM-free, GPU-free.
+
+CLI:
+  python benchmarks/coderag_bench.py [--limit N] [--datasets humaneval,mbpp]
+  python benchmarks/coderag_bench.py --limit 50 --datasets humaneval
+  python benchmarks/coderag_bench.py --out benchmarks/results/my_foils.json
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# Identifier tokenizer (same as the Helix lexical probe).
+_TOK = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+# k-values to evaluate (NDCG@10 is primary; recall/prec at 1, 5, 10).
+KS = (1, 5, 10)
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+def tok(s):
+    """Lowercase identifier tokenizer used for BM25 and overlap scoring."""
+    return _TOK.findall((s or "").lower())
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading (isolated so tests can mock/skip)
+# ---------------------------------------------------------------------------
+
+def load_corpus():
+    """Load the programming-solutions corpus from HuggingFace.
+
+    Returns (corpus, doc_index) where:
+      corpus    -- list of {"doc_id": str, "text": str}
+      doc_index -- {doc_id: corpus_index}
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        print("ERROR: 'datasets' not installed. pip install datasets", file=sys.stderr)
+        sys.exit(1)
+
+    ds = load_dataset("code-rag-bench/programming-solutions", split="train")
+    corpus = []
+    doc_index = {}
+    for row in ds:
+        meta = row.get("meta") or {}
+        task_name = meta.get("task_name") or ""
+        task_id = meta.get("task_id") or ""
+        did = f"{task_name}:{task_id}"
+        if did in doc_index:
+            continue
+        doc_index[did] = len(corpus)
+        corpus.append({"doc_id": did, "text": row.get("text") or ""})
+    return corpus, doc_index
+
+
+def load_queries(datasets):
+    """Load query sets from HuggingFace for the requested dataset names."""
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        print("ERROR: 'datasets' not installed. pip install datasets", file=sys.stderr)
+        sys.exit(1)
+
+    queries = []
+    if "humaneval" in datasets:
+        he = load_dataset("code-rag-bench/humaneval", split="train")
+        for ex in he:
+            queries.append({
+                "ds": "humaneval",
+                "query": ex.get("prompt") or "",
+                "gold": "humaneval:{}".format(ex.get("task_id", "")),
+            })
+
+    if "mbpp" in datasets:
+        mb = load_dataset("code-rag-bench/mbpp", split="train")
+        for ex in mb:
+            queries.append({
+                "ds": "mbpp",
+                "query": ex.get("text") or "",
+                "gold": "mbpp:{}".format(ex.get("task_id", "")),
+            })
+
+    return queries
+
+
+# ---------------------------------------------------------------------------
+# BM25 (floored-IDF Okapi, pure Python)
+# ---------------------------------------------------------------------------
+
+class BM25:
+    """Okapi BM25 with IDF floored at 0 (avoids negative IDF on small corpora).
+
+    Accepts pre-tokenised document lists for easy unit testing.
+    """
+
+    def __init__(self, corpus_tokens, k1=1.5, b=0.75):
+        self.k1 = k1
+        self.b = b
+        self.N = len(corpus_tokens)
+        self.dl = [len(d) for d in corpus_tokens]
+        self.avgdl = (sum(self.dl) / self.N) if self.N else 0.0
+
+        df = collections.defaultdict(int)
+        self.tf = []
+        for d in corpus_tokens:
+            f = collections.defaultdict(int)
+            for t in d:
+                f[t] += 1
+            self.tf.append(f)
+            for t in f:
+                df[t] += 1
+
+        self.idf = {
+            t: max(0.0, math.log((self.N - n + 0.5) / (n + 0.5) + 1.0))
+            for t, n in df.items()
+        }
+
+    def scores(self, q_tokens):
+        """Return BM25 score for each document."""
+        qset = set(q_tokens)
+        out = [0.0] * self.N
+        for i in range(self.N):
+            f = self.tf[i]
+            denom = (
+                self.k1 * (1 - self.b + self.b * self.dl[i] / self.avgdl)
+                if self.avgdl else self.k1
+            )
+            s = 0.0
+            for t in qset:
+                ft = f.get(t, 0)
+                if ft:
+                    s += self.idf.get(t, 0.0) * (ft * (self.k1 + 1)) / (ft + denom)
+            out[i] = s
+        return out
+
+    def rank_gold_pos(self, q_tokens, gold_idx):
+        """Return 0-based rank position of gold_idx when ranked by BM25 desc."""
+        sc = self.scores(q_tokens)
+        order = sorted(range(self.N), key=lambda i: (-sc[i], i))
+        return order.index(gold_idx)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def ndcg_at(pos0, k):
+    """Single-gold NDCG@k from 0-based rank position. IDCG = 1.
+
+    ndcg = 1/log2(rank+1) if rank <= k (1-based), else 0.
+    """
+    r = pos0 + 1
+    return (1.0 / math.log2(r + 1)) if r <= k else 0.0
+
+
+def recall_at(pos0, k):
+    """Recall@k for a single-gold query: 1.0 if in top-k else 0.0."""
+    return 1.0 if (pos0 + 1) <= k else 0.0
+
+
+def precision_at(pos0, k):
+    """Precision@k for a single-gold query: (1/k) if in top-k else 0.0."""
+    return (1.0 / k) if (pos0 + 1) <= k else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Efficiency layer
+# ---------------------------------------------------------------------------
+
+def token_estimate(texts):
+    """Rough token estimate for a list of text strings.
+
+    Whitespace-split word count * 1.3, rounded. Used to estimate injected
+    tokens if the top-k documents were included in context verbatim.
+    """
+    words = sum(len((t or "").split()) for t in texts)
+    return round(words * 1.3)
+
+
+def _percentile(values, pct):
+    """Return pct-th percentile (0-100) of values; empty -> 0."""
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * pct / 100
+    lo, hi = int(k), min(int(k) + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def efficiency_stats(token_counts):
+    """Return median and p90 injected token estimates."""
+    return {
+        "median_injected_tokens": round(_percentile(token_counts, 50), 1),
+        "p90_injected_tokens": round(_percentile(token_counts, 90), 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core scoring
+# ---------------------------------------------------------------------------
+
+def _make_random_pos(gold_id, qi, n_corpus):
+    """Deterministic per-query random rank position (floor arm A)."""
+    return hash((gold_id, qi)) % n_corpus
+
+
+def run(corpus, doc_index, queries, limit=0):
+    """Score the foil arms (random + BM25) and return (summary, per_query_rows).
+
+    Parameters
+    ----------
+    corpus     : list of {"doc_id", "text"}
+    doc_index  : {doc_id: corpus_index}
+    queries    : list of {"ds", "query", "gold"}
+    limit      : cap per-dataset (0 = all)
+
+    Returns
+    -------
+    summary        : per-dataset metric dict
+    per_query_rows : per-query data (consumed by coderag_bench_helix.py)
+    """
+    # Resolve gold indices; drop unresolvable.
+    resolved = []
+    miss = 0
+
+    for q in queries:
+        if q["gold"] in doc_index:
+            q = dict(q)
+            q["gold_idx"] = doc_index[q["gold"]]
+            resolved.append(q)
+        else:
+            miss += 1
+
+    if miss:
+        print("[coderag_bench] {} queries dropped (gold not in corpus)".format(miss),
+              flush=True)
+
+    # Apply per-dataset limit.
+    if limit:
+        per_ds = collections.defaultdict(list)
+        for q in resolved:
+            per_ds[q["ds"]].append(q)
+        resolved = []
+        for ds_rows in per_ds.values():
+            resolved.extend(ds_rows[:limit])
+
+    n_corpus = len(corpus)
+    print("[coderag_bench] corpus={} docs, queries={} resolved".format(
+          n_corpus, len(resolved)), flush=True)
+
+    bm = BM25([tok(c["text"]) for c in corpus])
+
+    def _zero_agg():
+        a = {"n": 0, "bm25_ndcg10": 0.0, "rand_ndcg10": 0.0,
+             "bm25_top10_tokens": [], "rand_top10_tokens": []}
+        for k in KS:
+            a["bm25_recall@{}".format(k)] = 0.0
+            a["rand_recall@{}".format(k)] = 0.0
+            a["bm25_precision@{}".format(k)] = 0.0
+            a["rand_precision@{}".format(k)] = 0.0
+        return a
+
+    agg = collections.defaultdict(_zero_agg)
+    per_query_rows = []
+
+    for qi, q in enumerate(resolved):
+        ds = q["ds"]
+        gi = q["gold_idx"]
+        qt = tok(q["query"])
+
+        bm25_pos = bm.rank_gold_pos(qt, gi)
+        rand_pos = _make_random_pos(q["gold"], qi, n_corpus)
+
+        a = agg[ds]
+        a["n"] += 1
+        a["bm25_ndcg10"] += ndcg_at(bm25_pos, 10)
+        a["rand_ndcg10"] += ndcg_at(rand_pos, 10)
+        for k in KS:
+            a["bm25_recall@{}".format(k)] += recall_at(bm25_pos, k)
+            a["rand_recall@{}".format(k)] += recall_at(rand_pos, k)
+            a["bm25_precision@{}".format(k)] += precision_at(bm25_pos, k)
+            a["rand_precision@{}".format(k)] += precision_at(rand_pos, k)
+
+        bm25_sc = bm.scores(qt)
+        bm25_order = sorted(range(n_corpus), key=lambda i: (-bm25_sc[i], i))
+        bm25_top10_texts = [corpus[i]["text"] for i in bm25_order[:10]]
+        a["bm25_top10_tokens"].append(float(token_estimate(bm25_top10_texts)))
+
+        rand_order = sorted(range(n_corpus), key=lambda i: hash((q["gold"], qi, i)))
+        rand_top10_texts = [corpus[i]["text"] for i in rand_order[:10]]
+        a["rand_top10_tokens"].append(float(token_estimate(rand_top10_texts)))
+
+        per_query_rows.append({
+            "ds": ds,
+            "query": q["query"],
+            "gold": q["gold"],
+            "gold_idx": gi,
+            "bm25_rank": bm25_pos,
+        })
+
+    summary = {}
+    for ds, a in sorted(agg.items()):
+        n = a["n"]
+        if n == 0:
+            continue
+        eff_bm25 = efficiency_stats(a["bm25_top10_tokens"])
+        eff_rand = efficiency_stats(a["rand_top10_tokens"])
+        row = {
+            "n": n,
+            "corpus": n_corpus,
+            "bm25_ndcg@10": round(a["bm25_ndcg10"] / n, 4),
+            "rand_ndcg@10": round(a["rand_ndcg10"] / n, 4),
+            "bm25_efficiency": eff_bm25,
+            "rand_efficiency": eff_rand,
+        }
+        for k in KS:
+            row["bm25_recall@{}".format(k)] = round(a["bm25_recall@{}".format(k)] / n, 4)
+            row["rand_recall@{}".format(k)] = round(a["rand_recall@{}".format(k)] / n, 4)
+            row["bm25_precision@{}".format(k)] = round(a["bm25_precision@{}".format(k)] / n, 4)
+            row["rand_precision@{}".format(k)] = round(a["rand_precision@{}".format(k)] / n, 4)
+        summary[ds] = row
+
+    return summary, per_query_rows
+
+
+def _print_table(summary):
+    header = (
+        "{:<12} {:>5} {:>8}  {:>9} {:>7} {:>7} {:>7}  {:>8} {:>8}".format(
+            "dataset", "n", "corpus", "ndcg@10", "r@1", "r@5", "r@10", "med_tok", "p90_tok"
+        )
+    )
+    print("\n" + header)
+    print("-" * len(header))
+    for ds, s in summary.items():
+        eff = s.get("bm25_efficiency", {})
+        print("{:<12} {:>5} {:>8}  {:>9.4f} {:>7.4f} {:>7.4f} {:>7.4f}  {:>8.0f} {:>8.0f}".format(
+            "BM25:" + ds, s["n"], s["corpus"],
+            s["bm25_ndcg@10"], s["bm25_recall@1"], s["bm25_recall@5"], s["bm25_recall@10"],
+            eff.get("median_injected_tokens", 0), eff.get("p90_injected_tokens", 0),
+        ))
+        eff_r = s.get("rand_efficiency", {})
+        print("{:<12} {:>5} {:>8}  {:>9.4f} {:>7.4f} {:>7.4f} {:>7.4f}  {:>8.0f} {:>8.0f}".format(
+            "rand:" + ds, s["n"], s["corpus"],
+            s["rand_ndcg@10"], s["rand_recall@1"], s["rand_recall@5"], s["rand_recall@10"],
+            eff_r.get("median_injected_tokens", 0), eff_r.get("p90_injected_tokens", 0),
+        ))
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=(
+            "CodeRAG-Bench (Step-2) foils: random + BM25 over the "
+            "programming-solutions corpus. Writes per-query dump for the Helix arm."
+        )
+    )
+    ap.add_argument(
+        "--datasets", default="humaneval,mbpp",
+        help="Comma-separated dataset names (default: 'humaneval,mbpp'). Valid: humaneval, mbpp.",
+    )
+    ap.add_argument(
+        "--limit", type=int, default=0,
+        help="Cap queries per dataset (0 = all). Useful for smoke runs.",
+    )
+    ap.add_argument(
+        "--out", default=None,
+        help="Override path for the summary JSON (default: benchmarks/results/coderag_foils_{ts}.json)",
+    )
+    ap.add_argument(
+        "--queries-out", default=None, dest="queries_out",
+        help="Override path for the per-query dump (default: benchmarks/results/coderag_queries_{ts}.json)",
+    )
+    args = ap.parse_args()
+
+    datasets = [d.strip().lower() for d in args.datasets.split(",") if d.strip()]
+    valid = {"humaneval", "mbpp"}
+    bad = set(datasets) - valid
+    if bad:
+        print("ERROR: unknown datasets: {}. Valid: {}".format(bad, valid), file=sys.stderr)
+        sys.exit(1)
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    print("[coderag_bench] Loading corpus...", flush=True)
+    corpus, doc_index = load_corpus()
+    print("[coderag_bench] corpus: {} docs".format(len(corpus)), flush=True)
+
+    print("[coderag_bench] Loading queries: {}...".format(datasets), flush=True)
+    queries = load_queries(datasets)
+    print("[coderag_bench] queries loaded: {}".format(len(queries)), flush=True)
+
+    summary, per_query_rows = run(corpus=corpus, doc_index=doc_index,
+                                   queries=queries, limit=args.limit)
+    _print_table(summary)
+
+    out_path = Path(args.out) if args.out else RESULTS_DIR / "coderag_foils_{}.json".format(ts)
+    queries_path = (Path(args.queries_out) if args.queries_out
+                    else RESULTS_DIR / "coderag_queries_{}.json".format(ts))
+
+    result_blob = {
+        "benchmark": "coderag_bench",
+        "timestamp": ts,
+        "datasets": datasets,
+        "limit": args.limit,
+        "license": "CC-BY-SA-4.0 (internal measurement; verify before public claim)",
+        "metrics": "NDCG@10 (primary), Recall@{1,5,10}, Precision@{1,5,10}",
+        "efficiency": "median/p90 injected tokens from top-10 docs",
+        "summary": summary,
+    }
+
+    out_path.write_text(json.dumps(result_blob, indent=2), encoding="utf-8")
+    queries_path.write_text(json.dumps(per_query_rows, ensure_ascii=False), encoding="utf-8")
+
+    print("\n-> summary:        {}".format(out_path))
+    print("-> per-query dump: {}".format(queries_path))
+    print("   (Helix arm: python benchmarks/coderag_bench_helix.py --queries {})".format(
+          queries_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/coderag_bench_helix.py
+++ b/benchmarks/coderag_bench_helix.py
@@ -1,0 +1,420 @@
+"""CodeRAG-Bench (Step-2) Helix arm: HTTP fingerprint retriever over a live
+helix server (the "helix063" daemon, bench lane :11439).
+
+Reads the per-query dump written by coderag_bench.py, issues one
+POST /fingerprint per query, extracts the ranked list of doc_* paths,
+resolves them back to corpus indices, and scores NDCG@10 + Recall@{1,5,10}
++ Precision@{1,5,10}. Also computes the efficiency layer (median/p90 injected
+tokens from the fingerprint previews, plus per-query latency).
+
+DESIGN NOTES
+- The Helix server must have the programming-solutions corpus ingested before
+  this script runs. Use coderag_bench.py to build the per-query dump, then
+  ingest via 'helix ingest' or the server /ingest endpoint.
+- Retrieval via POST /fingerprint with score_floor=0, profile="fast",
+  max_results=50 (NDCG@10 saturates well below 50).
+- The fingerprint "source" field carries the doc_{idx} path set at ingest.
+- LLM-free, GPU-free (lexical profile; dense/splade OFF on bench server).
+
+METRICS
+  - NDCG@10 (primary, per CodeRAG-Bench paper)
+  - Recall@{1,5,10}
+  - Precision@{1,5,10}
+  - Efficiency: median/p90 injected-token estimate + median/p90 latency (ms)
+
+WRITES
+  benchmarks/results/coderag_helix_{timestamp}.json
+
+CLI
+  # Requires a live Helix server at --helix-url with the corpus pre-ingested.
+  python benchmarks/coderag_bench_helix.py \
+      --queries benchmarks/results/coderag_queries_<ts>.json \
+      --helix-url http://127.0.0.1:11439 \
+      --limit 50
+
+  # Run all queries (HumanEval + MBPP):
+  python benchmarks/coderag_bench_helix.py \
+      --queries benchmarks/results/coderag_queries_<ts>.json \
+      --helix-url http://127.0.0.1:11439
+
+License: CC-BY-SA-4.0 (internal measurement OK; verify before public claim).
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime
+import json
+import math
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+_TOK = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+# k values: NDCG@10 primary; recall/precision at 1, 5, 10.
+KS = (1, 5, 10)
+
+
+# ---------------------------------------------------------------------------
+# Metric helpers
+# ---------------------------------------------------------------------------
+
+def ndcg_at(pos0, k):
+    """Single-gold NDCG@k from 0-based rank. IDCG = 1."""
+    r = pos0 + 1
+    return (1.0 / math.log2(r + 1)) if r <= k else 0.0
+
+
+def recall_at(pos0, k):
+    """1.0 if gold in top-k else 0.0."""
+    return 1.0 if (pos0 + 1) <= k else 0.0
+
+
+def precision_at(pos0, k):
+    """Precision@k for a single-gold query."""
+    return (1.0 / k) if (pos0 + 1) <= k else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Efficiency helpers
+# ---------------------------------------------------------------------------
+
+def _percentile(values, pct):
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * pct / 100
+    lo, hi = int(k), min(int(k) + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def efficiency_stats(token_counts, latency_ms):
+    return {
+        "median_injected_tokens": round(_percentile(token_counts, 50), 1),
+        "p90_injected_tokens": round(_percentile(token_counts, 90), 1),
+        "median_latency_ms": round(_percentile(latency_ms, 50), 1),
+        "p90_latency_ms": round(_percentile(latency_ms, 90), 1),
+    }
+
+
+def preview_token_estimate(previews):
+    """Rough token count from fingerprint preview strings."""
+    words = sum(len((p or "").split()) for p in previews)
+    return round(words * 1.3)
+
+
+# ---------------------------------------------------------------------------
+# Source-id parser: "doc_42" -> 42
+# ---------------------------------------------------------------------------
+
+def parse_doc_idx(source):
+    """Parse doc_{idx} -> int, or None if pattern does not match."""
+    if not source:
+        return None
+    m = re.match(r"doc_(\d+)$", str(source))
+    if m:
+        try:
+            return int(m.group(1))
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# /fingerprint HTTP call
+# ---------------------------------------------------------------------------
+
+def fingerprint(helix_url, query, max_results=50, timeout_s=30.0):
+    """POST /fingerprint and return (fingerprints_list, latency_ms).
+
+    Raises urllib.error.URLError on network failure.
+    """
+    url = helix_url.rstrip("/") + "/fingerprint"
+    payload = json.dumps({
+        "query": query,
+        "max_results": max_results,
+        "score_floor": 0,
+        "profile": "fast",
+    }).encode()
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+        body = json.loads(resp.read())
+    latency_ms = (time.time() - t0) * 1000.0
+    return body.get("fingerprints", []), latency_ms
+
+
+# ---------------------------------------------------------------------------
+# Core scoring loop
+# ---------------------------------------------------------------------------
+
+def score_queries(queries, helix_url, max_results=50, timeout_s=30.0, n_corpus=None):
+    """Run /fingerprint for each query; return (summary, per_query_rows).
+
+    Parameters
+    ----------
+    queries      : list of {"ds", "query", "gold", "gold_idx", ...}
+    helix_url    : base URL of the Helix server
+    max_results  : /fingerprint max_results
+    timeout_s    : per-request HTTP timeout
+    n_corpus     : corpus size; used as rank sentinel when gold unretrieved
+
+    Returns
+    -------
+    summary        : per-dataset NDCG@10 / Recall / Precision + efficiency
+    per_query_rows : per-query details for downstream analysis
+    """
+    def _zero_agg():
+        a = {"n": 0, "err": 0, "ndcg10": 0.0, "token_counts": [], "latency_ms": []}
+        for k in KS:
+            a["recall@{}".format(k)] = 0.0
+            a["precision@{}".format(k)] = 0.0
+        return a
+
+    agg = collections.defaultdict(_zero_agg)
+    per_query_rows = []
+    n_total = len(queries)
+    fallback_n = n_corpus or n_total
+
+    for qi, q in enumerate(queries):
+        ds = q["ds"]
+        gi = q["gold_idx"]
+        a = agg[ds]
+
+        if (qi + 1) % 50 == 0 or qi == 0:
+            print("[helix] {}/{} queries scored...".format(qi + 1, n_total), flush=True)
+
+        try:
+            fps, lat_ms = fingerprint(helix_url, q["query"], max_results, timeout_s)
+        except Exception as exc:
+            a["err"] += 1
+            per_query_rows.append({
+                "ds": ds, "gold": q["gold"], "gold_idx": gi,
+                "helix_rank": None, "error": repr(exc),
+            })
+            continue
+
+        ranked_idxs = []
+        previews = []
+        for fp in fps:
+            idx = parse_doc_idx(fp.get("source") or fp.get("path"))
+            if idx is not None:
+                ranked_idxs.append(idx)
+                previews.append(fp.get("preview") or "")
+
+        if gi in ranked_idxs:
+            pos0 = ranked_idxs.index(gi)
+        else:
+            pos0 = fallback_n
+
+        a["n"] += 1
+        a["ndcg10"] += ndcg_at(pos0, 10)
+        for k in KS:
+            a["recall@{}".format(k)] += recall_at(pos0, k)
+            a["precision@{}".format(k)] += precision_at(pos0, k)
+        a["token_counts"].append(float(preview_token_estimate(previews[:10])))
+        a["latency_ms"].append(lat_ms)
+
+        per_query_rows.append({
+            "ds": ds,
+            "gold": q["gold"],
+            "gold_idx": gi,
+            "helix_rank": pos0,
+            "n_retrieved": len(ranked_idxs),
+            "latency_ms": round(lat_ms, 1),
+        })
+
+    summary = {}
+    for ds, a in sorted(agg.items()):
+        n = a["n"]
+        if n == 0:
+            continue
+        eff = efficiency_stats(a["token_counts"], a["latency_ms"])
+        row = {
+            "n": n,
+            "err": a["err"],
+            "helix_ndcg@10": round(a["ndcg10"] / n, 4),
+            "efficiency": eff,
+        }
+        for k in KS:
+            row["helix_recall@{}".format(k)] = round(a["recall@{}".format(k)] / n, 4)
+            row["helix_precision@{}".format(k)] = round(a["precision@{}".format(k)] / n, 4)
+        summary[ds] = row
+
+    return summary, per_query_rows
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print table
+# ---------------------------------------------------------------------------
+
+def _print_table(summary, foils_path=None):
+    foils = {}
+    if foils_path and Path(foils_path).exists():
+        try:
+            foils = json.loads(Path(foils_path).read_text(encoding="utf-8")).get("summary", {})
+        except Exception:
+            pass
+
+    header = (
+        "{:<14} {:>5}  {:>9} {:>7} {:>7} {:>7}  {:>8} {:>8}  {:>8}".format(
+            "dataset", "n", "ndcg@10", "r@1", "r@5", "r@10",
+            "med_tok", "p90_tok", "med_ms"
+        )
+    )
+    print("\nCodeRAG-Bench -- Helix arm (D)")
+    print(header)
+    print("-" * len(header))
+    for ds, s in summary.items():
+        eff = s.get("efficiency", {})
+        print("{:<14} {:>5}  {:>9.4f} {:>7.4f} {:>7.4f} {:>7.4f}  {:>8.0f} {:>8.0f}  {:>8.1f}".format(
+            "helix:" + ds, s["n"],
+            s["helix_ndcg@10"], s["helix_recall@1"], s["helix_recall@5"], s["helix_recall@10"],
+            eff.get("median_injected_tokens", 0), eff.get("p90_injected_tokens", 0),
+            eff.get("median_latency_ms", 0),
+        ))
+        if ds in foils:
+            f = foils[ds]
+            feff = f.get("bm25_efficiency", {})
+            print("{:<14} {:>5}  {:>9.4f} {:>7.4f} {:>7.4f} {:>7.4f}  {:>8.0f} {:>8.0f}  {:>8}".format(
+                "BM25:" + ds, f["n"],
+                f.get("bm25_ndcg@10", 0), f.get("bm25_recall@1", 0),
+                f.get("bm25_recall@5", 0), f.get("bm25_recall@10", 0),
+                feff.get("median_injected_tokens", 0), feff.get("p90_injected_tokens", 0),
+                "n/a",
+            ))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=(
+            "CodeRAG-Bench (Step-2) Helix arm. "
+            "Requires a live Helix server with the corpus pre-ingested. "
+            "Reads the per-query dump from coderag_bench.py."
+        )
+    )
+    ap.add_argument(
+        "--queries", default=None,
+        help=(
+            "Path to the per-query dump JSON written by coderag_bench.py. "
+            "If omitted, uses the most recent coderag_queries_*.json in "
+            "benchmarks/results/."
+        ),
+    )
+    ap.add_argument(
+        "--helix-url", default="http://127.0.0.1:11439", dest="helix_url",
+        help="Base URL of the Helix bench server (default: http://127.0.0.1:11439)",
+    )
+    ap.add_argument(
+        "--max-results", type=int, default=50, dest="max_results",
+        help="max_results for /fingerprint (default 50; covers NDCG@10 well)",
+    )
+    ap.add_argument(
+        "--limit", type=int, default=0,
+        help="Cap total queries to score (0 = all from dump)",
+    )
+    ap.add_argument(
+        "--timeout", type=float, default=30.0,
+        help="Per-request HTTP timeout in seconds (default 30)",
+    )
+    ap.add_argument(
+        "--foils", default=None,
+        help="Path to foils summary JSON from coderag_bench.py (enables side-by-side table)",
+    )
+    ap.add_argument(
+        "--out", default=None,
+        help="Override output JSON path (default: benchmarks/results/coderag_helix_{ts}.json)",
+    )
+    args = ap.parse_args()
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    if args.queries:
+        queries_path = Path(args.queries)
+    else:
+        candidates = sorted(RESULTS_DIR.glob("coderag_queries_*.json"))
+        if not candidates:
+            print(
+                "ERROR: no coderag_queries_*.json in benchmarks/results/.\n"
+                "  Run coderag_bench.py first: python benchmarks/coderag_bench.py",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        queries_path = candidates[-1]
+
+    if not queries_path.exists():
+        print("ERROR: queries file not found: {}".format(queries_path), file=sys.stderr)
+        sys.exit(1)
+
+    print("[helix] Loading queries from {}".format(queries_path), flush=True)
+    queries = json.loads(queries_path.read_text(encoding="utf-8"))
+    if args.limit:
+        queries = queries[:args.limit]
+    print("[helix] {} queries to score against {}".format(len(queries), args.helix_url),
+          flush=True)
+
+    # Health check.
+    try:
+        health_url = args.helix_url.rstrip("/") + "/health"
+        with urllib.request.urlopen(health_url, timeout=5) as r:
+            health = json.loads(r.read())
+        print("[helix] server health: {} docs={}".format(
+              health.get("status", "ok"), health.get("document_count", "?")), flush=True)
+    except Exception as exc:
+        print(
+            "ERROR: cannot reach Helix server at {}: {}\n"
+            "  Start it: python -m uvicorn helix_context._asgi:app --port 11439".format(
+                args.helix_url, exc),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    summary, per_query_rows = score_queries(
+        queries=queries,
+        helix_url=args.helix_url,
+        max_results=args.max_results,
+        timeout_s=args.timeout,
+    )
+
+    _print_table(summary, foils_path=args.foils)
+
+    out_path = Path(args.out) if args.out else RESULTS_DIR / "coderag_helix_{}.json".format(ts)
+
+    result_blob = {
+        "benchmark": "coderag_bench",
+        "arm": "helix_fingerprint",
+        "timestamp": ts,
+        "helix_url": args.helix_url,
+        "queries_file": str(queries_path),
+        "limit": args.limit,
+        "max_results": args.max_results,
+        "license": "CC-BY-SA-4.0 (internal measurement; verify before public claim)",
+        "metrics": "NDCG@10 (primary), Recall@{1,5,10}, Precision@{1,5,10}",
+        "efficiency": "median/p90 injected tokens (preview-based) + latency",
+        "summary": summary,
+        "per_query_sample": per_query_rows[:20],
+    }
+
+    out_path.write_text(json.dumps(result_blob, indent=2), encoding="utf-8")
+    print("\n-> {}".format(out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/coderag_diag.py
+++ b/benchmarks/coderag_diag.py
@@ -1,0 +1,342 @@
+"""CodeRAG-Bench (Step-2) Helix diagnostic: why does Helix miss lexically-obvious
+gold docs on the canonical programming-solutions corpus?
+
+For each sampled query, reports whether the gold doc is:
+  (a) absent from Helix's scored set (gating/shortlist excludes it), or
+  (b) present but out-ranked (additive fusion / IDF buries it).
+
+Also reports:
+  - query token count and overlap with gold doc (lexical sanity check)
+  - top-3 retrieved (idx, score)
+  - BM25 rank for the same query (reference foil)
+
+USAGE (requires in-process Helix -- run in helix063 venv DIRECTLY):
+  python benchmarks/coderag_diag.py --n 12 --ds humaneval
+  python benchmarks/coderag_diag.py --n 20 --ds mbpp --queries-json benchmarks/results/coderag_queries_<ts>.json
+
+Reads per-query dump from benchmarks/results/coderag_queries_*.json (or
+--queries-json override). Falls back to a tiny inline fixture for smoke-testing.
+
+LLM-free, GPU-free (lexical probe config).
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import math
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+
+_TOK = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+
+def tok(s):
+    return set(_TOK.findall((s or "").lower()))
+
+
+# ---------------------------------------------------------------------------
+# Inline smoke-test fixture (used when no dump exists)
+# ---------------------------------------------------------------------------
+
+def _smoke_corpus():
+    return [
+        {"doc_id": "humaneval:0",
+         "text": "def has_close_elements(numbers, threshold):\n"
+                 "    for i, a in enumerate(numbers):\n"
+                 "        for j, b in enumerate(numbers):\n"
+                 "            if i != j and abs(a-b) < threshold:\n"
+                 "                return True\n"
+                 "    return False\n"},
+        {"doc_id": "humaneval:1",
+         "text": "def separate_paren_groups(paren_string):\n"
+                 "    result = []\n"
+                 "    current = []\n"
+                 "    depth = 0\n"
+                 "    for c in paren_string:\n"
+                 "        if c == '(': depth += 1; current.append(c)\n"
+                 "        elif c == ')': depth -= 1; current.append(c)\n"
+                 "        if depth == 0 and current:\n"
+                 "            result.append(''.join(current))\n"
+                 "            current = []\n"
+                 "    return result\n"},
+        {"doc_id": "humaneval:2",
+         "text": "def truncate_number(number):\n    return number % 1.0\n"},
+    ]
+
+
+def _smoke_queries():
+    return [
+        {
+            "ds": "humaneval",
+            "query": ("def has_close_elements(numbers, threshold):\n"
+                      '    """Check if any two numbers are closer than threshold."""\n'),
+            "gold": "humaneval:0",
+            "gold_idx": 0,
+        },
+        {
+            "ds": "humaneval",
+            "query": ("def separate_paren_groups(paren_string):\n"
+                      '    """Input: string of nested parentheses groups."""\n'),
+            "gold": "humaneval:1",
+            "gold_idx": 1,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# In-process Helix wiring
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONFIG_CANDIDATES = [
+    Path(__file__).resolve().parents[1] / "docs" / "benchmarks" / "helix_probe_lexical.toml",
+    Path("F:/tmp/cb_helix_probe/helix_probe.toml"),
+]
+
+
+def _find_default_config():
+    for p in _DEFAULT_CONFIG_CANDIDATES:
+        if Path(p).exists():
+            return str(p)
+    return None
+
+
+def build_helix(genome_dir, config_path):
+    """Return a HelixContextManager with a fresh genome at genome_dir."""
+    os.environ.pop("HELIX_USE_SHARDS", None)
+    os.environ["HELIX_CONFIG"] = config_path
+    os.environ["HELIX_GENOME_PATH"] = os.path.join(genome_dir, "genome.db")
+    shutil.rmtree(genome_dir, ignore_errors=True)
+    os.makedirs(genome_dir, exist_ok=True)
+    from helix_context.config import load_config
+    from helix_context.context_manager import HelixContextManager
+    return HelixContextManager(load_config())
+
+
+def _gene_doc_idx(g):
+    """Extract corpus index from gene source_id / metadata path "doc_{idx}"."""
+    src = getattr(g, "source_id", None)
+    if not src and getattr(g, "promoter", None) and g.promoter.metadata:
+        src = g.promoter.metadata.get("path")
+    if src and str(src).startswith("doc_"):
+        try:
+            return int(str(src).split("doc_", 1)[1])
+        except ValueError:
+            return None
+    return None
+
+
+def helix_scores(helix, query, n_corpus):
+    """Return {corpus_idx: best_score} for this query over the genome."""
+    _eq, dom, ent = helix._prepare_query_signals(
+        query, session_context=None, expand_query=False
+    )
+    cands = helix._retrieve(
+        dom, ent, n_corpus,
+        query_text=query, include_cold=None,
+        party_id="default", use_harmonic=False, use_sr=False,
+    )
+    cands, _ = helix._apply_candidate_refiners(
+        query, cands, n_corpus,
+        use_cymatics=False, use_harmonic_bin=False, use_tcm=True, allow_rerank=False,
+    )
+    raw = dict(getattr(helix.genome, "last_query_scores", None) or {})
+    best = {}
+    for g in cands:
+        di = _gene_doc_idx(g)
+        if di is None:
+            continue
+        s = raw.get(g.gene_id, 0.0)
+        if di not in best or s > best[di]:
+            best[di] = s
+    return best
+
+
+# ---------------------------------------------------------------------------
+# BM25 reference
+# ---------------------------------------------------------------------------
+
+class _BM25:
+    def __init__(self, corpus_tokens, k1=1.5, b=0.75):
+        self.k1, self.b = k1, b
+        self.N = len(corpus_tokens)
+        self.dl = [len(d) for d in corpus_tokens]
+        self.avgdl = sum(self.dl) / self.N if self.N else 0.0
+        df = collections.defaultdict(int)
+        self.tf = []
+        for d in corpus_tokens:
+            f = collections.defaultdict(int)
+            for t in d:
+                f[t] += 1
+            self.tf.append(f)
+            for t in f:
+                df[t] += 1
+        self.idf = {
+            t: max(0.0, math.log((self.N - n + 0.5) / (n + 0.5) + 1.0))
+            for t, n in df.items()
+        }
+
+    def rank_pos(self, q_tokens, gold_idx):
+        qset = set(q_tokens)
+        sc = [0.0] * self.N
+        for i in range(self.N):
+            f = self.tf[i]
+            denom = (self.k1 * (1 - self.b + self.b * self.dl[i] / self.avgdl)
+                     if self.avgdl else self.k1)
+            s = 0.0
+            for t in qset:
+                ft = f.get(t, 0)
+                if ft:
+                    s += self.idf.get(t, 0.0) * (ft * (self.k1 + 1)) / (ft + denom)
+            sc[i] = s
+        order = sorted(range(self.N), key=lambda i: (-sc[i], i))
+        return order.index(gold_idx)
+
+
+# ---------------------------------------------------------------------------
+# Main diagnostic loop
+# ---------------------------------------------------------------------------
+
+def diagnose(corpus, queries, helix, n=12, ds_filter=None):
+    """Run per-query diagnostics; return list of result dicts."""
+    filtered = [q for q in queries if not ds_filter or q.get("ds") == ds_filter]
+    if n:
+        filtered = filtered[:n]
+
+    n_corpus = len(corpus)
+    corpus_texts = [c["text"] for c in corpus]
+    bm = _BM25([list(tok(c["text"])) for c in corpus])
+
+    results = []
+    for q in filtered:
+        gi = q["gold_idx"]
+        query = q["query"]
+        qt = list(tok(query))
+
+        scores = helix_scores(helix, query, n_corpus)
+        in_scored = gi in scores
+        order = sorted(scores.keys(), key=lambda d: (-scores[d], d))
+        gold_rank = order.index(gi) if in_scored else None
+        overlap = len(tok(query) & tok(corpus_texts[gi]))
+        qn = len(tok(query))
+        bm25_rank = bm.rank_pos(qt, gi)
+        top3 = [(d, round(scores[d], 4)) for d in order[:3]]
+
+        row = {
+            "gold": q["gold"],
+            "retrieved_count": len(scores),
+            "gold_in_scored": in_scored,
+            "gold_rank": gold_rank,
+            "gold_score": round(scores.get(gi, 0.0), 4),
+            "query_tok_count": qn,
+            "overlap_with_gold": overlap,
+            "bm25_rank": bm25_rank,
+            "top3": top3,
+        }
+        results.append(row)
+        print(
+            "{}: scored={} in_scored={} gold_rank={} gold_score={} "
+            "| q_tok={} overlap={} | bm25_rank={} | top3={}".format(
+                q["gold"], len(scores), in_scored, gold_rank,
+                row["gold_score"], qn, overlap, bm25_rank, top3,
+            ),
+            flush=True,
+        )
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=(
+            "CodeRAG-Bench diagnostic: per-query retrieved-vs-not-retrieved "
+            "for the first N queries. Requires in-process Helix (helix063 venv)."
+        )
+    )
+    ap.add_argument("--n", type=int, default=12, help="Number of queries to diagnose")
+    ap.add_argument(
+        "--ds", default="humaneval", choices=["humaneval", "mbpp"],
+        help="Dataset to focus on (default: humaneval)",
+    )
+    ap.add_argument(
+        "--corpus-json", default=None, dest="corpus_json",
+        help="Path to a pre-built corpus JSON (list of {doc_id, text}).",
+    )
+    ap.add_argument(
+        "--queries-json", default=None, dest="queries_json",
+        help="Path to the per-query dump JSON from coderag_bench.py.",
+    )
+    ap.add_argument(
+        "--helix-config", default=None, dest="helix_config",
+        help="Path to lexical-probe helix.toml. Falls back to HELIX_CONFIG env var.",
+    )
+    ap.add_argument(
+        "--genome-dir", default=None, dest="genome_dir",
+        help="Scratch dir for the temporary genome DB.",
+    )
+    args = ap.parse_args()
+
+    helix_config = (
+        args.helix_config
+        or os.environ.get("HELIX_CONFIG")
+        or _find_default_config()
+    )
+    if not helix_config or not Path(helix_config).exists():
+        print(
+            "ERROR: No helix config found. Provide --helix-config or set HELIX_CONFIG.\n"
+            "  See docs/benchmarks/helix_probe_lexical.toml for a template.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    genome_dir = args.genome_dir or os.path.join(
+        os.environ.get("TEMP", "/tmp"), "coderag_diag_genome"
+    )
+
+    # Load corpus.
+    if args.corpus_json and Path(args.corpus_json).exists():
+        corpus = json.loads(Path(args.corpus_json).read_text(encoding="utf-8"))
+        print("[diag] corpus from {}: {} docs".format(args.corpus_json, len(corpus)), flush=True)
+    else:
+        corpus = _smoke_corpus()
+        print("[diag] Using inline smoke fixture corpus ({} docs)".format(len(corpus)), flush=True)
+
+    # Load queries.
+    if args.queries_json and Path(args.queries_json).exists():
+        queries = json.loads(Path(args.queries_json).read_text(encoding="utf-8"))
+        print("[diag] queries from {}: {}".format(args.queries_json, len(queries)), flush=True)
+    else:
+        candidates = sorted(RESULTS_DIR.glob("coderag_queries_*.json"))
+        if candidates:
+            queries = json.loads(candidates[-1].read_text(encoding="utf-8"))
+            print("[diag] queries auto-loaded from {}: {}".format(
+                  candidates[-1], len(queries)), flush=True)
+        else:
+            queries = _smoke_queries()
+            print("[diag] Using inline smoke fixture queries ({} queries)".format(
+                  len(queries)), flush=True)
+
+    print("[diag] Building Helix genome at {}...".format(genome_dir), flush=True)
+    helix = build_helix(genome_dir, helix_config)
+
+    ing_err = 0
+    for di, doc in enumerate(corpus):
+        try:
+            helix.ingest(doc["text"], content_type="code", metadata={"path": "doc_{}".format(di)})
+        except Exception:
+            ing_err += 1
+
+    print("[diag] ingested {}/{} docs ({} errors)".format(
+          len(corpus) - ing_err, len(corpus), ing_err), flush=True)
+    print("\n[diag] Diagnosing first {} '{}' queries:\n".format(args.n, args.ds))
+
+    diagnose(corpus, queries, helix, n=args.n, ds_filter=args.ds)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/contextbench_step0.py
+++ b/benchmarks/contextbench_step0.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+ContextBench Step-0 offline retrieval scorer for Helix.
+
+Measures CODE-context retrieval on its designed terrain (path/symbol/structure),
+LLM-free, scored by the OFFICIAL ContextBench evaluator (tree-sitter alignment).
+
+Arms:
+  none              no-retrieval floor (empty pred -> recall 0)
+  bm25:<budget>     BM25-dump foil, fill to a token budget (e.g. bm25:8k, bm25:27k)
+  helix_fingerprint Helix /fingerprint ranked retrieval (recall ceiling)  [needs --helix-url]
+  helix_packet      Helix /context/packet delivered evidence              [needs --helix-url]
+
+Per task:
+  checkout repo@base_commit (contextbench.core.checkout, cached + shared with evaluator)
+   -> retriever -> emit unified-format pred JSON
+   -> score via `python -m contextbench.evaluate` (Coverage=recall, Precision @ file/symbol/span/line)
+   -> join evaluator per-instance line/file metrics with our injected-token tallies
+   -> table + summary JSON (recall vs injected-tokens is the headline).
+
+Discipline: retrieval is LLM-free; repo is never mutated; gold/patch/test_patch
+are NEVER indexed (only base_commit tree is read). Failures are recorded, not swallowed.
+"""
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+
+CONTEXTBENCH_SRC = os.environ.get("CONTEXTBENCH_SRC", "F:/Projects/contextbench-src")
+sys.path.insert(0, CONTEXTBENCH_SRC)
+
+from contextbench.core import checkout  # noqa: E402
+from contextbench.extractors import available as ts_available  # noqa: E402
+
+import tiktoken  # noqa: E402
+from rank_bm25 import BM25Okapi  # noqa: E402
+
+ENC = tiktoken.get_encoding("cl100k_base")
+
+# Index any source/text file; gold is always real source. Exclude only generated/binary trees.
+# Code + core docs only. Kept symmetric with the Helix arm (cb_helix_pred.py): high-volume
+# non-code (.po/.html/.json/.css/.xml...) is excluded because Helix's spaCy ingest chokes on
+# django's thousands of .po files and they are never code gold. The gold-file warn flags any drop.
+SRC_EXT = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".c", ".h", ".cpp", ".cc",
+    ".hpp", ".hh", ".java", ".cs", ".rb", ".php", ".swift", ".kt", ".scala",
+    ".cfg", ".ini", ".toml", ".yaml", ".yml", ".pyi",
+}
+SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".mypy_cache", ".pytest_cache",
+    ".tox", ".eggs", "dist", "build", ".venv", "venv",
+}
+MAX_FILE_BYTES = 2_000_000  # skip pathological/generated files; gold chunks are small
+CHUNK_LINES = 50            # BM25 chunk window (lines)
+
+
+# ----------------------------- tokenization -----------------------------------
+_WORD = re.compile(r"[A-Za-z0-9_]+")
+_SUB = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+")
+
+
+def code_tokens(text):
+    """Lexical tokens for BM25: whole identifiers + camelCase/snake_case subtokens."""
+    out = []
+    for m in _WORD.findall(text):
+        ml = m.lower()
+        out.append(ml)
+        for p in _SUB.findall(m):
+            pl = p.lower()
+            if pl and pl != ml:
+                out.append(pl)
+    return out
+
+
+def ntok(text):
+    return len(ENC.encode(text, disallowed_special=()))
+
+
+# ----------------------------- repo walking -----------------------------------
+def iter_repo_files(repo_dir):
+    """Yield (rel_path, abs_path) for indexable files under repo_dir."""
+    for root, dirs, files in os.walk(repo_dir):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for fn in files:
+            ext = os.path.splitext(fn)[1].lower()
+            if ext not in SRC_EXT:
+                continue
+            ap = os.path.join(root, fn)
+            try:
+                if os.path.getsize(ap) > MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel = os.path.relpath(ap, repo_dir).replace("\\", "/")
+            yield rel, ap
+
+
+def read_lines(abs_path):
+    try:
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read().split("\n")
+    except OSError:
+        return None
+
+
+def chunk_file(rel, lines, window=CHUNK_LINES):
+    """Yield (rel, start_line, end_line, text) line-window chunks (1-indexed inclusive)."""
+    n = len(lines)
+    i = 0
+    while i < n:
+        seg = lines[i:i + window]
+        text = "\n".join(seg)
+        if text.strip():
+            yield rel, i + 1, min(i + len(seg), n), text
+        i += window
+
+
+# ----------------------------- arms -------------------------------------------
+def arm_none(task, repo_dir):
+    return {"pred_files": [], "pred_spans": {}}, {"injected_tokens": 0, "n_chunks": 0, "n_indexed_files": 0}
+
+
+def arm_bm25(task, repo_dir, budget_tokens, gold_files=None):
+    """BM25 over fixed line-window chunks; greedily fill ranked chunks to a token budget."""
+    chunks = []          # (rel, s, e, text)
+    corpus = []          # token lists
+    indexed = set()
+    n_files = 0
+    for rel, ap in iter_repo_files(repo_dir):
+        lines = read_lines(ap)
+        if lines is None:
+            continue
+        n_files += 1
+        indexed.add(rel)
+        for c_rel, s, e, text in chunk_file(rel, lines):
+            chunks.append((c_rel, s, e, text))
+            corpus.append(code_tokens(text))
+
+    # Fairness guard: a gold file unindexable by extension/size hard-caps recall for EVERY arm.
+    missing_gold = [g for g in (gold_files or []) if g not in indexed]
+    if missing_gold:
+        print(f"  [WARN] {task['instance_id']}: {len(missing_gold)} gold file(s) NOT indexed "
+              f"(extension/size excluded -> recall capped): {missing_gold[:5]}", file=sys.stderr)
+
+    if not chunks:
+        return {"pred_files": [], "pred_spans": {}}, {
+            "injected_tokens": 0, "n_chunks": 0, "n_indexed_files": n_files,
+            "n_candidate_chunks": 0, "gold_files_missing": len(missing_gold)}
+
+    bm25 = BM25Okapi(corpus)
+    q = code_tokens(task["problem_statement"] or "")
+    scores = bm25.get_scores(q)
+    order = sorted(range(len(chunks)), key=lambda i: scores[i], reverse=True)
+
+    spans = defaultdict(list)
+    files = set()
+    injected = 0
+    picked = 0
+    for i in order:
+        rel, s, e, text = chunks[i]
+        t = ntok(text)
+        if picked >= 1 and injected + t > budget_tokens:
+            continue  # skip oversized chunk, keep packing smaller high-ranked chunks (fairer fill)
+        spans[rel].append({"start": s, "end": e})
+        files.add(rel)
+        injected += t
+        picked += 1
+        if injected >= budget_tokens:
+            break
+
+    pred = {"pred_files": sorted(files), "pred_spans": {k: v for k, v in spans.items()}}
+    meta = {"injected_tokens": injected, "n_chunks": picked, "n_indexed_files": n_files,
+            "n_candidate_chunks": len(chunks), "gold_files_missing": len(missing_gold)}
+    return pred, meta
+
+
+def arm_helix(task, repo_dir, mode, helix_url):
+    """Placeholder for Helix arms (wired once a code-genome daemon is up).
+
+    mode in {"fingerprint","packet"}. Will POST the problem_statement to the
+    helix endpoint and translate ranked spans -> unified pred. Raises until wired.
+    """
+    raise NotImplementedError(
+        f"helix arm '{mode}' not yet wired (needs --helix-url + code-genome daemon). "
+        "Build/validate the BM25 + scoring pipeline first.")
+
+
+def parse_arm(spec):
+    """'bm25:27k' -> ('bm25', 27000); 'none' -> ('none', None); 'helix_packet' -> ('helix_packet', None)."""
+    if spec.startswith("bm25:"):
+        b = spec.split(":", 1)[1].lower().replace("k", "000")
+        return "bm25", int(b)
+    return spec, None
+
+
+# ----------------------------- scoring ----------------------------------------
+def run_evaluator(gold_pq, pred_path, cache_dir, out_jsonl, env):
+    """Run the official evaluator. Returns (rows, returncode). Deletes any stale --out first so a
+    crash cannot be mistaken for a real empty result (the evaluator writes --out only at the end)."""
+    cmd = [sys.executable, "-m", "contextbench.evaluate",
+           "--gold", gold_pq, "--pred", pred_path, "--cache", cache_dir, "--out", out_jsonl]
+    print(f"  [eval] {' '.join(cmd)}", file=sys.stderr)
+    if os.path.isfile(out_jsonl):
+        os.remove(out_jsonl)
+    r = subprocess.run(cmd, env=env, creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    rows = []
+    if os.path.isfile(out_jsonl):
+        with open(out_jsonl, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+    if r.returncode != 0 or not rows:
+        print(f"  [eval] ERROR rc={r.returncode} rows={len(rows)} -- arm result UNTRUSTWORTHY "
+              f"(evaluator crashed?); NOT reported as a real 0", file=sys.stderr)
+    return rows, r.returncode
+
+
+def micro(results, gran):
+    """Micro-average matching the official aggregate_results/coverage_precision convention exactly."""
+    valid = [r for r in results if "error" not in r]
+    inter = sum(r.get("final", {}).get(gran, {}).get("intersection", 0) for r in valid)
+    gold = sum(r.get("final", {}).get(gran, {}).get("gold_size", 0) for r in valid)
+    pred = sum(r.get("final", {}).get(gran, {}).get("pred_size", 0) for r in valid)
+    cov = inter / gold if gold else 1.0     # evaluator: gold==0 -> coverage 1.0
+    prec = inter / pred if pred else 1.0    # evaluator: pred==0 -> precision 1.0
+    f1 = (2 * cov * prec / (cov + prec)) if (cov + prec) else 0.0
+    return {"recall": cov, "precision": prec, "f1": f1,
+            "inter": inter, "gold": gold, "pred": pred, "n_valid": len(valid)}
+
+
+# ----------------------------- main -------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(description="ContextBench Step-0 offline retrieval scorer")
+    ap.add_argument("--gold", required=True, help="Gold parquet (e.g. gold_smoke_4repo.parquet)")
+    ap.add_argument("--arms", default="bm25:8k,bm25:27k",
+                    help="comma list: bm25:8k,bm25:27k,helix_fingerprint,helix_packet,none "
+                         "(note: 'none' yields all-error rows, reported as not-measured)")
+    ap.add_argument("--limit", type=int, default=0, help="cap number of tasks (0=all in gold)")
+    ap.add_argument("--cache", default="F:/Projects/_cache/cb_repos", help="repo base-clone cache")
+    ap.add_argument("--worktree-root", default="F:/Projects/_cache/cb_wt", help="CONTEXTBENCH_TMP_ROOT (worktrees)")
+    ap.add_argument("--helix-url", default="", help="Helix bench-lane base URL, e.g. http://127.0.0.1:11439")
+    ap.add_argument("--out", default="", help="summary JSON output path")
+    args = ap.parse_args()
+
+    if not ts_available():
+        print("FATAL: tree-sitter not available (pip install tree-sitter==0.20.4 tree-sitter-languages==1.10.2)",
+              file=sys.stderr)
+        sys.exit(2)
+
+    os.makedirs(args.cache, exist_ok=True)
+    os.makedirs(args.worktree_root, exist_ok=True)
+    os.environ["CONTEXTBENCH_TMP_ROOT"] = args.worktree_root
+    os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = CONTEXTBENCH_SRC + os.pathsep + env.get("PYTHONPATH", "")
+    env["CONTEXTBENCH_TMP_ROOT"] = args.worktree_root
+    env["GIT_LFS_SKIP_SMUDGE"] = "1"
+
+    # Load gold tasks (we need problem_statement + repo_url + base_commit; gold metrics come from the parquet).
+    import pyarrow.dataset as ds
+    table = ds.dataset(args.gold, format="parquet").to_table().to_pylist()
+    if args.limit and args.limit > 0:
+        table = table[:args.limit]
+    tasks = []
+    for r in table:
+        try:
+            gc = json.loads(r["gold_context"]) if r.get("gold_context") else []
+        except Exception:  # noqa: BLE001
+            gc = []
+        gold_files = sorted({(e.get("file") or "").replace("\\", "/").lstrip("/")
+                             for e in gc if e.get("file")})
+        tasks.append({
+            "instance_id": r["instance_id"],
+            "repo": r.get("repo"),
+            "repo_url": r.get("repo_url"),
+            "base_commit": r.get("base_commit"),
+            "problem_statement": r.get("problem_statement") or "",
+            "gold_files": gold_files,
+        })
+    print(f"loaded {len(tasks)} tasks from {args.gold}", file=sys.stderr)
+
+    arms = [parse_arm(a.strip()) for a in args.arms.split(",") if a.strip()]
+    out_dir = os.path.join(os.path.dirname(os.path.abspath(args.gold)), "results")
+    os.makedirs(out_dir, exist_ok=True)
+
+    # 1) checkout every task once (shared cache; evaluator reuses these worktrees).
+    repo_dirs = {}
+    checkout_errors = {}
+    for i, t in enumerate(tasks):
+        print(f"[checkout {i+1}/{len(tasks)}] {t['instance_id']} {t['repo']}@{(t['base_commit'] or '')[:10]}",
+              file=sys.stderr)
+        t0 = time.time()
+        try:
+            rd = checkout(t["repo_url"], t["base_commit"], args.cache)
+        except Exception as e:  # noqa: BLE001
+            rd = None
+            checkout_errors[t["instance_id"]] = repr(e)
+        if not rd or not os.path.isdir(rd):
+            checkout_errors[t["instance_id"]] = checkout_errors.get(t["instance_id"], "checkout_returned_none")
+            print(f"  CHECKOUT FAILED: {checkout_errors[t['instance_id']]}", file=sys.stderr)
+        else:
+            repo_dirs[t["instance_id"]] = rd
+            print(f"  ok in {time.time()-t0:.1f}s -> {rd}", file=sys.stderr)
+
+    # 2) per arm: retrieve -> pred JSON -> evaluate -> metrics.
+    summary = {"gold": args.gold, "n_tasks": len(tasks), "checkout_errors": checkout_errors, "arms": {}}
+    for arm_name, budget in arms:
+        label = arm_name if budget is None else f"{arm_name}:{budget//1000}k"
+        print(f"\n===== ARM {label} =====", file=sys.stderr)
+        preds = []
+        per_inst_meta = {}
+        for i, t in enumerate(tasks):
+            iid = t["instance_id"]
+            rd = repo_dirs.get(iid)
+            if not rd:
+                continue  # checkout failed; recorded above
+            try:
+                if arm_name == "none":
+                    pred, meta = arm_none(t, rd)
+                elif arm_name == "bm25":
+                    pred, meta = arm_bm25(t, rd, budget, t["gold_files"])
+                elif arm_name in ("helix_fingerprint", "helix_packet"):
+                    mode = "fingerprint" if arm_name.endswith("fingerprint") else "packet"
+                    pred, meta = arm_helix(t, rd, mode, args.helix_url)
+                else:
+                    raise ValueError(f"unknown arm {arm_name}")
+            except NotImplementedError as e:
+                print(f"  {label}: {e}", file=sys.stderr)
+                preds = None
+                break
+            preds.append({
+                "instance_id": iid,
+                "traj_data": {"pred_steps": [], "pred_files": pred["pred_files"], "pred_spans": pred["pred_spans"]},
+                "model_patch": "",
+            })
+            per_inst_meta[iid] = meta
+            if (i + 1) % 5 == 0 or i + 1 == len(tasks):
+                print(f"  retrieved {i+1}/{len(tasks)} (last injected_tokens={meta.get('injected_tokens')})",
+                      file=sys.stderr)
+        if preds is None:
+            summary["arms"][label] = {"skipped": "not_implemented"}
+            continue
+
+        pred_path = os.path.join(out_dir, f"{label.replace(':','_')}_pred.json")
+        with open(pred_path, "w", encoding="utf-8") as f:
+            json.dump(preds, f)
+        out_jsonl = os.path.join(out_dir, f"{label.replace(':','_')}_eval.jsonl")
+        results, rc = run_evaluator(args.gold, pred_path, args.cache, out_jsonl, env)
+
+        eval_errors = Counter(r.get("error") for r in results if r.get("error"))
+        n_scored = sum(1 for r in results if "error" not in r)
+        # An evaluator crash or an all-error arm (e.g. 'none') is NOT a real 0 -> mark not-measured.
+        if rc != 0 or n_scored == 0:
+            summary["arms"][label] = {
+                "not_measured": True, "eval_crashed": rc != 0, "returncode": rc,
+                "n_pred": len(preds), "n_scored": n_scored, "eval_errors": dict(eval_errors),
+                "pred_path": pred_path, "eval_jsonl": out_jsonl,
+            }
+            print(f"  {label}: NOT MEASURED (rc={rc}, scored={n_scored}, errors={dict(eval_errors)})",
+                  file=sys.stderr)
+            continue
+
+        # join evaluator metrics with our token tallies
+        inj = [per_inst_meta.get(r["instance_id"], {}).get("injected_tokens", 0)
+               for r in results if "error" not in r]
+        gran = {g: micro(results, g) for g in ("file", "symbol", "span", "line")}
+        med_inj = statistics.median(inj) if inj else 0
+        p90_inj = sorted(inj)[int(0.9 * (len(inj) - 1))] if inj else 0
+        line_recall = gran["line"]["recall"]
+        rec_per_1k = (line_recall / (med_inj / 1000.0)) if med_inj else 0.0
+        n_gold_missing = sum(per_inst_meta.get(r["instance_id"], {}).get("gold_files_missing", 0)
+                             for r in results if "error" not in r)
+
+        summary["arms"][label] = {
+            "n_pred": len(preds), "n_scored": n_scored, "eval_errors": dict(eval_errors),
+            "granularity": gran,
+            "median_injected_tokens": med_inj, "p90_injected_tokens": p90_inj,
+            "recall_per_1k_tokens": rec_per_1k, "gold_files_unindexable": n_gold_missing,
+            "pred_path": pred_path, "eval_jsonl": out_jsonl,
+        }
+        print(f"  {label}: line recall={line_recall:.3f} prec={gran['line']['precision']:.3f} "
+              f"file recall={gran['file']['recall']:.3f} sym recall={gran['symbol']['recall']:.3f} "
+              f"median_inj={med_inj} rec/1k={rec_per_1k:.3f} scored={n_scored} "
+              f"gold_unindexable={n_gold_missing}", file=sys.stderr)
+
+    # 3) report
+    print("\n" + "=" * 96)
+    hdr = ["arm", "scored", "file_R", "line_R", "line_P", "line_F1", "sym_R", "med_inj", "p90_inj", "R/1k"]
+    print(("{:<16}" + "{:>8}" * (len(hdr) - 1)).format(*hdr))
+    for label, a in summary["arms"].items():
+        if "granularity" not in a:
+            reason = "eval_crashed" if a.get("eval_crashed") else (
+                "not_measured" if a.get("not_measured") else "skipped(impl)")
+            print(f"{label:<16}  ({reason}; scored={a.get('n_scored','?')})")
+            continue
+        g = a["granularity"]
+        print(("{:<16}" + "{:>8}" * 9).format(
+            label, a["n_scored"],
+            f"{g['file']['recall']:.3f}", f"{g['line']['recall']:.3f}", f"{g['line']['precision']:.3f}",
+            f"{g['line']['f1']:.3f}", f"{g['symbol']['recall']:.3f}",
+            a["median_injected_tokens"], a["p90_injected_tokens"], f"{a['recall_per_1k_tokens']:.3f}"))
+    print("=" * 96)
+    print("Headline: line_R (recall) vs med_inj (median injected tokens) — high recall at low tokens wins.")
+
+    out_path = args.out or os.path.join(out_dir, "step0_summary.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    print(f"\nsummary -> {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/diag_blob_vs_shard_tiers.py
+++ b/benchmarks/diag_blob_vs_shard_tiers.py
@@ -1,0 +1,591 @@
+"""
+diag_blob_vs_shard_tiers.py -- Per-tier candidate-pool decomposition diagnostic.
+
+Localise WHY the unified ("blob") genome out-ranks the sharded genome at
+recall@1/MRR by decomposing the advantage into two failure modes:
+
+  A. Candidate-generation loss  -- gold is NOT IN the sharded pool at all
+  B. Ranking loss               -- gold IS in the sharded pool but rank > 10
+
+For the "blob-good / shard-bad" set (blob rank <= 10, shard rank > 10 or absent)
+the diagnostic reports median per-tier score contributions for blob vs sharded,
+making it possible to name which tier(s) surface the gold in the blob but fail
+in the sharded merge.
+
+WIRE SCHEMA (routes_context.py L800-826):
+  Each item in fingerprints[] contains:
+    "rank"               int   0-based rank
+    "gene_id"            str
+    "score"              float final score (base + tcm_bonus)
+    "source"             str   source_id / path used for gold matching
+    "path"               str   metadata path (may differ from source)
+    "tier_contributions" dict  {tier_name: float, ...}  -- the key field
+    "preview"            str
+    "domains"            list
+    "entities"           list
+    "chromatin"          int
+
+  tier_contributions is built from _merge_tier_contributions(
+      helix.genome.last_tier_contributions,   # lexical + co-activation tiers
+      refiner_contrib,                         # tcm, cymatics, harmonic_bin
+  ) and then rounded to 4dp, sorted by key (routes_context.py L817-819).
+
+  Known tier names (non-exhaustive; server emits whatever the retrieval
+  pipeline populates):
+    fts5, tag_exact, tag_prefix, co_activation, dense, splade,
+    sema_boost, sema_cold, lex_anchor, authority, harmonic, harmonic_bin,
+    cymatics, tcm, sr (seeded-edges), ray_trace
+
+USAGE
+-----
+python benchmarks/diag_blob_vs_shard_tiers.py \\
+    --needles  benchmarks/results/shard_gold_medium.jsonl \\
+    --blob-url     http://127.0.0.1:11437 \\
+    --sharded-url  http://127.0.0.1:11438 \\
+    --label    medium
+
+Optional:
+    --max-results 200      (default 200; deep golds captured)
+    --blob-rank-cap 10     (default 10; "blob-good" threshold)
+    --shard-bury-cap 10    (default 10; "shard-bad"  threshold)
+    --limit  N             (cap needles for quick smoke-test)
+    --timeout 45           (per-request HTTP timeout in seconds)
+    --out  path/to.json    (override output path)
+    --verbose              (print per-needle detail to stdout)
+
+NO SERVER IS STARTED.  This script calls already-running server URLs.
+No GPU, no network fetch, no /tmp writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Path normalisation + gold match  (identical to bench_shard_recall.py)
+# ---------------------------------------------------------------------------
+
+def _norm(path: Optional[str]) -> str:
+    return str(path or "").replace("\\", "/").lower().strip()
+
+
+def _gold_hit(source: Optional[str], gold_paths: List[str]) -> bool:
+    """True if source matches any gold path (bidirectional case-insensitive
+    forward-slash substring rule from bench_shard_recall.py)."""
+    sn = _norm(source)
+    if not sn:
+        return False
+    for gp in gold_paths:
+        gn = _norm(gp)
+        if gn and (gn in sn or sn in gn):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# /fingerprint HTTP call
+# ---------------------------------------------------------------------------
+
+def _fingerprint(
+    helix_url: str,
+    query: str,
+    max_results: int = 200,
+    timeout_s: float = 45.0,
+) -> Tuple[List[Dict[str, Any]], float]:
+    """POST /fingerprint; return (fingerprints, latency_ms).
+
+    Request body: {query, max_results, score_floor:0.0, profile:"fast"}.
+    max_results=200 so deep golds (rank > 10) are still captured for pool
+    analysis.  score_floor=0.0 so nothing is filtered.
+    """
+    url = helix_url.rstrip("/") + "/fingerprint"
+    payload = json.dumps({
+        "query": query,
+        "max_results": max_results,
+        "score_floor": 0.0,
+        "profile": "fast",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+        body = json.loads(resp.read())
+    latency_ms = (time.time() - t0) * 1000.0
+    return body.get("fingerprints", []), latency_ms
+
+
+# ---------------------------------------------------------------------------
+# Per-needle gold lookup
+# ---------------------------------------------------------------------------
+
+def _find_gold(
+    fingerprints: List[Dict[str, Any]],
+    gold_paths: List[str],
+) -> Dict[str, Any]:
+    """Scan fingerprints list for the first gold hit.
+
+    The "source" field (routes_context.py L813) carries source_id which is
+    what bench_shard_recall.py matches against.  "path" is the metadata path
+    and may differ; we check both for robustness.
+
+    Returns:
+      in_pool  bool
+      rank     int | None  (1-based; wire schema rank is 0-based -> +1)
+      score    float | None
+      tiers    dict        tier_contributions of the gold item (or {})
+    """
+    for fp in fingerprints:
+        # Prefer source field; fall back to path field
+        source = fp.get("source") or fp.get("path") or ""
+        if _gold_hit(source, gold_paths):
+            return {
+                "in_pool": True,
+                "rank":    int(fp["rank"]) + 1,   # convert 0-based to 1-based
+                "score":   float(fp.get("score", 0.0)),
+                "tiers":   dict(fp.get("tier_contributions") or {}),
+            }
+    return {
+        "in_pool": False,
+        "rank":    None,
+        "score":   None,
+        "tiers":   {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Single-needle analysis
+# ---------------------------------------------------------------------------
+
+def _analyse_needle(
+    needle: Dict[str, Any],
+    blob_fps: List[Dict[str, Any]],
+    shard_fps: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build per-needle result dict."""
+    gold_paths = needle.get("gold_paths", [])
+    blob_gold  = _find_gold(blob_fps,  gold_paths)
+    shard_gold = _find_gold(shard_fps, gold_paths)
+    return {
+        "id":         needle.get("id"),
+        "type":       needle.get("type", "within"),
+        "question":   (needle.get("question") or "")[:200],
+        "gold_paths": gold_paths,
+        "blob":       blob_gold,
+        "sharded":    shard_gold,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Median helper
+# ---------------------------------------------------------------------------
+
+def _safe_median(values: List[float]) -> Optional[float]:
+    if not values:
+        return None
+    return statistics.median(values)
+
+
+# ---------------------------------------------------------------------------
+# Aggregate
+# ---------------------------------------------------------------------------
+
+def _aggregate(
+    per_needle: List[Dict[str, Any]],
+    blob_rank_cap: int = 10,
+    shard_bury_cap: int = 10,
+) -> Dict[str, Any]:
+    """Compute the aggregate payload focusing on blob-good / shard-bad cases.
+
+    Classification:
+      blob-good   : blob rank <= blob_rank_cap
+      shard-bad   : shard rank > shard_bury_cap  OR  not in sharded pool
+      divergent   : blob-good AND shard-bad
+
+    Within divergent:
+      candidate_gen_loss  -- gold NOT in sharded pool (shard cannot even see it)
+      ranking_loss        -- gold IS in sharded pool but buried deep
+
+    Tier delta for ranking-loss set: median(blob tiers) - median(shard tiers)
+    per tier, sorted by delta desc -- this names which tier(s) the blob uses
+    to surface the gold that the sharded merge loses.
+
+    Tier summary for cand-gen-loss set: blob tier medians only (shard has
+    no data) to show what caused the blob to include the gold at all.
+    """
+    total = len(per_needle)
+
+    blob_good_set: List[Dict[str, Any]] = []
+    for row in per_needle:
+        b_rank = row["blob"]["rank"]
+        if b_rank is not None and b_rank <= blob_rank_cap:
+            blob_good_set.append(row)
+
+    # Classify divergent
+    divergent: List[Dict[str, Any]] = []
+    for row in blob_good_set:
+        s_rank = row["sharded"]["rank"]
+        s_in   = row["sharded"]["in_pool"]
+        shard_bad = (not s_in) or (s_rank is not None and s_rank > shard_bury_cap)
+        if shard_bad:
+            divergent.append(row)
+
+    cand_gen_loss = [r for r in divergent if not r["sharded"]["in_pool"]]
+    ranking_loss  = [r for r in divergent if r["sharded"]["in_pool"]]
+
+    blob_pool_total  = sum(1 for r in per_needle if r["blob"]["in_pool"])
+    shard_pool_total = sum(1 for r in per_needle if r["sharded"]["in_pool"])
+    shard_bad_count  = sum(
+        1 for r in per_needle
+        if (not r["sharded"]["in_pool"]) or (
+            r["sharded"]["rank"] is not None
+            and r["sharded"]["rank"] > shard_bury_cap
+        )
+    )
+
+    # --- Tier delta for RANKING-LOSS set ---
+    rl_tier_names: set = set()
+    for row in ranking_loss:
+        rl_tier_names.update(row["blob"]["tiers"].keys())
+        rl_tier_names.update(row["sharded"]["tiers"].keys())
+
+    tier_delta_ranking: Dict[str, Dict[str, Any]] = {}
+    for tier in sorted(rl_tier_names):
+        blob_vals  = [row["blob"]["tiers"].get(tier, 0.0)    for row in ranking_loss]
+        shard_vals = [row["sharded"]["tiers"].get(tier, 0.0) for row in ranking_loss]
+        blob_med   = _safe_median(blob_vals)
+        shard_med  = _safe_median(shard_vals)
+        delta = None
+        if blob_med is not None and shard_med is not None:
+            delta = round(blob_med - shard_med, 5)
+        tier_delta_ranking[tier] = {
+            "blob_median":  round(blob_med,  5) if blob_med  is not None else None,
+            "shard_median": round(shard_med, 5) if shard_med is not None else None,
+            "delta":        delta,
+        }
+
+    # Sorted by delta desc (largest blob-advantage first)
+    tier_ranking_summary = sorted(
+        [
+            {
+                "tier":         t,
+                "blob_median":  v["blob_median"],
+                "shard_median": v["shard_median"],
+                "delta":        v["delta"],
+            }
+            for t, v in tier_delta_ranking.items()
+            if v["delta"] is not None and v["delta"] > 0.0
+        ],
+        key=lambda x: x["delta"],
+        reverse=True,
+    )
+
+    # --- Tier summary for CANDIDATE-GEN-LOSS set ---
+    cg_tier_names: set = set()
+    for row in cand_gen_loss:
+        cg_tier_names.update(row["blob"]["tiers"].keys())
+
+    tier_cand_gen_summary: List[Dict[str, Any]] = []
+    for tier in sorted(cg_tier_names):
+        blob_vals = [row["blob"]["tiers"].get(tier, 0.0) for row in cand_gen_loss]
+        blob_med  = _safe_median(blob_vals)
+        tier_cand_gen_summary.append({
+            "tier":       tier,
+            "blob_median": round(blob_med, 5) if blob_med is not None else None,
+        })
+    tier_cand_gen_summary.sort(
+        key=lambda x: x["blob_median"] or 0.0, reverse=True
+    )
+
+    tier_overall_delta_rank = [t["tier"] for t in tier_ranking_summary]
+
+    return {
+        "total_needles":          total,
+        "blob_good_count":        len(blob_good_set),
+        "shard_bad_count":        shard_bad_count,
+        "divergent_count":        len(divergent),
+        "candidate_gen_loss":     len(cand_gen_loss),
+        "ranking_loss":           len(ranking_loss),
+        "blob_pool_total":        blob_pool_total,
+        "shard_pool_total":       shard_pool_total,
+        "tier_ranking_summary":   tier_ranking_summary,
+        "tier_cand_gen_summary":  tier_cand_gen_summary,
+        "tier_overall_delta_rank": tier_overall_delta_rank,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stdout summary
+# ---------------------------------------------------------------------------
+
+def _print_summary(agg: Dict[str, Any], label: str,
+                   blob_rank_cap: int = 10, shard_bury_cap: int = 10) -> None:
+    div   = agg["divergent_count"]
+    cgl   = agg["candidate_gen_loss"]
+    rl    = agg["ranking_loss"]
+    total = agg["total_needles"]
+
+    print()
+    print("=" * 66)
+    print(f"Blob-vs-Shard tier diagnostic  [{label}]")
+    print("=" * 66)
+    print(f"  Total needles                 : {total}")
+    print(f"  Blob gold in pool (any rank)  : {agg['blob_pool_total']}/{total}")
+    print(f"  Sharded gold in pool (any)    : {agg['shard_pool_total']}/{total}")
+    print(f"  Blob-good  (rank <= {blob_rank_cap})        : {agg['blob_good_count']}")
+    print(f"  Shard-bad  (rank >  {shard_bury_cap} or absent): {agg['shard_bad_count']}")
+    print(f"  Divergent (blob-good AND shard-bad): {div}")
+    if div:
+        pct_cgl = 100 * cgl / div
+        pct_rl  = 100 * rl  / div
+        print(f"    Candidate-gen loss (NOT in shard pool): {cgl}  ({pct_cgl:.1f}%)")
+        print(f"    Ranking loss (in pool but buried)     : {rl}   ({pct_rl:.1f}%)")
+    print()
+
+    if agg["tier_ranking_summary"]:
+        print("  RANKING-LOSS tier delta  (blob_median - shard_median, desc):")
+        print(f"    {'tier':<22}  {'blob_med':>9}  {'shard_med':>9}  {'delta':>9}")
+        print("    " + "-" * 55)
+        for row in agg["tier_ranking_summary"]:
+            print(
+                f"    {row['tier']:<22}  {row['blob_median']:>9.4f}"
+                f"  {row['shard_median']:>9.4f}  {row['delta']:>9.4f}"
+            )
+    else:
+        print("  RANKING-LOSS set: 0 cases or no tier differences.")
+
+    print()
+    if agg["tier_cand_gen_summary"]:
+        print("  CAND-GEN-LOSS blob tiers  (what surfaced gold in blob only):")
+        print(f"    {'tier':<22}  {'blob_med':>9}")
+        print("    " + "-" * 34)
+        for row in agg["tier_cand_gen_summary"]:
+            print(f"    {row['tier']:<22}  {row['blob_median']:>9.4f}")
+    else:
+        print("  CAND-GEN-LOSS set: 0 cases or no tier data.")
+
+    print()
+    if agg["tier_overall_delta_rank"]:
+        ranked = ", ".join(agg["tier_overall_delta_rank"])
+        print("  ANSWER -- tiers ranked by blob-advantage over sharded")
+        print(f"  (ranking-loss cases, delta desc):")
+        print(f"    {ranked}")
+    print("=" * 66)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator (also importable for tests)
+# ---------------------------------------------------------------------------
+
+def run(
+    needles: List[Dict[str, Any]],
+    blob_url: str,
+    sharded_url: str,
+    max_results: int = 200,
+    timeout_s: float = 45.0,
+    blob_rank_cap: int = 10,
+    shard_bury_cap: int = 10,
+    verbose: bool = False,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Run the diagnostic against two live servers.
+
+    Importable entry-point used by tests (which inject mock HTTP responses
+    via unittest.mock.patch on urllib.request.urlopen).
+
+    Returns (per_needle_results, aggregate).
+    """
+    per_needle: List[Dict[str, Any]] = []
+    n = len(needles)
+
+    for qi, needle in enumerate(needles):
+        if (qi + 1) % 25 == 0 or qi == 0:
+            print(f"[diag_blob_vs_shard] {qi+1}/{n} ...", flush=True)
+
+        query      = needle.get("question", "")
+        gold_paths = needle.get("gold_paths", [])
+
+        blob_fps:  List[Dict[str, Any]] = []
+        shard_fps: List[Dict[str, Any]] = []
+        blob_err:  Optional[str] = None
+        shard_err: Optional[str] = None
+
+        try:
+            blob_fps, _ = _fingerprint(blob_url, query, max_results, timeout_s)
+        except Exception as exc:
+            blob_err = repr(exc)
+
+        try:
+            shard_fps, _ = _fingerprint(sharded_url, query, max_results, timeout_s)
+        except Exception as exc:
+            shard_err = repr(exc)
+
+        row = _analyse_needle(needle, blob_fps, shard_fps)
+        if blob_err:
+            row["blob_error"] = blob_err
+        if shard_err:
+            row["shard_error"] = shard_err
+
+        if verbose:
+            b = row["blob"]
+            s = row["sharded"]
+            _b = f"rank={b['rank']}" if b["in_pool"] else "NOT_IN_POOL"
+            _s = f"rank={s['rank']}" if s["in_pool"] else "NOT_IN_POOL"
+            print(f"  [{qi+1}] blob={_b}  shard={_s}  q={query[:80]}")
+
+        per_needle.append(row)
+
+    agg = _aggregate(per_needle, blob_rank_cap=blob_rank_cap,
+                     shard_bury_cap=shard_bury_cap)
+    return per_needle, agg
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Per-tier blob-vs-sharded candidate-pool decomposition diagnostic.\n"
+            "Requires two already-running Helix servers (no server is started here)."
+        )
+    )
+    ap.add_argument(
+        "--needles",
+        default=str(RESULTS_DIR / "shard_gold_medium.jsonl"),
+        help="JSONL needle file (build_shard_gold.py output).",
+    )
+    ap.add_argument(
+        "--blob-url",
+        default="http://127.0.0.1:11437",
+        dest="blob_url",
+        help="Base URL of the unified-blob Helix server.",
+    )
+    ap.add_argument(
+        "--sharded-url",
+        default="http://127.0.0.1:11438",
+        dest="sharded_url",
+        help="Base URL of the sharded Helix server.",
+    )
+    ap.add_argument("--label", default="medium",
+                    help="Run label for results filename.")
+    ap.add_argument("--max-results", type=int, default=200, dest="max_results",
+                    help="max_results for /fingerprint (default 200).")
+    ap.add_argument("--blob-rank-cap", type=int, default=10, dest="blob_rank_cap",
+                    help="Blob rank threshold for 'blob-good' (default 10).")
+    ap.add_argument("--shard-bury-cap", type=int, default=10, dest="shard_bury_cap",
+                    help="Shard rank threshold for 'shard-bad' (default 10).")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Cap needles for smoke-test (0 = all).")
+    ap.add_argument("--timeout", type=float, default=45.0,
+                    help="Per-request HTTP timeout in seconds (default 45).")
+    ap.add_argument("--out", default=None,
+                    help="Override output JSON path.")
+    ap.add_argument("--verbose", action="store_true",
+                    help="Print per-needle detail to stdout.")
+    args = ap.parse_args(argv)
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    needles_path = Path(args.needles)
+    if not needles_path.exists():
+        print(f"ERROR: needles file not found: {needles_path}", file=sys.stderr)
+        print(
+            f"  Run: python benchmarks/build_shard_gold.py --out {needles_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    needles: List[Dict[str, Any]] = []
+    with needles_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                needles.append(json.loads(line))
+
+    if args.limit:
+        needles = needles[:args.limit]
+
+    print(f"[diag_blob_vs_shard] {len(needles)} needles from {needles_path}")
+    print(f"[diag_blob_vs_shard] blob={args.blob_url}  sharded={args.sharded_url}")
+
+    for arm_label, url in [("blob", args.blob_url), ("sharded", args.sharded_url)]:
+        try:
+            health_url = url.rstrip("/") + "/health"
+            with urllib.request.urlopen(health_url, timeout=10) as r:
+                health = json.loads(r.read())
+            doc_count = health.get("document_count", "?")
+            print(f"[diag_blob_vs_shard] {arm_label} OK  docs={doc_count}")
+        except Exception as exc:
+            print(
+                f"ERROR: cannot reach {arm_label} at {url}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+    per_needle, agg = run(
+        needles=needles,
+        blob_url=args.blob_url,
+        sharded_url=args.sharded_url,
+        max_results=args.max_results,
+        timeout_s=args.timeout,
+        blob_rank_cap=args.blob_rank_cap,
+        shard_bury_cap=args.shard_bury_cap,
+        verbose=args.verbose,
+    )
+
+    _print_summary(agg, args.label, args.blob_rank_cap, args.shard_bury_cap)
+
+    out_path = (
+        Path(args.out) if args.out
+        else RESULTS_DIR / f"diag_blob_vs_shard_{args.label}_{ts}.json"
+    )
+    result = {
+        "benchmark":    "diag_blob_vs_shard_tiers",
+        "label":        args.label,
+        "timestamp":    ts,
+        "blob_url":     args.blob_url,
+        "sharded_url":  args.sharded_url,
+        "needles_file": str(needles_path),
+        "n_needles":    len(needles),
+        "max_results":  args.max_results,
+        "blob_rank_cap":    args.blob_rank_cap,
+        "shard_bury_cap":   args.shard_bury_cap,
+        "gold_match_rule": (
+            "bidirectional case-insensitive forward-slash substring: "
+            "norm(gold) in norm(source) OR norm(source) in norm(gold)"
+        ),
+        # Document where tier_contributions lives in the wire response
+        "fingerprint_tier_field": (
+            "fingerprints[*].tier_contributions  "
+            "(routes_context.py L817-819, dict {tier_name: float})"
+        ),
+        "aggregate":  agg,
+        "per_needle": per_needle,
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"-> {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/diag_global_idf_counterfactual.py
+++ b/benchmarks/diag_global_idf_counterfactual.py
@@ -1,0 +1,434 @@
+"""diag_global_idf_counterfactual.py — counterfactual for the cross-shard
+global-IDF lexical re-score (HELIX_SHARD_GLOBAL_IDF, #182).
+
+Hypothesis under test
+---------------------
+The HELIX_SHARD_GLOBAL_IDF rescore regressed medium-sharded recall
+(0.347 -> 0.168) because the manual BM25 used the SMOOTHED, always-positive
+IDF ``ln(... + 1.0)`` instead of SQLite FTS5's RAW idf ``ln((N-n+0.5)/(n+0.5))``
+(which can be negative). With the parity-correct raw-idf formula and
+all-column tf/dl, manual-LOCAL BM25 must reproduce ``bm25(genes_fts)``
+bit-exactly, and manual-GLOBAL BM25 (raw idf, global N=Σshard_n,
+global df=Σshard_dfs) should re-rank buried golds ABOVE their wrong
+same-/cross-shard incumbents.
+
+What it measures, per buried gold (a gold ranked below a non-gold incumbent
+on the engine-LOCAL lexical signal):
+  (a) parity error: |manual-local-BM25 − engine bm25()| for gold + top
+      wrong incumbent
+  (b) go/no-go: fraction of buried golds where manual-GLOBAL-BM25 re-ranks
+      the gold ABOVE the wrong incumbent
+  (c) median rank improvement of the gold under global vs local lexical
+
+This is a LEXICAL-ONLY counterfactual: it scores candidates purely by the
+FTS5 lexical sub-score (the exact quantity the router splices in
+``corrected = raw − old_local_fts5 + new_global_fts5``), so it isolates the
+re-score math from dense/tag/SR tiers. No server, no GPU, no network,
+read-only via ``immutable=1``.
+
+Gold-match rule and query-signal extraction are reused from
+bench_shard_recall.py / diag_shard_score.py (bidirectional substring on
+normalised paths; helix_context.accel.extract_query_signals).
+
+CLI
+---
+python benchmarks/diag_global_idf_counterfactual.py \
+    --root genomes/bench/matrix-sharded/medium \
+    --needles benchmarks/results/shard_gold_medium.jsonl \
+    --limit 10 \
+    --out benchmarks/results/diag_global_idf_counterfactual_medium.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+K1, B = 1.2, 0.75
+
+
+# ── gold match (identical to bench_shard_recall.py / diag_shard_score.py) ──
+def _norm(path: Optional[str]) -> str:
+    return str(path or "").replace("\\", "/").lower().strip()
+
+
+def _gold_hit(source: Optional[str], gold_paths: List[str]) -> bool:
+    sn = _norm(source)
+    if not sn:
+        return False
+    for gp in gold_paths:
+        gn = _norm(gp)
+        if gn and (gn in sn or sn in gn):
+            return True
+    return False
+
+
+def _raw_idf(N: int, n: int) -> float:
+    """SQLite FTS5's RAW (unsmoothed) Robertson-Sparck-Jones IDF, with FTS5's
+    exact non-positive clamp. The engine computes
+    ``ln((N - n + 0.5) / (n + 0.5))`` then forces ``if (idf <= 0) idf = 1e-6``
+    (fts5_aux.c) — a term in > half the corpus contributes ~nothing rather
+    than subtracting. Reproduced here so manual BM25 is bit-exact with
+    bm25() even when a query term is near-ubiquitous."""
+    idf = math.log((N - n + 0.5) / (n + 0.5))
+    return idf if idf > 0.0 else 1e-6
+
+
+def _single_token(t: str) -> bool:
+    """True iff ``t`` is a single FTS token (alphanumeric / underscore only).
+
+    Hyphenated or dotted query phrases (e.g. ``end-to-end``, ``amazon.nova``)
+    tokenize into MULTIPLE FTS tokens and FTS5 scores them as a PHRASE; the
+    ``genes_fts_vocab`` shadow table stores only single tokens, so neither
+    the manual BM25 here NOR the production
+    ``KnowledgeStore.rescore_lexical_global_idf`` (which reads the same vocab)
+    can reproduce a multi-token phrase's contribution. We exclude such terms
+    from BOTH the engine query and the manual sum so the parity number
+    measures the single-token case the vocab path actually scores. The
+    production splice is unaffected by the omission: local and global rescore
+    use the SAME vocab lookup, so any multi-token shortfall cancels in
+    ``corrected = raw − old_local_fts5 + new_global_fts5`` for the same doc."""
+    return bool(t) and t.replace("_", "").isalnum()
+
+
+# ── shard discovery ──
+def _discover_shards(root: Path) -> Dict[str, Path]:
+    """{shard_name: db_path} for every *.genome.db under root except main."""
+    shards: Dict[str, Path] = {}
+    for db in sorted(root.rglob("*.genome.db")):
+        if db.name == "main.genome.db":
+            continue
+        shards[db.stem.replace(".genome", "")] = db
+    return shards
+
+
+def _ro(db: Path) -> sqlite3.Connection:
+    con = sqlite3.connect("file:" + str(db) + "?immutable=1", uri=True)
+    con.row_factory = sqlite3.Row
+    return con
+
+
+class Shard:
+    """Read-only FTS5 view of one shard, with the parity-correct manual BM25."""
+
+    def __init__(self, name: str, db: Path) -> None:
+        self.name = name
+        self.con = _ro(db)
+        cur = self.con.cursor()
+        self.N = cur.execute("SELECT COUNT(*) FROM genes_fts").fetchone()[0]
+        # The ``genes_fts_vocab`` fts5vocab shadow table is created at DB
+        # init for current stores but absent on legacy shards. It is the
+        # only practical source of per-doc tf/dl, which manual BM25 needs.
+        # When absent on an immutable DB we cannot CREATE it (read-only), so
+        # this shard still contributes N + phrase_df to the GLOBAL idf basis
+        # (read-only COUNT/MATCH), but its candidates are NOT manually
+        # re-scored. The parity + go/no-go stats then come from shards that
+        # do carry the vocab (the common ``within``-shard gold case).
+        self.has_vocab = bool(cur.execute(
+            "SELECT 1 FROM sqlite_master WHERE name='genes_fts_vocab'"
+        ).fetchone())
+        self.avgdl = 1.0
+        self._dl: Dict[int, int] = {}
+        if self.has_vocab:
+            tot = cur.execute("SELECT COUNT(*) FROM genes_fts_vocab").fetchone()[0]
+            self.avgdl = (tot / float(self.N)) if self.N else 1.0
+            if self.avgdl <= 0:
+                self.avgdl = 1.0
+            # per-doc length over ALL columns (FTS5's D)
+            for r in cur.execute(
+                "SELECT doc, COUNT(*) c FROM genes_fts_vocab GROUP BY doc"
+            ):
+                self._dl[int(r[0])] = int(r[1])
+
+    def engine_local(self, terms: List[str], limit: int) -> List[Tuple[int, str, float]]:
+        """FTS5 engine ranking: [(rowid, source_id, -bm25)] (positive lexical)."""
+        bm = [t for t in terms if len(t) > 2 and _single_token(t)]
+        if not bm:
+            return []
+        match = " OR ".join('"' + t.replace('"', '""') + '"' for t in bm)
+        cur = self.con.cursor()
+        try:
+            rows = cur.execute(
+                "SELECT f.rowid AS rid, g.source_id AS src, bm25(genes_fts) AS r "
+                "FROM genes_fts f JOIN genes g ON g.gene_id = f.gene_id "
+                "WHERE genes_fts MATCH ? ORDER BY rank LIMIT ?",
+                (match, limit),
+            ).fetchall()
+        except Exception:
+            return []
+        return [(int(x["rid"]), x["src"], -float(x["r"])) for x in rows]
+
+    def phrase_df(self, term: str) -> int:
+        """Rows matching the phrase in ANY column — FTS5's n (cached)."""
+        cache = getattr(self, "_df_cache", None)
+        if cache is None:
+            cache = self._df_cache = {}
+        if term in cache:
+            return cache[term]
+        try:
+            n = self.con.execute(
+                "SELECT COUNT(*) FROM genes_fts WHERE genes_fts MATCH ?",
+                ('"' + term.replace('"', '""') + '"',),
+            ).fetchone()[0]
+        except Exception:
+            n = 0
+        cache[term] = n
+        return n
+
+    def tf_batch(self, rowids: List[int], terms: List[str]) -> Dict[int, Dict[str, int]]:
+        """{rowid: {term: tf}} over ALL columns, one GROUP-BY query per term.
+        Mirrors the batched per-term tf probe in
+        KnowledgeStore.rescore_lexical_global_idf (which also does one
+        ``GROUP BY doc`` query per scored term, bounded by query length)."""
+        out: Dict[int, Dict[str, int]] = {rid: {} for rid in rowids}
+        if not self.has_vocab or not rowids:
+            return out
+        ph = ",".join("?" * len(rowids))
+        for t in terms:
+            if len(t) <= 2:
+                continue
+            try:
+                rows = self.con.execute(
+                    f"SELECT doc, COUNT(*) c FROM genes_fts_vocab "
+                    f"WHERE term=? AND doc IN ({ph}) GROUP BY doc",
+                    (t, *rowids),
+                ).fetchall()
+            except Exception:
+                continue
+            for r in rows:
+                rid = int(r[0])
+                if rid in out:
+                    out[rid][t] = int(r[1])
+        return out
+
+    def manual_bm25(self, rowid: int, terms: List[str], idf_map: Dict[str, float],
+                    tf_map: Dict[str, int]) -> float:
+        """Parity-correct manual BM25 (positive sum) with injected idf_map.
+        Verbatim with KnowledgeStore.rescore_lexical_global_idf: all-column
+        tf/dl/avgdl, signed idf, k1=1.2, b=0.75. ``tf_map`` is this doc's
+        per-term tf (from :meth:`tf_batch`)."""
+        dl = float(self._dl.get(rowid, 0)) or 1.0
+        s = 0.0
+        for t in terms:
+            if len(t) <= 2 or t not in idf_map:
+                continue
+            tf = float(tf_map.get(t, 0))
+            if tf <= 0:
+                continue
+            denom = tf + K1 * (1.0 - B + B * (dl / self.avgdl))
+            if denom <= 0:
+                continue
+            s += float(idf_map[t]) * (tf * (K1 + 1.0)) / denom
+        return s
+
+
+def _load_needles(path: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            nd = json.loads(line)
+            q = nd.get("question") or nd.get("query")
+            gp = nd.get("gold_paths") or nd.get("gold_path")
+            if isinstance(gp, str):
+                gp = [gp]
+            if not q or not gp:
+                continue
+            out.append({"question": q, "gold_paths": gp})
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="genomes/bench/matrix-sharded/medium")
+    ap.add_argument("--needles", default="benchmarks/results/shard_gold_medium.jsonl")
+    ap.add_argument("--limit", type=int, default=10,
+                    help="per-shard FTS engine candidate depth")
+    ap.add_argument("--out", default="benchmarks/results/diag_global_idf_counterfactual_medium.json")
+    args = ap.parse_args()
+
+    from helix_context.accel import extract_query_signals
+
+    root = Path(args.root)
+    shard_paths = _discover_shards(root)
+    if not shard_paths:
+        print(f"no shards under {root}", file=sys.stderr)
+        return 2
+    shards = {n: Shard(n, p) for n, p in shard_paths.items()}
+    total_N = sum(s.N for s in shards.values())
+
+    needles = _load_needles(args.needles)
+
+    per: List[Dict[str, Any]] = []
+    parity_errs: List[float] = []
+    buried = 0
+    reranked_above = 0
+    rank_improvements: List[int] = []
+
+    for nd in needles:
+        q = nd["question"]
+        gold_paths = nd["gold_paths"]
+        domains, entities = extract_query_signals(q)
+        # idf terms: dedup, len>2 (mirrors ShardRouter.query_genes)
+        seen: set = set()
+        idf_terms: List[str] = []
+        for t in (domains or []) + (entities or []):
+            if not t:
+                continue
+            k = t.lower()
+            if k in seen or len(k) <= 2 or not _single_token(k):
+                continue
+            seen.add(k)
+            idf_terms.append(k)
+        if not idf_terms:
+            continue
+
+        # Global N/df aggregated across shards (raw-idf basis).
+        global_df: Dict[str, int] = {t: 0 for t in idf_terms}
+        for s in shards.values():
+            for t in idf_terms:
+                global_df[t] += s.phrase_df(t)
+        global_idf = {t: _raw_idf(total_N, global_df[t]) for t in idf_terms}
+
+        # Fan out: per-shard engine-local FTS candidates. Merge into one
+        # candidate pool keyed by (shard, rowid). The LOCAL lexical signal is
+        # the engine bm25() (per-shard local idf). The GLOBAL signal is the
+        # parity-correct manual BM25 with the aggregated raw global idf.
+        cands: List[Dict[str, Any]] = []
+        for s in shards.values():
+            # per-shard LOCAL idf map (for the parity check only)
+            local_idf = {t: _raw_idf(s.N, s.phrase_df(t)) for t in idf_terms}
+            engine_rows = s.engine_local(idf_terms, args.limit)
+            rowids = [rid for rid, _src, _e in engine_rows]
+            tf_all = s.tf_batch(rowids, idf_terms) if s.has_vocab else {}
+            for rid, src, eng_local in engine_rows:
+                if s.has_vocab:
+                    tfm = tf_all.get(rid, {})
+                    man_local = s.manual_bm25(rid, idf_terms, local_idf, tfm)
+                    man_global = s.manual_bm25(rid, idf_terms, global_idf, tfm)
+                    parity_err = abs(eng_local - man_local)
+                else:
+                    # no vocab on this (legacy, read-only) shard — cannot
+                    # form manual tf/dl. Use the engine-local value as a
+                    # stand-in for ordering so the doc still competes, but
+                    # exclude it from parity/go-no-go stats.
+                    man_local = man_global = eng_local
+                    parity_err = None
+                cands.append({
+                    "shard": s.name, "rowid": rid, "source_id": src,
+                    "engine_local": eng_local,
+                    "manual_local": man_local,
+                    "manual_global": man_global,
+                    "is_gold": _gold_hit(src, gold_paths),
+                    "parity_err": parity_err,
+                    "manual_ok": s.has_vocab,
+                })
+        if not cands:
+            continue
+
+        # rank by engine-local lexical (the baseline ordering the splice acts on)
+        by_local = sorted(cands, key=lambda c: -c["engine_local"])
+        gold_idx = next((i for i, c in enumerate(by_local) if c["is_gold"]), None)
+        if gold_idx is None:
+            continue  # gold not in lexical pool at all
+
+        gold = by_local[gold_idx]
+        # wrong incumbents ranked ABOVE the gold on the local signal
+        wrong_above = [c for c in by_local[:gold_idx] if not c["is_gold"]]
+        if gold.get("parity_err") is not None:
+            parity_errs.append(gold["parity_err"])
+        rec: Dict[str, Any] = {
+            "question": q[:80],
+            "gold": {k: gold[k] for k in
+                     ("shard", "source_id", "engine_local", "manual_local",
+                      "manual_global", "parity_err")},
+            "local_rank": gold_idx + 1,
+            "n_wrong_above": len(wrong_above),
+        }
+        if wrong_above:
+            top_wrong = wrong_above[0]
+            rec["top_wrong"] = {k: top_wrong[k] for k in
+                                ("shard", "source_id", "engine_local",
+                                 "manual_local", "manual_global", "parity_err")}
+            if top_wrong.get("parity_err") is not None:
+                parity_errs.append(top_wrong["parity_err"])
+            # Go/no-go only counts buried golds where BOTH the gold and the
+            # top wrong incumbent are manually scorable (vocab present), so
+            # the comparison is on real manual-global BM25, not the
+            # engine-local stand-in used for vocab-less legacy shards.
+            scorable = gold.get("manual_ok") and top_wrong.get("manual_ok")
+            rec["scorable"] = bool(scorable)
+            if scorable:
+                buried += 1
+                # GO/NO-GO: does GLOBAL manual BM25 put gold above top wrong?
+                global_above = gold["manual_global"] > top_wrong["manual_global"]
+                rec["global_reranks_above_top_wrong"] = global_above
+                if global_above:
+                    reranked_above += 1
+                # rank improvement under global lexical ordering (over the
+                # manually-scorable candidates only, to keep it apples-to-apples)
+                scorable_cands = [c for c in cands if c.get("manual_ok")]
+                by_global = sorted(scorable_cands, key=lambda c: -c["manual_global"])
+                by_local_sc = sorted(scorable_cands, key=lambda c: -c["engine_local"])
+                def _rank(seq):
+                    return next(
+                        (i for i, c in enumerate(seq)
+                         if c["shard"] == gold["shard"] and c["rowid"] == gold["rowid"]),
+                        None,
+                    )
+                gr, lr = _rank(by_global), _rank(by_local_sc)
+                if gr is not None and lr is not None:
+                    rec["local_rank_scorable"] = lr + 1
+                    rec["global_rank_scorable"] = gr + 1
+                    rank_improvements.append(lr - gr)
+        per.append(rec)
+
+    def _med(xs: List[float]) -> Optional[float]:
+        return statistics.median(xs) if xs else None
+
+    summary = {
+        "root": str(root),
+        "n_shards": len(shards),
+        "total_N": total_N,
+        "n_needles": len(needles),
+        "n_gold_in_lexical_pool": len(per),
+        "n_buried_golds": buried,
+        "median_parity_error": _med(parity_errs),
+        "max_parity_error": max(parity_errs) if parity_errs else None,
+        "parity_bit_exact": (max(parity_errs) < 1e-9) if parity_errs else None,
+        "frac_buried_golds_global_reranks_above": (
+            reranked_above / buried if buried else None),
+        "n_buried_reranked_above": reranked_above,
+        "median_rank_improvement": _med([float(x) for x in rank_improvements]),
+    }
+
+    out = {"summary": summary, "needles": per}
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2)
+
+    print("=== global-IDF counterfactual (medium sharded) ===")
+    for k, v in summary.items():
+        print(f"  {k}: {v}")
+    print(f"\nwrote {args.out}")
+    go = summary["frac_buried_golds_global_reranks_above"]
+    if go is not None:
+        verdict = "GO" if go >= 0.5 else "WEAK/NO-GO"
+        print(f"\nHYPOTHESIS {verdict}: global-BM25 re-ranks {go:.0%} of buried golds above their wrong incumbent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/diag_shard_dense.py
+++ b/benchmarks/diag_shard_dense.py
@@ -1,0 +1,543 @@
+"""
+diag_shard_dense.py — Gold-free retrieval diagnostic: tier-contribution + dense-fired flag.
+
+Usage:
+    python benchmarks/diag_shard_dense.py --helix-url http://127.0.0.1:11437 --label unsharded
+    python benchmarks/diag_shard_dense.py --helix-url http://127.0.0.1:11438 --label sharded
+
+For each query the script calls:
+    POST /fingerprint  {query, max_results:10, score_floor:0, profile:"fast"}
+    POST /context/packet {query}
+
+From the responses it extracts per-query contributing tiers from
+``fingerprints[*].tier_contributions`` (the primary, per-result field,
+present in every /fingerprint response at routes_context.py L817-819) and
+from ``agent.tier_totals`` (aggregate, routes_context.py L880).
+
+The dense-tier signal uses the exact set of tier names used by
+know_decision._DENSE_TIERS (scoring/know_decision.py L222-228):
+    {"dense", "splade", "sema_boost", "sema_cold"}
+
+The canonical "BGE-M3 dense recall fired" check is:
+    tier_contributions for ANY result contains key "dense" with value > 0
+    (knowledge_store.py L1993/L2021/L2024; shard_router.py L508/L612)
+
+The /context/packet response is used to cross-check via KnowBlock.lexical_dense_agree
+(schemas.py L535) which is True only when dense and lexical tiers agree on >= 1 doc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Dense-tier names (mirrors scoring/know_decision.py _DENSE_TIERS L222-228)
+# ---------------------------------------------------------------------------
+_DENSE_TIERS: frozenset[str] = frozenset({"dense", "splade", "sema_boost", "sema_cold"})
+
+# The canonical BGE-M3 dense-recall tier key written by knowledge_store.py
+# at L1993: tier_contrib[gid]["dense"] = float(cosine)
+# and propagated by shard_router.py at L508/L612.
+_BGE_DENSE_TIER = "dense"
+
+# ---------------------------------------------------------------------------
+# Default query set (~16 queries, tuned to medium/xl CODE projects)
+#
+# Projects represented in the medium/xl corpus:
+#   BookKeeper, CosmicTasha, Education, helix-context, MaxExpressKit,
+#   two-brain-audit
+#
+# "within" queries are natural-language paraphrases of project-specific
+# facts with LOW literal token overlap (tests semantic recall).
+# "cross" queries span multiple projects (tests cross-project reasoning).
+# ---------------------------------------------------------------------------
+DEFAULT_QUERIES: list[dict[str, str]] = [
+    # -- within: helix-context --
+    {
+        "id": "w01",
+        "type": "within",
+        "query": (
+            "How does Helix decide which tier of the retrieval budget "
+            "to place a response in — the very narrow set versus the "
+            "broader wider set?"
+        ),
+    },
+    {
+        "id": "w02",
+        "type": "within",
+        "query": (
+            "Where in the pipeline does the system decide whether "
+            "it actually found the answer versus needs to escalate?"
+        ),
+    },
+    {
+        "id": "w03",
+        "type": "within",
+        "query": (
+            "What mechanism tracks which documents have already been "
+            "sent to a session so they are not repeated on subsequent turns?"
+        ),
+    },
+    {
+        "id": "w04",
+        "type": "within",
+        "query": (
+            "Which component is responsible for giving each document a "
+            "condensed shorter representation to reduce token cost?"
+        ),
+    },
+    {
+        "id": "w05",
+        "type": "within",
+        "query": (
+            "How is the freshness of the top-ranked retrieved document "
+            "validated against the file it came from?"
+        ),
+    },
+    # -- within: BookKeeper --
+    {
+        "id": "w06",
+        "type": "within",
+        "query": (
+            "What approach does BookKeeper use to ensure only authorised "
+            "users can access particular routes or resources?"
+        ),
+    },
+    {
+        "id": "w07",
+        "type": "within",
+        "query": (
+            "How are amounts and financial figures stored internally to "
+            "avoid floating-point rounding problems in BookKeeper?"
+        ),
+    },
+    # -- within: CosmicTasha --
+    {
+        "id": "w08",
+        "type": "within",
+        "query": (
+            "What rendering approach does CosmicTasha use for displaying "
+            "celestial objects and trajectories in real time?"
+        ),
+    },
+    # -- within: Education --
+    {
+        "id": "w09",
+        "type": "within",
+        "query": (
+            "How does the Education project track learner progress through "
+            "a module and record completion status?"
+        ),
+    },
+    # -- within: MaxExpressKit --
+    {
+        "id": "w10",
+        "type": "within",
+        "query": (
+            "What is the middleware chain order in MaxExpressKit and how "
+            "are errors from handlers surfaced back to callers?"
+        ),
+    },
+    # -- cross-project --
+    {
+        "id": "c01",
+        "type": "cross",
+        "query": (
+            "Which of the projects in this corpus store and query data "
+            "using a local embedded SQL database?"
+        ),
+    },
+    {
+        "id": "c02",
+        "type": "cross",
+        "query": (
+            "Compare how task ordering or job scheduling is handled "
+            "across the different projects in this corpus."
+        ),
+    },
+    {
+        "id": "c03",
+        "type": "cross",
+        "query": (
+            "Which projects expose a REST or HTTP API and what "
+            "authentication scheme do they rely on?"
+        ),
+    },
+    {
+        "id": "c04",
+        "type": "cross",
+        "query": (
+            "Across the projects here, which ones write structured "
+            "log output and what format or library do they use?"
+        ),
+    },
+    {
+        "id": "c05",
+        "type": "cross",
+        "query": (
+            "Identify projects that have a concept of user sessions "
+            "or identity and explain how they manage them."
+        ),
+    },
+    {
+        "id": "c06",
+        "type": "cross",
+        "query": (
+            "Which projects in the corpus have automated test suites, "
+            "and what testing framework is each one using?"
+        ),
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tier extraction helpers
+# ---------------------------------------------------------------------------
+
+def _extract_tiers_from_fingerprint(fp_response: dict) -> tuple[list[str], bool]:
+    """Return (tiers_fired, dense_fired) from a /fingerprint response.
+
+    Primary signal: fingerprints[*].tier_contributions
+        - routes_context.py L817-819: each result row carries
+          ``tier_contributions: {tier_name: score}``
+        - A tier is "fired" if it appears with a non-zero score in
+          at least one result.
+
+    Secondary / aggregate signal: agent.tier_totals
+        - routes_context.py L880: sum of all per-result tier scores.
+
+    ``dense_fired`` = True if the "dense" key appears with value > 0
+    in ANY result's tier_contributions (canonical BGE-M3 signal).
+    """
+    all_tiers: set[str] = set()
+    dense_fired = False
+
+    fingerprints = fp_response.get("fingerprints") or []
+    for fp in fingerprints:
+        tc = fp.get("tier_contributions") or {}
+        for tier, score in tc.items():
+            score_f = float(score) if score is not None else 0.0
+            if score_f > 0:
+                all_tiers.add(tier)
+                if tier == _BGE_DENSE_TIER:
+                    dense_fired = True
+
+    # Cross-check with agent.tier_totals (aggregate, covers refiner tiers
+    # like "tcm" that may not appear per-fingerprint)
+    agent = fp_response.get("agent") or {}
+    tier_totals = agent.get("tier_totals") or {}
+    for tier, score in tier_totals.items():
+        score_f = float(score) if score is not None else 0.0
+        if score_f > 0:
+            all_tiers.add(tier)
+            if tier == _BGE_DENSE_TIER:
+                dense_fired = True
+
+    return sorted(all_tiers), dense_fired
+
+
+def _extract_from_packet(packet_response: dict) -> dict[str, Any]:
+    """Extract supplementary signals from a /context/packet response.
+
+    Returns:
+        lexical_dense_agree: from KnowBlock.lexical_dense_agree (schemas.py L535)
+        know_found: True if a KnowBlock was returned
+        confidence: KnowBlock.confidence if present
+        top_sources: list of source paths from verified items
+    """
+    result: dict[str, Any] = {
+        "lexical_dense_agree": None,
+        "know_found": False,
+        "confidence": None,
+        "top_sources": [],
+    }
+    know = packet_response.get("know")
+    if know:
+        result["know_found"] = bool(know.get("found", False))
+        result["confidence"] = know.get("confidence")
+        result["lexical_dense_agree"] = know.get("lexical_dense_agree")
+
+    verified = packet_response.get("verified") or []
+    for item in verified[:5]:
+        src = item.get("source_id") or item.get("title") or ""
+        if src:
+            result["top_sources"].append(src)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _post(client: httpx.Client, url: str, payload: dict, timeout: float = 30.0) -> dict:
+    resp = client.post(url, json=payload, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Core diagnostic runner
+# ---------------------------------------------------------------------------
+
+def run_diagnostic(
+    helix_url: str,
+    queries: list[dict],
+    *,
+    label: str = "run",
+    verbose: bool = False,
+) -> dict:
+    """Run the diagnostic against a live Helix server.
+
+    Returns the full result dict (per-query rows + aggregate).
+    """
+    base = helix_url.rstrip("/")
+    fp_url = f"{base}/fingerprint"
+    packet_url = f"{base}/context/packet"
+
+    rows: list[dict] = []
+    errors: list[dict] = []
+
+    with httpx.Client() as client:
+        for q in queries:
+            qid = q["id"]
+            qtext = q["query"]
+            qtype = q.get("type", "unknown")
+
+            if verbose:
+                print(f"  [{qid}] {qtype}: {qtext[:80]}...", flush=True)
+
+            row: dict[str, Any] = {
+                "id": qid,
+                "type": qtype,
+                "query": qtext,
+                "tiers_fired": [],
+                "dense_fired": False,
+                "lexical_dense_agree": None,
+                "know_found": None,
+                "confidence": None,
+                "top_sources": [],
+                "fp_count": 0,
+                "fp_error": None,
+                "packet_error": None,
+            }
+
+            # -- /fingerprint -------------------------------------------------
+            try:
+                fp_resp = _post(client, fp_url, {
+                    "query": qtext,
+                    "max_results": 10,
+                    "score_floor": 0,
+                    "profile": "fast",
+                })
+                tiers, dense = _extract_tiers_from_fingerprint(fp_resp)
+                row["tiers_fired"] = tiers
+                row["dense_fired"] = dense
+                row["fp_count"] = fp_resp.get("count", 0)
+            except Exception as exc:
+                row["fp_error"] = str(exc)
+                if verbose:
+                    print(f"    /fingerprint error: {exc}", flush=True)
+                errors.append({"id": qid, "endpoint": "fingerprint", "error": str(exc)})
+
+            # -- /context/packet ----------------------------------------------
+            try:
+                pkt_resp = _post(client, packet_url, {"query": qtext})
+                pkt_info = _extract_from_packet(pkt_resp)
+                row.update(pkt_info)
+            except Exception as exc:
+                row["packet_error"] = str(exc)
+                if verbose:
+                    print(f"    /context/packet error: {exc}", flush=True)
+                errors.append({"id": qid, "endpoint": "packet", "error": str(exc)})
+
+            rows.append(row)
+
+            if verbose:
+                dense_marker = "[DENSE]" if row["dense_fired"] else "      "
+                tiers_short = ", ".join(row["tiers_fired"][:6])
+                print(f"    {dense_marker} tiers={tiers_short}", flush=True)
+
+    # -- Aggregate ------------------------------------------------------------
+    n = len(rows)
+    n_dense = sum(1 for r in rows if r["dense_fired"])
+    pct_dense = round(100.0 * n_dense / n, 1) if n else 0.0
+
+    by_type: dict[str, dict] = {}
+    for r in rows:
+        t = r["type"]
+        if t not in by_type:
+            by_type[t] = {"n": 0, "dense_fired": 0}
+        by_type[t]["n"] += 1
+        if r["dense_fired"]:
+            by_type[t]["dense_fired"] += 1
+    for t, d in by_type.items():
+        d["pct_dense"] = round(100.0 * d["dense_fired"] / d["n"], 1) if d["n"] else 0.0
+
+    # Tier frequency across all queries
+    tier_freq: dict[str, int] = {}
+    for r in rows:
+        for tier in r["tiers_fired"]:
+            tier_freq[tier] = tier_freq.get(tier, 0) + 1
+
+    return {
+        "label": label,
+        "helix_url": base,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "queries": rows,
+        "aggregate": {
+            "n": n,
+            "n_dense_fired": n_dense,
+            "pct_dense_fired": pct_dense,
+            "by_type": by_type,
+            "tier_frequency": dict(sorted(tier_freq.items(), key=lambda kv: -kv[1])),
+            "errors": errors,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pretty printer
+# ---------------------------------------------------------------------------
+
+def _print_table(result: dict) -> None:
+    label = result["label"]
+    agg = result["aggregate"]
+    rows = result["queries"]
+
+    print(f"\n{'='*72}")
+    print(f"  Helix Shard*Dense Diagnostic  |  label={label}")
+    print(f"  URL: {result['helix_url']}")
+    print(f"  Run: {result['timestamp']}")
+    print(f"{'='*72}")
+
+    # Per-query table
+    col_w = [5, 6, 58, 7, 8]
+    hdr = (
+        f"{'ID':<{col_w[0]}} {'TYPE':<{col_w[1]}} "
+        f"{'QUERY':<{col_w[2]}} {'DENSE':>{col_w[3]}} {'FP_CNT':>{col_w[4]}}"
+    )
+    print(f"\n{hdr}")
+    print("-" * (sum(col_w) + len(col_w)))
+    for r in rows:
+        q_short = r["query"][:55] + "..." if len(r["query"]) > 58 else r["query"]
+        dense_mark = "YES" if r["dense_fired"] else "no"
+        fp_cnt = str(r.get("fp_count", "?"))
+        print(
+            f"{r['id']:<{col_w[0]}} "
+            f"{r['type']:<{col_w[1]}} "
+            f"{q_short:<{col_w[2]}} "
+            f"{dense_mark:>{col_w[3]}} "
+            f"{fp_cnt:>{col_w[4]}}"
+        )
+
+    # Tier frequency
+    print(f"\n  Tier frequency (n queries with non-zero contribution):")
+    tf = agg.get("tier_frequency", {})
+    for tier, cnt in sorted(tf.items(), key=lambda kv: -kv[1]):
+        bar = "#" * cnt
+        marker = " <-- BGE-M3 dense" if tier == _BGE_DENSE_TIER else ""
+        print(f"    {tier:<20} {cnt:>3}  {bar}{marker}")
+
+    # Aggregate
+    print(f"\n  Aggregate:")
+    print(f"    Total queries      : {agg['n']}")
+    print(f"    Dense tier fired   : {agg['n_dense_fired']} / {agg['n']}  ({agg['pct_dense_fired']}%)")
+    for t, d in agg.get("by_type", {}).items():
+        print(f"    by_type [{t}]     : {d['dense_fired']}/{d['n']} dense ({d['pct_dense']}%)")
+    if agg.get("errors"):
+        print(f"\n  Errors ({len(agg['errors'])}):")
+        for e in agg["errors"]:
+            print(f"    [{e['id']}] {e['endpoint']}: {e['error']}")
+    print(f"{'='*72}\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Gold-free retrieval diagnostic: tier-contribution + dense-fired."
+    )
+    parser.add_argument(
+        "--helix-url",
+        default="http://127.0.0.1:11437",
+        help="Base URL of the Helix server (default: http://127.0.0.1:11437)",
+    )
+    parser.add_argument(
+        "--queries",
+        default=None,
+        metavar="FILE",
+        help=(
+            "JSON file with query list. Each entry: "
+            "{id, type, query}. Defaults to the embedded 16-query set."
+        ),
+    )
+    parser.add_argument(
+        "--label",
+        default="run",
+        help="Short label embedded in the output filename and summary (e.g. 'unsharded', 'sharded').",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help=(
+            "Output JSON path. Default: "
+            "benchmarks/results/diag_shard_dense_<label>_<ts>.json"
+        ),
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Print per-query progress.",
+    )
+    args = parser.parse_args(argv)
+
+    # Load queries
+    if args.queries:
+        with open(args.queries, encoding="utf-8") as f:
+            queries = json.load(f)
+    else:
+        queries = DEFAULT_QUERIES
+
+    # Output path
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_dir = Path(__file__).parent / "results"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"diag_shard_dense_{args.label}_{ts}.json"
+
+    print(
+        f"Running diagnostic: label={args.label!r} url={args.helix_url} "
+        f"queries={len(queries)}",
+        flush=True,
+    )
+
+    result = run_diagnostic(
+        args.helix_url,
+        queries,
+        label=args.label,
+        verbose=args.verbose,
+    )
+
+    _print_table(result)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+    print(f"Results written: {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/diag_shard_score.py
+++ b/benchmarks/diag_shard_score.py
@@ -1,0 +1,440 @@
+"""diag_shard_score.py -- localize cross-shard gold score depression (#181).
+
+In-process diagnostic for the sharded retrieval path. For each gold needle
+it runs the SAME query path the server uses (``open_read_source`` with
+``HELIX_USE_SHARDS=1`` -> ``ShardedGenomeAdapter.query_docs`` ->
+``ShardRouter.query_genes``), with ``HELIX_SHARD_SCORE_DEBUG=1`` so the
+router populates ``ShardRouter.last_score_breakdown`` for EVERY merged
+candidate (including golds that fell below the merge truncation).
+
+For each needle it reports:
+  - the gold gene(s) (matched to a gold_path by the bidirectional substring
+    rule from bench_shard_recall.py) with rank + score breakdown
+    {shard, raw, m_shard, doc_type_boost, corrected, rrf}
+  - the NON-gold genes ranked ABOVE the gold (the "wrong high-ranking"
+    incumbents), with their breakdowns, so it is visible whether the gold's
+    ``corrected`` is depressed by a low ``m_shard`` (the IDF clip), a low
+    ``raw`` (within-shard scoring), or the doc-type boost.
+
+Aggregate across needles:
+  - median gold m_shard
+  - fraction of golds whose m_shard hit the clip floor (IDF_CLIP_LO=0.5)
+    or ceiling (IDF_CLIP_HI=3.0)
+  - median (wrong_top_corrected - gold_corrected) gap
+
+No server, no network, no GPU. The sharded adapter does not load the dense
+codec at the adapter level (each shard handles its own lexical scoring), and
+this harness passes ``sema_codec=None`` and leaves dense default-off, so the
+lexical cross-shard scoring under test is exercised exactly as the server's
+default sharded config exercises it.
+
+CLI
+---
+python benchmarks/diag_shard_score.py \\
+    --genome genomes/main/main.genome.db \\
+    --needles benchmarks/results/shard_gold_medium.jsonl \\
+    --helix-config helix.toml \\
+    --limit 8 \\
+    --out benchmarks/results/diag_shard_score_medium.json
+
+GOLD-PATH MATCH RULE (same as bench_shard_recall.py)
+----------------------------------------------------
+A candidate's source_id S matches a gold_path G when normalise(G) is a
+substring of normalise(S) OR normalise(S) is a substring of normalise(G),
+where normalise(x) = x.replace("\\\\", "/").lower().strip().
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Make the package importable when run from the repo root or benchmarks/.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Path normalisation + gold match (identical to bench_shard_recall.py)
+# ---------------------------------------------------------------------------
+
+def _norm(path: Optional[str]) -> str:
+    return str(path or "").replace("\\", "/").lower().strip()
+
+
+def _gold_hit(source: Optional[str], gold_paths: List[str]) -> bool:
+    """True if source matches any gold path (bidirectional substring)."""
+    sn = _norm(source)
+    if not sn:
+        return False
+    for gp in gold_paths:
+        gn = _norm(gp)
+        if gn and (gn in sn or sn in gn):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# In-process retrieval wiring
+# ---------------------------------------------------------------------------
+
+def _genome_kwargs_from_config(config: Any) -> Dict[str, Any]:
+    """Build the retrieval-affecting kwargs the server forwards to each shard.
+
+    Mirrors ``HelixContextManager.__init__``'s ``open_read_source`` call
+    (context_manager.py ~530) for the keys that drive scoring/fusion, but
+    forces ``sema_codec=None`` and leaves dense default-off so no model is
+    loaded (no-GPU constraint). The cross-shard lexical scoring under test
+    is unaffected by these two omissions.
+    """
+    r = config.retrieval
+    ing = config.ingestion
+    kwargs: Dict[str, Any] = {
+        "synonym_map": getattr(config, "synonym_map", None),
+        "sema_codec": None,  # no model load
+        "splade_enabled": getattr(ing, "splade_enabled", False),
+        "entity_graph": getattr(ing, "entity_graph", False),
+        "sr_enabled": getattr(r, "sr_enabled", False),
+        "sr_gamma": getattr(r, "sr_gamma", 0.85),
+        "sr_k_steps": getattr(r, "sr_k_steps", 4),
+        "sr_weight": getattr(r, "sr_weight", 1.5),
+        "sr_cap": getattr(r, "sr_cap", 3.0),
+        "seeded_edges_enabled": getattr(r, "seeded_edges_enabled", False),
+        "fusion_mode": getattr(r, "fusion_mode", "additive"),
+        "entity_graph_retrieval_enabled": getattr(
+            r, "entity_graph_retrieval_enabled", False
+        ),
+        # dense left default-off (no GPU); the bug is in lexical cross-shard
+        # scoring, and the server's default sharded config runs dense off too.
+        "dense_embedding_enabled": False,
+    }
+    # Optional scoring weights / knobs — pass through only if present so a
+    # config schema drift doesn't crash the harness.
+    for opt in (
+        "filename_anchor_enabled", "filename_anchor_weight",
+        "bm25_shortlist_enabled", "bm25_shortlist_size",
+        "bm25_prefilter_enabled", "bm25_prefilter_size",
+        "rrf_k", "fts5_weight", "tag_exact_weight", "tag_prefix_weight",
+        "sema_cold_weight", "lex_anchor_weight", "harmonic_weight",
+        "entity_graph_weight",
+    ):
+        if hasattr(r, opt):
+            kwargs[opt] = getattr(r, opt)
+    return kwargs
+
+
+def _open_router_source(genome_path: str, config: Any):
+    """Open the sharded read source exactly as the server would.
+
+    Returns the ``ShardedGenomeAdapter`` (or a bare ``Genome`` if the path
+    isn't a routing DB / sharding disabled — in which case there's nothing
+    to diagnose and we say so).
+    """
+    os.environ["HELIX_USE_SHARDS"] = "1"
+    os.environ["HELIX_SHARD_SCORE_DEBUG"] = "1"
+    from helix_context.sharding import open_read_source
+
+    kwargs = _genome_kwargs_from_config(config)
+    return open_read_source(genome_path=genome_path, **kwargs)
+
+
+def _router_of(source: Any):
+    """Return the underlying ShardRouter from a ShardedGenomeAdapter, or None."""
+    return getattr(source, "_router", None)
+
+
+# ---------------------------------------------------------------------------
+# Per-needle diagnosis
+# ---------------------------------------------------------------------------
+
+def _run_needle(
+    source: Any,
+    router: Any,
+    question: str,
+    gold_paths: List[str],
+    max_genes: int,
+) -> Dict[str, Any]:
+    """Run one query; extract gold rank + score-depression breakdown."""
+    from helix_context.accel import extract_query_signals
+
+    domains, entities = extract_query_signals(question)
+
+    genes = source.query_docs(domains, entities, max_genes=max_genes)
+
+    breakdown: Dict[str, dict] = dict(getattr(router, "last_score_breakdown", {}) or {})
+    shard_mults: Dict[str, float] = dict(getattr(router, "last_shard_multipliers", {}) or {})
+
+    # Returned ranking (post-merge, post-truncation, post-coactivation).
+    ranked = []
+    for g in genes:
+        ranked.append({
+            "gene_id": getattr(g, "gene_id", None),
+            "source_id": getattr(g, "source_id", None),
+        })
+
+    # Locate gold(s) in the RETURNED ranking (1-based rank; None if not
+    # returned). Also keep the gene's full breakdown if present.
+    gold_entries: List[Dict[str, Any]] = []
+    gold_gene_ids = set()
+    for idx, row in enumerate(ranked):
+        if _gold_hit(row["source_id"], gold_paths):
+            gid = row["gene_id"]
+            gold_gene_ids.add(gid)
+            bd = breakdown.get(gid, {})
+            gold_entries.append({
+                "rank": idx + 1,
+                "gene_id": gid,
+                "source_id": row["source_id"],
+                "breakdown": bd,
+            })
+
+    # If gold never reached the returned ranking, look for it in the FULL
+    # candidate breakdown (it may have been admitted to the pool but cut by
+    # the merge truncation) — that's exactly the depression we want to see.
+    if not gold_entries:
+        for gid, bd in breakdown.items():
+            # breakdown rows don't carry source_id; resolve via returned set
+            # is impossible here, so we can only flag "in pool but not
+            # returned" when the caller already knows the gold gene_id. We
+            # surface the whole pool size for context instead.
+            pass
+
+    # Non-gold incumbents ranked ABOVE the best gold (the "wrong high-ranking"
+    # docs). Use the best (lowest-rank) gold as the cutoff.
+    best_gold_rank = min((e["rank"] for e in gold_entries), default=None)
+    wrong_above: List[Dict[str, Any]] = []
+    if best_gold_rank is not None:
+        for idx, row in enumerate(ranked):
+            rank = idx + 1
+            if rank >= best_gold_rank:
+                break
+            if row["gene_id"] in gold_gene_ids:
+                continue
+            wrong_above.append({
+                "rank": rank,
+                "gene_id": row["gene_id"],
+                "source_id": row["source_id"],
+                "breakdown": breakdown.get(row["gene_id"], {}),
+            })
+
+    return {
+        "question": question,
+        "gold_paths": gold_paths,
+        "n_returned": len(ranked),
+        "n_pool": len(breakdown),
+        "shard_multipliers": shard_mults,
+        "gold": gold_entries,
+        "best_gold_rank": best_gold_rank,
+        "wrong_above_gold": wrong_above,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def _aggregate(per_needle: List[Dict[str, Any]]) -> Dict[str, Any]:
+    from helix_context.shard_router import IDF_CLIP_LO, IDF_CLIP_HI
+
+    gold_ms: List[float] = []
+    floor_hits = 0
+    ceil_hits = 0
+    gold_m_total = 0
+    gaps: List[float] = []
+    golds_found = 0
+    golds_not_returned = 0
+
+    eps = 1e-9
+    for nd in per_needle:
+        golds = nd.get("gold", [])
+        if not golds:
+            golds_not_returned += 1
+            continue
+        golds_found += 1
+        # Use the best-ranked gold for the per-needle stats.
+        best = min(golds, key=lambda e: e["rank"])
+        bd = best.get("breakdown", {})
+        m = bd.get("m_shard")
+        if isinstance(m, (int, float)):
+            gold_ms.append(float(m))
+            gold_m_total += 1
+            if abs(float(m) - IDF_CLIP_LO) <= eps:
+                floor_hits += 1
+            if abs(float(m) - IDF_CLIP_HI) <= eps:
+                ceil_hits += 1
+        gold_corr = bd.get("corrected")
+        wrong = nd.get("wrong_above_gold", [])
+        if wrong and isinstance(gold_corr, (int, float)):
+            # gap = top wrong incumbent's corrected - gold corrected
+            wrong_top = wrong[0].get("breakdown", {}).get("corrected")
+            if isinstance(wrong_top, (int, float)):
+                gaps.append(float(wrong_top) - float(gold_corr))
+
+    def _median(xs: List[float]) -> Optional[float]:
+        return statistics.median(xs) if xs else None
+
+    return {
+        "n_needles": len(per_needle),
+        "golds_found_in_ranking": golds_found,
+        "golds_not_returned": golds_not_returned,
+        "idf_clip_lo": IDF_CLIP_LO,
+        "idf_clip_hi": IDF_CLIP_HI,
+        "median_gold_m_shard": _median(gold_ms),
+        "frac_gold_m_at_floor": (floor_hits / gold_m_total) if gold_m_total else None,
+        "frac_gold_m_at_ceiling": (ceil_hits / gold_m_total) if gold_m_total else None,
+        "median_wrong_top_minus_gold_corrected": _median(gaps),
+        "n_gaps_measured": len(gaps),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Needle loading
+# ---------------------------------------------------------------------------
+
+def _load_needles(path: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            nd = json.loads(line)
+            q = nd.get("question") or nd.get("query")
+            gp = nd.get("gold_paths") or nd.get("gold_path")
+            if isinstance(gp, str):
+                gp = [gp]
+            if not q or not gp:
+                continue
+            out.append({"question": q, "gold_paths": gp})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Localize cross-shard gold score depression (#181). In-process; "
+            "no server, no network, no GPU."
+        ),
+    )
+    ap.add_argument("--genome", required=True,
+                    help="path to the sharded routing DB (main.genome.db).")
+    ap.add_argument("--needles", required=True,
+                    help="jsonl with question/gold_paths (build_shard_gold.py output).")
+    ap.add_argument("--helix-config", default=None,
+                    help="helix.toml path (default: load_config's default search).")
+    ap.add_argument("--limit", type=int, default=8,
+                    help="max_genes passed to query_docs (default 8).")
+    ap.add_argument("--out", default=None,
+                    help="write the full JSON report here.")
+    ap.add_argument("--max-needles", type=int, default=0,
+                    help="cap needles processed (0 = all).")
+    args = ap.parse_args(argv)
+
+    from helix_context.config import load_config
+    config = load_config(args.helix_config)
+
+    source = _open_router_source(args.genome, config)
+    router = _router_of(source)
+    if router is None:
+        print(
+            "ERROR: opened source is not a sharded adapter (no _router). "
+            "Either HELIX_USE_SHARDS didn't take or --genome is not a "
+            "main.genome.db routing DB. Nothing to diagnose.",
+            file=sys.stderr,
+        )
+        return 2
+
+    needles = _load_needles(args.needles)
+    if args.max_needles > 0:
+        needles = needles[: args.max_needles]
+    if not needles:
+        print("ERROR: no needles loaded.", file=sys.stderr)
+        return 2
+
+    per_needle: List[Dict[str, Any]] = []
+    for nd in needles:
+        try:
+            res = _run_needle(
+                source, router, nd["question"], nd["gold_paths"], args.limit,
+            )
+        except Exception as exc:  # noqa: BLE001 — diagnostic, keep going
+            res = {
+                "question": nd["question"],
+                "gold_paths": nd["gold_paths"],
+                "error": repr(exc),
+            }
+        per_needle.append(res)
+
+    agg = _aggregate([n for n in per_needle if "error" not in n])
+
+    report = {
+        "genome": args.genome,
+        "needles_file": args.needles,
+        "limit": args.limit,
+        "aggregate": agg,
+        "per_needle": per_needle,
+    }
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        print(f"wrote {args.out}")
+
+    # Compact summary to stdout.
+    print("\n=== cross-shard gold score-depression summary ===")
+    print(f"needles              : {agg['n_needles']}")
+    print(f"golds found in rank  : {agg['golds_found_in_ranking']}")
+    print(f"golds NOT returned   : {agg['golds_not_returned']}")
+    print(f"median gold m_shard  : {agg['median_gold_m_shard']}")
+    print(f"clip range           : [{agg['idf_clip_lo']}, {agg['idf_clip_hi']}]")
+    print(f"frac gold m @ floor  : {agg['frac_gold_m_at_floor']}")
+    print(f"frac gold m @ ceiling: {agg['frac_gold_m_at_ceiling']}")
+    print(f"median (wrong_top.corrected - gold.corrected): "
+          f"{agg['median_wrong_top_minus_gold_corrected']} "
+          f"(n={agg['n_gaps_measured']})")
+
+    # Show the 3 worst-depressed needles (largest positive gap).
+    scored = [
+        (n, n.get("wrong_above_gold", [None])[0])
+        for n in per_needle
+        if n.get("gold") and n.get("wrong_above_gold")
+    ]
+
+    def _gap(n: Dict[str, Any]) -> float:
+        g = n.get("gold")
+        w = n.get("wrong_above_gold")
+        if not g or not w:
+            return float("-inf")
+        gc = min(g, key=lambda e: e["rank"])["breakdown"].get("corrected")
+        wc = w[0]["breakdown"].get("corrected")
+        if not isinstance(gc, (int, float)) or not isinstance(wc, (int, float)):
+            return float("-inf")
+        return wc - gc
+
+    worst = sorted(per_needle, key=_gap, reverse=True)[:3]
+    if worst:
+        print("\n-- worst-depressed needles (top wrong incumbent vs gold) --")
+        for n in worst:
+            if not n.get("gold") or not n.get("wrong_above_gold"):
+                continue
+            g = min(n["gold"], key=lambda e: e["rank"])
+            w = n["wrong_above_gold"][0]
+            print(f"\nQ: {n['question'][:90]}")
+            print(f"  gold  rank={g['rank']} {g['breakdown']}")
+            print(f"  wrong rank={w['rank']} {w['breakdown']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/repobench_r.py
+++ b/benchmarks/repobench_r.py
@@ -1,0 +1,303 @@
+"""RepoBench-R (Step-1) foils: random + Jaccard-overlap + BM25 candidate ranking.
+
+RepoBench-R = given in-file `code` context, rank the cross-file `context` candidate
+snippets; gold = `golden_snippet_index`. Metric = acc@k (acc@1/3 easy; acc@1/3/5 hard).
+LLM-free, GPU-free. Run in cb-step0 venv (rank-bm25 + huggingface_hub).
+
+Baselines:
+  - random   : per-example floor (~1/avg_candidates).
+  - overlap  : Jaccard token overlap -- the RepoBench paper's "lexical" baseline.
+  - bm25     : BM25Okapi. NOTE its IDF goes NEGATIVE for terms appearing in >half the
+               candidates, which on ~6-candidate sets penalises shared tokens and can
+               sink below random. Kept to show why naive BM25 is the wrong foil here.
+               The global-arm (repobench_r_helix_global.py) uses a floored-IDF variant.
+
+Settings (--config):
+  python_cff  = XF-F: cross-file, next-line prediction (file context comes from
+                  other files in the same repo that are imported/used).
+  python_cfr  = XF-R: cross-file, random snippet (harder; snippet is randomly sampled
+                  from same-repo cross-file dependencies).
+  java_cff    = XF-F setting for Java.
+  java_cfr    = XF-R setting for Java.
+
+HF dataset: tianyang/repobench-r (CC-BY-4.0). Data are gzipped pickle files; the
+HF loader itself uses gzip+pickle (see note in load_split). Fetched via hf_hub_download
+(content-addressed, cached). Source: arxiv.org/abs/2306.03091.
+
+Writes:
+  benchmarks/results/repobench_r_{config}_{level}_n{n}.json   per-example query/cand dump
+  benchmarks/results/repobench_r_{config}_foils_{timestamp}.json  summary
+  (Helix arm in repobench_r_helix.py reads the per-example json.)
+
+CLI:
+  python benchmarks/repobench_r.py --config python_cff --n 200
+  python benchmarks/repobench_r.py --config python_cfr --n 200 --levels hard
+  python benchmarks/repobench_r.py --config java_cff   --n 200
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import gzip
+import json
+import os
+import pickle
+import re
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# Gold key name used in the dataset (both spellings appear across HF versions).
+GOLD_KEY = "golden_snippet_index"
+GOLD_KEY_ALT = "gold_snippet_index"
+
+# Number of trailing lines from in-file code used as the query.
+QUERY_TAIL_LINES = 30
+
+_TOK = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+
+def tok(s):
+    return _TOK.findall(s or "")
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading
+# ---------------------------------------------------------------------------
+
+def load_split(config, split, level, n):
+    """Load one (config, split, level) slice from HF.
+
+    NOTE (pickle safety): RepoBench-R is distributed ONLY as gzipped pickle
+    (the official HF loader itself does gzip+pickle). Source is the published
+    CC-BY-4.0 research dataset `tianyang/repobench-r`, fetched via
+    hf_hub_download (content-addressed, cached). No untrusted/user-supplied
+    path is ever unpickled here. Accepted.
+    """
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        print("ERROR: huggingface_hub not installed. pip install huggingface_hub",
+              file=sys.stderr)
+        sys.exit(1)
+
+    gz = hf_hub_download(
+        "tianyang/repobench-r",
+        f"data/{config}.gz",
+        repo_type="dataset",
+    )
+    obj = pickle.load(gzip.open(gz, "rb"))  # noqa: S301  (see note above)
+    rows = obj[split][level]
+    if n and n < len(rows):
+        step = len(rows) // n
+        rows = [rows[i * step] for i in range(n)]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Query construction
+# ---------------------------------------------------------------------------
+
+def make_query(ex):
+    """Build the retrieval query for an example: imports + last N code lines."""
+    code = ex.get("code", "") or ""
+    tail = "\n".join(code.splitlines()[-QUERY_TAIL_LINES:])
+    imports = ex.get("import_statement", "") or ""
+    return (imports + "\n" + tail).strip()
+
+
+# ---------------------------------------------------------------------------
+# Rankers
+# ---------------------------------------------------------------------------
+
+def rank_random(cands, ex_key):
+    """Deterministic per-example permutation -- varies with ex_key."""
+    return sorted(range(len(cands)), key=lambda i: hash((ex_key, i)))
+
+
+def rank_overlap(query, cands):
+    """Jaccard token overlap -- RepoBench paper's lexical baseline."""
+    qs = set(tok(query))
+    if not qs:
+        return list(range(len(cands)))
+
+    def jac(c):
+        cs = set(tok(c))
+        return (len(qs & cs) / len(qs | cs)) if cs else 0.0
+
+    return sorted(range(len(cands)), key=lambda i: jac(cands[i]), reverse=True)
+
+
+def rank_bm25(query, cands):
+    """BM25Okapi over the candidate pool (IDF can go negative on tiny pools)."""
+    try:
+        from rank_bm25 import BM25Okapi
+    except ImportError:
+        print("ERROR: rank-bm25 not installed. pip install rank-bm25", file=sys.stderr)
+        sys.exit(1)
+
+    corpus = [tok(c) for c in cands]
+    if not any(corpus):
+        return list(range(len(cands)))
+    bm = BM25Okapi(corpus)
+    scores = bm.get_scores(tok(query))
+    return sorted(range(len(cands)), key=lambda i: scores[i], reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def acc_at(order, gold, k):
+    """Return 1.0 if gold is in the top-k of the ranked order, else 0.0."""
+    return 1.0 if gold in order[:k] else 0.0
+
+
+def _ks_for_level(level):
+    """Return the k values to evaluate for a given difficulty level.
+
+    Strategy doc section 3: acc@1/3 for easy; acc@1/3/5 for hard.
+    """
+    if level == "hard":
+        return [1, 3, 5]
+    return [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="RepoBench-R foils: random / Jaccard-overlap / BM25Okapi"
+    )
+    ap.add_argument(
+        "--config",
+        default="python_cff",
+        choices=["python_cff", "python_cfr", "java_cff", "java_cfr"],
+        help="Dataset config: {python,java}_{cff=XF-F, cfr=XF-R}",
+    )
+    ap.add_argument(
+        "--n",
+        type=int,
+        default=200,
+        help="Max examples per difficulty level (0 = all)",
+    )
+    ap.add_argument(
+        "--levels",
+        default="easy,hard",
+        help="Comma-separated difficulty levels to run (easy, hard)",
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Override output JSON path for the summary (default: results/ auto-name)",
+    )
+    args = ap.parse_args()
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    levels = [x.strip() for x in args.levels.split(",") if x.strip()]
+    methods = ["random", "overlap", "bm25"]
+    summary = {
+        "config": args.config,
+        "n_per_level": args.n,
+        "timestamp": ts,
+        "levels": {},
+    }
+
+    for level in levels:
+        ks = _ks_for_level(level)
+        rows = load_split(args.config, "test", level, args.n)
+        dump = []
+
+        # Per-method per-k accumulators
+        acc = {m: {k: 0.0 for k in ks} for m in methods}
+        ncand = 0
+
+        for ei, ex in enumerate(rows):
+            cands = ex.get("context", []) or []
+            gold = int(ex.get(GOLD_KEY, ex.get(GOLD_KEY_ALT, -1)))
+            if not cands or gold < 0 or gold >= len(cands):
+                continue
+
+            q = make_query(ex)
+            ncand += len(cands)
+            ex_key = (level, ei)
+
+            orders = {
+                "random": rank_random(cands, ex_key),
+                "overlap": rank_overlap(q, cands),
+                "bm25": rank_bm25(q, cands),
+            }
+            for m in methods:
+                for k in ks:
+                    acc[m][k] += acc_at(orders[m], gold, k)
+
+            dump.append({
+                "repo": ex.get("repo_name"),
+                "file": ex.get("file_path"),
+                "query": q,
+                "candidates": cands,
+                "gold": gold,
+            })
+
+        m_ = len(dump)
+        # Write per-example dump for the Helix arms to consume.
+        dump_path = RESULTS_DIR / f"repobench_r_{args.config}_{level}_n{m_}.json"
+        dump_path.write_text(
+            json.dumps(dump, ensure_ascii=False), encoding="utf-8"
+        )
+
+        lvl_summary = {
+            "n": m_,
+            "avg_cands": round(ncand / m_, 1) if m_ else 0,
+        }
+        for me in methods:
+            for k in ks:
+                lvl_summary[f"{me}_acc@{k}"] = round(acc[me][k] / m_, 3) if m_ else 0.0
+
+        summary["levels"][level] = lvl_summary
+
+    # Print results table
+    print(
+        f"\nRepoBench-R foils -- {args.config}, n={args.n}/level, "
+        f"query=imports+last {QUERY_TAIL_LINES} code lines"
+    )
+    all_ks = []
+    for lv in levels:
+        for k in _ks_for_level(lv):
+            if k not in all_ks:
+                all_ks.append(k)
+
+    hdr = f"{'level':<8}{'n':>5}{'avgC':>6}"
+    for m in methods:
+        for k in all_ks:
+            hdr += f"  {(m+'@'+str(k)):>10}"
+    print(hdr)
+    print("-" * len(hdr))
+    for lv in levels:
+        s = summary["levels"][lv]
+        row = f"{lv:<8}{s['n']:>5}{s['avg_cands']:>6}"
+        for me in methods:
+            for k in all_ks:
+                key = f"{me}_acc@{k}"
+                val = s.get(key, "n/a")
+                row += f"  {str(val):>10}"
+        print(row)
+
+    # Write summary JSON
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        out_path = RESULTS_DIR / f"repobench_r_{args.config}_foils_{ts}.json"
+    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(f"\n-> per-example dumps + summary in {RESULTS_DIR}/")
+    print(f"   summary: {out_path}")
+    print("   (Helix arms read the per-example JSON files)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/repobench_r_helix.py
+++ b/benchmarks/repobench_r_helix.py
@@ -1,0 +1,320 @@
+"""RepoBench-R (Step-1) Helix arm -- per-example genome variant.
+
+For each example, spins up a fresh in-process genome, ingests each candidate snippet
+as one gene (metadata path = "cand_{i}"), then fingerprints the query and ranks
+candidates by their best gene score.  Metric: acc@k (acc@1/3 easy; acc@1/3/5 hard).
+
+This "per-example" approach gives Helix the smallest possible retrieval corpus
+(~5-17 snippets) which degrades lexical IDF statistics.  See repobench_r_helix_global.py
+for the "global genome" arm which injects the whole candidate union into one corpus --
+a fairer test of Helix's retrieval pipeline at realistic corpus sizes.
+
+Reads the per-example dumps written by repobench_r.py (same examples as the foils),
+so random/overlap/bm25/helix are all scored on an IDENTICAL set.
+
+LLM-free, GPU-free (lexical config: dense/splade/ribosome OFF).
+Run in the helix063 venv DIRECTLY, never via uv (ProcessPoolExecutor/trampoline issue):
+  F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix.py
+
+Config:
+  HELIX_CONFIG env var or --helix-config flag -- path to a helix.toml with
+  dense/splade/ribosome all disabled (the "lexical probe" profile).
+  Defaults to the repo's docs/benchmarks/helix_probe_lexical.toml template.
+
+Writes:
+  benchmarks/results/repobench_r_{config}_helix_{timestamp}.json  (summary)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import gc
+import glob
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+# Default lexical-probe config search order.
+_DEFAULT_CONFIG_CANDIDATES = [
+    Path(__file__).resolve().parents[1] / "docs" / "benchmarks" / "helix_probe_lexical.toml",
+    Path("F:/tmp/cb_helix_probe/helix_probe.toml"),
+]
+
+GOLD_KEY = "golden_snippet_index"
+GOLD_KEY_ALT = "gold_snippet_index"
+
+
+def _find_default_config():
+    for p in _DEFAULT_CONFIG_CANDIDATES:
+        if Path(p).exists():
+            return str(p)
+    return None
+
+
+def _ks_for_level(level):
+    """acc@1/3 easy; acc@1/3/5 hard -- per strategy doc section 3."""
+    return [1, 3, 5] if level == "hard" else [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# Helix wiring
+# ---------------------------------------------------------------------------
+
+def build_helix(genome_dir, config_path):
+    """Build an in-process HelixContextManager with a fresh genome."""
+    os.environ.pop("HELIX_USE_SHARDS", None)
+    os.environ["HELIX_CONFIG"] = config_path
+    os.environ["HELIX_GENOME_PATH"] = os.path.join(genome_dir, "genome.db")
+    os.makedirs(genome_dir, exist_ok=True)
+
+    from helix_context.config import load_config
+    from helix_context.context_manager import HelixContextManager
+
+    return HelixContextManager(load_config())
+
+
+def gene_cand_idx(g):
+    """Recover the candidate index from a retrieved gene's source_id/metadata."""
+    src = getattr(g, "source_id", None)
+    if not src and getattr(g, "promoter", None) and g.promoter.metadata:
+        src = g.promoter.metadata.get("path")
+    if src and str(src).startswith("cand_"):
+        try:
+            return int(str(src).split("cand_", 1)[1])
+        except ValueError:
+            return None
+    return None
+
+
+def rank_helix(helix, query, n_cands):
+    """Rank candidate indices by best gene score (desc); unretrieved appended last."""
+    _eq, dom, ent = helix._prepare_query_signals(query, session_context=None,
+                                                 expand_query=False)
+    cands = helix._retrieve(dom, ent, 400, query_text=query, include_cold=None,
+                            party_id="default", use_harmonic=False, use_sr=False)
+    cands, _ = helix._apply_candidate_refiners(query, cands, 400, use_cymatics=False,
+                                               use_harmonic_bin=False, use_tcm=True,
+                                               allow_rerank=False)
+    base_scores = dict(helix.genome.last_query_scores or {})
+    best = {}
+    for g in cands:
+        ci = gene_cand_idx(g)
+        if ci is None:
+            continue
+        s = base_scores.get(g.gene_id, 0.0)
+        if ci not in best or s > best[ci]:
+            best[ci] = s
+
+    ranked = sorted(best, key=lambda i: best[i], reverse=True)
+    # Append candidates never retrieved (score 0) to complete the ranking.
+    ranked += [i for i in range(n_cands) if i not in best]
+    return ranked
+
+
+def process_example(payload, config_path, genome_root):
+    """Run one example in isolation -- build genome, ingest, rank, teardown."""
+    ex, ei = payload
+    gdir = os.path.join(genome_root, str(ei))
+    shutil.rmtree(gdir, ignore_errors=True)
+    helix = None
+    try:
+        helix = build_helix(gdir, config_path)
+        for i, c in enumerate(ex["candidates"]):
+            try:
+                helix.ingest(c, content_type="code", metadata={"path": f"cand_{i}"})
+            except Exception:  # noqa: BLE001
+                pass
+        order = rank_helix(helix, ex["query"], len(ex["candidates"]))
+        gold = ex["gold"]
+        ks = _ks_for_level(ex.get("level", "easy"))
+        return {"a": {k: (1.0 if gold in order[:k] else 0.0) for k in ks}}
+    except Exception as e:  # noqa: BLE001
+        return {"error": repr(e)}
+    finally:
+        try:
+            if helix is not None and getattr(helix, "genome", None) is not None:
+                cl = getattr(helix.genome, "close", None)
+                if callable(cl):
+                    cl()
+        except Exception:  # noqa: BLE001
+            pass
+        gc.collect()
+        shutil.rmtree(gdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Level runner
+# ---------------------------------------------------------------------------
+
+def run_level(level, config_name, helix_config, genome_root, limit, workers):
+    """Score one difficulty level; returns stats dict or None on missing dump."""
+    pattern = str(RESULTS_DIR / f"repobench_r_{config_name}_{level}_n*.json")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        print(
+            f"[{level}] no dump found at {pattern}\n"
+            f"  -> Run repobench_r.py first: "
+            f"python benchmarks/repobench_r.py --config {config_name}",
+            file=sys.stderr,
+        )
+        return None
+
+    rows = json.loads(Path(files[-1]).read_text(encoding="utf-8"))
+    if limit:
+        rows = rows[:limit]
+
+    # Tag each row with level so process_example knows which ks to use.
+    for r in rows:
+        r["level"] = level
+
+    ks = _ks_for_level(level)
+    payloads = [(ex, f"{level}_{i}") for i, ex in enumerate(rows)]
+    acc = {k: 0.0 for k in ks}
+    n = err = 0
+
+    if workers > 1:
+        # NOTE: run DIRECTLY (not via uv) to avoid ProcessPoolExecutor trampoline
+        # deadlock. Pass config_path and genome_root explicitly.
+        from concurrent.futures import ProcessPoolExecutor, as_completed
+        import functools
+
+        _fn = functools.partial(process_example, config_path=helix_config,
+                                genome_root=genome_root)
+        with ProcessPoolExecutor(max_workers=workers, max_tasks_per_child=20) as pool:
+            futs = {pool.submit(_fn, p): p for p in payloads}
+            for fut in as_completed(futs):
+                r = fut.result()
+                if r.get("error"):
+                    err += 1
+                    continue
+                for k in ks:
+                    acc[k] += r["a"].get(k, 0.0)
+                n += 1
+    else:
+        for p in payloads:
+            r = process_example(p, config_path=helix_config, genome_root=genome_root)
+            if r.get("error"):
+                err += 1
+                continue
+            for k in ks:
+                acc[k] += r["a"].get(k, 0.0)
+            n += 1
+
+    result = {"n": n, "err": err}
+    for k in ks:
+        result[f"helix_acc@{k}"] = round(acc[k] / n, 3) if n else 0.0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="RepoBench-R Helix per-example arm -- acc@k retrieval benchmark"
+    )
+    ap.add_argument(
+        "--config",
+        default="python_cff",
+        choices=["python_cff", "python_cfr", "java_cff", "java_cfr"],
+        help="Dataset config (must match dump written by repobench_r.py)",
+    )
+    ap.add_argument(
+        "--levels",
+        default="easy,hard",
+        help="Comma-separated difficulty levels",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap examples/level from dump (0 = all)",
+    )
+    ap.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Parallel workers (default 1; set >1 only when running DIRECTLY, not via uv)",
+    )
+    ap.add_argument(
+        "--helix-config",
+        default=None,
+        help="Path to lexical-probe helix.toml (dense/splade/ribosome OFF). "
+             "Falls back to HELIX_CONFIG env var, then repo default.",
+    )
+    ap.add_argument(
+        "--genome-root",
+        default=None,
+        help="Scratch dir for per-example genome DBs (default: auto temp dir)",
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Override output path for the summary JSON",
+    )
+    args = ap.parse_args()
+
+    helix_config = (
+        args.helix_config
+        or os.environ.get("HELIX_CONFIG")
+        or _find_default_config()
+    )
+    if not helix_config or not Path(helix_config).exists():
+        print(
+            "ERROR: No helix config found. Provide --helix-config or set HELIX_CONFIG.\n"
+            "  Expected a lexical-probe helix.toml (dense/splade/ribosome OFF).\n"
+            "  See docs/benchmarks/helix_probe_lexical.toml for a template.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    genome_root = args.genome_root or os.path.join(
+        os.environ.get("TEMP", "/tmp"), "repobench_r_genomes"
+    )
+    os.makedirs(genome_root, exist_ok=True)
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    levels = [x.strip() for x in args.levels.split(",") if x.strip()]
+
+    summary = {
+        "config": args.config,
+        "helix_config": helix_config,
+        "timestamp": ts,
+        "arm": "helix_per_example",
+        "levels": {},
+    }
+
+    for level in levels:
+        print(f"[{level}] running...", flush=True)
+        r = run_level(
+            level=level,
+            config_name=args.config,
+            helix_config=helix_config,
+            genome_root=genome_root,
+            limit=args.limit,
+            workers=args.workers,
+        )
+        if r is None:
+            continue
+        summary["levels"][level] = r
+        ks = _ks_for_level(level)
+        acc_str = "  ".join(f"acc@{k}={r[f'helix_acc@{k}']}" for k in ks)
+        print(f"[{level}] n={r['n']} err={r['err']}  {acc_str}", flush=True)
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        out_path = RESULTS_DIR / f"repobench_r_{args.config}_helix_{ts}.json"
+    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(f"\n-> {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/repobench_r_helix_global.py
+++ b/benchmarks/repobench_r_helix_global.py
@@ -1,0 +1,377 @@
+"""RepoBench-R (Step-1) Helix GLOBAL-genome arm.
+
+One persistent genome over the deduped union of ALL candidate snippets across both
+difficulty levels.  Scores two ways:
+
+  B (pool-rank, directly comparable to foils):
+      Retrieve globally, then rank ONLY this example's candidate set by score.
+      acc@1/3 (easy) and acc@1/3/5 (hard).  Directly comparable to repobench_r.py foils.
+
+  C (global-rank, realistic agent scenario):
+      Gold counts only if its snippet lands in the global top-k against the whole
+      corpus.  recall@1/3/5/10.  This is the real multi-project Helix use-case.
+
+Also computes a matched global-BM25 foil (floored-IDF Okapi, same identifier
+tokenizer) scored both ways.
+
+Motivation: the per-example arm (repobench_r_helix.py) gives each query a corpus
+of only ~5-17 snippets.  BM25 IDF is degenerate at that scale. A realistic
+deployment ingests many documents, so the global arm gives a fairer picture.
+
+LLM-free, GPU-free (lexical config).  Run DIRECTLY (not via uv):
+  F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix_global.py
+
+Reads per-example dumps from benchmarks/results/ (written by repobench_r.py).
+
+Writes:
+  benchmarks/results/repobench_r_{config}_global_{timestamp}.json
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import glob
+import json
+import math
+import os
+import re
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BENCH_DIR / "results"
+RESULTS_DIR.mkdir(exist_ok=True)
+
+_DEFAULT_CONFIG_CANDIDATES = [
+    Path(__file__).resolve().parents[1] / "docs" / "benchmarks" / "helix_probe_lexical.toml",
+    Path("F:/tmp/cb_helix_probe/helix_probe.toml"),
+]
+
+_TOK = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+
+def tok(s):
+    return _TOK.findall(s or "")
+
+
+def _find_default_config():
+    for p in _DEFAULT_CONFIG_CANDIDATES:
+        if Path(p).exists():
+            return str(p)
+    return None
+
+
+def _ks_for_level(level):
+    """acc@1/3 easy; acc@1/3/5 hard."""
+    return [1, 3, 5] if level == "hard" else [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# Floored-IDF BM25 over the global corpus.
+# Avoids the negative-IDF sink that affects the per-pool foil in repobench_r.py
+# on small candidate sets.
+# ---------------------------------------------------------------------------
+
+class BM25:
+    """Okapi BM25 with IDF floored at 0."""
+
+    def __init__(self, corpus_tokens, k1=1.5, b=0.75):
+        self.k1, self.b = k1, b
+        self.docs = corpus_tokens
+        self.N = len(corpus_tokens)
+        self.dl = [len(d) for d in corpus_tokens]
+        self.avgdl = (sum(self.dl) / self.N) if self.N else 0.0
+        df = defaultdict(int)
+        self.tf = []
+        for d in corpus_tokens:
+            f = defaultdict(int)
+            for t in d:
+                f[t] += 1
+            self.tf.append(f)
+            for t in f:
+                df[t] += 1
+        # Floor at 0 -- avoids negative IDF on high-frequency terms in small corpora.
+        self.idf = {
+            t: max(0.0, math.log((self.N - n + 0.5) / (n + 0.5) + 1.0))
+            for t, n in df.items()
+        }
+
+    def scores(self, q_tokens):
+        qset = set(q_tokens)
+        out = [0.0] * self.N
+        for i in range(self.N):
+            f = self.tf[i]
+            denom_dl = (
+                self.k1 * (1 - self.b + self.b * self.dl[i] / self.avgdl)
+                if self.avgdl
+                else self.k1
+            )
+            s = 0.0
+            for t in qset:
+                ft = f.get(t, 0)
+                if ft:
+                    s += self.idf.get(t, 0.0) * (ft * (self.k1 + 1)) / (ft + denom_dl)
+            out[i] = s
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Helix wiring
+# ---------------------------------------------------------------------------
+
+def build_helix(genome_dir, config_path):
+    os.environ.pop("HELIX_USE_SHARDS", None)
+    os.environ["HELIX_CONFIG"] = config_path
+    os.environ["HELIX_GENOME_PATH"] = os.path.join(genome_dir, "genome.db")
+    shutil.rmtree(genome_dir, ignore_errors=True)
+    os.makedirs(genome_dir, exist_ok=True)
+    from helix_context.config import load_config
+    from helix_context.context_manager import HelixContextManager
+    return HelixContextManager(load_config())
+
+
+def gene_sid(g):
+    """Recover the snippet index from a retrieved gene's source_id/metadata."""
+    src = getattr(g, "source_id", None)
+    if not src and getattr(g, "promoter", None) and g.promoter.metadata:
+        src = g.promoter.metadata.get("path")
+    if src and str(src).startswith("snip_"):
+        try:
+            return int(str(src).split("snip_", 1)[1])
+        except ValueError:
+            return None
+    return None
+
+
+def helix_sid_scores(helix, query, n_corpus):
+    """Return {sid: best_score} for this query over the whole genome."""
+    _eq, dom, ent = helix._prepare_query_signals(query, session_context=None,
+                                                 expand_query=False)
+    cands = helix._retrieve(dom, ent, n_corpus, query_text=query, include_cold=None,
+                            party_id="default", use_harmonic=False, use_sr=False)
+    cands, _ = helix._apply_candidate_refiners(query, cands, n_corpus,
+                                               use_cymatics=False,
+                                               use_harmonic_bin=False,
+                                               use_tcm=True, allow_rerank=False)
+    raw = dict(helix.genome.last_query_scores or {})
+    best = {}
+    for g in cands:
+        sid = gene_sid(g)
+        if sid is None:
+            continue
+        s = raw.get(g.gene_id, 0.0)
+        if sid not in best or s > best[sid]:
+            best[sid] = s
+    return best
+
+
+def rank_pool(score_of, cand_sids):
+    """B-mode: rank this example's candidate indices by global score (missing = 0)."""
+    return sorted(range(len(cand_sids)), key=lambda j: (-score_of(cand_sids[j]), j))
+
+
+def global_rank_pos(scores_by_sid, gold_sid):
+    """C-mode: 0-based position of gold_sid in the full corpus ranking."""
+    order = sorted(scores_by_sid.keys(), key=lambda s: (-scores_by_sid[s], s))
+    pos = {s: i for i, s in enumerate(order)}
+    if gold_sid in pos:
+        return pos[gold_sid]
+    # Gold was never retrieved: place it after all scored items.
+    return len(order)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="RepoBench-R Helix global-genome arm -- B (pool-rank) + C (global-rank)"
+    )
+    ap.add_argument(
+        "--config",
+        default="python_cff",
+        choices=["python_cff", "python_cfr", "java_cff", "java_cfr"],
+        help="Dataset config (must match dump written by repobench_r.py)",
+    )
+    ap.add_argument(
+        "--levels",
+        default="easy,hard",
+        help="Comma-separated difficulty levels",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap examples/level (0 = all from dump)",
+    )
+    ap.add_argument(
+        "--helix-config",
+        default=None,
+        help="Path to lexical-probe helix.toml. Falls back to HELIX_CONFIG env var.",
+    )
+    ap.add_argument(
+        "--genome-dir",
+        default=None,
+        help="Directory for the global genome DB (default: auto temp dir)",
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Override output path for the summary JSON",
+    )
+    args = ap.parse_args()
+
+    helix_config = (
+        args.helix_config
+        or os.environ.get("HELIX_CONFIG")
+        or _find_default_config()
+    )
+    if not helix_config or not Path(helix_config).exists():
+        print(
+            "ERROR: No helix config found. Provide --helix-config or set HELIX_CONFIG.\n"
+            "  See docs/benchmarks/helix_probe_lexical.toml for a template.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    genome_dir = args.genome_dir or os.path.join(
+        os.environ.get("TEMP", "/tmp"), "repobench_r_global_genome"
+    )
+    ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    levels = [x.strip() for x in args.levels.split(",") if x.strip()]
+
+    # ---- Load per-example dumps ----
+    rows_by_level = {}
+    for lv in levels:
+        pattern = str(RESULTS_DIR / f"repobench_r_{args.config}_{lv}_n*.json")
+        files = sorted(glob.glob(pattern))
+        if not files:
+            print(
+                f"[{lv}] no dump found at {pattern}\n"
+                f"  -> Run: python benchmarks/repobench_r.py --config {args.config}",
+                file=sys.stderr,
+            )
+            continue
+        rows = json.loads(Path(files[-1]).read_text(encoding="utf-8"))
+        if args.limit:
+            rows = rows[: args.limit]
+        rows_by_level[lv] = rows
+
+    if not rows_by_level:
+        print("ERROR: No dump files found. Run repobench_r.py first.", file=sys.stderr)
+        sys.exit(1)
+
+    # ---- Build deduped global corpus ----
+    content2sid = {}
+    sid2content = []
+    for lv in levels:
+        for ex in rows_by_level.get(lv, []):
+            for c in ex["candidates"]:
+                if c not in content2sid:
+                    content2sid[c] = len(sid2content)
+                    sid2content.append(c)
+    n_corpus = len(sid2content)
+    total_examples = sum(len(rows_by_level.get(lv, [])) for lv in levels)
+    print(
+        f"global corpus: {n_corpus} unique snippets "
+        f"(from {total_examples} examples across {len(rows_by_level)} level(s))",
+        flush=True,
+    )
+
+    # ---- Ingest into Helix ----
+    helix = build_helix(genome_dir, helix_config)
+    ing_err = 0
+    for sid, content in enumerate(sid2content):
+        try:
+            helix.ingest(content, content_type="code", metadata={"path": f"snip_{sid}"})
+        except Exception:  # noqa: BLE001
+            ing_err += 1
+    print(f"ingested {n_corpus - ing_err}/{n_corpus} ({ing_err} ingest errors)",
+          flush=True)
+
+    # ---- BM25 over global corpus ----
+    bm = BM25([tok(c) for c in sid2content])
+
+    # k values for global C-mode recall (fixed across levels).
+    C_KS = (1, 3, 5, 10)
+
+    summary = {
+        "config": args.config,
+        "helix_config": helix_config,
+        "timestamp": ts,
+        "arm": "helix_global",
+        "corpus_size": n_corpus,
+        "ingest_errors": ing_err,
+        "levels": {},
+    }
+
+    for lv in levels:
+        rows = rows_by_level.get(lv, [])
+        B_KS = _ks_for_level(lv)
+        agg = {
+            "helix": {"B": {k: 0.0 for k in B_KS}, "C": {k: 0.0 for k in C_KS}},
+            "bm25":  {"B": {k: 0.0 for k in B_KS}, "C": {k: 0.0 for k in C_KS}},
+        }
+        n = 0
+
+        for ex in rows:
+            cands = ex["candidates"]
+            gold_local = ex["gold"]
+            if not cands or gold_local < 0 or gold_local >= len(cands):
+                continue
+            cand_sids = [content2sid[c] for c in cands]
+            gold_sid = content2sid[cands[gold_local]]
+            q = ex["query"]
+
+            # -- Helix --
+            h = helix_sid_scores(helix, q, n_corpus)
+            h_score = lambda s: h.get(s, 0.0)
+            h_pool = rank_pool(h_score, cand_sids)
+            for k in B_KS:
+                agg["helix"]["B"][k] += 1.0 if gold_local in h_pool[:k] else 0.0
+            h_pos = global_rank_pos(h, gold_sid)
+            for k in C_KS:
+                agg["helix"]["C"][k] += 1.0 if h_pos < k else 0.0
+
+            # -- BM25 --
+            bs = bm.scores(tok(q))
+            b_score = lambda s: bs[s]
+            b_pool = rank_pool(b_score, cand_sids)
+            for k in B_KS:
+                agg["bm25"]["B"][k] += 1.0 if gold_local in b_pool[:k] else 0.0
+            b_order = sorted(range(n_corpus), key=lambda s: (-bs[s], s))
+            b_pos = b_order.index(gold_sid)
+            for k in C_KS:
+                agg["bm25"]["C"][k] += 1.0 if b_pos < k else 0.0
+
+            n += 1
+
+        lvl = {"n": n, "corpus": n_corpus}
+        for arm in ("helix", "bm25"):
+            for k in B_KS:
+                lvl[f"{arm}_B_acc@{k}"] = round(agg[arm]["B"][k] / n, 3) if n else 0.0
+            for k in C_KS:
+                lvl[f"{arm}_C_recall@{k}"] = round(agg[arm]["C"][k] / n, 3) if n else 0.0
+        summary["levels"][lv] = lvl
+
+        b_str = "  ".join(f"B@{k}={lvl[f'helix_B_acc@{k}']}" for k in B_KS)
+        c_str = "  ".join(f"C@{k}={lvl[f'helix_C_recall@{k}']}" for k in C_KS)
+        print(f"[{lv}] n={n}  HELIX {b_str} | {c_str}", flush=True)
+
+        bm_b = "  ".join(f"B@{k}={lvl[f'bm25_B_acc@{k}']}" for k in B_KS)
+        bm_c = "  ".join(f"C@{k}={lvl[f'bm25_C_recall@{k}']}" for k in C_KS)
+        print(f"[{lv}]   BM25 {bm_b} | {bm_c}", flush=True)
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        out_path = RESULTS_DIR / f"repobench_r_{args.config}_global_{ts}.json"
+    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(f"\n-> {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/architecture/2026-06-07-pipeline-and-switchboard.md
+++ b/docs/architecture/2026-06-07-pipeline-and-switchboard.md
@@ -1,0 +1,454 @@
+# Helix Retrieval Pipeline + Switchboard Architecture
+
+Status: as-shipped reference (2026-06-07)
+Scope: ingestion -> switchboard/routing -> tiered retrieval -> fusion -> scoring -> delivery
+
+## Provenance
+
+This document records the **as-shipped behavior of the helix063 wheel** (the
+measured artifact behind the 2026-06-07 code-context benchmark sweep), located at:
+
+```
+F:/Projects/_venvs/helix063/Lib/site-packages/helix_context/
+```
+
+The source-repo `master` is stale (local master is 0.5.0; shipped tags are
+v0.6.2 / v0.6.3). **Verify every claim against the wheel, not the source tree.**
+All `file:line` citations below are relative to the wheel package root above
+unless otherwise noted. The retrieval entry method is named `query_docs()` in
+the code (the brief's informal "query_genes()"); the genes/documents vocabulary
+is the Helix bio-Rosetta for "documents/chunks".
+
+---
+
+## 0. Executive summary
+
+Helix `query_docs()` is a **single shared multi-tier retrieval engine** used by
+both prose corpora (EnterpriseRAG) and code corpora (RepoBench-R / CodeRAG-Bench).
+It accumulates per-document scores across lexical, sparse, and dense tiers, then
+ranks. The default fusion strategy is **`additive`** (`gene_scores += tier_score`),
+NOT rank fusion.
+
+**Known scoring defect (2026-06-07):** under the default `additive` fusion the
+IDF-free tag tiers (`tag_exact` x3.0, `tag_prefix` x1.5) inject flat,
+query-independent "magnet" mass that buries the true gold, whose IDF-correct
+FTS5/BM25 advantage is **capped at 6.0**. Flipping `fusion_mode -> rrf`
+(already in the wheel) recovers most of the loss. See Section 7.
+
+```
+INGEST                 SWITCHBOARD            RETRIEVE (query_docs)        DELIVER
+------                 -----------            ---------------------        -------
+content                query_type hint  -->  Tier 1  tag_exact      x3.0
+  | spaCy/extract      (caller-supplied)     Tier 2  tag_prefix     x1.5
+  v                    classify_query   -->  Tier 3  FTS5 (cap 6.0)        sort by
+genes + tags           (decoder_mode,        Tier 3.5 SPLADE (off)         last_query_scores
+promoter_index         max_genes cap)        Tier 4  dense / SEMA          per-gene budget
+genes_fts (FTS5)       shard_router     -->  Tier .5 filename_anchor       context packet
+entity_graph           (which shards)        lex_anchor (IDF)
+embedding_dense_v2                           authority / harmonic
+                                             --------- FUSION ---------
+                                             additive (default) | rrf
+                                             --------- REFINERS -------
+                                             cymatics / harmonic_bin /
+                                             tcm / rerank (off)
+```
+
+---
+
+## 1. Ingestion pipeline
+
+Ingestion turns raw content into the SQLite artifacts each retrieval tier reads.
+One genome = one SQLite DB (sharded; see Section 8).
+
+| Artifact | Produced from | Read by tier |
+|---|---|---|
+| `genes` table | document chunk + metadata (`source_id`, `content`, `chromatin` lifecycle) | all (final row fetch, lifecycle gate) |
+| `promoter_index` (gene_id, tag_value) | extracted domains+entities tags | Tier 1 `tag_exact`, Tier 2 `tag_prefix`, `lex_anchor` IDF |
+| `genes_fts` (FTS5 virtual table over content + complement) | full chunk text + promoter tags | Tier 3 FTS5, bm25 prefilter/shortlist |
+| `entity_graph` | entity co-occurrence | Tier 5b entity-graph boost (off by default) |
+| `embedding_dense_v2` (BGE-M3 1024-d) | dense encode at ingest | Tier 4 dense recall |
+| `splade_terms` | SPLADE sparse expansion (off by default) | Tier 3.5 SPLADE |
+
+Key mechanics:
+- `promoter_index` is (re)built per gene by `rebuild_promoter_index(cur, gene_id, gene)` (`knowledge_store.py:1224-1231`).
+- `genes_fts` is a content+complement FTS5 index; rebuild SQL at `knowledge_store.py:3623-3635` (`INSERT INTO genes_fts(gene_id, content, complement) ...` joining `promoter_index`).
+- **Dense write at ingest** is gated by `_dense_embed_on_ingest` (`knowledge_store.py:460`, consumed `:2610-2632`). Config default `[ingestion] dense_embed_on_ingest = True` (`config.py:230`); independent of the retrieval gate `dense_embedding_enabled`.
+
+**Lexical-probe ingest config** (the code-context benchmark setup) disables the
+two model-heavy ingest stages:
+- `[ingestion] dense_embed_on_ingest = false` -> no BGE-M3 vectors written (Tier 4 dark).
+- `[ingestion] splade_enabled = false` -> no `splade_terms` table (Tier 3.5 never fires; default already off, `config.py:218`).
+
+This leaves a pure lexical corpus: `genes` + `promoter_index` + `genes_fts`. The
+benchmark therefore measures the lexical/tag fusion path in isolation -- which is
+exactly where the magnet defect in Section 7 lives.
+
+---
+
+## 2. Switchboard / Tier-0 routing
+
+The "switchboard" is **not** a single module; it is a thin, cheap, LLM-free
+routing layer assembled from three distinct mechanisms. None of them does
+automatic basic-vs-semantic classification -- `query_type` is a **caller-supplied
+per-call hint**, not an inferred label.
+
+### 2.1 `query_type` (basic | semantic) -- caller-supplied
+
+```
+client request body
+  --> data.get("query_type")            routes_context.py:269  (/context)
+                                         routes_context.py:738  (/fingerprint)
+  --> build_context / _retrieve         context_manager.py:1041, 2108
+  --> query_docs(query_type=...)        knowledge_store.py:1488
+  --> shard_router.route(query_type=...) shard_router.py:375
+```
+
+- Parsed from the request body, lowercased, defaulting to `None`
+  (`routes_context.py:269`, `:738`). The comment is explicit: *"Production
+  callers omit it ... a runtime semantic detector is a separate track"*
+  (`routes_context.py:733-737`). The bench injects the needle's ground-truth
+  type to A/B the semantic arm.
+- `query_type=="semantic"` changes retrieval **only** when env
+  `HELIX_SEMANTIC_ARM=1`, in two coupled places:
+  1. **Dense weight scaling** (`knowledge_store.py:2119-2120`): the additive-mode
+     dense term is scaled by `_semantic_dense_additive_weight` (default 12.0,
+     `config.py:397`) instead of `_dense_additive_weight` (4.0). Env override
+     `HELIX_SEMANTIC_DENSE_WEIGHT` (`knowledge_store.py:2124-2128`).
+  2. **Routing broaden** (`shard_router.py:393-401`): bypass the LIKE shard
+     gate, fan out to **all healthy shards** so dense-top golds in
+     literal-mismatched shards still enter the pool. Disable with
+     `HELIX_SEMANTIC_BROADEN=0` (`shard_router.py:397-399`).
+- Any other `query_type` value, or the arm off, is **byte-identical** to
+  baseline. The dense-ANN solo branch (`query_docs_ann`) is deliberately NOT
+  threaded with `query_type` -- the arm is sharded-only
+  (`context_manager.py:2112-2116`).
+
+### 2.2 Injection-router query classifier (decoder_mode + max_genes cap)
+
+A separate, pure regex classifier shapes **delivery**, not retrieval-tier gating:
+`retrieval/query_classifier.py`.
+
+- `classify_query()` (`query_classifier.py:147`) buckets the NL query into
+  `arithmetic | factual | procedural | multi_hop | default` via keyword/operator
+  scans (`:160-208`). Infallible by construction (returns `default` on error).
+- Each class carries an `assembly_max_genes_cap` and a `decoder_mode`
+  (`query_classifier.py:162-206`): e.g. arithmetic caps to 2 genes / `minimal`
+  decoder; factual 5 / `condensed`; procedural 6 / `full`; multi_hop 8 / `full`.
+- `resolve_decoder_mode(cls, caller_model_class)` (`:133`) maps the class x
+  caller-model matrix (`DECODER_MODE_TABLE`, `:124-130`) to a final decoder mode.
+- This influences how much context is assembled and how it is framed; it does
+  **not** turn tiers on/off.
+
+### 2.3 Shard router (which shards fire)
+
+`shard_router.py:route()` (`:371`) selects shards by a LIKE scan over
+`fingerprint_index.domains/entities` ordered by hit count (`:417-428`). Empty
+query or no terms -> all healthy shards (`:404-405`). The semantic-arm broaden
+(2.1) is the only behavior that ignores the LIKE gate.
+
+### 2.4 Intent router (sub-query templates)
+
+`retrieval/intent_router.py` maps an `IntentClass` to 3 point-fact sub-query
+templates (`intent_router.py:12-64`). Used by the LLM-free decomposition path
+only; orthogonal to the per-call tier scoring.
+
+**Switchboard summary:** routing is cheap and signal-light. The only retrieval
+behavior it gates is the (default-off) semantic dense arm. Everything else is
+delivery shaping (decoder_mode, max_genes cap) and shard selection.
+
+---
+
+## 3. Retrieval pipeline, tier by tier
+
+Entry: `query_docs(domains, entities, max_genes, ..., query_type, question_text)`
+at `knowledge_store.py:1478`. `limit = max_genes * 2` (`:1530`). A `Fuser`
+(Section 4) is built unconditionally (`:1574-1575`) but only *consulted* under
+`fusion_mode == "rrf"`.
+
+Per-tier accumulation writes BOTH `gene_scores[gid] += tier_score` (additive
+path) AND `fuser.add_tier(name, ranked_list, weight)` (rrf path).
+
+### 3.1 Tier table (as-shipped weights)
+
+| # | Tier | Additive contribution | IDF-weighted? | RRF raw score fed | Default | Cite |
+|---|---|---|---|---|---|---|
+| 0.5 | filename_anchor | `+filename_anchor_weight` per stem match (4.0) | No | per-match contrib | OFF (`filename_anchor_enabled=False`) | `:1739-1748`; cfg `config.py:302-303` |
+| 1 | tag_exact | `match_count * 3.0` | **No (flat magnet)** | raw `match_count*3.0` | ON | `:1771-1778` |
+| 2 | tag_prefix | `match_count * 1.5` | **No (flat magnet)** | raw `match_count*1.5` | ON | `:1811-1815` |
+| 3 | FTS5 | `min(-rank, 6.0)` **(capped)** | Yes (BM25) | **raw uncapped `-rank`** | ON if FTS available | `:1865-1874` |
+| 3.5 | SPLADE | `min(score,20)*3.5/20` | Sparse-learned | raw uncapped score | OFF (`splade_enabled=False`) | `:1904-1911`; cfg `config.py:218` |
+| 4 | dense / SEMA | additive: `cosine * dense_additive_weight` (4.0) | dense (cosine) | raw cosine | ON (`dense_embedding_enabled=True`) | `:2118-2137`, `:2082-2096`; cfg `config.py:323` |
+| 4b | lex_anchor (IDF) | `min(idf*1.5, 3.0)` per term, summed | **Yes** | summed contrib | ON | `:2174-2200` |
+| 5 | harmonic co-activation | per-link 1.0, cap 3.0 | n/a (graph) | per-link | ON if links present | `:2212-2224` |
+| 5b | entity_graph | `entity_graph_weight` (0.5) | n/a (graph) | overlap | OFF (`entity_graph_retrieval_enabled=False`) | cfg `config.py:317` |
+| RR | authority/recency | +2.0 source / +1.5 domain / +0.5 recency | n/a (re-rank) | additive on fused | ON | `:1321-1326`, applied `:2206-2210` |
+
+Notes on the load-bearing constants:
+- **tag_exact** literal `r["match_count"] * 3.0` (`knowledge_store.py:1771`).
+- **tag_prefix** literal `r["match_count"] * 1.5` (`knowledge_store.py:1811`).
+- **FTS5 cap** literal `fts_score = min(-fts_ranks[gid], 6.0)` with the code
+  comment *"(was 15*3=45 -- drowned out tag matches at 3-9)"*
+  (`knowledge_store.py:1864-1865`). The RRF path is fed the **uncapped**
+  `-fts_ranks[gid]` (`:1873`) precisely so rank order survives cap saturation.
+- **lex_anchor** is a genuinely IDF-weighted tier (`idf = log(total/term_freq)`,
+  `boost = min(idf*1.5, 3.0)`, only applied when `boost > 1.0`)
+  (`knowledge_store.py:2174-2176`). It is *separate* from tag_exact/tag_prefix and
+  partially offsets -- but does not cure -- the flat-magnet problem, because its
+  cap (3.0) is below the magnet mass a boilerplate doc accrues from many common
+  tokens (~6 tokens x 3.0 = ~18 on tag_exact alone).
+
+### 3.2 Dense recall is first-class in BOTH modes (since Tier-0 PR-3)
+
+`dense_embedding_enabled` alone gates dense recall (`knowledge_store.py:2052`);
+the old `and fusion_mode=="rrf"` gate was removed (`:2035-2041`) -- so the
+ingest-time BGE-M3 vectors are no longer dark under the default additive mode.
+`fusion_mode` only decides HOW dense enters:
+- **rrf**: `fuser.add_tier("dense", dense_hits, weight=dense_weight)` (`:2082-2086`).
+- **additive**: `gene_scores[gid] += cosine * dense_additive_weight` above the
+  `dense_additive_min_cosine` (0.15) floor (`:2130-2137`).
+
+Note: with `dense_embedding_enabled=True` (shipped default), `_retrieve` routes
+to `query_docs_ann` (the ANN-threshold path), NOT `query_docs`
+(`context_manager.py:2146-2159`). The `query_type` semantic arm is threaded only
+through the **`query_docs` sharded path** (`:2160-2172`), i.e. it engages when
+dense retrieval is OFF or in the sharded merge -- a subtlety relevant to the
+2026-06-07 reconciliation (Section 7).
+
+### 3.3 Candidate gating
+
+- **BM25 prefilter** (pre-scoring): `bm25_prefilter_enabled` -> `_bm25_candidate_set`
+  scopes every tier's SQL to FTS5 top-N (`knowledge_store.py:1534-1547`,
+  helper `:1455-1474`). Default OFF; size 200 (`config.py:312-313`).
+- **BM25 shortlist** (post-scoring filter): `bm25_shortlist_enabled` -> after all
+  tiers, drop any `gene_scores` gene not in FTS5 top-N (`:2415-2444`). Default OFF;
+  size 50 (`config.py:310-311`). Mutually exclusive with prefilter
+  (`:2417`, "don't double-filter").
+- In both the code and prose benches the gold is confirmed present in the BM25
+  shortlist and scored -- the defect is **ranking**, not candidate generation.
+
+---
+
+## 4. Fusion: `additive` (default) vs `rrf`
+
+`retrieval/fusion.py` -- a pure `Fuser` data structure (no SQL, no telemetry).
+
+`score(d) = sum over tiers t of  weight_t * 1/(k + rank_t(d))`, k=60 Cormack
+default (`fusion.py:13-19, 42, 122-127`). Ranks are computed by sorting each
+tier's `(gid, raw_score)` list `(-score, gid)` (`:117-120`) -- so the raw scores
+only determine ORDER, never magnitude. This is why the FTS5 tier feeds the
+**uncapped** `-rank` to the Fuser: under RRF the 6.0 cap is irrelevant, only the
+relative order matters.
+
+Final-ranking branch (`knowledge_store.py:2451-2494`):
+- **additive (DEFAULT, `config.py:369`)**: `ranked_ids = sorted(gene_scores, key=gene_scores.get, reverse=True)[:limit]` (`:2492-2494`). The Fuser is built but never queried (`:1565-1567`). `last_query_scores = gene_scores` accumulator.
+- **rrf**: `fused_scores = fuser.all_scores()`, plus `rerank_additive` (authority etc.) on top, restricted to genes surviving the shortlist filter, then sorted (`:2459-2483`). `last_query_scores = final fused+additive` (`:2482-2483`).
+
+**Crucial:** because additive is the default, the live ranking is dominated by
+raw, non-commensurate tier magnitudes. The module docstring itself warns that
+summing non-commensurate scores *"lets one over-scaled tier dominate"*
+(`fusion.py:8-11`) -- which is exactly the observed magnet failure.
+
+---
+
+## 5. Scoring -> ranking -> delivery
+
+1. **Tier accumulation** -> `gene_scores` + parallel `tier_contrib[gid][tier]`
+   (`knowledge_store.py:1556`, surfaced as `last_tier_contributions`).
+2. **Authority / harmonic / SR re-rank** additives (`:2206-2224`).
+3. **Optional gates**: bm25 shortlist (`:2415-2444`), walking tie-break
+   (`HELIX_WALKING_TIEBREAK=1`, `:2504-2511`), Hebbian seeded-edge writeback
+   (`:2521-2528`).
+4. **Final sort** -> `ranked_ids` (`:2459-2494`); rows fetched and order
+   preserved (`:2530-2539`); co-activation pull-forward + dedupe (`:2542-2552`).
+5. `self.last_query_scores` is set (additive accumulator or rrf fused map). The
+   orchestrator reads it via `genome.last_query_scores` under a lock
+   (`context_manager.py:1223-1224`) for: candidate sort by score
+   (`context_manager.py:2376-2380`), small_moe answer slate best-first
+   (`:1433-1442`), and trim ordering (`:2567-2583`).
+6. **Refiners** (`_apply_candidate_refiners` -> `scoring/blend.py`): cymatics
+   (`blend.py:52-74`), cross-encoder **rerank** (`:87-118`, gated on
+   `rerank_enabled` AND a ribosome with `.rerank` -- both OFF in the probe;
+   `config.py:220` default `False`), harmonic_bin (`:120-151`), tcm
+   (`:153-166`). All bonuses fold back into `last_query_scores` and re-sort.
+7. **Per-gene budget / context packet**: `compute_uniform_targets(...)`
+   (`context_manager.py:1463-1473`) allocates per-gene char budgets;
+   `per_gene_budget` mode `fixed` (1000 chars) vs `dynamic` (floor-then-greedy
+   fill of `expression_tokens` headroom up to `per_gene_ceiling_chars`). Optional
+   content-aware surplus keyed on a tier's `tier_contrib`
+   (`per_gene_budget_relevance_signal`, `:1456-1462`). The assembled window is
+   wrapped and returned via `/context`; `/context/packet` returns a
+   freshness-labeled evidence packet (`routes_context.py:546-547`).
+
+### Endpoints (`server/routes_context.py`)
+| Endpoint | Handler | query_type thread |
+|---|---|---|
+| `POST /context` | `context_endpoint` (`:151`) | yes (`:269` -> `build_context_async :271-283`) |
+| `POST /context/packet` | `context_packet_endpoint` (`:546`) | evidence packet path |
+| `POST /fingerprint` | `fingerprint_endpoint` (`:662`) | yes (`:738` -> `_retrieve :753-763`) -- recall path |
+
+---
+
+## 6. Config knob map
+
+`[retrieval]` / `[ingestion]` keys map to Genome ctor kwargs in `config.py`
+(`:729-827`). Defaults are the as-shipped `RetrievalConfig` / `IngestionConfig`
+dataclass values.
+
+| Knob | Section | Default | Effect | Cite |
+|---|---|---|---|---|
+| `fusion_mode` | retrieval | `additive` | `additive` = sum tier scores; `rrf` = rank fusion | `config.py:369`, applied `knowledge_store.py:2459` |
+| `rrf_k` | retrieval | `60` | RRF saturation constant | `config.py:370` |
+| `tag_exact_weight` | retrieval | `3.0` | Tier-1 magnet weight (RRF post-mult; additive uses literal x3.0) | `config.py:373`; `knowledge_store.py:1771` |
+| `tag_prefix_weight` | retrieval | `1.5` | Tier-2 magnet weight | `config.py:374`; `:1811` |
+| `fts5_weight` | retrieval | `3.0` | RRF post-mult for FTS5 (additive uses min(-rank,6.0) cap) | `config.py:371`; `:1865` |
+| `splade_weight` | retrieval | `3.5` | RRF post-mult for SPLADE | `config.py:372` |
+| `lex_anchor_weight` | retrieval | `1.5` | IDF anchor multiplier (additive caps at 3.0) | `config.py:376`; `:2175` |
+| `dense_weight` | retrieval | `1.0` | RRF post-mult for dense | `config.py:379` |
+| `dense_additive_weight` | retrieval | `4.0` | additive-mode dense cosine scale | `config.py:384`; `:2118` |
+| `dense_additive_min_cosine` | retrieval | `0.15` | additive dense noise floor | `config.py:390`; `:2131` |
+| `semantic_dense_additive_weight` | retrieval | `12.0` | dense scale when query_type==semantic AND HELIX_SEMANTIC_ARM=1 | `config.py:397`; `:2120` |
+| `semantic_broaden_routing` | retrieval | `True` | broaden to all shards under semantic arm | `config.py:398`; `shard_router.py:393` |
+| `dense_embedding_enabled` | retrieval | `True` | gate Tier-4 dense recall (routes _retrieve to query_docs_ann) | `config.py:323`; `:2052` |
+| `dense_embedding_dim` | retrieval | `1024` | BGE-M3 Matryoshka dim | `config.py:327` |
+| `ann_similarity_threshold` | retrieval | `0.58` | ANN dynamic-count cut (dim-1024 calibrated) | `config.py:334` |
+| `ann_threshold_min_genes` | retrieval | `1` | ANN floor count | `config.py:335` |
+| `ann_threshold_max_genes` | retrieval | `12` | ANN ceiling count (cap-collapse prod note) | `config.py:336` |
+| `dense_pool_size` | retrieval | `500` | dense recall candidate pool | `config.py:348` |
+| `dense_prefilter_enabled` | retrieval | `False` | scope dense matmul to lex/SPLADE candidates | `config.py:354` |
+| `bm25_prefilter_enabled` | retrieval | `False` | scope all tiers to FTS5 top-N before scoring | `config.py:312`; `:1534` |
+| `bm25_prefilter_size` | retrieval | `200` | prefilter top-N | `config.py:313` |
+| `bm25_shortlist_enabled` | retrieval | `False` | drop non-FTS5-top-N genes before final sort | `config.py:310`; `:2415` |
+| `bm25_shortlist_size` | retrieval | `50` | shortlist top-N | `config.py:311` |
+| `filename_anchor_enabled` | retrieval | `False` | Tier-0.5 filename-stem boost | `config.py:302`; `:1739` |
+| `filename_anchor_weight` | retrieval | `4.0` | per-stem-match boost | `config.py:303` |
+| `entity_graph_retrieval_enabled` | retrieval | `False` | Tier-5b entity co-occurrence boost | `config.py:317` |
+| `sr_enabled` | retrieval | `False` | Successor-Representation graph boost (dark) | `config.py:284` |
+| `seeded_edges_enabled` | retrieval | `False` | Hebbian edge evidence writeback | `config.py:296` |
+| `splade_enabled` | ingestion | `False` | write `splade_terms` + Tier-3.5 SPLADE | `config.py:218` |
+| `dense_embed_on_ingest` | ingestion | `True` | write BGE-M3 vectors at ingest | `config.py:230` |
+| `rerank_enabled` | ingestion | `False` | cross-encoder rerank refiner (needs ribosome) | `config.py:220`; `blend.py:89-93` |
+
+Env switches (not in helix.toml): `HELIX_SEMANTIC_ARM`, `HELIX_SEMANTIC_BROADEN`,
+`HELIX_SEMANTIC_DENSE_WEIGHT`, `HELIX_QUESTION_DENSE`, `HELIX_WALKING_TIEBREAK`,
+`HELIX_RERANK_CAPTURE`/`HELIX_RERANK_DIAG`.
+
+---
+
+## 7. 2026-06-07 findings / known issues
+
+A code-context benchmark sweep (RepoBench-R, CodeRAG-Bench) exposed a
+**re-ranking defect in the default `additive` fusion**. Verified against the
+wheel code as cited.
+
+### 7.1 Symptom
+
+CodeRAG-Bench canonical retrieval (programming-solutions, 1128 docs;
+HumanEval 164 + MBPP 500 queries) is **lexically saturated** -- the gold doc
+embeds the query verbatim -- so plain BM25 scores NDCG@10 = 0.998 (HumanEval) /
+0.982 (MBPP). Helix under `fusion_mode=additive` scored only
+**NDCG@10 = 0.439 / 0.332** -- missing the obvious gold ~35-41% of the time even
+at rank 10.
+
+### 7.2 Root cause (confirmed by per-query diagnostic)
+
+The gold is ALWAYS in Helix's BM25 shortlist and scored, but the ranking buries
+it:
+
+- IDF-free `tag_exact` (`match_count * 3.0`, `knowledge_store.py:1771`) and
+  `tag_prefix` (`* 1.5`, `:1811`) accumulate **flat, query-independent magnet
+  mass** (~18 = ~6 common tokens x 3.0) on boilerplate-dense docs.
+- The gold's IDF-correct FTS5/BM25 advantage is **capped at 6.0**
+  (`fts_score = min(-fts_ranks[gid], 6.0)`, `:1865`) -- the literal code comment
+  *"(was 15*3=45 -- drowned out tag matches at 3-9)"* documents that the cap was
+  intentionally lowered to stop FTS5 dominating tags. The cap now over-corrects:
+  a boilerplate-dense doc matching many common tokens outranks the true gold
+  even at 100% query-token overlap.
+- The IDF-weighted `lex_anchor` tier (`:2174-2176`) exists and helps, but its own
+  3.0 cap is below the magnet mass, so it cannot fully recover the gold.
+
+This is a structural consequence of **additive** fusion summing
+non-commensurate tiers -- the exact failure the `fusion.py` docstring warns
+about (`fusion.py:8-11`).
+
+### 7.3 Fix demonstrated (config-only; RRF already in the wheel)
+
+Flipping `fusion_mode -> rrf`:
+- HumanEval NDCG@10 0.439 -> **0.684** (r@1 0.268 -> **0.549**, 2x; r@10 0.652 -> **0.823**).
+- MBPP NDCG@10 0.332 -> **0.404**.
+
+Still below BM25's 0.998 because the IDF-free tag tiers still inject rank-noise
+into the fused order (each magnet doc still earns a high tag rank). The FULL fix
+is to **IDF-weight the tag tiers** (so common-token matches stop contributing
+flat magnet mass) and/or **lift the FTS5 6.0 cap** (so true BM25 ordering
+survives in additive mode). Both are code changes, not config.
+
+### 7.4 Systemic implication (prose confound)
+
+`query_docs()` is the SHARED retrieval engine for prose (EnterpriseRAG) and
+code. Since `additive` is the default (`config.py:369`), the same magnet bug
+**suppresses prose basic-recall too**. This means the prior *"the encoder is the
+recall lever"* conclusion is **confounded for the basic/lexical bucket** -- the
+basic-recall ceiling may be a fusion-ranking artifact, not an embedding-geometry
+limit. Only the pure *semantic* bucket (paraphrase, ~zero surface overlap)
+genuinely needs the dense encoder.
+
+**Pending confirming experiment:** re-run EnterpriseRAG recall under
+`fusion_mode=rrf`, split by `query_type`. Prediction: basic-recall rises,
+semantic-recall stays flat.
+
+### 7.5 Code reconciliation notes (for the brief author)
+
+Differences found between the brief and the wheel code -- none change the
+conclusion, but flag for accuracy:
+
+1. **Method name.** The retrieval entry is `query_docs()`
+   (`knowledge_store.py:1478`), not `query_genes()`. The internal accumulator,
+   tiers, and cap are as the brief describes.
+2. **Line numbers drift slightly** from the brief: tag_exact x3.0 is at
+   `:1771` (brief said ~tier block), the FTS5 cap + "was 15*3=45" comment is at
+   `:1864-1865` (brief said ~1865 -- correct), the additive `gene_scores +=`
+   ctor comment is at `:489-493` (brief said ~489-491 -- correct), RRF raw-rank
+   feed at `:1873`/`:1910` (matches brief). The bm25 shortlist is `:2415-2444`,
+   idf boost `:2174-2175`.
+3. **An IDF-weighted tier already exists** (`lex_anchor`, `:2174-2200`) -- it is
+   distinct from the tag tiers and partially offsets the magnet, capped at 3.0.
+   The brief's framing ("IDF-free tag tiers") is correct for tag_exact/tag_prefix
+   specifically; the doc above makes the lex_anchor coexistence explicit so the
+   "IDF-weight the tag tiers" fix is not mistaken for "add IDF anywhere".
+4. **Dense default is ON, and routes around `query_docs`.** With shipped default
+   `dense_embedding_enabled=True`, `_retrieve` calls `query_docs_ann`
+   (`context_manager.py:2146-2159`), and the `query_type` semantic arm is threaded
+   only through the `query_docs` sharded branch (`:2160-2172`). For the
+   *lexical-probe* config (dense off) the code path is `query_docs` directly, so
+   the benchmark exercised the exact tier-accumulation path documented here. Worth
+   confirming whether the prose EnterpriseRAG runs used the ANN path (dense on) or
+   the lexical path -- the magnet defect is present in BOTH (tag tiers accumulate
+   identically), but the dense additive term shifts the magnitudes.
+
+---
+
+## 8. Sharding (context)
+
+- `shard_router.py` selects shards (Section 2.3); per-shard `query_docs` runs and
+  results merge "first-shard-wins on ties" (`shard_router.py:422-427`).
+- `sharding.py` / `pipeline/sharding.py` own shard layout; `pipeline/tier_logic.py`
+  and `pipeline/filename_anchor.py` host the extracted tier helpers.
+- The semantic-arm broaden (2.1) is a shard-routing change: it widens the shard
+  fan-out, not the within-shard tier set.
+
+---
+
+## Appendix: file index (wheel)
+
+| File | Role |
+|---|---|
+| `knowledge_store.py` | core: `query_docs()` retrieval + tier accumulator + fusion branch |
+| `retrieval/fusion.py` | RRF `Fuser` data structure |
+| `scoring/blend.py` | post-retrieve refiners (cymatics/rerank/harmonic_bin/tcm) |
+| `context_manager.py` | orchestration: `_prepare_query_signals`, `_retrieve`, `_apply_candidate_refiners`, per-gene budget |
+| `config.py` | `[retrieval]`/`[ingestion]`/`[ribosome]` -> Genome ctor kwargs |
+| `server/routes_context.py` | `/context`, `/context/packet`, `/fingerprint`, query_type thread |
+| `retrieval/query_classifier.py` | injection-router class -> decoder_mode + max_genes cap |
+| `retrieval/intent_router.py` | LLM-free sub-query templates |
+| `shard_router.py` | shard selection + semantic broaden |
+| `pipeline/tier_logic.py`, `filename_anchor.py`, `sharding.py` | extracted tier/shard helpers |

--- a/docs/benchmarks/2026-06-04-code-context-benchmark-strategy.md
+++ b/docs/benchmarks/2026-06-04-code-context-benchmark-strategy.md
@@ -1,0 +1,140 @@
+# Helix Code-Context Evaluation — Benchmark-Strategy Reference
+**As-of 2026-06-04. Verification provenance: 4 independent fact-check clusters (arXiv + GitHub + Hugging Face). Web takes precedence over the Jan-2026 model cutoff. Every stat tagged MEASURED (web-confirmed) vs CLAIMED (GPT, corrected where wrong).**
+
+---
+
+## 1. TL;DR + the prose-vs-code strategic reframe
+
+**Lead with the reframe, because it rewrites where bench effort should go.**
+
+Helix is being optimized on its **worst terrain** and has **never been scored on its designed terrain.** That is the strategic error this reference exists to correct.
+
+- **Prose terrain (where it's being ground):** On EnterpriseRAG-Bench / Onyx (prose: slack/gmail/gdrive/docs, 850K genes), **semantic recall@10 = 2.4%** — the lone broken bucket (other types 42–82%). On 2026-06-04 the *cheap* fix (semantic-aware routing-broaden + dense-dominant fusion) was **smoke-REFUTED** — 1/9 @10 at dense-weight 12; broadening the router *floods* the 200-pool, hurting rank. That **re-implicates the encoder** (geometry residual ≈ 54% of the semantic miss), so the next prose-semantic lever is **encoder re-embed — expensive, GB10-gated.** This is the most expensive possible capital aimed at the worst-fit terrain.
+- **Code terrain (where the design should win, UNMEASURED):** Helix is *targeted* code-context injection — a small, project-aware packet (path/filename anchors, symbols, tags, cross-file structure), explicitly positioned **against grep/BM25 dumps and broad vector-RAG floods**. Its **measured** strength is lexical/structural: **SPLADE earns +6pp on CODE corpora (0pp on prose Onyx)** [MEASURED]; lexical_rescue is "apt for code, UNMEASURED." Retrieval is **LLM-free and deterministic** (ribosome off by design), so the clean test is retrieval quality (recall/precision/gold-density/injected-tokens), fully separable from generation. **Zero code-context retrieval numbers exist.**
+
+**The encoder re-implication tie-in (the technical heart of the reframe).** The prose conclusion — "dense is the only lever, must re-embed" — **does not transfer to code.** On prose, semantic paraphrase is the whole game, so dense is the only knob (hence the stuck 2.4%). On code, the gold signal is dominated by **exact lexical tokens dense bi-encoders systematically under-weight**: identifiers, import paths, filenames, symbol/type names — precisely what SPLADE/lexical nails (the measured +6pp) and what dense blurs. External corroboration: **CodeRAG-Bench's own measured finding** — a 7B dense embedder (SFR-Mistral) gives better retrieval but **~5× index size and ~100× encode latency** (3.7ms GIST-base → 316ms SFR-Mistral) [MEASURED]. So on code the cheap lexical/structural levers Helix already owns are expected near the *top* of the lever ladder, not the bottom.
+
+**Therefore the bottom line:** measuring code-context first is not just a new datapoint — it is the **cheaper path to a defensible win** *and* it **de-risks the GB10-gated encoder spend** by telling you whether the semantic problem even generalizes off prose. If code-context shows the encoder is not the bottleneck off-prose, the re-embed reframes from "necessary" to "prose-only, defer." High-value finding either way.
+
+**The single highest-ROI action:** wire Helix as an **LLM-free retriever into ContextBench's offline gold spans** (Apache-2.0, on HF, file/block/line gold) over the 500-task `verified` subset, and report **recall/precision/F1 @ file/block/line + injected-token count**, with `princeton-nlp/SWE-bench_bm25_27K` as the side-by-side "dump" baseline. ContextBench is the only benchmark whose *own headline finding* — agents over-retrieve, flooding context and killing precision — **is literally Helix's positioning.**
+
+---
+
+## 2. Verified benchmark table (real stats, corrected vs GPT)
+
+Legend: **R-iso** = retrieval-isolable without an LLM hiding failures. Confidence is the verification clusters' agreement level. "GPT" = the originating proposal being fact-checked.
+
+| Benchmark | Real stats (MEASURED, corrected vs GPT) | R-iso | Gold granularity | License / access | Helix-fit | Conf | URL |
+|---|---|---|---|---|---|---|---|
+| **ContextBench** (arXiv 2602.05892, Feb 2026) | 1,136 issue-resolution tasks / 66 repos / **8 langs = Python, Java, JS, TS, Go, Rust, C, C++** ⚠ **NOT C#** (GPT implied C#; corrected). Gold = 522,115 lines / 23,116 blocks / 4,548 files. Lite/`verified` = 500. Leaderboard (2026-06-04): best Pass@1 Claude-Sonnet-4.5 **53.0%**, context-F1 **0.344**, avg line-F1 **0.325**; Gemini-2.5-Pro **0.632 block recall / 0.403 precision** (field maxes recall by flooding, sacrificing precision). | **YES** — process-oriented; recall/prec/F1/efficiency scored *independently* of patch Pass@1. ⚠ **Official harness is trajectory/agent-based, ships ZERO BM25/dense baselines** (GPT overstated "turnkey retriever socket"). Workaround = offline custom scorer (see §3/§4). | **file + block(AST symbol) + line** — best in cluster. ⚠ Gold provenance = **patch-SEEDED → human-traced → LLM-verified-sufficient**, not annotated-from-scratch (GPT's "human-annotated" is fair but imprecise). | **Apache-2.0** (harness); data on HF (`Contextbench/ContextBench`, full 1136 + `verified` 500). ⚠ Dataset-license vs harness-license + 66 source-repo licenses **not separately published — verify on HF card** before public/commercial claims. | **BEST FIT** | high | arxiv.org/abs/2602.05892 · github.com/EuniAI/ContextBench · huggingface.co/datasets/Contextbench/ContextBench · contextbench.github.io |
+| **CodeRAG-Bench** (arXiv 2406.14497, NAACL'25 Findings) | **8 datasets** (GPT said "8 tasks" — read *datasets*): HumanEval, MBPP, LiveCodeBench, DS-1000, ODEX, RepoEval, SWE-bench-Lite, CodeSearchNet-Py. 10 retrievers × 10 LMs. Larger-embedder tradeoff **CONFIRMED VERBATIM** (SFR-Mistral best NDCG, ~5× index / ~100× latency). | **YES** — native retrieval track, **NDCG@10 primary** + Precision + Recall, retriever-swappable (cleanest out-of-box socket). | doc/snippet (mixed: function → file). Coarser than ContextBench. | ⚠ **CC-BY-SA-4.0 (ShareAlike copyleft)** — commercial-OK but viral attribution; per-source upstream licenses vary. GitHub + HF org. | **STRONG** (the efficiency-argument vehicle) | high | arxiv.org/abs/2406.14497 · github.com/code-rag-bench/code-rag-bench · code-rag-bench.github.io |
+| **RepoBench-R** (arXiv 2306.03091, ICLR'24) | R/C/P decomposition confirmed exactly. **Python + Java only**. RepoBench-R = standalone retrieval, metric **acc@k** (acc@1/3 easy; acc@1/3/5 hard); settings XF-F / XF-R. | **YES** — dedicated retrieval split, zero generation, lowest wire-effort. | block/snippet (cross-file dependency snippet). ⚠ closed candidate-pool ranking (easier than open-repo localization). | **CC-BY-4.0** (permissive). HF `tianyang/repobench_python_v1.1` (+Java). ⚠ confirm HF card before commercial. | **STRONG, low-effort** | high | arxiv.org/abs/2306.03091 · github.com/Leolty/repobench · huggingface.co/datasets/tianyang/repobench_python_v1.1 |
+| **CrossCodeEval** (arXiv 2310.11248, NeurIPS'23) | Static-analysis-built cross-file completion. **Languages Py/Java/TS/C# CONFIRMED — this is where C# actually lives** (not ContextBench). Ships BM25 / UniXCoder / Ada retrieval settings. | **PARTIAL** — retrieval measurable but judged largely via downstream completion EM/ES (downstream-proxy). Static-analysis cross-file symbol is a usable recall target. | file + symbol (static-analysis-pinned). | Apache-2.0 repo; permissively-licensed source repos. ⚠ **raw data EMAIL-GATED** (not one-click HF) — access friction. | **USABLE comparator** (the only multilingual / TS+C# one; ships B+C baselines for free) | high | arxiv.org/abs/2310.11248 · github.com/amazon-science/cceval · crosscodeeval.github.io |
+| **SWE-bench (+ RAG tooling)** (arXiv 2310.06770, ICLR'24) | 2,294 issue→PR pairs / 12 Python repos; Lite/Verified/Multimodal. `create_text_dataset` + `bm25_retrieval` + `tokenize_dataset` + `eval_retrieval` all real. Pre-built BM25 datasets `SWE-bench_bm25_13K/27K/40K` + `_oracle`. **BM25-dump degradation MEASURED**: BM25@27K retrieves a superset of oracle files in **~40%** of instances, **none** in ~half; Claude-2 **4.8%→1.96%** oracle→BM25, GPT-4 **≈0%**. | **INDIRECT** — native metric = %Resolved (generation). Isolate via `eval_retrieval` / oracle-file recall (file-level). | **file-level only** (gold-patch files). | **MIT** (most permissive/established). HF `princeton-nlp/SWE-bench_*`. | **BEST "dump" baseline substrate** (canonical packet-vs-BM25 head-to-head; also Phase-2 e2e) | high | swebench.com/SWE-bench/guides/create_rag_datasets/ · github.com/SWE-bench/SWE-bench · huggingface.co/datasets/princeton-nlp/SWE-bench_bm25_27K |
+| **FEA-Bench** (arXiv 2503.06680, ACL'25) | ⚠ GPT **understated**: **1,401 instances** / 83 repos / **Python-only** (GPT gave only "83 repos"). Execution-verified feature-impl; DeepSeek-R1 ~10% resolved. | **NO** — execution-only (% resolved); Oracle variant *bypasses* retrieval, doesn't score it. | new functions/classes (execution-verified); file-level recoverable but not a scored retrieval gold. ⚠ **full dataset NOT released** ("licensing/company policies") — reconstruct from GitHub. | Code MIT; HF card license "other". | **WEAK for retrieval-only**; Phase-2 e2e demo at best | high | arxiv.org/abs/2503.06680 · github.com/microsoft/FEA-Bench · huggingface.co/datasets/microsoft/FEA-Bench |
+| **RACE-bench** (arXiv 2603.26337, Mar 2026) | **CONFIRMED real** (GPT's highest-risk pick, not a hallucination). 528 feature-addition instances / 12 repos (**Python**, SWE-bench-family) / pytest verification / 4-stage reasoning GT. **File Localization scored separately as Recall@RelevantFiles + OverPrediction@RelevantFiles** (over-prediction = literally Helix's injected-noise axis). | **YES (one track)** — file-localization isolable. | file-level (localization). | ⚠⚠ **arXiv-only; NO public GitHub/HF as-of 2026-06-04** → **NOT WIREABLE TODAY**. License = arXiv perpetual non-exclusive (paper only). | **CONCEPTUALLY IDEAL, BLOCKED** (best-named noise metric in existence for the thesis; watch for code drop) | medium | arxiv.org/abs/2603.26337 |
+| **Legacy smoke: CodeSearchNet / CoSQA / CodeXGLUE** | Pure NL→code search. CodeSearchNet 6 langs, MRR/NDCG; CoSQA 20k+ real queries; CodeXGLUE AdvTest MRR. | **YES** (pure MRR/NDCG/MAP) | function/snippet | MIT (CodeSearchNet, CodeXGLUE code). ⚠ **CodeXGLUE *data* under C-UDA — not blanket-commercial**; CoSQA verify. | **SMOKE-ONLY** — NL→snippet *semantic* search = Helix's **WEAK** bucket; no repo structure | high | github.com/github/CodeSearchNet · arxiv.org/abs/2102.04664 · arxiv.org/abs/2105.13239 |
+
+**GPT error/uncertainty summary:** (a) ContextBench language set — **C# WRONG**, corrected to Py/Java/JS/TS/Go/Rust/C/C++; (b) ContextBench "turnkey retriever socket" — **OVERSTATED**, official harness is agent-trajectory, no BM25/dense baselines; (c) ContextBench "human-annotated" — **NUANCE**, gold is patch-seeded→traced→LLM-verified; (d) CodeRAG-Bench "8 tasks" → **8 datasets**; (e) FEA-Bench scope **UNDERSTATED** (omitted 1,401 instances, Python-only); (f) RACE-bench — **CONFIRMED real** but **UNCONFIRMED accessible** (no release). One disambiguation: a separate "SWE Context Bench" (arXiv 2602.08316) is a **different paper** (context *learning*) — do not conflate; GPT's stats map to the real 2602.05892.
+
+---
+
+## 3. Fit ranking — Phase-1 retrieval-only vs Phase-2 assisted-coding, with the ContextBench adjudication
+
+**Scoring axes (Helix-specific):** retrieval-isolable · gold granularity (file/block/line beats doc/snippet) · lexical/structural strength surface · access+license · effort-to-wire.
+
+### Phase 1 — RETRIEVAL-ONLY (the clean test: recall/precision/gold-density/injected-tokens, no generation)
+1. **ContextBench** — BEST FIT. file/block/line gold, separable scoring, Apache-2.0, data released. Needs an offline custom scorer (no socket).
+2. **RepoBench-R** — STRONG, lowest wire-effort (acc@k, one-click HF, CC-BY-4.0). Closed candidate-pool = tests ranking, not open-repo localization at scale.
+3. **CodeRAG-Bench** — STRONG, cleanest out-of-box socket (NDCG@10), and the vehicle for the cheap-vs-7B-embedder efficiency argument. Doc/snippet gold; ShareAlike.
+4. **CrossCodeEval** — USABLE multilingual comparator (only TS/C#); ships BM25+dense baselines (= arms B/C for free). Retrieval is downstream-proxy; data email-gated.
+5. **SWE-bench (`eval_retrieval`/oracle)** — file-level only, but the canonical packet-vs-BM25-dump substrate with a published strawman. MIT.
+6. **RACE-bench** — conceptually ideal (OverPrediction@RelevantFiles), **blocked** (no release).
+— **Legacy smoke** — regression layer only; NL→snippet semantic search is Helix's weak bucket.
+
+### Phase 2 — ASSISTED-CODING E2E (does the packet help patch?)
+1. **SWE-bench (Verified/Lite, Docker harness)** — drop Helix in as retriever via `create_text_dataset`, hold generator fixed, attribute Δ-resolved + token-budget to retrieval. Max already runs SWE-bench-like harnesses. Max external credibility.
+2. **CodeRAG-Bench (generation arm)** — RACG lift on real codegen; embedder-latency finding stages the "deterministic, cheap" counter-pitch.
+3. **FEA-Bench** — hard feature-impl arena; no separate retrieval score, dataset not turnkey.
+4. **CrossCodeEval (completion-lift arm)** — cross-file context → EM/ES lift vs BM25/oracle; multilingual.
+5. **RACE-bench (dual-track)** — blocked.
+
+### The ContextBench adjudication
+**GPT's "ContextBench first" is CORRECT — and it is *better* for Helix than GPT pitched it.** All four verification clusters converge: it exists (arXiv 2602.05892, Apache-2.0, on HF) and the headline stats verify near-exactly. This is **not** a case where RepoBench-R / CodeRAG-Bench / CrossCodeEval should displace it — each loses on the load-bearing axis:
+- **RepoBench-R** — cleaner socket but closed candidate-pool + snippet gold + Python/Java only.
+- **CodeRAG-Bench** — best plug-and-play socket but doc/snippet gold, heterogeneous, ShareAlike; weak on repo cross-file structure.
+- **CrossCodeEval** — only multilingual one, but retrieval is downstream-proxy + email-gated.
+
+ContextBench wins because its gold is **file/block/line** (Helix's exact claim surface) and its **own central finding** — "LLMs favor recall over precision, retrieve broad context introducing substantial noise, limited precision/F1 gains" — **is the documented failure mode Helix claims to fix.** If Helix hits comparable recall at materially higher precision/efficiency, that is a publishable, **third-party-scored** result against named agent baselines (Sonnet-4.5 0.344 F1, Gemini-2.5-Pro 0.632 recall / 0.403 precision).
+
+---
+
+## 4. Recommended sequence (highest-ROI first)
+
+**Step 0 — MVV, the single highest-ROI action (target 1–2 days, $0–low).** Build the **ContextBench offline retrieval scorer** and run Helix **LLM-free** over the 500-task `verified` subset (start with a 100-task Python slice).
+- Pipeline: for each instance, clone `repo_url` @ `base_commit` → ingest into a Helix genome → query with `problem_statement` → capture Helix's ranked packet (paths/symbols/spans) → emit ContextBench `pred_spans` JSON `{"file_path":[{"type":"line","start":N,"end":M}]}` → score with `python -m contextbench.evaluate --gold data/full.parquet --pred helix.traj.json --out results.jsonl`. **~50–100 LOC emitter; no agent, no LLM, no GPU re-embed.**
+- Report exactly two things: **(a) block/line recall — Helix (arm D) vs BM25 dump (arm B); (b) injected-tokens / gold-density — D vs B.** One 2-D plot (recall@k on x, injected-tokens on y, one point per arm) is the whole story.
+- Baseline foil: `princeton-nlp/SWE-bench_bm25_27K` (already on HF) + SWE-bench's published oracle→BM25 collapse (4.8%→1.96%, GPT-4 ≈0) as a third-party sanity anchor and the **best single citation for "the dump is the problem."**
+
+**Step 1 — RepoBench-R `acc@k`.** Lowest-effort independent corroboration of cross-file lexical strength (CC-BY-4.0, one-click HF). Pure retrieval, no LLM.
+
+**Step 2 — CodeRAG-Bench canonical NDCG@10 / Recall.** Stage the "cheap deterministic retriever vs 7B-embedder ~5× index / ~100× latency" efficiency argument *using their own measured numbers.*
+
+**Step 3 — CrossCodeEval.** Multilingual (TS/C#) cross-file comparator; reuse its shipped BM25/UniXCoder/Ada settings as arms B/C rather than building them.
+
+**Step 4 (Phase-2, only if Step 0 is positive) — SWE-bench e2e.** Swap BM25 for Helix in `create_text_dataset`, hold one fixed generator (the local Gemma/Haiku-4.5 rig), measure %Resolved lift + token efficiency vs `bm25_27K` and vs the oracle ceiling. The recognizable-name demo.
+
+**Watchlist — RACE-bench.** Revisit the instant code/data drops; its `OverPrediction@RelevantFiles` is the best-named injected-noise metric in existence for Helix's thesis.
+
+**Demote / hold:** prose-semantic Onyx as a **background** encoder experiment, explicitly gated on whether code-context shows the encoder is even the bottleneck off-prose. Legacy smoke set = regression layer only.
+
+**Arm posture (applies across runs):** keep arm **A (no-retrieval floor)**, make arm **B (tuned BM25/grep dump)** the essential foil, keep **C (vector-RAG flood)**, **D (Helix packet)** is the deliverable, and **demote E (Helix+semantic-store) to a diagnostic ablation** — dense is Helix's weak bucket on *both* terrains, so present E as "does dense add over lexical+structural on code?" with an honest predicted near-zero lift, never as a hero arm.
+
+---
+
+## 5. The Helix-native spec→project benchmark (repeatable in-house option)
+
+Use **third-party benches as the headline, the dogfood self-made bench as corroboration** — "and the same pattern holds on our own 22M/57M-gene production code." Never the reverse: you built the corpus, the gold method, *and* the system under test, so a self-made bench has a structural credibility ceiling no rigor fully removes. Build it only **after** the ContextBench MVV is positive.
+
+**Design (clean two-score split, ribosome-off):**
+- **Score 1 — Retrieval quality (the real Helix test, no LLM):** recall@k, precision@k, gold-density (gold-tokens / injected-tokens), injected-token count, latency.
+- **Score 2 — Downstream (optional, expensive):** feed each arm's packet to ONE fixed generator, measure patch-pass / hallucinated-edits / unnecessary-touches. Run only after Score-1 shows a packet-vs-dump gap; hold the generator constant so context is the only variable.
+
+**Gold construction — patch-derived, never author-chosen (borrow ContextBench's own method: patch-seed → trace → verify):**
+- Pick real **merged PRs/commits from the repo's own history**; gold files/symbols/lines = what the diff touched. Do **not** hand-author "which file answers this" — that is the cherry-pick trap.
+- **Query = the PR issue text / title, with filename, symbol names, and path tokens SCRUBBED** so lexical strength comes from Helix's index, not from the query leaking the path.
+- **Temporal cut:** ingest the genome **at the parent commit** of each gold PR so the fix isn't already in the corpus.
+- **Distractors must be present and counted:** the whole repo is the distractor pool → **report precision, not just recall**, or the bench is meaningless.
+
+**Anti-cherry-pick / leak-guard (non-negotiable):**
+- **Pre-register the task set** (all merged PRs in a date window touching ≥1 and ≤N files, auto-selected) — no manual curation of "good" questions.
+- **Report the full distribution including losses** (carry the same honest posture used for the prose 2.4% bucket).
+- Run B/C/D/E on the identical task set with the identical generator (for Score-2).
+
+**Reuse vs new (≈70% port, not rewrite):**
+- **Reuse the EnterpriseRAG patterns, not the corpus** (Onyx is prose; this is code — that's the whole point). Port `make_gold_index` / `load_needles` / the **FIXED `_rel_after_sources`** path-normalization (the `sources/`-prefix false-gold bug **will recur on code** — deeper/messier paths — so add a code-path unit test up front); carry `min_genes≥10` gate + `HELIX_SHARD_WORKERS` order-preserving fan-out unchanged; reuse the Sonnet-judge only for the optional Score-2 arm; reuse the bench venv but **relocate it out of volatile `/f/tmp` first**.
+- **New:** the trajectory emitter (Helix packet → ContextBench/`pred_spans` JSON, ~50–100 LOC) and code-aware symbol/line-range gold matching.
+
+**Prerequisite gap:** the dogfood corpora (`genomes/bench/matrix-sharded/medium` ≈22M, `xl` ≈57M gene-scale) have **no wired `questions.jsonl` gold — latency-only today.** ContextBench supplies external gold so you can start immediately; the patch-seed→trace→verify pattern is the template to bootstrap dogfood gold later.
+
+---
+
+## 6. Honest caveats — what could NOT be verified, and licensing blockers
+
+**Could not verify (FLAGGED):**
+- **ContextBench *dataset* license** (distinct from the Apache-2.0 *harness*) and the **66 source-repo licenses** are not separately published on the pages reviewed. Verify on the HF dataset card before any public/commercial claim.
+- **ContextBench gold provenance precision** — confirmed patch-seeded→human-traced→LLM-verified, but the exact human-vs-LLM split per span is not enumerated.
+- **RepoBench-R license** — HF card (`tianyang/repobench_python_v1.1`) not directly read; CC-BY-4.0 reported by the cluster — confirm before commercial use.
+- **CrossCodeEval** — per-language instance counts not enumerated; **raw data is email-gated** (not one-click HF), so plan a request step.
+- **RACE-bench** — paper real and stats confirmed, but **no public GitHub/HF as-of 2026-06-04**; dataset/code license unconfirmed. Not actionable until release. (Do not confuse with the unrelated `github.com/jszheng21/RACE` readability benchmark.)
+- **The "Improving Code Localization" paper** (OpenReview 8yjWLJy2eX) PDF would not render; its specific BM25-vs-dense file-localization recall@k numbers are unconfirmed — but SWE-bench's own oracle-vs-BM25 collapse already carries the file-localization argument with MEASURED third-party numbers.
+
+**Licensing blockers, ranked by how much they constrain a commercial/public claim:**
+1. **RACE-bench — hard blocker (no artifact).** Watch + revisit; do not commit plans to it.
+2. **CrossCodeEval — access friction.** Email-gated raw data; Apache-2.0 code, "permissively-licensed" repos not enumerated.
+3. **CodeRAG-Bench — CC-BY-SA-4.0 ShareAlike copyleft.** Commercial-OK but any redistributed processed data must carry the same license; per-source upstream licenses vary (StackOverflow CC-BY-SA, etc.).
+4. **CodeXGLUE *data* — C-UDA.** Permits computational/research use, **not** blanket commercial redistribution. Confirm before any product use.
+5. **FEA-Bench — full dataset not released** (company policy); reconstruct from GitHub; HF card license "other."
+6. **ContextBench dataset-license unstated; SWE-bench MIT, RepoBench-R CC-BY-4.0, CodeSearchNet/CodeXGLUE-code MIT** — the most permissive of the set; still verify per-card before public claims.
+
+**Net:** the recommended primary track (ContextBench MVV → RepoBench-R → CodeRAG-Bench → SWE-bench) is buildable **this week, against published agent baselines, on released data, with no annotation and no LLM** — pending only the two ContextBench license confirmations above. The conceptually-best noise metric (RACE-bench's OverPrediction) is parked behind a release blocker, and the prose-semantic encoder fight should be held as a gated background experiment, not the headline.

--- a/docs/benchmarks/2026-06-18-contextbench-step0-master-vs-bm25.md
+++ b/docs/benchmarks/2026-06-18-contextbench-step0-master-vs-bm25.md
@@ -1,0 +1,50 @@
+# ContextBench Step-0 — master+#224 vs BM25 (code retrieval)
+
+**Date:** 2026-06-18
+**Build:** `origin/master` @`3aa6c5c` + #224 (`fix-224-content-type` @`5d48321`, == v0.7.1 dev)
+**Gold:** `benchmarks/contextbench/gold_smoke_4repo.parquet` (26 tasks; django / scikit-learn / requests)
+**Scorer:** official ContextBench evaluator (`contextbench.evaluate`, tree-sitter span alignment), micro-average.
+**Retrieval:** LLM-free, in-process, lexical config (`helix_probe.toml`: dense / SPLADE / rerank / cymatics all OFF). Repo is never mutated; gold/patch/test_patch are never indexed.
+
+## Result (full 26-task smoke)
+
+| arm | file_R | **line_R** | sym_R | median injected tok |
+|---|---|---|---|---|
+| bm25:8k | 0.690 | 0.314 | 0.404 | 8k |
+| bm25:27k | 0.881 | 0.484 | 0.585 | 27k |
+| **MASTER packet** | 0.810 | **0.655** | 0.591 | < 27k |
+| **MASTER fingerprint@27k** | 0.762 | **0.570** | 0.560 | 27k |
+| MASTER fingerprint@8k | 0.595 | 0.241 | 0.316 | 8k |
+| wt fingerprint@27k (prior) | 0.762 | 0.549 | 0.539 | 27k |
+| wt packet (prior) | 0.833 | 0.655 | 0.591 | < 27k |
+| v062 fingerprint@27k (prior) | 0.762 | 0.549 | 0.539 | 27k |
+
+`line_R` = line-level coverage (recall); `file_R` / `sym_R` = file- / symbol-level recall. Precision is metric-tiny for every arm at these budgets (recall-at-budget is the axis that matters here).
+
+## Findings
+
+1. **Master's packet beats the BM25 dump on line recall by +17pp** — 0.655 vs BM25's best 0.484@27k — at *fewer* injected tokens, and also edges BM25 on symbol recall (0.591 vs 0.585). On its designed terrain (path / symbol / structure) Helix returns materially more relevant lines and symbols than a raw lexical fill.
+
+2. **Master is the strongest Helix build to date.** Fingerprint@27k 0.570 beats the prior `wt` and `v062` builds (both 0.549, **+2.1pp**) and beats BM25@27k (0.484, **+8.6pp**). The 47 commits between v0.6.x and current master (#217 dense-floor, #218 config-reconcile, #220 lazy-encoders, …) improved code fingerprinting without regressing the packet (packet ties `wt` at 0.655).
+
+3. **Harness validation:** the BM25 arms reproduce the frozen baseline (`step0_summary.json`) exactly — 0.314@8k / 0.484@27k — so the comparison is sound.
+
+4. **Where BM25 still wins:** raw file coverage (0.881 vs 0.810) and the tight 8k budget (line_R 0.314 vs master fingerprint 0.241). Helix's fingerprint under-fills at 8k — the one concrete weakness worth chasing on the code track.
+
+## Run notes / caveats
+
+- **Two-pass run.** The 3-worker run crashed at task 17 with `BrokenProcessPool` — a transient OOM from each worker eagerly loading the BGE/SEMA sentence-transformer **even under a fully lexical config** (dense/cymatics off). The first 16 (django) completed and were pred-written; the remaining 10 (scikit-learn / requests) were re-run at `workers=1` and merged. See issue: SEMA eager-load bypasses #220 lazy-encoders.
+- A 16-task (django-only) subset scored before the merge gave the same ranking (master packet 0.658, master fp@27k 0.542, BM25@27k 0.516) — the full-26 numbers above are the canonical, repo-diverse figures.
+
+## Reproduce
+
+```bash
+# Helix arm (per-task fresh genome, in-process, lexical):
+#   venv: master+#224 ; HELIX_CONFIG=helix_probe.toml ; CONTEXTBENCH_SRC=contextbench-src
+python benchmarks/cb_helix_pred.py --tasks <tasks.json> --tag master \
+  --config helix_probe.toml --modes fingerprint,packet --budgets 8000,27000 \
+  --dense-device cpu --workers 1            # workers=1 until the SEMA eager-load is fixed
+
+# Score (cb-step0 venv, official evaluator):
+python benchmarks/cb_score_all.py          # BM25 from step0_summary.json + every helix_*_pred.json
+```

--- a/docs/benchmarks/2026-06-27-cast-vs-greedy-contextbench-step0.md
+++ b/docs/benchmarks/2026-06-27-cast-vs-greedy-contextbench-step0.md
@@ -1,0 +1,36 @@
+# cAST recursive chunking — ContextBench Step-0 (Phase 1 acceptance)
+
+**Date:** 2026-06-27
+**Build:** master + #224 + #227 (SEMA-off) + cAST recursive split-then-merge (PR #228, byte-exact)
+**Gold:** `benchmarks/contextbench/gold_smoke_4repo.parquet` (26 tasks; django / scikit-learn / requests)
+**Scorer:** official ContextBench evaluator, micro-average over the common 26-task set.
+**Config:** lexical (dense / SPLADE / rerank / cymatics off), `sema_embed_on_ingest = false`. LLM-free, in-process.
+
+## Result
+
+| arm | file_R | **line_R** | sym_R |
+|---|---|---|---|
+| BM25:8k | 0.690 | 0.314 | 0.404 |
+| BM25:27k | 0.881 | 0.484 | 0.585 |
+| greedy-AST fp@8k | 0.500 | 0.134 | 0.228 |
+| greedy-AST fp@27k | 0.667 | 0.626 | 0.591 |
+| greedy-AST packet | 0.714 | 0.662 | 0.622 |
+| cAST fp@8k | 0.571 | 0.222 | 0.352 |
+| cAST fp@27k | 0.833 | 0.679 | 0.746 |
+| **cAST packet** | **0.881** | **0.804** | **0.808** |
+
+## Verdict — Phase 1 acceptance: PASS
+
+- **cAST beats BM25 decisively.** Packet line recall **0.804 vs BM25's best 0.484 (+32pp)**, at lower injected tokens; matches BM25's file coverage (0.881) while far exceeding it on line and symbol recall.
+- **cAST beats greedy-AST.** Packet **+14.2pp line** (0.804 vs 0.662), **+18.6pp symbol** (0.808 vs 0.622), **+16.7pp file** (0.881 vs 0.714). fp@27k **+5.3pp line** (0.679 vs 0.626). The recursive split-then-merge — keeping whole methods instead of char-cutting oversized classes — is the lever, as cAST (arXiv 2506.15655) predicted.
+- **The one soft spot improved too.** At the tight 8k budget cAST fp lifts line recall 0.134 → 0.222 (+8.8pp); BM25:8k (0.314) still edges it, but the gap roughly halved.
+
+## Methodology note — a bug the measurement caught
+
+The first cAST draft reassembled decoded piece text and **dropped whitespace-only interstitial gaps**, so a merged chunk was no longer a verbatim substring of the source. ContextBench maps retrieved genes back to line ranges by exact-substring match (`recover_lines`), so those chunks failed to line-map and were dropped — collapsing cAST packet to a spurious **0.141** even though retrieval (`gold_in_rank`) was unchanged. Per-task gene survival was the tell: packet kept g8/5k tokens vs the baseline's g47/37k. The fix emits each chunk as an exact `code_bytes[start:end]` slice (verified 0/1189 non-verbatim over the helix corpus); gene survival recovered to g50/37k and the scores above followed. This is also strictly better for real use (citations / line-mapping rely on verbatim chunks).
+
+## Lineage of baselines on this gold
+- BM25:27k line_R 0.484 (reproduces the frozen `step0_summary` baseline exactly).
+- regex chunking (no tree-sitter), packet 0.655 (prior `m224` run).
+- greedy-AST packet 0.662.
+- **cAST packet 0.804.**

--- a/docs/benchmarks/2026-06-28-ws2-symbol-graph-contextbench.md
+++ b/docs/benchmarks/2026-06-28-ws2-symbol-graph-contextbench.md
@@ -1,0 +1,31 @@
+# WS2 symbol graph — ContextBench Step-0 validation
+
+**Date:** 2026-06-28
+**Build:** cAST byte-exact + WS2 (`symbol_graph` on) vs the same build with WS2 off (`cast_fix`).
+**Gold:** `gold_smoke_4repo.parquet` (26 tasks). Official evaluator, lexical + SEMA-off, micro-avg over the common 26.
+
+## Result
+
+| arm | file_R | line_R | line_P | sym_R |
+|---|---|---|---|---|
+| BM25:27k | 0.881 | 0.484 | 0.020 | 0.585 |
+| WS2-off fp@8k | 0.571 | 0.222 | 0.027 | 0.352 |
+| WS2-off fp@27k | 0.833 | 0.679 | 0.026 | 0.746 |
+| WS2-off packet | 0.881 | 0.804 | 0.023 | 0.808 |
+| WS2-on fp@8k | 0.595 | 0.212 | 0.026 | 0.352 |
+| WS2-on fp@27k | 0.786 | **0.538** | 0.020 | 0.648 |
+| **WS2-on packet** | 0.881 | **0.825** | 0.018 | 0.829 |
+
+## Verdict — net win on the packet, regression on unranked budget-fill
+
+- **Packet (the production delivery path): WS2 lifts line recall +2.1pp (0.804 → 0.825) and symbol recall +2.1pp (0.808 → 0.829)**, file coverage tied at 0.881, with a small precision dip (0.023 → 0.018) expected from adding genes. Symbol expansion pulls referenced definitions that are gold into the delivered set. This is the WS2 win, on the arm that matters.
+- **Fingerprint@27k: WS2 regresses line recall −14pp (0.679 → 0.538).** The fingerprint fills a 27k budget greedily; **unranked, unbounded** symbol expansion dumps referenced definitions into the budget and displaces gold lines. The packet avoids this because it caps genes (max 32), so its expansion is naturally curated.
+
+## Interpretation → motivates WS3
+
+The symbol graph demonstrably surfaces real gold definitions (packet recall up), but raw expansion is too aggressive for a large unranked budget. This is precisely the gap **WS3 (personalized PageRank + budget-ordered trim)** closes: rank the expanded definitions by structural centrality and let the budget keep the central ones, dropping noise. Expected to recover the fingerprint regression while preserving the packet gain.
+
+## Recommendation
+- Keep WS2 (edges + the packet win are real; the packet is the production path).
+- Before WS3 lands, bound the expansion (cap referenced definitions added per query) to avoid the fingerprint-style dilution on budget-fill paths.
+- WS3 is the proper fix (rank-then-trim); prioritize it. WS3 slice 1 (the PageRank scoring module) is built (PR pending).

--- a/docs/benchmarks/coderag_bench_runbook.md
+++ b/docs/benchmarks/coderag_bench_runbook.md
@@ -1,0 +1,361 @@
+# CodeRAG-Bench Step-2 Runbook
+
+**Benchmark:** CodeRAG-Bench (arXiv 2406.14497, NAACL'25 Findings)
+**Primary metric:** NDCG@10 — the paper's own primary; lower ranks penalised by 1/log2(rank+1)
+**Supporting metrics:** Recall@{1,5,10}, Precision@{1,5,10}
+**Efficiency layer:** median/p90 injected tokens from top-10 docs, median/p90 per-query latency
+**Arms:** A (random floor) + B (BM25 foil) in `coderag_bench.py`; D (Helix /fingerprint) in `coderag_bench_helix.py`
+**LLM-free, GPU-free** (foils + Helix lexical arm; no SPLADE, no BGE-M3, no ribosome)
+
+---
+
+## 0. Strategic context
+
+CodeRAG-Bench is the **efficiency-argument vehicle** from the code-context benchmark strategy doc
+(`docs/benchmarks/2026-06-04-code-context-benchmark-strategy.md`, section 2):
+
+> *"SFR-Mistral gives better NDCG but ~5× index size and ~100× encode latency
+> (3.7ms GIST-base → 316ms SFR-Mistral). [MEASURED]"*
+
+Our job is to show Helix's cheap deterministic retriever is competitive with or beats BM25
+(the canonical foil, arm B) at a fraction of the 7B-dense-embedder cost. The efficiency layer
+(injected tokens + latency) makes that argument concrete.
+
+The two datasets in scope:
+
+| Dataset | # Queries | Gold type | Helix difficulty |
+|---------|-----------|-----------|-----------------|
+| HumanEval | 164 | Prompt shares function name with gold | LEXICALLY EASY (sanity floor) |
+| MBPP | ~974 | NL problem statement -> code solution | MORE SEMANTIC (harder contrast) |
+
+Corpus = `code-rag-bench/programming-solutions` (~1138 docs after dedup). One gold per query.
+
+---
+
+## 1. License and data access
+
+**CC-BY-SA-4.0 (ShareAlike copyleft).**
+
+- Commercial use is permitted.
+- Any **redistributed processed data** (e.g. a published results file derived from the dataset)
+  must carry the same CC-BY-SA-4.0 license.
+- Per-source upstream licenses (StackOverflow CC-BY-SA, etc.) vary — confirm before
+  any public dataset redistribution.
+- Internal measurement and benchmark reporting: OK.
+- Dataset access: HuggingFace `code-rag-bench/programming-solutions`, `code-rag-bench/humaneval`,
+  `code-rag-bench/mbpp` — public, no auth required.
+- GitHub: `github.com/code-rag-bench/code-rag-bench` (Apache-2.0 harness code).
+
+---
+
+## 2. Prerequisites
+
+### Foils arm (random + BM25) — no Helix needed
+
+```powershell
+pip install datasets rank-bm25
+```
+
+### Helix arm — bench server required
+
+1. Start the Helix bench server (dedicated bench lane, port 11439):
+   ```powershell
+   # In helix063 venv, from the repo root:
+   $env:HELIX_CONFIG = "F:\Projects\helix-context\helix.toml"
+   python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11439
+   ```
+   Use a **separate port from dev** (11437) so the bench genome is isolated.
+
+2. The bench server needs the programming-solutions corpus ingested.
+   See step 3b below — ingest after building the per-query dump.
+
+### Lexical-probe config (dense/splade/ribosome OFF)
+
+The Helix arm targets the lexical/structural retriever, not dense embedding.
+Confirm `helix.toml` (or the bench config) has:
+
+```toml
+[ribosome]
+backend = "none"
+
+[ingestion]
+splade_enabled = false
+
+[retrieval]
+dense_embedding_enabled = false
+```
+
+---
+
+## 3. Step-by-step: foils first, then Helix
+
+### Step 3a — Run foils (random + BM25), write per-query dump
+
+```powershell
+# Full run (HumanEval + MBPP, all queries)
+python benchmarks/coderag_bench.py
+
+# Smoke run (50 queries per dataset)
+python benchmarks/coderag_bench.py --limit 50
+
+# HumanEval only
+python benchmarks/coderag_bench.py --datasets humaneval
+
+# Custom output path
+python benchmarks/coderag_bench.py --out benchmarks/results/coderag_foils_myrun.json
+```
+
+Outputs written to `benchmarks/results/`:
+
+```
+coderag_foils_{ts}.json     -- summary: BM25 + random NDCG@10, Recall, Precision, efficiency
+coderag_queries_{ts}.json   -- per-query dump (query text, gold_idx, bm25_rank)
+                               consumed by the Helix arm
+```
+
+### Step 3b — Ingest corpus into the bench Helix server
+
+The Helix arm expects documents ingested with `path=doc_{idx}` metadata so it can map
+fingerprint sources back to corpus indices.
+
+```powershell
+# Ingest via the /ingest endpoint (one doc at a time via HTTP, or use CLI):
+# The per-query dump contains the query text only; you need the corpus.
+# Option 1: use helix ingest CLI (if corpus JSON is available):
+# python benchmarks/coderag_bench.py writes coderag_queries_*.json with
+# query+gold_idx but NOT the corpus texts themselves.
+# Re-run the corpus build step and POST each doc via /ingest:
+
+python - << 'EOF'
+import json, urllib.request
+corpus = json.load(open("benchmarks/results/coderag_corpus.json"))  # if saved
+for di, doc in enumerate(corpus):
+    payload = json.dumps({
+        "content": doc["text"],
+        "content_type": "code",
+        "metadata": {"path": "doc_{}".format(di)}
+    }).encode()
+    req = urllib.request.Request(
+        "http://127.0.0.1:11439/ingest",
+        data=payload, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    urllib.request.urlopen(req, timeout=30)
+    if di % 100 == 0:
+        print("ingested {}/{}".format(di, len(corpus)))
+print("done")
+EOF
+```
+
+Alternatively, save the corpus during the foil run by adding `--corpus-out`:
+
+```powershell
+# (coderag_bench.py already writes corpus via the run() function;
+#  to save it separately for ingest, pipe corpus through coderag_diag.py
+#  or extend coderag_bench.py with --corpus-out if needed)
+```
+
+### Step 3c — Run the Helix arm
+
+```powershell
+# Auto-discovers the most recent coderag_queries_*.json
+python benchmarks/coderag_bench_helix.py --helix-url http://127.0.0.1:11439
+
+# Explicit queries file + side-by-side foils comparison table
+python benchmarks/coderag_bench_helix.py \
+    --queries benchmarks/results/coderag_queries_20260613T120000Z.json \
+    --foils benchmarks/results/coderag_foils_20260613T120000Z.json \
+    --helix-url http://127.0.0.1:11439
+
+# Smoke run (50 queries)
+python benchmarks/coderag_bench_helix.py \
+    --queries benchmarks/results/coderag_queries_<ts>.json \
+    --helix-url http://127.0.0.1:11439 \
+    --limit 50
+
+# Custom output
+python benchmarks/coderag_bench_helix.py \
+    --queries benchmarks/results/coderag_queries_<ts>.json \
+    --helix-url http://127.0.0.1:11439 \
+    --out benchmarks/results/coderag_helix_myrun.json
+```
+
+Output: `benchmarks/results/coderag_helix_{ts}.json`
+
+---
+
+## 4. Metrics reference
+
+### Primary: NDCG@10
+
+```
+NDCG@10 = (1/N) * sum_i [ 1/log2(rank_i + 1) if rank_i <= 10 else 0 ]
+```
+
+IDCG = 1 for all queries (single gold). Range [0, 1]; higher is better.
+
+### Recall@k
+
+```
+Recall@k = (1/N) * sum_i [ 1 if gold in top-k else 0 ]
+```
+
+Reported at k = 1, 5, 10. Monotonic: recall@1 <= recall@5 <= recall@10.
+
+### Precision@k
+
+For a single-gold query, Precision@k = Recall@k / k. Reported at k = 1, 5, 10.
+
+### Efficiency layer
+
+| Metric | Source | Purpose |
+|--------|--------|---------|
+| `median_injected_tokens` | word-count × 1.3, top-10 docs | Token budget impact |
+| `p90_injected_tokens` | 90th percentile of above | Worst-case token budget |
+| `median_latency_ms` | per-query /fingerprint wall time | Speed comparison |
+| `p90_latency_ms` | 90th percentile | Tail latency |
+
+The efficiency layer is the **core of the cheap-vs-7B-dense argument**: at comparable or
+better NDCG, Helix uses <1ms query encoding vs 316ms SFR-Mistral (100× measured).
+
+---
+
+## 5. Result table format
+
+The summary JSON (both foils and Helix arm) contains one entry per dataset:
+
+```json
+{
+  "humaneval": {
+    "n": 164,
+    "corpus": 1138,
+    "bm25_ndcg@10": 0.9123,
+    "bm25_recall@1": 0.8780,
+    "bm25_recall@5": 0.9573,
+    "bm25_recall@10": 0.9695,
+    "bm25_precision@1": 0.8780,
+    "bm25_precision@5": 0.1915,
+    "bm25_precision@10": 0.0970,
+    "bm25_efficiency": {
+      "median_injected_tokens": 4200,
+      "p90_injected_tokens": 6100
+    }
+  }
+}
+```
+
+Helix arm adds `helix_ndcg@10`, `helix_recall@{k}`, `helix_precision@{k}`, and `efficiency`
+(which includes latency).
+
+---
+
+## 6. Diagnostic arm
+
+When Helix underperforms BM25, use `coderag_diag.py` to identify whether the miss is:
+- **(a) gating** — gold doc never reached the scored set (entity/domain gating excludes it)
+- **(b) ranking** — gold is scored but buried (additive fusion / IDF not discriminating)
+
+```powershell
+# Run in helix063 venv DIRECTLY (not via uv):
+F:\Projects\_venvs\helix063\Scripts\python.exe -u benchmarks/coderag_diag.py `
+    --n 12 --ds humaneval `
+    --queries-json benchmarks/results/coderag_queries_<ts>.json `
+    --helix-config F:\Projects\helix-context\helix.toml
+
+# MBPP (harder, semantic)
+F:\Projects\_venvs\helix063\Scripts\python.exe -u benchmarks/coderag_diag.py `
+    --n 20 --ds mbpp
+```
+
+Per-query output:
+```
+humaneval:42: scored=18 in_scored=True gold_rank=0 gold_score=0.812
+  | q_tok=34 overlap=28 | bm25_rank=0 | top3=[(42, 0.812), (17, 0.543), (88, 0.421)]
+```
+
+Key fields:
+- `in_scored=False` → gating miss (FTS/domain filter dropped the gold)
+- `in_scored=True, gold_rank>10` → ranking miss (present but buried by noise)
+- `overlap=0` → query and gold share no identifier tokens (MBPP pure-NL queries)
+
+---
+
+## 7. Leak guards
+
+These are non-negotiable for result integrity:
+
+1. **Ingest only at query time, not gold time.** The corpus is the canonical solutions; the
+   queries are the prompts/problem statements. Never ingest the query text as a document.
+2. **No query in the genome.** After ingestion, the genome contains only the programming
+   solutions. Query text is sent via `/fingerprint` at score time.
+3. **Deterministic random seed.** The random floor (arm A) uses `hash((gold_id, query_idx)) % N`
+   — deterministic, no seeded RNG needed.
+4. **Stamp every result.** Both output JSONs include `timestamp`, `datasets`, `limit`, and
+   `license` fields. The Helix arm adds `helix_url` and `queries_file`.
+5. **Report full distribution.** Do not filter out datasets where Helix loses. MBPP is expected
+   to be harder than HumanEval; both should be reported.
+
+---
+
+## 8. Tests
+
+```powershell
+# Run the unit tests (no network, no server, no GPU):
+python -m pytest tests/test_coderag_bench_harness.py -v --noconftest
+
+# Specific test classes:
+python -m pytest tests/test_coderag_bench_harness.py -v --noconftest -k "TestNdcgAt or TestBM25 or TestRunPipeline"
+python -m pytest tests/test_coderag_bench_harness.py -v --noconftest -k "TestScoreQueriesMocked"
+```
+
+72 tests covering: NDCG@10/Recall@k/Precision@k correctness, BM25 IDF floor, tok()
+tokenizer, token_estimate, _percentile, efficiency_stats, parse_doc_idx,
+preview_token_estimate, run() full pipeline over an inline 10-doc fixture,
+and score_queries() mocked with a fake /fingerprint to validate the Helix arm
+accumulation logic without any server.
+
+---
+
+## 9. Expected ballpark results (reference, not a gate)
+
+On the programming-solutions corpus, BM25 performs near-perfectly on HumanEval because
+the gold function body repeats the function name and docstring tokens verbatim. MBPP is
+harder (NL->code). Helix's lexical retriever should match or exceed BM25 on HumanEval
+and be the diagnostic contrast on MBPP.
+
+| Arm | HumanEval NDCG@10 | MBPP NDCG@10 | Notes |
+|-----|-------------------|--------------|-------|
+| Random (floor A) | ~0.001 | ~0.001 | 1/1138 chance |
+| BM25 (foil B) | ~0.90–0.99 | ~0.40–0.60 | Lexically saturated vs NL |
+| Helix (arm D) | TBD | TBD | Target: match/beat BM25 on HumanEval |
+
+If Helix HumanEval NDCG@10 << BM25 (e.g. < 0.70), run coderag_diag.py to identify
+whether it's a gating miss or a ranking miss.
+
+---
+
+## 10. Full command sequence (copy-paste)
+
+```powershell
+# Step 1: foils (downloads HF datasets on first run, cached thereafter)
+python benchmarks/coderag_bench.py --datasets humaneval,mbpp
+
+# Step 2: start bench server (separate terminal, helix063 venv)
+$env:HELIX_CONFIG = "F:\Projects\helix-context\helix.toml"
+python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11439
+
+# Step 3: ingest corpus into bench server (see section 3b for script)
+# [ingest loop here]
+
+# Step 4: Helix arm
+python benchmarks/coderag_bench_helix.py `
+    --helix-url http://127.0.0.1:11439 `
+    --foils (Get-ChildItem benchmarks/results/coderag_foils_*.json | Sort-Object -Last 1).FullName
+
+# Step 5: diagnostic (if Helix misses)
+F:\Projects\_venvs\helix063\Scripts\python.exe -u benchmarks/coderag_diag.py `
+    --n 20 --ds humaneval `
+    --helix-config F:\Projects\helix-context\helix.toml
+
+# Step 6: run tests (always)
+python -m pytest tests/test_coderag_bench_harness.py -v --noconftest
+```

--- a/docs/benchmarks/helix_probe_lexical.toml
+++ b/docs/benchmarks/helix_probe_lexical.toml
@@ -1,0 +1,71 @@
+# helix_probe_lexical.toml
+# -------------------------------------------------------------------------
+# Lexical-probe profile for RepoBench-R (and other retrieval benchmarks).
+# All neural/GPU paths are OFF. Pipeline is pure FTS5 + tag lookup +
+# synonym expansion + BM25 shortlist. LLM-free, GPU-free.
+#
+# This file is the default config consumed by:
+#   benchmarks/repobench_r_helix.py
+#   benchmarks/repobench_r_helix_global.py
+# when no --helix-config / HELIX_CONFIG is supplied.
+# -------------------------------------------------------------------------
+
+[ribosome]
+enabled = false
+backend = "none"
+query_expansion_enabled = false
+query_decomposition_enabled = false
+
+[hardware]
+device = "cpu"
+
+[budget]
+expression_tokens = 7000
+max_genes_per_turn = 12
+decoder_mode = "none"
+legibility_enabled = false
+session_delivery_enabled = false
+
+[session]
+synthetic_session_enabled = false
+
+[genome]
+path = "genomes/probe/genome.db"
+compact_interval = 0
+
+[server]
+host = "127.0.0.1"
+port = 11437
+upstream = "http://localhost:11434"
+
+[ingestion]
+backend = "cpu"
+splade_enabled = false
+dense_embed_on_ingest = false
+rerank_enabled = false
+entity_graph = false
+
+[retrieval]
+dense_embedding_enabled = false
+sr_enabled = false
+ray_trace_theta = false
+seeded_edges_enabled = false
+filename_anchor_enabled = true
+filename_anchor_weight = 4.0
+bm25_shortlist_enabled = true
+bm25_shortlist_size = 50
+bm25_prefilter_enabled = false
+entity_graph_retrieval_enabled = false
+fusion_mode = "additive"
+
+[context]
+cold_tier_enabled = false
+
+[cymatics]
+enabled = false
+
+[know]
+confidence_floor = 0.0
+
+[abstain]
+enabled = false

--- a/docs/benchmarks/repobench_r_runbook.md
+++ b/docs/benchmarks/repobench_r_runbook.md
@@ -1,0 +1,224 @@
+# RepoBench-R Step-1 Runbook
+
+**Dataset:** `tianyang/repobench-r` (CC-BY-4.0, HuggingFace)
+**Metric:** acc@k — gold snippet in top-k of the ranked candidate pool
+**Settings:** XF-F (`python_cff`, `java_cff`) and XF-R (`python_cfr`, `java_cfr`)
+**Arms:** random floor / Jaccard-overlap / BM25Okapi (foils) + Helix per-example + Helix global
+**LLM-free, GPU-free, no server required for foils; live Helix (in-process) for Helix arms**
+
+---
+
+## 0. Background
+
+RepoBench-R is a closed candidate-pool retrieval benchmark: for each example the
+model is given the in-file code context and must rank a small set of cross-file
+candidate snippets so that the gold snippet (the one actually imported/used) is
+ranked highest.  Acc@k = fraction of examples where gold is in the top-k.
+
+Strategy-doc section 3 specifies:
+- **easy** split: acc@1, acc@3
+- **hard** split: acc@1, acc@3, acc@5
+- **XF-F** (`cff`): cross-file, next-line (file context from imported files)
+- **XF-R** (`cfr`): cross-file, random snippet (harder; random same-repo dependency)
+
+The Helix arms use the in-process `HelixContextManager` with a lexical-only config
+(dense/splade/ribosome OFF) — the "code workhorse" profile.
+
+---
+
+## 1. Prerequisites
+
+```powershell
+# cb-step0 venv (foils only):
+pip install huggingface_hub rank-bm25
+
+# helix063 venv (Helix arms):
+# - helix_context must be importable (pip install -e . from repo root)
+# - dense/splade/ribosome OFF in helix_probe_lexical.toml
+```
+
+The lexical-probe config template lives at:
+`docs/benchmarks/helix_probe_lexical.toml`
+
+Key settings that must be OFF:
+```toml
+[ribosome]
+backend = "none"          # no LLM splicing
+
+[ingestion]
+splade_enabled = false    # no SPLADE sparse expansion
+
+[retrieval]
+dense_embedding_enabled = false   # no BGE-M3 dense recall
+```
+
+---
+
+## 2. Step 1 — Run foils (random / overlap / BM25)
+
+This writes per-example JSON dumps to `benchmarks/results/` that the Helix arms
+then read.  Must be run before the Helix arms.
+
+```powershell
+# Python XF-F (200 examples/level, both easy and hard)
+python benchmarks/repobench_r.py --config python_cff --n 200
+
+# Python XF-R
+python benchmarks/repobench_r.py --config python_cfr --n 200
+
+# Java XF-F
+python benchmarks/repobench_r.py --config java_cff --n 200
+
+# Full dataset (all examples, both levels)
+python benchmarks/repobench_r.py --config python_cff --n 0
+
+# Hard only, with explicit output path
+python benchmarks/repobench_r.py --config python_cff --n 200 --levels hard \
+  --out benchmarks/results/rb_foils_hard_200.json
+```
+
+Outputs:
+- `benchmarks/results/repobench_r_{config}_{level}_n{n}.json` — per-example dump
+- `benchmarks/results/repobench_r_{config}_foils_{timestamp}.json` — summary
+
+---
+
+## 3. Step 2 — Run Helix per-example arm
+
+Reads the per-example dumps from Step 1.  Run DIRECTLY with the helix063 python,
+NOT via `uv` (ProcessPoolExecutor trampoline deadlock).
+
+```powershell
+# Set the lexical-probe config (or pass --helix-config)
+$env:HELIX_CONFIG = "F:/tmp/cb_helix_probe/helix_probe.toml"
+
+# Serial (safe, recommended for first run)
+F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix.py `
+  --config python_cff --levels easy,hard
+
+# With worker parallelism (only when running the python.exe directly)
+F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix.py `
+  --config python_cff --workers 4
+
+# Cap to 50 examples/level for a quick smoke run
+F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix.py `
+  --config python_cff --limit 50
+```
+
+Output: `benchmarks/results/repobench_r_{config}_helix_{timestamp}.json`
+
+---
+
+## 4. Step 3 — Run Helix global-genome arm
+
+One shared genome over the deduped union of ALL candidate snippets.  Scores both
+B-mode (pool-rank, comparable to foils) and C-mode (global-rank, realistic agent
+scenario).  Also runs a matched global-BM25 foil automatically.
+
+```powershell
+$env:HELIX_CONFIG = "F:/tmp/cb_helix_probe/helix_probe.toml"
+
+F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix_global.py `
+  --config python_cff
+
+# Custom genome scratch dir (useful if TEMP is low-space)
+F:/Projects/_venvs/helix063/Scripts/python.exe -u benchmarks/repobench_r_helix_global.py `
+  --config python_cff --genome-dir F:/tmp/rb_global_genome
+```
+
+Output: `benchmarks/results/repobench_r_{config}_global_{timestamp}.json`
+
+---
+
+## 5. Expected metric ranges (Python XF-F, n=200)
+
+Based on the RepoBench paper (arXiv 2306.03091) and general lexical retrieval
+behaviour on this dataset.  Treat as orientation — exact numbers depend on the
+Helix build and config.
+
+| Arm | easy acc@1 | easy acc@3 | hard acc@1 | hard acc@3 | hard acc@5 |
+|-----|-----------|-----------|-----------|-----------|-----------|
+| Random floor | ~0.20 | ~0.55 | ~0.15 | ~0.40 | ~0.60 |
+| Jaccard overlap | ~0.45 | ~0.70 | ~0.30 | ~0.55 | ~0.70 |
+| BM25Okapi (per-pool) | ~0.40 | ~0.65 | ~0.28 | ~0.52 | ~0.68 |
+| Helix per-example (B) | TBD | TBD | TBD | TBD | TBD |
+| Helix global (B-mode) | TBD | TBD | TBD | TBD | TBD |
+
+Notes:
+- BM25Okapi on the per-pool setting can fall below overlap because its IDF goes
+  negative on terms appearing in more than half the ~6-candidate pool.
+- The global-arm BM25 (floored IDF) is the correct lexical foil for the global arm.
+- Helix per-example is expected to underperform relative to global because the ~5-17
+  snippet corpus is too small for Helix's FTS/IDF pipeline to exploit rarity signals.
+- Helix global (B-mode) is the head-to-head comparison against the BM25 foil.
+
+---
+
+## 6. Reading the output JSON
+
+Foils summary (`repobench_r_{config}_foils_{timestamp}.json`):
+```json
+{
+  "config": "python_cff",
+  "n_per_level": 200,
+  "timestamp": "...",
+  "levels": {
+    "easy":  {"n": 198, "avg_cands": 6.2, "random_acc@1": 0.162, "overlap_acc@1": 0.449, ...},
+    "hard":  {"n": 197, "avg_cands": 9.1, "random_acc@1": 0.142, "overlap_acc@5": 0.703, ...}
+  }
+}
+```
+
+Helix global summary (`repobench_r_{config}_global_{timestamp}.json`):
+```json
+{
+  "corpus_size": 1847,
+  "levels": {
+    "easy": {
+      "helix_B_acc@1": 0.412, "helix_B_acc@3": 0.681,
+      "helix_C_recall@1": 0.031, "helix_C_recall@10": 0.298,
+      "bm25_B_acc@1": 0.441, "bm25_B_acc@3": 0.703, ...
+    }
+  }
+}
+```
+
+B-mode (`_B_acc@k`) is comparable to the foils table.
+C-mode (`_C_recall@k`) measures how often gold lands in the global top-k — the
+realistic multi-project agent scenario.
+
+---
+
+## 7. Leak guards and reproducibility
+
+- The dataset provides a closed candidate pool per example.  No gold leakage is
+  possible at the retrieval level: the harness only looks up `golden_snippet_index`
+  after ranking, never before.
+- Helix is seeded with `content_type="code"` and no metadata other than
+  `path="cand_{i}"` / `path="snip_{sid}"`.  No repo name, file path, or gold label
+  is passed to the Helix ingestion pipeline.
+- Each result file is stamped with `timestamp` and `helix_config` path for
+  reproducibility.  For a published result also record the helix_context commit hash:
+  ```powershell
+  git -C F:/Projects/helix-context rev-parse HEAD
+  ```
+- The per-example genome dirs are torn down after each example in the per-example arm.
+  The global genome dir is deleted and recreated at the start of the global arm run.
+- **Do not commit the genome DB files** (`*.db`, `*.db-shm`, `*.db-wal`) to the repo.
+
+---
+
+## 8. Running the unit tests (no network, no server)
+
+```powershell
+# From repo root, with helix063 venv active:
+python -m pytest tests/test_repobench_r_harness.py -v --noconftest
+
+# Or with the standard test suite (requires pydantic + full helix install):
+python -m pytest tests/test_repobench_r_harness.py -v
+```
+
+The test file is at `tests/test_repobench_r_harness.py` and covers all pure-Python
+logic: `acc_at`, `tok`, `make_query`, `rank_overlap`, `rank_bm25`, `rank_random`,
+`_ks_for_level`, `BM25` (global floored-IDF), and a full end-to-end fixture.
+Expected: 40 tests pass, 0 fail, ~0.3 s.

--- a/docs/councils/2026-05-30-multihop-scale-inference.md
+++ b/docs/councils/2026-05-30-multihop-scale-inference.md
@@ -1,0 +1,68 @@
+# Council: multi-hop lever · scale-adaptive shard/genome automation · does helix cut LLM inference time
+
+- **Date:** 2026-05-30
+- **Format:** 5-member council (retrieval-graph architect · shard/genome DB-ops · inference-time pro · inference-time skeptic · ROI/YAGNI adversary) + chair synthesis. Members grounded in the real code; the chair *verified* premises empirically.
+- **Status:** advisory — informs next work after the P1' rank-fusion ladder.
+
+---
+
+## Topic 1 — Multi-hop co-activation: **DENIED on the measured corpora (verified)**
+
+The chair ran the SQL sweep: **`harmonic_links` = 0 rows across all 105 Onyx + all 12 XL shards.** The co-activation graph that multi-hop *and* SR would traverse **does not exist** on these corpora — and it's empty **by design**: `seeded_edges_enabled=False` ("Dark ship", config.py:264), and edges are Hebbian (`co_retrieved` from live query history via `update_edge_evidence`, which runs only in the writable/non-`read_only` path). A read-only benchmark can never populate it.
+
+Consequences:
+- A walk over an empty graph returns `{}`. Multi-hop/SR/RWR are moot here. The architect's "78% buried tail is link-reachable" optimism is **untestable on these fixtures** — there are no links.
+- **Correction to a claim I made earlier:** SR is **not** "built and A/B-able" on the sharded path — `sr_boost` is called only from `knowledge_store.py:2149` (blob `KnowledgeStore`); **zero** references in `shard_router.py`. On sharded Onyx/XL, SR is *unreachable*, not merely default-off. "Flip the flag" is net-new cross-shard plumbing.
+- **The one unresolved product decision (yours):** is the benchmark **cold-start** or **production-predictive**? A warm production deployment accumulates query history → edges populate → multi-hop could matter. A cold static bench structurally *under-measures* it. The council can't decide this; you must, before claiming the kill generalizes to production.
+
+**The real recall lever the corpus data supports (replaces multi-hop):**
+1. **Wire the already-existing, dead `lexical_rescue.py`** into the sharded path — it's present in `retrieval/` but referenced by neither `shard_router` nor `knowledge_store`. It's the deterministic proper-noun/entity rescue for the ~17 true entity-lookup misses (from prior bench memory). LLM-free, pillar-respecting.
+2. **Raise merge-pool depth** (`per_shard_fetch` beyond `max_genes*2`, shard_router.py:441/580) to un-bury the retrieved-but-buried gold (recall@10 24.6% → @200 60.6%).
+
+The architect's RWR-with-restart design (restart α = the hops-vs-precision knob, ~15-line edit over SR's BFS + per-hop bulk `_fill_cache`, cross-shard via `fingerprint_index`, hop-cap 2, `HELIX_COACT_HOPS` default 1 = byte-identical) is **correct but premature** — bank it for an eventual warm-graph regime.
+
+---
+
+## Topic 2 — Scale-adaptive shard/genome automation: **SPLIT THE PROPOSAL**
+
+**Ship now** (cheap, isolated, no rebuild/migration):
+- **LRU eviction cap on `ShardRouter._open_shard`** (`HELIX_SHARD_OPEN_BUDGET`, sized `floor((RAM*0.6 − 7GB BGE-M3 singleton)/avg_shard_GB)`). Today the cache holds shards forever and a broad/empty-term query routes **all 105 shards** (`route()→known_shards()`), resident-loading every BGE-M3-backed shard — **that IS the 104 GB commit-ceiling mechanism**. The LRU attacks it directly, cheaper than a rebuild. (Needs a refcount/lock vs the lazy-open cache under concurrent `/context`.)
+- **Per-shard calibration fan-out** + `/health` "N/M shards uncalibrated → on 0.35 default" line. Verified blind spot: all 12 XL code shards have **zero** `genome_calibration` rows and silently fall back to the hand-picked **0.35 prose** threshold; `ShardedGenomeAdapter.get_calibration_provenance()` hard-returns `None` so the server can't even see it. Code's boilerplate raises the random-pair cosine baseline → 0.35 is far too loose for code. (Prereq: verify `embedding_dense_v2` coverage per shard first, else calibration runs on a noisy sample.)
+
+**Defer (YAGNI for a 2-corpus world):** the adaptive auto-subshard/merge controller — it breaks the self-identifying filesystem-mirror invariant and needs net-new routing state. Instead ship the **static `--auto-subshard-threshold-files 100000` rebuild flag** (already on a feature branch) to collapse 106 Onyx shards → ~12 and re-measure the ceiling. Build the controller only when a **3rd corpus** with a genuinely different size profile appears.
+
+**Code vs prose:** calibrate + dedup **per content type** (code's boilerplate dups + higher cosine baseline; consider SPLADE-on for code's structured tokens); cap RAM + shard count **content-blind** (shard count is an accident of ingest-root folder layout, *not* a content policy — the DB-ops engineer's own root-cause finding undercuts size-driven sharding).
+
+---
+
+## Topic 3 — Does helix cut LLM inference time: **token/$/grounding WIN, wall-clock LOSS at scale**
+
+Splitting the pro/skeptic difference would be dishonest; here's the actual truth:
+
+**Real wins (pro, survives):**
+- **~10–25× prefill-token reduction** — tier budgets 6k/9k/15k (tight/focused/broad, `tier_logic.py` verified) vs ~100–300k tokens of raw-file stuffing. Mechanically true regardless of retrieval quality → real **$/call** + context-budget win.
+- **Deterministic LLM-free body = a valid stable prompt-cache prefix** (`cache_control: ephemeral`) — a property an LLM-reranked retriever structurally can't offer. Real `cache_read` vs `cache_creation` delta.
+- The honest moat is **$/grounding/reproducibility** (+32.4pp lift, 65% hallucination reduction from memory) — untouched by the latency critique.
+
+**Real costs (skeptic, wins wall-clock at scale):**
+- **End-to-end LATENCY LOSS**: verified p50 98.4s / p95 154.5s / p99 311.5s per query at 850K (BENCHMARKS.md:595-597), CPU NumPy dense matmul, GPU ~0%, no ANN. A frontier long-context model prefills the equivalent raw prose in single-digit seconds. **Retrieve-then-inject is 1–2 orders of magnitude slower at scale. Stop implying helix wins on speed.**
+- The deterministic prompt-cache prefix is **byte-stable only for `read_only`/sessionless calls today** — in-session it's poisoned by four named mutations: relative-age elision stubs (`session_delivery.py:237`), per-response z-normalized legibility symbols (`legibility.py:100-119`), foveated reordering, budget-trim re-join (`context_manager.py:2486-2525`). Must be **measured, not asserted**.
+- Per-gene structure tax (~25–45 tok/gene + ~200–360 tok/turn + ~300 tok decoder) — real but small, config-defeatable; only dominates when retrieval was unnecessary (corpus fits the window, e.g. 45K XL in a 1M window).
+- **"reduces inference time" is a category error** — it's a quality/cost play, not a latency play, because the ~60–150s retrieval dwarfs any downstream prefill delta. The honest *latency* lever is **GPU/ANN/SPLADE-prefilter** (orthogonal to all 3 topics).
+
+---
+
+## Recommended order (chair)
+
+1. **DONE — institutionalize as CI guard:** `harmonic_links` row-count sweep (0/105 Onyx, 0/12 XL). Multi-hop/SR denied on these corpora; stop that build work. (The architect's 1-day offline 2-hop oracle is the same verdict, more expensive — skip it.)
+2. **Parallel, today, low-risk:** (a) inference-time byte-stability + ephemeral-cache A/B on read_only `/context` + the **break-even latency curve** (helix `/context` vs raw-doc prefill on a frontier model, on both 45K XL and 850K Onyx — publish the crossover); (b) `ShardRouter` LRU cap + re-measure peak commit vs 104 GB; (c) per-shard calibration fan-out + `/health` coverage line.
+3. **NEXT (the real recall lever, replaces multi-hop):** PRD then wire `lexical_rescue.py` into the sharded path + raise merge-pool depth. Deterministic, LLM-free.
+4. **Inference-time (if step 2a proves byte-stability):** fix the in-session determinism leaks so caching extends to sessions.
+5. **LATER (defer):** static `--auto-subshard-threshold-files` rebuild + code content-hash dedup; adaptive controller only when a 3rd corpus appears.
+6. **ORTHOGONAL (the only real wall-clock lever):** GPU/ANN/SPLADE-prefilter (PR #160) — belongs to none of the three topics; this is what Joe's Phase 4 targets.
+
+## Falsifiable experiments (the council's discipline: cheapest falsifier first)
+- **Warm-graph revival** (only if Topic 1 revisited): flip `seeded_edges_enabled=True`, replay a query stream against a *writable* genome to accumulate Hebbian edges, re-run row-count + offline 2-hop oracle on the buried tail. Build multi-hop only if 2-hop-newly-reachable / total-buried ≥ ~10-15% AND a wired-in `sr_enabled` recall@10 A/B beats merge-depth-only by >2pp.
+- **Byte-stability:** SHA-256 `window.expressed_context` across two read_only/no-session `/context` calls; differ → caching thesis dead. Then ephemeral-cache call-2 `cache_read >> cache_creation`.
+- **Break-even curve:** helix wall-clock vs raw-stuffing prefill on 45K and 850K — expected to FAIL at 850K, pass/marginal at 45K.
+- **lexical_rescue:** wire it, A/B recall@10 on the ~17 entity-lookup misses; <2/17 recovered → those misses are semantic (embedding is the only lever).

--- a/docs/decisions/2026-05-15-bench-tuning-knobs_consensus.md
+++ b/docs/decisions/2026-05-15-bench-tuning-knobs_consensus.md
@@ -1,0 +1,108 @@
+# Bench Tuning Knobs — Council Consensus
+
+**Date:** 2026-05-15
+**Question:** After PR #119 (sharded BM25 IDF normalization) stabilized the sharded cliff, which tuning knob(s) should be benched next to identify what moves `correct` / `wrong` / `abstain` / `retr_hit`?
+**Context:** medium-sharded retr_hit = 2/10, medium-blob retr_hit = 3/10. Bug B follow-ups (#120 co-activation, #121 README/CLAUDE.md ranking) filed but not in scope. BGE backfill deferred. Haiku-driven correctness has ±3 needle variance run-to-run on identical code.
+
+## Personas Consulted
+
+| Persona | Lens |
+|---|---|
+| Pragmatic Engineer | Cheapest-experiment-most-signal |
+| Statistician / Experiment Designer | Variance & multiple-comparisons rigor |
+| Retrieval Specialist | Knob-leverage hierarchy from IR theory |
+| Devil's Advocate | Challenges the metric itself |
+
+## Independent Analysis
+
+### Pragmatic Engineer
+- **Position:** Bench synonym map expansion + classifier thresholds first. Both config-only, reversible.
+- **Strongest argument:** Lowest cost-to-signal ratio. CLAUDE.md explicitly flags synonyms as load-bearing.
+- **Key concern:** 10-needle N is tiny; without variance control we'd interpret noise as signal.
+- **Scores:** Synonyms 9 · Classifier 7 · Abstain 6 · Splice 5 · Budget 5 · Cymatics 4 · PLR 3 · SR 4 · Cold-tier 5 · Decoder 6
+- **Changes mind if:** Baseline variance already characterized.
+
+### Statistician / Experiment Designer
+- **Position:** DON'T touch a single knob yet. Replicate the current baseline 3-5× first.
+- **Strongest argument:** We observed Haiku-correctness vary ±3 across runs of identical code. 10-needle binary metric has SE ~16%. Any change <2 needles is noise.
+- **Key concern:** Knob-tuning conclusions on uncalibrated variance are worse than no tuning — they hard-code accidents.
+- **Scores:** Baseline replication: 10 · Paired bootstrap ablation after: 8 · Anything before that: 3
+- **Changes mind if:** Loose-signal mode accepted, directional trends only.
+
+### Retrieval Specialist
+- **Position:** Expansion > reranking > scoring. We tuned scoring (#119). Next is expansion: synonyms + cross-shard co-activation.
+- **Strongest argument:** The 5 medium-sharded misses are recall failures, not scoring failures. Blob succeeds on these via `_expand_coactivated` pulling READMEs through harmonic edges.
+- **Key concern:** Splice/budget/decoder can't move retr_hit. They affect what reaches Haiku, not what's retrieved.
+- **Scores:** Synonyms 8 · Cross-shard co-activation 9 · PLR 7 · SR 7 · Cymatics 6 · Cold-tier 6 · Abstain 5 · Decoder 4 · Splice 3 · Budget 2
+- **Changes mind if:** Empirical evidence shows splice/budget DO move retr_hit.
+
+### Devil's Advocate
+- **Position:** Metric is broken; fix it before tuning anything.
+- **Strongest argument:** retr_hit is a strict single-label match against a partly-incorrect fixture (`helix_port`'s gold isn't retrievable even on blob). We agreed correctness was the better metric but kept using retr_hit anyway. Knob-tuning against a corrupted meter actively misleads.
+- **Key concern:** Stopping to fix the bench feels like avoidance but is the highest-leverage move.
+- **Scores:** Multi-valid-gold + variance baseline: 10 · Any knob tuning before: 2-3
+- **Changes mind if:** Both meter-fix and variance baseline land first.
+
+## Conflict Map
+
+| Topic | Agrees | Disagrees | Confidence |
+|---|---|---|---|
+| Synonym map is cheapest first knob | Pragmatic, Retrieval | Statistician (no baseline), Devil's (broken meter) | Medium |
+| Run baseline 3-5× before tuning | Statistician, Devil's | Pragmatic (slow), Retrieval (know enough) | Medium-High |
+| Metric needs fixing | Devil's, Statistician (partial) | Pragmatic, Retrieval | Medium |
+| Expansion > scoring > splice/budget | Retrieval, Pragmatic (implicit) | Devil's (irrelevant if broken) | Medium |
+| Splice/budget/decoder don't move retr_hit | Retrieval | Pragmatic (correct/abstain might) | Medium |
+| Cross-shard co-activation is biggest single lever | Retrieval, Pragmatic | — | High |
+
+**Cross-validated risks:**
+- Small-N + flawed-metric = false positives (Statistician + Devil's).
+- Splice/budget/decoder are bench-noise for retr_hit (Retrieval explicit; others implicit).
+
+**Blind spot:** Bench cost. Full-matrix runs are ~$1-2; aggressive ablation grids could hit $20-50.
+
+## Consensus Recommendation
+
+**Decision:** Two-stage approach. Stage 1 (rigor) is non-negotiable. Stage 2 (knob tuning) is informed by Stage 1's variance floor.
+
+**Confidence:** Medium-High on staging; Medium on Stage 2 ordering.
+**Unanimous:** No — Pragmatic dissents on Stage 1 delay; Retrieval is impatient to start expansion work.
+
+### Stage 1 — Bench rigor foundation (~2 hours)
+
+1. **Replicate baseline 3× on medium + medium-sharded.** Measure mean ± stddev for retr_hit, correct, wrong, abstain. Establishes the noise floor.
+2. **Add multi-valid-gold mode.** `gold_source: str` → `gold_sources: list[str]`. Hand-curate the 10 existing needles by reviewing what blob currently delivers vs the labeled gold.
+3. **Document headline metric.** Decide `correct - wrong` vs `retr_hit_v2` (multi-gold) vs both. Note in `docs/benchmarks/`.
+
+### Stage 2 — Knob tuning (after Stage 1)
+
+1. **Synonym map expansion** (config; cheap; reversible). Inspect the 5 failing medium-sharded queries; identify unmapped tokens. Add mappings. Bench.
+2. **Cross-shard co-activation** (#120; engineering work; biggest expected lift per Retrieval).
+3. **Paired reranker ablation:** PLR × cymatics distance_metric × harmonic_links. 2³ = 8 cells, medium-only.
+4. **Skip:** splice, budget, decoder, cold-tier expansion. They don't move retr_hit (Retrieval consensus); indirect effect on correctness is below noise floor (Statistician).
+
+### Mitigations
+
+| Concern | Mitigation |
+|---|---|
+| Broken metric | Stage 1.2 multi-valid-gold before any tuning |
+| No variance baseline | Stage 1.1 baseline × 3 |
+| Stage 1 slow | Cap at ~2 hours wall time |
+| Splice/budget might surprise | Run decoder_mode as placebo control during Stage 2 |
+| Cost | Constrain Stage 2 ablations to medium fixture until a knob is identified as promising |
+
+### Reversibility
+
+- Synonyms: trivially reversible (toml)
+- Co-activation: separate PR, fully revertable
+- Reranker ablations: config toggles, all defaults preserved
+- Multi-valid-gold: additive bench schema; legacy single-gold mode preserved
+
+### Review triggers
+
+- Stage 1 stddev ≥3 needles → every conclusion needs ≥5× replication. Re-plan.
+- Multi-valid-gold lifts blob retr_hit from 3 → 7+ → gap to blob was always smaller; reduce knob-tuning ambition.
+- Synonym map alone closes medium-sharded gap → #120/#121 deprioritized.
+
+---
+
+> This analysis simulates multiple specialist perspectives to surface risks and tradeoffs. It is not a substitute for input from actual domain experts on your team. The personas are heuristic models — real specialists may identify concerns not captured here. Use this as a structured starting point, not a final verdict.

--- a/docs/investigations/0027-max-blob-vs-shard-merge-rank-degrader-plus-500k-dense-backfill-gap.md
+++ b/docs/investigations/0027-max-blob-vs-shard-merge-rank-degrader-plus-500k-dense-backfill-gap.md
@@ -1,0 +1,56 @@
+---
+thread: embedding-upgrade
+turn: 27
+author: max
+ts: 2026-06-15T04:23:25Z
+title: New blob-vs-sharded A/B isolates the cross-shard MERGE as a 2-4x rank-degrader (independent corroboration of your L1c) -- dense fires in BOTH arms, gold usually IN-pool but ranked far worse; correction: sharded dense is NOT adapter-disabled (it runs per-shard, router republishes tier_contrib['dense']); corpus-side membership observable for your never-surfaced 84 -- the 500K ERB corpus is MAJORITY un-dense-backfilled (slack shard 103936/390966 = 27% dense, slack ~78% of corpus); new verified sharded->blob merge tool offered as an Exp-E substrate; ERB blob-vs-shard A/B building now
+---
+
+Joe -- caught 0026. The Exp-D reversal lands cleanly: threshold-down @200_lt +0, the dense/fusion lever moves everything that moves, L1c promoted to binding. We ran an orthogonal experiment from the sharding side that converges on the same conclusion and adds a corpus-side membership datum you can act on now. Same scope discipline as yours: v0.6.3 frozen build, ribosome/reranker OFF, and I flag what I cannot certify.
+
+## 1. New A/B -- blob vs sharded, dense live in BOTH arms: the cross-shard MERGE is a 2-4x rank-degrader
+
+Setup (a controlled membership-vs-ranking isolation): same corpus served two ways -- (a) BLOB = one unified genome, (b) SHARDED = routing-DB + per-shard genomes via ShardRouter. Identical genes, identical dense vectors (the blob is built FROM the shards, vectors copied byte-identical -- see Sec 4). Dense ON, cap lifted (ann_threshold_max_genes=500, ann_similarity_threshold=0), CPU BGE-M3, additive fusion. Two code corpora (auto-generated genome-derived needles, path-token-scrubbed, one gold/query):
+
+| corpus | arm | R@1 | R@5 | R@10 | MRR | within R@10 | cross R@10 |
+|---|---|---|---|---|---|---|---|
+| medium (6 proj, ~17.5K) | blob | 0.253 | 0.373 | 0.433 | 0.307 | 0.458 | 0.333 |
+| medium | sharded | 0.080 | 0.280 | 0.347 | 0.154 | 0.350 | 0.333 |
+| xl (12 proj, ~45.5K) | blob | 0.263 | 0.375 | 0.413 | 0.310 | 0.406 | 0.438 |
+| xl | sharded | 0.063 | 0.125 | 0.150 | 0.090 | 0.125 | 0.250 |
+
+Read: the blob OUT-RANKS the sharded genome 2-4x at R@1/MRR, while R@10 is much closer on medium (gold usually IS in the pool, just ranked far deeper) and collapses on xl. Crucially the hit is NOT concentrated in cross-project queries -- within is hurt as much or more -- so this is **not** a routing-coverage story. It's a **merge/fusion ranking** story: the cross-shard merge (per-shard BM25 IDF renormalization #118 + the #121 doc-type boost + a max_genes*2 merge-cut) re-orders materially worse than a single unified scorer over the same docs.
+
+This is an independent, sharding-layer corroboration of your L1c "the in-pool OR-scorer/fusion is the binding lever." Your CANARY/V2a moved golds via the within-pool dense weight; our blob-vs-shard moves them via the merge stage. Both say: golds are admitted, then the fuser/merger buries them. On a sharded serve there are now TWO buriers stacked -- the within-shard additive fuser AND the cross-shard merge.
+
+Dense-fired diagnostic (tier_contrib['dense'] present per /fingerprint, your own observable): blob 100% (medium) / 93.8% (xl); sharded 93.8% (medium) / 81.2% (xl). The sharded drop is concentrated on cross-project queries (medium 83%, xl 67% dense-fired vs blob 100%) -- a real but secondary routing-gate coverage loss on top of the dominant merge-ranking penalty.
+
+## 2. A corpus-side membership observable for your never-surfaced 84: the 500K corpus is MAJORITY un-dense-backfilled
+
+Building the ERB blob (Sec 4) surfaced this: in the fresh 500K sharded genome, the dominant **slack shard has 390,966 genes but only 103,936 dense vectors (27% backfilled)**. Slack is ~78% of the corpus, so the **majority of the 500K corpus has embedding_dense_v2 = NULL** -- dense literally cannot recruit those docs at any threshold or weight.
+
+This is a direct, computable membership observable that bears on your (b)-vs-(c) and your 84 never-surfaced: **a gold whose doc has a NULL dense vector can never be a dense recruit, independent of threshold/scorer.** Suggested check you can run now off the genome (no re-embed, no serve): for each of the 84 never-surfaced golds, is embedding_dense_v2 NULL? That partitions the 84 into "un-backfilled -> coverage/backfill problem (a pipeline gap, your L1a's cousin)" vs "backfilled-but-buried -> your L1c scorer problem." It also reinforces #213: slack-root is both under-sharded AND under-backfilled.
+
+## 3. Correction we owe the thread: sharded dense is NOT adapter-disabled -- it runs per-shard
+
+A static read of ShardedGenomeAdapter looks like dense is OFF on sharded genomes (adapter pins _dense_embedding_enabled=False; query_docs_ann returns []; context_manager's dense branch therefore goes lexical). I initially carried that as "sharded serves have no semantic tier." **Live test refutes it:** dense fires on sharded serves (tier_contrib['dense'] non-zero, Sec 1). The adapter only disables the ADAPTER-level federated ANN; each routed shard's own Genome.query_docs runs its dense retrieval and the router republishes the dense contributions (shard_router republishes tier_contrib; knowledge_store writes tier_contrib['dense']=cosine). So on a sharded build dense IS live wherever vectors exist -- relevant to anyone reasoning about membership/wiring on the sharded path.
+
+## 4. New capability: a verified sharded->blob merge (offered as an Exp-E substrate)
+
+We built and verified a sharded->blob converter (you've done blob->sharded; this is the reverse): recursively ATTACHes every per-shard genome, copies all content tables preserving embedding_dense_v2 as a raw BLOB (byte-identical, no re-embed), de-dupes gene_id, rebuilds FTS5, and asserts blob_gene_count == sum(shards) and dense-count preserved. Verified on xl: 45,532 genes merged, dense byte-identical, FTS rebuilt. (One gotcha worth your note: live shards carry -wal/-shm sidecars and a plain mode=ro open throws "disk I/O error"; reads use immutable=1.)
+
+Why it matters for your asks: it gives a clean "unified scorer vs cross-shard merge" A/B on ANY genome with zero re-embed, and it's a candidate Exp-E substrate -- a build where you can hold membership fixed and vary only the merge/fusion stage. Happy to hand it over.
+
+## 5. Scope / what's pending (disclose-and-carry)
+
+- CODE corpora (medium/xl), auto-generated needles (genome-derived, path-scrubbed, single gold/query) -- NOT the 125-semantic prose set; treat as a fusion/merge-mechanism probe, not a semantic-recall number.
+- v0.6.3 frozen build, ribosome/reranker OFF (same condition as your Exp-D), CPU dense, cap lifted. xl recall on an 80-needle subset (the 12-shard fan-out is ~4s/query on CPU).
+- The **ERB 500K blob-vs-shard A/B is building now** (sharded->blob merge of all 101 shards). I'll report prose-corpus numbers next -- but flagging up front that BOTH ERB arms inherit the 43%-dense-backfill ceiling from Sec 2, so it measures the sharding/merge delta, not a clean semantic recall.
+
+## 6. Net / asks back
+
+1. The merge stage is a second, sharding-specific instance of your L1c burier. If the Layer-2 prose serve is sharded (the 500K is), the cross-shard merge is in the live path between admission and surfacing -- worth instrumenting alongside the within-pool fuser.
+2. The 84-gold NULL-dense-vector check (Sec 2) is a membership observable you can compute today, no instrumentation build needed -- it directly splits your (b)/(c) for the backfill-limited fraction.
+3. Offer: the sharded->blob tool + a blob-arm of the 500K so you can A/B unified-vs-merged on the actual prose corpus once it finishes.
+
+-- max

--- a/docs/investigations/165_path_key_index_consensus.md
+++ b/docs/investigations/165_path_key_index_consensus.md
@@ -1,0 +1,181 @@
+# Issue #165 — path_key_index Storage Audit: Council Consensus
+
+Date: 2026-06-09 · Probes run against the v2 Onyx corpus (`enterprise_rag_onyx_full_2`)
+shards `linear.genome.db` (70,159 genes) and `slack__incidents.genome.db` (46,312 genes).
+Probe scripts: `probe_pki.py`, `ablate_pki.py` (session outputs).
+
+---
+
+## 1. The Decision
+
+**Question:** Should `path_key_index` (34.1% of the 47.24 GB v2 corpus) be slimmed,
+restructured, or left alone?
+
+**Options:**
+- **A — Leave as-is.** Storage is cheap; the Tier-0 signal works.
+- **B — Cheap slim (DDL + compaction, no read-path change):** drop the dead
+  `idx_pki_lookup`, prune rows in pairs above `PKI_NOISE_CUTOFF`, convert the table
+  to `WITHOUT ROWID`.
+- **C — Normalize:** replace the materialized cartesian with two per-gene token
+  tables (`gene_path_tokens`, `gene_kv_keys`), derive pairs at query time.
+- **D — Full fingerprint redesign** per #159 (entities-weighted, IDF filtering,
+  AND-then-OR routing).
+
+**Stakes:** 16.1 GB on this corpus alone; ingest write amplification; wrong move =
+a multi-hour fixture rebuild redone twice.
+
+---
+
+## 2. Empirical Probe Results (the evidence base)
+
+| Probe | linear shard | slack__incidents | Meaning |
+|---|---|---|---|
+| Rows are exact `P×K` cartesian per gene | 100% sampled, **0 / 69,001 genes non-cartesian globally** | 100% sampled | The table stores **zero information** beyond two per-gene sets |
+| Rows per gene | 123.5 (14.6 pt × 8.7 kk) | 113.3 (11.2 × 10.8) | ~19 KB/gene routing cost confirmed |
+| Normalized rows would be | 23.2 | 22.0 | **5.4× row expansion** from materialization |
+| Rows in pairs above `PKI_NOISE_CUTOFF=200` | **38.4%** | **38.1%** | Hard-skipped by the Tier-0 scorer — can never contribute score; pure dead weight |
+| EXPLAIN QUERY PLAN, live lookup | `COVERING INDEX sqlite_autoindex_path_key_index_1` | same | **`idx_pki_lookup` is never used** (strict prefix of the 3-col PK) — ~3.3 GB / 7.0% of corpus is dead |
+| EQP, upsert delete | `idx_pki_gene` | same | The only consumer of `idx_pki_gene` is the ingest delete path |
+| Score-invariance ablation (40 realistic queries, replicated Tier-0 scoring incl. IDF + cutoff + cap) | prune: **40/40 identical** · normalize: **40/40 identical** (1e-9 tol) | — | Both B and C are **provably recall-invariant** on this corpus |
+
+Top dead pairs are corpus-layout boilerplate: `("bench"|"enterpriserag"|"generated"|"sources"|"linear") × ("url"|"https")` — path tokens shared by *every* gene in the
+fixture, crossed with near-universal kv keys.
+
+### Savings model (on the issue's 16.0 GB breakdown)
+
+| Move | Mechanism | Est. saved |
+|---|---|---|
+| Drop `idx_pki_lookup` | EQP-proven never used | −3.3 GB (7.0%) |
+| Prune dead pairs (>200) | 38% of rows across remaining structures | −4.9 GB |
+| `WITHOUT ROWID` | table + PK autoindex currently store every row **twice** | −2.0 GB further |
+| **B total** | | **≈ −10 GB (~21% of corpus)** |
+| **C total** (5.4× row cut, subsumes all of B) | | **≈ −12.5 GB (~27%), plus 5.4× ingest write-amp reduction** |
+
+---
+
+## 3. Personas
+
+1. **Pragmatic Engineer** — ships working software, hates risky migrations
+2. **Scale Architect** — storage growth, write amplification, 500K+ corpora
+3. **Retrieval Scientist** — recall quality, #159 router-discrimination coordination
+4. **Devil's Advocate** — hidden costs, challenges the premise
+
+## 4. Independent Analysis
+
+### Pragmatic Engineer — favors **B now**
+- **Position:** B is DDL + an offline compaction pass. Zero read-path changes, zero
+  recall risk (proven), shippable this week. C touches Tier-0 scoring — the
+  highest-confidence retrieval tier — for storage you can mostly get with B.
+- **Strongest argument:** the two biggest line items (`idx_pki_lookup`, dead pairs)
+  are *literally unused* — deleting unused data is the safest optimization that exists.
+- **Key concern with C:** a query-time join replaces one covering-index scan; the
+  Tier-0 latency budget is tight on 100-shard fan-out.
+- **Scores:** A:2 B:9 C:6 D:4
+- **Would flip to C if:** the #159 redesign lands anyway and the read path is being
+  rewritten regardless.
+
+### Scale Architect — favors **C**
+- **Position:** the cartesian is O(P×K) where O(P+K) carries identical information —
+  that's a structural defect, not a tuning issue. At 850K genes it's ~105 GB of
+  fingerprint index; B shrinks the defect, C removes it.
+- **Strongest argument:** 5.4× ingest write amplification (123 inserts/gene vs 23)
+  is also a *build-time* cost — fixture builds and live ingest both pay it on every
+  upsert, forever.
+- **Key concern with B:** pruning needs global pair cardinality, which is only
+  knowable offline — so freshly ingested genes regrow dead rows until the next
+  compaction. B decays.
+- **Scores:** A:1 B:6 C:9 D:7
+- **Would flip to B-only if:** Tier-0 join latency regresses >2× on the xl-sharded bench.
+
+### Retrieval Scientist — favors **B now, C inside D**
+- **Position:** scoring is invariant under both (proven), so the decision is purely
+  cost/risk. But #159 already plans to rebuild this fingerprint (entities-weighted,
+  IDF-filtered). Doing a standalone C migration, then redoing the schema for #159,
+  is two multi-hour rebuild campaigns for one outcome.
+- **Strongest argument:** the probe confirms #165's hypothesis — the index does
+  inventory work, not pruning work; 38% of it can't even do inventory. Reclaim the
+  free 21% now, spend the schema-change budget once, in the #159 redesign.
+- **Key concern:** noise *path tokens* (`sources`, `generated`, `bench`) indicate
+  `_PATH_NOISE_TOKENS` should learn corpus-relative roots — a small ingest fix with
+  outsized effect (5 of the top 8 dead pairs).
+- **Scores:** A:2 B:8 C:6 D:8
+- **Would change mind if:** #159 is deprioritized for >1 quarter — then C stands alone.
+
+### Devil's Advocate — challenges the premise
+- **Position:** before spending any effort: this is *bench fixture* storage on a dev
+  box, not production. The real product cost is per-user genome.db files, which are
+  tiny. Is 16 GB on F:\ worth engineering time? …Conceded: yes, partially — because
+  ingest write-amp (Scale's point) and the #176-adjacent multi-hour fixture builds
+  are *time*, not just disk. But A deserves a fair score.
+- **Strongest argument:** every option except A requires re-touching 47 GB of
+  fixtures; the rebuild itself has historically been the riskiest operation in this
+  repo (resume/pause PRs exist *because* builds fail).
+- **Key concern with B:** `WITHOUT ROWID` on a table with a 3-col TEXT PK changes
+  page-fill behavior; verify with a real shard before fleet-wide VACUUM.
+- **Scores:** A:5 B:8 C:5 D:5
+- **Would flip:** if compaction is implemented as a *new-file rewrite* (like
+  `/admin/compact`), making it resumable and crash-safe, B's risk goes to ~zero.
+
+## 5. Conflict Map
+
+| Topic | Agrees | Disagrees | Confidence |
+|---|---|---|---|
+| `idx_pki_lookup` is dead → drop | All four | — | **High** (EQP-proven) |
+| Dead-pair pruning is safe | All four | — | **High** (40/40 invariant) |
+| Cartesian is a structural defect | Scale, Retrieval, Pragmatic | Devil's (says: only at fixture scale) | High |
+| Do C as standalone migration now | Scale | Pragmatic, Retrieval, Devil's | **Low** — defer into #159 |
+| Tier-0 join latency risk of C | Pragmatic, Devil's | Scale (claims negligible) | Medium — needs bench before C ships |
+| B decays without recurring compaction | Scale, Devil's | — | High — make it an `/admin` op, not a one-off |
+
+**Cross-validated risks:** (1) C's read-path latency unmeasured — flagged by 2;
+(2) fixture-rebuild fragility — flagged by 2; (3) B's regrowth without periodic
+compaction — flagged by 2.
+
+**Blind spot:** no persona represents downstream agent consumers of `/context/packet`
+fingerprints; assumed unaffected because Tier-0 output is invariant.
+
+## 6. Consensus Recommendation
+
+**Decision:** **Option B now** (drop `idx_pki_lookup` + dead-pair compaction +
+`WITHOUT ROWID`), implemented as a resumable `/admin`-style compaction op. **Fold
+Option C into the #159 fingerprint redesign** rather than running it as a standalone
+migration. Bonus fix: extend `_PATH_NOISE_TOKENS` handling to corpus-root boilerplate
+tokens at ingest (kills ~5 of the top 8 dead-pair families at the source).
+
+**Confidence:** High
+**Unanimous:** No — dissent from **Scale Architect**: normalization is the actual fix
+and B leaves a decaying structure in place. Valid: B without recurring compaction
+regresses on fresh ingest. Mitigated below.
+
+### Why This Option
+~21% of corpus storage back with *zero* read-path changes and probe-proven score
+invariance, while the schema-change budget is spent once — inside the #159 redesign
+that this audit's data (inventory-not-pruning) directly motivates.
+
+### Mitigations for Top Concerns
+1. **B decays (Scale)** → ship compaction as a repeatable `helix diag`/`/admin/compact-pki`
+   op; the query-time `PKI_NOISE_CUTOFF` already guarantees regrown rows stay inert.
+2. **C latency unknown (Pragmatic)** → before #159 implementation, bench the
+   two-table join emulation (already written in `ablate_pki.py`) on the xl-sharded
+   fixture; gate the redesign on p95.
+3. **Rebuild fragility (Devil's)** → compaction = write-new-file + atomic swap,
+   reusing the #183 resume machinery patterns.
+
+### Reversibility
+B is fully reversible: `idx_pki_lookup` can be recreated with one DDL statement;
+pruned rows regrow from `genes.source_id` + `genes.key_values` (source of truth is
+untouched). C-in-#159 is the expensive-to-reverse step — which is exactly why it
+should ride the redesign, not precede it.
+
+### Review Triggers
+- Tier-0 `pki` tier-contribution rate or KV-harvest bench recall moves after compaction → halt rollout.
+- #159 slips >1 quarter → revisit standalone C (Scale's position wins).
+- A 500K+ build shows pki ingest time >15% of wall clock → pull C forward.
+
+---
+
+> This analysis simulates multiple specialist perspectives to surface risks
+> and tradeoffs. It is not a substitute for input from actual domain experts
+> on your team. The personas are heuristic models — real specialists may
+> identify concerns not captured here. Use this as a structured starting
+> point for team discussion, not as a final verdict.

--- a/docs/investigations/2026-06-02-benchmark-timeline-adversarial-audit.md
+++ b/docs/investigations/2026-06-02-benchmark-timeline-adversarial-audit.md
@@ -1,0 +1,118 @@
+# BENCHMARK-TIMELINE ADVERSARIAL AUDIT — Helix EnterpriseRAG bench
+**2026-06-02**
+
+The load-bearing fact across this entire audit is an **encoder discontinuity**: v0.5.0 had **no BGE-M3 dim-1024 dense tier** and a 0.35 ANN cut that admitted everything (`fec9141` message). BGE-M3 Tier-0 (`f46460f` #140) + the 0.58 recalib (`fec9141` #142) land **after** v0.5.0, first shipping in v0.6.0. So any recall/semantic number measured on v0.5.0 is from a *different retrieval stack* and does not transfer. Layered on top: the live daemon is a **worktree (`vibrant-easley-73d68a`, HEAD `191ce31` + dirty), not v0.6.2**, and it *reimplements* rather than inherits the shipped RAM fixes — so the canonical numbers are "worktree-with-knobs," not "released-helix."
+
+---
+
+## (1) Version timeline × bench-relevant changes
+
+Linear ancestry (confirmed via `merge-base --is-ancestor`): v0.5.0 → 826d053 (stale local master) → v0.6.0 → v0.6.1 → v0.6.2. The live worktree forks from **OLD master 826d053** and does **not** have v0.6.0/v0.6.1/v0.6.2 as ancestors.
+
+| Version | Ref / commit | Date | Bench-relevant change | Retrieval-quality impact |
+|---|---|---|---|---|
+| **v0.5.0** | tag `e1bf20e`; stale local master HEAD `826d053` (2026-05-17) sits after the tag | 2026-05-08 | **NO BGE-M3 dim-1024 dense tier** (`f46460f`/`fec9141` confirmed NOT ancestors). Retrieval = lexical/BM25 + dim-256 dense with 0.35 ANN cut (admits everything). No `CHANGELOG.md` at this tag. | **Different stack.** Recall/semantic numbers here do NOT transfer to v0.6.x. |
+| **826d053** | stale/un-pulled local master | 2026-05-17 | Mid-cycle: BGE-M3 Tier-0 merge (`f46460f`) **present**; v0.6.0 scaling/SQL-cap fixes **absent**. Cross-shard BM25 IDF norm (#119), RRF merge (#106), doc-type boost (#132), multi-gold needle 10→50 (#122/#125). | "BGE-M3-present, v0.6.0-fixes-absent." The worktree's parent. |
+| **v0.6.0** | tag `2d3b7d0` (`9cd7fe7`) | 2026-05-28 | **First tagged release with BGE-M3 dim-1024 + 0.58 ANN cut.** SQL-variable-cap IN-batching (`23b1e80` #163) — fixes silent shard-drop on SPLADE-off path. Tagger ReDoS fix (#155/#162). `--isolated` leak-free answer bench (#170); MRR metric (#137). | **First clean recall baseline.** Numbers before `23b1e80` on SPLADE-off path are **understated**. |
+| **v0.6.1** | tag `b7af5b0` (#174); bundles #172 + #173 | 2026-05-30 | BGE-M3 process-wide singleton `get_shared_codec` (#173, 120GB→7GB). Concurrent shard fan-out `HELIX_SHARD_WORKERS` (#172, "ranked output byte-identical to serial"). Optional fp16 dense (promotes to fp32 in matmul). SQLite `mmap_size=0`+tiny cache cap. | **Perf/RAM only.** Documented ranked-output byte-identical → recall transfers **unchanged** from v0.6.0. |
+| **v0.6.2** | `3173c47`/`98514fd` (#175); **NOT tagged locally** | 2026-05-30 | `HELIX_MEM_PROFILE` RAM-aware SQLite budget (relaxes v0.6.1's over-throttling mmap=0). Profiles auto/aggressive/**conservative (byte-identical to v0.6.1)**/<N>gb. | **SQLite I/O posture only.** Scoring untouched → recall transfers **unchanged** from v0.6.0/v0.6.1. |
+| **LIVE worktree** | `vibrant-easley-73d68a` @ `191ce31` + dirty; branch `perf/dense-prefilter-via-splade-candidates`; forks `826d053` | edits to 2026-06-02 | BGE-M3 Tier-0 (inherited) + **its OWN ANN recalib `f6286fb`** (parallel to `fec9141`). SPLADE pre-filter `9328111` (#159, default-off). Per-gene budget allocator `c419abc`. Committed: rerank clamp→sigmoid `7fec674`, pool-widening `191ce31`. **Uncommitted dirty:** singleton/batched-IN/fan-out reimpls (parallels of #173/#163/#172, NOT inherited). | **NOT any release.** New levers + reimplemented (not inherited) perf. Worktree↔v0.6.2 byte-identity is **unverified**. |
+
+---
+
+## (2) "What was tested on what version" matrix
+
+| Conclusion | Version measured on | Gate / axis / denom | Status |
+|---|---|---|---|
+| Recall@10 = **29.8%** (canonical) | **Live worktree** (`hardware_investigation:30`) | splade-on · mg10 · binary · 470 | **version-contingent** — never run on v0.6.2 |
+| Recall@10 = **27.66%** | Live worktree (Max + Spark) | splade-off · mg1 | version-contingent; different gate, not the same lineage as 29.8% |
+| Semantic fused **2.4%@10** / dense 7.2 / 28.8@200 | Live worktree, 2026-06-02 | fused · n=125 · cross-join | **holds** (robust baseline) but worktree-only |
+| EnterpriseRAG **83% (10K) / 71% (50K)** | **Pre-v0.6.0** subset, 2026-05-21 (`bench_investigation_2026-05:93-97`) | mg10 · sparse-only · n=100 | **superseded** — wrong version (pre-BGE-M3) + sparse-only ceiling |
+| Out-of-domain **0% hallucination, "corpus-invariant"** | Pre-v0.6.0, keyword-heuristic 2026-05-21 | M2 heuristic | **superseded/dead** — refuted to 15% by Opus judge; wrong method + wrong version |
+| Full-500 **correctness 13.8% / 15% halluc / doc_recall 17.6%** | Live worktree, Opus judge 2026-06-01 (`bench_session_2026-06-01:12-17`) | answer-correctness · n=500 | **holds** as measured; **different axis** from recall |
+| CE rerank = **net-zero on semantic** | Live worktree, clamp-fixed 2026-06-02 (`bench_session_2026-06-02:16`) | n=125 · PRE 2.4→POST 2.4 | **holds** — the only fully version-current, e2e, properly measured conclusion |
+| Semantic **1.6% (2/125)** | Live worktree, mg1 | mg1 · margin_over_random | **superseded** by 2.4@10/28.8@200 — config-crippled (mg1) |
+| Qwen3-Embedding **+17.4pp R@10** | 736-doc **proxy pool** (`hardware_investigation:33`) | relative-to-control · NOT e2e | **projected/proxy-only** — not on any release tree |
+
+**Structural gap: zero retrieval-quality numbers have been measured on v0.6.2 itself.** Every canonical recall/semantic/correctness number lives on the worktree. The byte-stable guarantee covers v0.6.0↔v0.6.2 but **does not bridge worktree↔v0.6.2** (the worktree carries its own `f6286fb` ANN recalib, `9328111` dense-prefilter, `c419abc` per-gene budget).
+
+---
+
+## (3) Provenance-trap findings (stale-master / old-worktree — may not hold on v0.6.2 / live)
+
+| # | Conclusion | Measured on | Why it may not transfer | Re-test needed |
+|---|---|---|---|---|
+| **P1** | EnterpriseRAG recall@10 = **83% (10K) / 71% (50K)** | 10K/50K subset, 2026-05-21 (`bench_investigation_2026-05:93-97`) | **Deepest trap.** Predates v0.6.0 (2026-05-28) → almost certainly **pre-BGE-M3 / dim-256 / 0.35-cut**, AND measured on SPLADE-off path **before** `23b1e80` (#163) SQL-cap shard-drop fix → potentially understated by silent shard-drop too. Also a subset, not 850K. | Re-run recall@10 at 10K/50K on **v0.6.2** with SQL-cap fix present. Expect collapse toward 28-29.8%. |
+| **P2** | Out-of-domain M2 = **0% hallucination, corpus-invariant** | 10K/50K keyword-heuristic, 2026-05-21 | Same pre-v0.6.0 stack as P1. "0%" was *also* a keyword-substring artifact (refuted to 15% by Opus, `semantic_rootcause:13`). **Doubly dead:** wrong method + wrong version. | None for 0% — already refuted. Do NOT resurrect "corpus-invariant 0%." |
+| **P3** | Canonical recall@10 = **29.8%** (splade-on, mg10, full-470) | Live worktree (`hardware_investigation:30`) | Worktree forks OLD master 826d053; lacks #173/#175 as ancestors; carries **own dirty** singleton+batched-IN+fan-out. Without batched-IN committed/active, SPLADE-off path can still hit SQL-cap shard-drop at 850K. ANN recalib is worktree's **own** `f6286fb`, not guaranteed byte-identical to shipped `fec9141`. | **#1 re-test:** re-baseline 29.8% on **v0.6.2**. Until then label "worktree, not v0.6.x." |
+| **P4** | Semantic fused recall@10 = **2.4%**; @200 geometry | Live worktree, 2026-06-02 | Baseline itself robust (matched pre-rerank exactly), but it is a **worktree** number inheriting worktree ANN recalib `f6286fb`. | Confirm 2.4% reproduces on v0.6.2 (cheap — `/fingerprint`, no LLM). |
+| **P5** | Semantic = **1.6% (2/125)** earlier headline | Worktree, mg1, splade-off (`bench_calibrated_470q:73`) | Superseded by mg10/@200 diagnostic (semantic@200=21.6% → "buried not absent"). 1.6% was **config-crippled** (mg1). | Retire 1.6%; superseded by 2.4@10 / 28.8@200 dense. |
+
+---
+
+## (4) Conflated-axes + proxy-only / projected — must NOT be stated as fact
+
+**Axis conflations (honest restatement required):**
+
+| # | Conflation | Honest restatement |
+|---|---|---|
+| **C1** | dense-only vs fused: "semantic 2.4%" vs "7.2%" are **different systems** (fused vs pure global-dense probe, `bench_session_2026-06-02:24`) | Tag: "fused 2.4% / pure-dense 7.2% → the **4.8pp gap is the wiring loss**." |
+| **C2** | recall vs correctness: "correctness 13.8%, doc_recall 17.6%" sit beside recall numbers | Never same scale. Correctness = retrieve+**generate**, Opus-judged. Onyx "Overall %" = answer-correctness, so recall@10 does NOT map to the leaderboard. **Submit the 29.8% fingerprint set, not the 17.6% delivered set.** |
+| **C3** | mg1 vs mg10: 27.66 / 29.8 / 28 presented as one "recall" lineage | Tag every recall number with its gate. Canonical = **29.8% = splade-on + mg10**. 27.66 = mg1. Not the same experiment. |
+| **C4** | proxy vs end-to-end: Qwen3 "+17.4pp" next to e2e 850K recall reads as a promised lift | Keep proxy numbers in a separate ledger (see X1). |
+| **C5** | no-gold types drag raw @10: `info_not_found` (20) + `high_level` (10) = **30 no-gold-by-design** questions scoring 0 | State the denominator: "**29.8% over 470 recall-applicable**" vs "**answerable-only ≈ 42.6%**" — a ~13pp swing from denominator choice. Score no-gold types via **abstain**, not recall. |
+| **C6** | encoder-attributed vs wiring-attributed semantic gap: old "embedding is THE semantic lever" framing | **Superseded 2026-06-02:** @10 gap is **WIRING** (routing+fusion discards 9 dense-good golds); re-embed is the @200 **residual (54%)**, not the @10 front-runner (`semantic_rootcause:37-43`). Don't attribute the @10 loss to the encoder. |
+
+**Proxy-only / projected (do NOT state as measured fact):**
+
+| # | Claim | Status | Correct framing |
+|---|---|---|---|
+| **X1** | Qwen3-Embedding-0.6B = **+17.4pp R@10** | **Proxy only** — 736-doc pool, relative-to-control, NOT a 2.4% e2e prediction; e2e blocked (GB10 GPU embed broken; CPU ~590h). | "Proxy suggests Qwen3 could help; **unmeasured e2e**; gated on GB10 GPU-embed." Never "+17.4pp on the bench." |
+| **X2** | Routing+dense-fusion fix → semantic@10 **3→~12 (~4×)** | **Projected, untested.** Critical: route-all **alone was NULL**, dense-weight **alone was NULL**; only the *untested combination* is claimed. n=9 golds. | "Projected ~4×; the combination is **untested**; both halves individually null." Hypothesis, not result. |
+| **X3** | **+8pp** delivery-clamp / conversion-gap config knob | **Projected.** 39 golds ranked@10 never delivered to answer ctx; consistent with shipped expression-budget fix but **not re-measured e2e on this fixture**. | "Projected +8pp correctness from a delivery-budget config; not yet re-run." |
+| **X4** | Encoder leaderboard ranks (Qwen3 ~70.58 MTEB; BGE-M3 mid-pack ~7-9th) | **CLAIMED** — third-party blog aggregations (awesomeagents/Mixpeek), not the live HF MTEB-v2 page (unfetched 2026-06-02). BGE-M3 *architecture* specs ARE confirmed (official card). | "BGE-M3 = 2024-era encoder (confirmed specs); leaderboard standing **claimed-not-verified** as of 2026-06-02." |
+| **X5** | CE rerank **net-zero on semantic** | **MEASURED** (valid 125-q, clamp-fixed, PRE 2.4→POST 2.4). The exception: properly e2e and version-current (worktree). | Genuinely measured. Safe to state. |
+
+---
+
+## (5) Verdict on the live picture
+
+**HOLDS (measured, version-current on the worktree, e2e):**
+- **CE rerank = net-zero on semantic** (X5) — the single fully-clean conclusion: properly e2e, clamp-fixed, version-current. The semantic ceiling is encoder-discrimination, not rerank.
+- **Semantic @10 = WIRING, @200 = GEOMETRY** (P4/C1): fused 2.4% vs pure-dense 7.2% → 4.8pp wiring loss; @200 geometry residual = 68/125 = 54% of semantic. Robust diagnostic, worktree-measured.
+- **Full-500 correctness 13.8% / 15% hallucination / 71% abstain** (Opus-judged) holds as measured — but is a **correctness axis**, not recall, and not leaderboard-mappable.
+
+**VERSION-CONTINGENT (worktree-real, but v0.6.2-unverified):**
+- **Canonical recall@10 = 29.8%** (P3) and **27.66% (mg1)** and **semantic 2.4@10 / 28.8@200** (P4) — all measured on the worktree, which carries its own ANN recalib (`f6286fb`), dense-prefilter (`9328111`), and per-gene budget (`c419abc`). The v0.6.0↔v0.6.2 byte-stable guarantee **does not bridge to the worktree**. Risk: without the worktree's uncommitted batched-IN active, the SPLADE-off path can silently drop shards at 850K → understated recall.
+
+**UNMEASURED on the current branch / dead:**
+- **Zero retrieval-quality numbers exist on v0.6.2 itself** — the entire v0.6.2 column is a GAP.
+- **83% / 71% EnterpriseRAG** (P1) and **0% corpus-invariant hallucination** (P2) are **DEAD**: wrong version (pre-BGE-M3) + (for P2) wrong method (keyword heuristic, refuted to 15%). Strike from all "general recall" framing; keep 83/71 only as a dated, version-tagged *sparse-path historical ceiling*.
+- **Qwen3 +17.4pp** (X1), **~4× wiring lift** (X2), **+8pp delivery** (X3) are **projections/proxy, not facts.**
+- **Provenance of which dirty-edit state** each worktree number was captured under is **not pinned** (batched-IN active or not?).
+
+---
+
+## (6) Prioritized re-test list (highest-value first)
+
+**RE-TEST #1 — Re-run the canonical recall bench on v0.6.2. (decisive, cheap)**
+Spin a daemon from **`3173c47` (v0.6.2)** + the bench venv; run `/fingerprint` recall@10 at **splade-on + mg10** on `enterprise_rag_onyx_full_2`, plus the semantic-125 @10/@200 probe. Retrieval-only, **no LLM** (~hours CPU, ~$0). Use `HELIX_MEM_PROFILE=conservative` (documented byte-identical to v0.6.1) so any delta vs the worktree is attributable to **algorithm** (`f6286fb` ANN recalib / dense-prefilter / per-gene budget), not I/O. **This single run converts P3, P4, and the entire §2 v0.6.2 column from GAP to measured, and validates or breaks the worktree↔release byte-stable assumption.** De-risks the most claims.
+
+**RE-TEST #2 — Re-measure EnterpriseRAG 10K/50K recall on v0.6.2. (kills the deepest trap)**
+The 83/71% number is the most-cited and most-contaminated (pre-BGE-M3 stack + pre-SQL-cap-fix + subset + likely sparse-only). Re-run at 10K/50K on v0.6.2 with the SQL-var fix present. Expected: collapse toward ~28-30%, confirming 83/71 was a pre-encoder-change / pre-fix artifact → strike from "general recall" framing, retain only as a dated sparse-path ceiling.
+
+**RE-TEST #3 — Pin the worktree dirty-edit state for the 29.8% capture.**
+Confirm batched-IN was active when 29.8% was measured, ruling out the SQL-cap shard-drop risk at 850K scale. Lower priority — RE-TEST #1 supersedes it by moving to a clean release tree, but valuable if v0.6.2 re-baselining is deferred.
+
+**One-line record-honesty rule:** state every bench number as
+`<metric> = <value> @ <version/tree> · <gate: mg1/mg10, splade on/off> · <axis: fused/dense, recall/correctness, proxy/e2e> · <denominator: 470/answerable-only/incl-no-gold>` — drop any axis and the number becomes a trap.
+
+**Evidence (absolute, read-only):**
+- `C:/Users/max/.claude/projects/f--Projects/memory/project_helix_hardware_investigation_2026-06-02.md` — 29.8%, three-way provenance, Qwen3 proxy, v0.6.2 recheck
+- `C:/Users/max/.claude/projects/f--Projects/memory/project_helix_semantic_rootcause_2026-06-01.md` — 6 refuted hyps, wiring-vs-geometry, lever ladder
+- `C:/Users/max/.claude/projects/f--Projects/memory/reference_helix_bench_session_2026-06-02.md` — rerank net-zero, per-type, no-gold types
+- `C:/Users/max/.claude/projects/f--Projects/memory/reference_helix_bench_session_2026-06-01.md` — full-500 correctness 13.8% / 15% halluc; doc_recall 17.6 vs submit-29.8
+- `C:/Users/max/.claude/projects/f--Projects/memory/project_helix_bench_investigation_2026-05.md` — 83/71% subset trap; 0%-hallucination keyword artifact
+- `C:/Users/max/.claude/projects/f--Projects/memory/project_helix_bench_calibrated_470q_2026-05-30.md` — 27.66 mg1, semantic 1.6→2.4 supersession, calibration=latency-only
+
+Git refs: v0.5.0 `e1bf20e` · stale master `826d053` · v0.6.0 `2d3b7d0` · v0.6.1 `b7af5b0` (#172/#173) · v0.6.2 `3173c47` (#175, untagged) · worktree `vibrant-easley-73d68a` @ `191ce31`+dirty (`perf/dense-prefilter-via-splade-candidates`, forks `826d053`). Encoder discontinuity: `f46460f` (#140 BGE-M3 Tier-0) + `fec9141` (#142 0.35→0.58 ANN) NOT ancestors of v0.5.0; worktree's own recalib = `f6286fb`; SQL-cap fix = `23b1e80` (#163); dense-prefilter = `9328111` (#159); per-gene budget = `c419abc`; rerank clamp→sigmoid = `7fec674`; pool-widening = `191ce31`.

--- a/docs/investigations/2026-06-02-hardware-optimization-investigation.md
+++ b/docs/investigations/2026-06-02-hardware-optimization-investigation.md
@@ -1,0 +1,588 @@
+# Helix-Context Hardware Optimization Investigation
+
+**Date:** 2026-06-02
+**Author:** Laude (+ 27-agent read-only investigation team)
+**Status:** Investigation / recommendation only — **nothing actioned.** Raude owns internals.
+**Scope:** gandalf dev rig + DGX Spark profiling · bench/normal-op tuning · dual-genome dynamic-port tray · switchboard visualizer.
+
+> **Method note.** 7 read-only mapping agents → 16 adversarial verify agents → 4 synthesis agents.
+> Everything below is grounded in code at `file:line`. The investigation did **not** touch the live
+> daemon (Raude was mid-benchmark on the 850K Onyx corpus at `:11437`). All "set X" lines are
+> recommendations, not changes. Anything touching public API / feature flags / retrieval behaviour
+> is **PRD-gated** per the project workflow.
+
+---
+
+## 0. Version provenance — a THREE-WAY split (read this first)
+
+> **2026-06-02 recheck (per Max): re-baselined against v0.6.2.** The first pass read the **stale local
+> `master`** and over-generalised from it. The corrected picture below supersedes that. Net: the live daemon
+> is *behind* shipped helix, and two "absent/refuted" findings were master-only artifacts.
+
+The single most important finding is not a hardware fact — it's a **tree fact**. Three trees diverge:
+
+| Tree | Ref | What it is | Has the perf machinery? |
+|---|---|---|---|
+| **Local `master`** | `826d053` v0.5.0 | **STALE / un-pulled**, behind every release. *What the first pass mistakenly read.* Not running, not shipped. | No (none of it) |
+| **LIVE daemon** (`:11437`) | worktree `vibrant-easley-73d68a` (`perf/dense-prefilter-via-splade-candidates`, `e54a250` + dirty), via `bgem3_gpu_venv` editable install (torch **cu121** → can see the GPU) | A perf *experiment* branched off **old** master 826d053. Has its own dense-prefilter/shard-worker/fp16 edits. | **Partial — LACKS #173 singleton & `HELIX_MEM_PROFILE`** |
+| **Shipped `v0.6.2`** | `3173c47` (on `origin/master` + 2 feat branches; not tagged v0.6.2 locally) | The PyPI release line. **The baseline to reason against.** | **Yes** (see recheck table) |
+
+**Consequence:** before trusting *any* env/config lever, confirm **which tree + which venv** the daemon
+launched from. The live daemon is **not** master and **not** v0.6.2 — it's a stale experiment branch *missing
+the very RAM fixes that target gandalf's 48 GB ceiling*. Lever tags below: `[v0.6.2]` = in shipped release ·
+`[worktree]` = only in the running experiment branch · `[OS/env]` = tree-independent. **A `[v0.6.2]` lever does
+NOT work on the currently-running worktree daemon until v0.6.2 is merged into it (or the daemon is relaunched on
+v0.6.2).**
+
+### Recheck table — keystone findings against v0.6.2 (verified at `3173c47`)
+
+| Finding | master 0.5.0 *(first read)* | **v0.6.2 (shipped)** | LIVE worktree *(running now)* |
+|---|---|---|---|
+| **BGE-M3 dense codec device** | CPU-pinned | **STILL CPU-pinned** — `knowledge_store.py:2524` `get_shared_codec(dim=…, share=…)` passes **no `device=`** → factory default `"cpu"` (`bgem3_codec.py:192`); ingest `context_manager.py:706` same; no `get_hardware()` for dense | CPU-pinned (`knowledge_store.py:2475`) |
+| `HELIX_MEM_PROFILE` (auto) | absent | **PRESENT** (`hardware.py:462,472`; RAM-aware SQLite budget + configurable `mmap_size`) | **absent** |
+| #173 singleton (120→7 GB) | absent | **PRESENT** (`get_shared_codec`, `HELIX_SHARE_DENSE_CODEC=0` reverts) | **absent** |
+| `HELIX_SHARD_WORKERS` | absent | **PRESENT** (`shard_router.py:66-74,597`) | present (own edit) |
+| `HELIX_DENSE_MATRIX_DTYPE=float16` | absent → *first pass "REFUTED"* | **PRESENT — real lever** (`knowledge_store.py:348`) | present (own edit) |
+| LRU shard cache | absent | **still absent** (`shard_router.py:319` dict + lock at `:343`, **no eviction**) | absent |
+| rerank `re_rank`/`rerank` split | present | **still present** (`deberta_backend.py:100 def re_rank` vs `blend.py:84 .rerank()`) | present |
+| dense_prefilter | absent | **absent** (worktree-only experiment) | present |
+
+### Corrections to the first-pass verify verdicts
+- ✅ **Keystone CONFIRMED on v0.6.2 too:** the BGE-M3 dense codec is CPU-pinned in *all three* trees — the #173
+  singleton dedup'd the model for RAM but never threaded the device. So `HELIX_DEVICE=cuda` does not move dense
+  encode on shipped helix. **An unmerged branch `chore/backfill-bgem3-device-env` (`6c149cf`, adds `BGEM3_DEVICE`
+  env) already addresses this — flag to Raude.** This *strengthens* recommendation #5 below.
+- ↩ **"`HELIX_DENSE_MATRIX_DTYPE=float16` doesn't exist" was a master-only artifact** — it IS a real shipped lever
+  in v0.6.2 (`knowledge_store.py:348`). Same for `HELIX_MEM_PROFILE` (real, `auto` default in v0.6.2). The
+  refutation held only against the stale master tree.
+- **PARTIAL (still stands):** the commit balloon (~240–247 GB → OOM on a small pagefile) + 240 GB-pagefile
+  requirement are real and measured, driven by **SQLite page heaps + per-shard model/cache + unbounded shard
+  cache**, not a 42.6 GB mmap. BUT this was measured on master/worktree which **lack `HELIX_MEM_PROFILE` + the
+  #173 singleton** — **v0.6.2 materially improves the RAM ceiling**, so re-measure the pagefile story on v0.6.2.
+
+> **★ Top operational takeaway (post-recheck):** the highest-value single action is to **run bench *and* normal-op
+> on v0.6.2** (or merge v0.6.2 → the worktree). The live daemon is a stale experiment missing `HELIX_MEM_PROFILE`
+> and the 120→7 GB singleton — the exact fixes for gandalf's Wall-1. **Benching on the worktree under-measures
+> what shipped helix already does.**
+
+## 0.5 LIVE-RUN UPDATE — supersedes the Wall-1 analysis (2026-06-02)
+
+Raude advanced the worktree to an unreleased **".3"** experiment (the *widened-rerank* PRD) and kicked off a run on
+`enterprise_rag` full_2 (100 shards). Live telemetry + a partial result (66/125) **corroborate the keystone and
+retire Wall-1**:
+
+- **Wall-1 (pagefile storm / 104 GB ceiling) is RETIRED for full_2 on this branch.** Live: **committed 38/288 GB**,
+  RAM 21.9/47.9 (46%), 24.1 GB shards in page cache, **Disk F at 3%** — no spill. The `get_shared_codec` singleton
+  (the 120→7 GB fix) is now present as an **uncommitted edit in the running worktree** (grep-confirmed in
+  `knowledge_store.py` + `bgem3_codec.py`; HEAD ancestry lacks `d5ade41` because it's *dirty*, not committed). 100
+  shards + the deberta cross-encoder fit with ~26 GB free. ⇒ **The only remaining wall is Wall-2** (brute-force/no-ANN
+  CPU scan, ~100 s/query). My "Wall-1 dominates" held only for the pre-singleton trees — strike it for this branch.
+- **GPU idle CONFIRMED empirically:** GPU0 1% / 30 °C — retrieval + the *now-working* CE rerank are 100% CPU
+  (keystone proof). **CPU 52% @ 4.68 GHz with `HELIX_SHARD_WORKERS=8` + `OMP_NUM_THREADS=1`** — the BLAS-pin +
+  parallel-fanout config (rec §2c) is already in use; ~100 s/query is CPU-bound brute-force, not contention.
+- **The `re_rank`/`rerank` mismatch was FIXED this session** (alias at `deberta_backend.py:189`) → the cross-encoder
+  now actively reorders. My "structurally dead" finding is now historical.
+- **But the working CE rerank is NET-ZERO on recall@10** (PRE 3.0% → POST 3.0%): of 12 in-pool-but-below-top-10
+  golds it rescued 2, displaced 2, whiffed 10. Not broken — a properly-functioning MS-MARCO cross-encoder simply
+  **can't separate gold from topical near-neighbors on paraphrase queries.** This is the clean verdict the clamp was
+  hiding, and it matches the encoder near-neighbor-dilution root cause.
+- **recall@200 = 21% (14/66)** → **~79% of semantic gold never enters the 200-pool.** Reach, not ranking, is the
+  dominant problem; rerank can't touch what retrieval never surfaces. **Lever-ladder rung #1 (rerank) is now
+  exhausted for a *real* reason** → weight shifts to (a) reach (recall@200 / offline rank-distribution probe +
+  expansion) and (b) encoder discrimination (fine-tune / re-embed) — i.e. the embedding track.
+
+**Two recommendations updated by this evidence:**
+1. **Dual-genome resource verdict SOFTENED** (§4): with the singleton active, one full_2 daemon ≈ 22 GB working +
+   ~24 GB *reclaimable* page cache. Two big genomes concurrently is no longer "OOM-infeasible" — but they'd contend
+   for page cache (the very thing giving Disk-3% / fast latency), so expect a **latency regression**, not an OOM.
+   Small-corpus pairing remains the clean recommendation.
+2. **GPU offload (encode / CE → CUDA) is a LATENCY lever, not a recall lever** (§2b/§2d #3,#7,#8): rerank is net-zero
+   on recall and reach is the bottleneck, so GPU work buys throughput/latency (and enables the eventual re-embed),
+   **not** recall. Keep it, but don't sell it as a recall fix.
+
+*(Partial: 66/125, ~1.7 h remaining. Full 125 + the offline rank-distribution probe pending from Raude.)*
+
+## 0.6 cc-exchange reconciliation — completed Spark + encoder data (2026-06-02)
+
+Two remote sources — **`github.com/addiplus/cc-exchange`** (the live Max↔Joe channel) and **`github.com/CosmicTasha/helix-bench`** (a mirror of the local bench) — supplied the completed numbers the local tree lacked, including the Spark figures this report earlier marked "not in Joe's files." Corrections, by section:
+
+**Spark worker sweep (Joe, v0.6.2, 470q, 100-shard onyx, 37 h, GPU 0% throughout) — sources the "w8 knee / 37h / matmul" terms:**
+
+| workers | p50 latency | recall@10 |
+|---:|---:|---:|
+| 1 | ~95.0 s | 27.45% |
+| **8** | **~53.1 s (knee, 1.8×)** | 27.66% |
+| 16 | ~62.7 s (slower!) | 27.66% |
+| 24 | ~62.3 s | 27.66% |
+
+- **Latency REGRESSES past w8 → bandwidth/merge-bound** (the one shape a GPU can't rescue). `HELIX_SHARD_WORKERS=8` is the measured knee. **Supersedes §2c's "leave serial (1)"** (that was under the now-retired Wall-1 assumption).
+
+**Wall-2 reframe (supersedes §1 ladder item 2 + §2):** the dense GEMV is **~13 ms ≈ 0.01%** of a 53–95 s query. The other ~99.9% is the **serial cross-shard merge + per-shard lexical (FTS5/BM25/SPLADE) + IO** path. So GPU / matmul / fp-precision is a **non-lever for query latency** (confirmed by GPU 0% + the regresses-past-w8 signature). The memory-bandwidth framing holds, but the expensive bytes are lexical+merge+IO, **not** the matmul.
+
+**fp16 correction (supersedes §2c float16 row):** `HELIX_DENSE_MATRIX_DTYPE=float16` is **storage-only on the CPU NumPy path** (NumPy promotes to fp32 in the matmul → *no* compute-bandwidth win today). It's a RAM-footprint lever; the bandwidth win materialises only after the `torch.cuda` kernel port.
+
+**Canonical recall (supersedes §3's 27.66/27.2 headline):** 27.66% is the **mg1** number. The apples-to-apples canonical is **recall@10 = 29.8%** (splade-on + `ann_threshold_min_genes=10`, binary, full-470): @1 17.7 / @3 21.5 / @5 24.7 / @10 29.8 (SPLADE +6 pp, mg gate +~8 pp, both order-preserving). **Semantic-type** recall@10 = 2.4% (end-to-end 850k) is the separate failure-mode number. Multi-gold-aware exact lands a touch under 29.8% (20% of Qs are multi-gold).
+
+**Latency ≠ bench score (sharpens §6):** the bench runs at 53–95 s/q against a **600 s/q budget** = 6–11× headroom. So every latency lever in this report is a **product-latency win, not a leaderboard mover.** The score is gated by **recall = the embedding.** Two orthogonal tracks: merge/IO = latency (Joe's box), embedding = score — don't pour GPU-time into shaving a 53 s query while the score is stuck at the encoder.
+
+**Full-500 correctness (Opus judge, splade-on/mg10):** correctness **13.8%** / completeness 8.6% / doc-recall(answer-pass) 17.6% / 71% abstain / **15% hallucination — NOT 0%** (68 genuine confident-wrong; **0 fabrication on the 20 unanswerable**) / gen $24.10. Hallucination is **retrieval-driven** (tracks low-recall types; semantic=21) → the embedding lift cuts hallucination **and** lifts recall.
+- **Conversion gap = +8 pp config knob:** of 79 golds ranked@10-but-answered-wrong, **39 were never delivered into the answer context** (per-gene delivery clamp) → ~+8 pp correctness from a config knob, no embedding work. Confirms the delivery-clamp finding.
+
+**Encoder benchoff — the re-embed candidate is now CHOSEN (feeds Appendix B's >20k track).** Joe ran a semantic-125 proxy (736-doc pool, 1024-dim, CPU; *relative-to-control only — NOT a 2.4% prediction*):
+
+| encoder | R@10 | R@200 | MRR@200 | ΔR@10 vs control |
+|---|---:|---:|---:|---:|
+| **Qwen3-Embedding-0.6B** | **86.8** | **100.0** | **0.699** | **+17.4 pp** |
+| bge-large-en-v1.5 | 74.4 | 98.4 | 0.549 | +5.0 pp |
+| BGE-M3 (control) | 69.4 | 98.4 | 0.473 | — |
+
+- **Qwen3-Embedding-0.6B wins** — MRR 0.47→0.70, R@200 100%, **1024-dim native** (zero schema change), **Apache-2.0** (commercial-OK). bge-large (MIT) is the fallback; NV-Embed-v2 disqualified (CC-BY-NC).
+- **Live blocker on the re-embed:** GPU embedding is **broken on the GB10** (Triton can't JIT CUDA kernels on ARM64/Blackwell; `gcc cuda_utils.c` link fails). Qwen3-0.6B at ~2.5 s/doc on CPU → full 850k re-embed ≈ **590 h CPU = infeasible.** Needs GPU embedding unblocked first (`attn_implementation="eager"` or vLLM). **This is the gate on the score-moving track.**
+
+**GPU kernel port — now owned by Joe (supersedes §2b/§2d "speculative"):** the `_ensure_dense_matrix`/codec → `torch.cuda` port is being taken, gated **for re-embed + bench throughput (GEMV→GEMM query-batching), not single-query latency.** Order: fp16 + fp32-accumulate → batch → optional fp8-coarse, each recall-identity-gated on semantic-125.
+
+## 1. Executive summary — the bottleneck ladder
+
+---
+
+## 1. Executive summary — the bottleneck ladder
+
+For both gandalf (live `device=cpu`, 850K Onyx) and the DGX Spark, current Helix retrieval is **CPU- and
+memory-bandwidth-bound, with both GPUs idle**. The cost ladder, in order:
+
+1. **Wall-1 — pagefile I/O storm (gandalf only, at ~100-shard scale).** The 850K Onyx genome drives daemon
+   private commit to **~240–247 GB** against 48 GB RAM → ~200 GB spills to the 980 Pro. Because **C: (pagefile)
+   and F: (corpus) are the same NVMe**, fault traffic serialises on one PCIe queue. This *dominates* wall-clock.
+   The Spark dissolves this entirely (128 GB unified, mmap-in-RAM) — that's its measured **2.1× p95 win**.
+2. **Wall-2 — bandwidth-bound dense GEMV.** `sims = matrix @ query_vec` is a single-threaded fp32 NumPy
+   matrix-vector product over every hot embedding (`knowledge_store.py:2635`). ~2 FLOP/byte → bytes/s is the wall.
+   gandalf's **mismatched DDR4 (2×16+2×8)** throttles exactly this kernel; AVX2-vs-AVX512 is irrelevant.
+   *(Note: "ANN" is a misnomer — there is no HNSW/IVF/faiss index anywhere.)*
+3. **CPU transformer encode.** BGE-M3 dense + SPLADE query encoders run on the 5800X. This is the *only* slice
+   the 3080 Ti would accelerate — and it's a fraction of per-query wall-clock at 850K scale.
+
+**Headline:** the GPU is **idle by explicit request** (`HELIX_DEVICE=cpu`, reserving the 3080 Ti for the Sonnet
+generation arm — `helix-bench/exchange/2026-05-31_results-and-embedding-track.md:30`). Even flipping the device
+**does not** reach the heaviest neural op, because the **BGE-M3 dense codec is hard-pinned to CPU** (constructed
+with no device arg at `knowledge_store.py:2443` → defaults `device="cpu"` at `bgem3_codec.py:57`; it never
+consults `get_hardware()`). SPLADE/SEMA/NLI *do* follow `get_hardware().device`. **This codec wiring gap is the
+single highest-leverage internals fix.**
+
+Also: the system `python` has `torch 2.11.0+cpu` (no CUDA) — only the bench venv (`/f/tmp/bgem3_gpu_venv`,
+`torch 2.5.1+cu121`) can physically see the GPU. **A torch-less interpreter silently degrades retrieval to
+lex-only** (`bgem3_codec.py:74-81`). Always launch from a cu121 venv.
+
+---
+
+## 2. Gandalf hardware profile + tuning
+
+**Box:** Ryzen 7 5800X (Zen 3, 8c/16t, single CCD/CCX, 32 MB L3, AVX2, **no AVX-512**) · 48 GB DDR4-3200
+**mismatched** (2×16 + 2×8) · Samsung 980 Pro 1 TB carrying **both C: and F:** · EVGA RTX 3080 Ti (GA102,
+12 GB GDDR6X, CC 8.6) · Win 11 Pro.
+
+### 2a. Config / env Max can set today (no code change)
+
+| Lever | Tree | Current | Recommended (this HW) | Effect | Helps |
+|---|---|---|---|---|---|
+| **Launch from cu121 venv** | OS | system `torch+cpu` | always cu121 venv | precondition for any GPU; prevents silent lex-only degrade (`bgem3_codec.py:74-81`) | both |
+| **`splade_enabled=false`** (`helix.toml:193`) | master | `true` | `false` **on Onyx 850K only** | PRD: SPLADE = **0 pp recall, 3-for-3** on Onyx, costs 94–153 s p95; splade-off is the **only** config with zero 10-min timeouts | both (Onyx) |
+| **`HELIX_DEVICE=cuda`** | master | `cpu` (pinned) | `cuda` **only for latency-only runs (GPU not generating)** | moves SPLADE/SEMA/NLI to GPU (they read `get_hardware().device`). **Does NOT move BGE-M3 dense** (codec gap §2b). Keep `cpu` while GPU generates. | bench |
+| **`ann_threshold_min_genes=10`** | master | `1` prod / `10` bench | `10` **recall-bench only** | adaptive cut can early-exit; min_genes=10 forces a true top-k floor (~**+8 pp** measured). **Never in prod `/context`** (forces ≥10 docs/answer) | bench |
+| **`HELIX_OTEL_ENABLED=1` + collector** (`otel.py:231`) | master | off → `_NoopMeter` | `1` via `backend-with-otel.bat` | makes any CPU→GPU win **measurable** (otherwise invisible) | measurement |
+| **Fewer-larger shards (≤~15)** | OS/build | ~100–105 (Onyx) | re-shard `--auto-subshard-threshold-files=100K` → ~12 shards | cuts the Wall-1 commit storm (~50 GB vs 240 GB) — the dominant cost | both |
+| **Keep ≥240 GB fixed pagefile** | OS | up to 240 GB | keep while serving 850K | 247 GB commit OOMs on a 56 GB pagefile (143 GB OOM measured). **Survival only — no speedup** | survival |
+| **Pagefile on a 2nd NVMe** (if available) | OS | C:+F: on 980 Pro | move pagefile off the corpus drive | de-contends pagefile faults from corpus reads on one queue | both (mag. speculative) |
+
+### 2b. Internals Raude must change (code)
+
+| Change | Current (file:line) | Recommendation | Why it matters |
+|---|---|---|---|
+| **Thread device into BGE-M3 codec** ★ | `BGEM3Codec(dim=...)` no device → CPU (`knowledge_store.py:2443`; default `bgem3_codec.py:57`) | `BGEM3Codec(dim=..., device=get_hardware().device)` at both call sites (+ ingest `context_manager.py:706`) | **Highest-leverage GPU enablement.** Without it `HELIX_DEVICE=cuda` leaves the heaviest per-query op on CPU. ~1 line each |
+| **fp16 + device on FlagEmbedding path** | `BGEM3FlagModel(use_fp16=False)`, no device (`bgem3_codec.py:76`) | `use_fp16=(device!='cpu')` + device | only the ST fallback honours `self._device` (`:80`); device-threading alone insufficient on a FlagEmbedding install |
+| **Move dense GEMV to GPU (torch/cupy)** | NumPy CPU `matrix @ query_vec` (`knowledge_store.py:2635`) | torch-CUDA matmul (fp16 matrix ≈ 1.65 GB, fits 12 GB easily) | GDDR6X ~900 GB/s vs DDR4-3200 ~40–50 GB/s — the only thing that beats the mismatched-kit wall. Bigger payoff = batched GEMM at index-time |
+| **LRU-bound the shard cache** | unbounded `self._shards`, never evicts (`shard_router.py:294-306`) | LRU cap (~32 open Genomes), reopen on miss | primary Wall-1 driver; lowest-risk durable fix. **Not yet written anywhere** |
+| **Fix rerank (3 independent blockers)** | `rerank_enabled=false`; DeBERTa exposes `re_rank` but blend calls `.rerank()` (`blend.py:81` vs `deberta_backend.py:100`); gated to `profile=='quality'` (`routes_context.py:754`, default `balanced`) | add `rerank` alias + relax profile gate, then config can enable | flipping the flag alone is a **silent no-op**. Reranker model already `.to(get_hardware().device)` — GPU-ready once reached. **But it only re-orders the existing pool — can't rescue gold dense never surfaced** |
+| **Process-shared codec singleton** | per-`KnowledgeStore` codec (`:2441-2443`), not injected into shards | inject one shared dense codec per shard `Genome` (mirror `sema_codec` at `context_manager.py:443-468`) | the "120 GB→7 GB singleton" fix is **not in master 0.5.0** — N shards can materialise N codecs |
+
+### 2c. Worktree-gated levers (need Raude's branch on master first)
+- **`HELIX_SHARD_WORKERS`** `[v0.6.2]` — parallel shard fan-out (`shard_router.py:65-79`). Order-preserving =
+  recall-identical, latency-only. **Set to 8 — the measured knee** (Joe's sweep: w1 95 s → **w8 53 s, 1.8×**; w16/w24
+  *regress* to ~62 s, the bandwidth/merge-bound signature). *(Supersedes the earlier "leave serial" — that assumed
+  the now-retired Wall-1; with the singleton active, w8 is the rec, and the live run already uses 8.)*
+- **BLAS pin** `[OS/env, but only with workers≥2]` — `OMP_NUM_THREADS=MKL_NUM_THREADS=OPENBLAS_NUM_THREADS=1`
+  removes the 8×16=128-thread oversubscription during the parallel GEMV burst (`throughput-and-concurrency.md:24`).
+  **Only pair with `HELIX_SHARD_WORKERS≥2`** — on serial master, BLAS should keep the cores for the single GEMV.
+- **`dense_prefilter_enabled=true`** `[worktree]` — ~170× FLOP cut, recall-neutral across 3 fixtures, but the win is
+  **un-measurable on gandalf while pagefile-bound** (it attacks Wall-2, not Wall-1).
+- **`HELIX_DENSE_MATRIX_DTYPE=float16`** `[v0.6.2 / worktree]` — ✅ real shipped lever in v0.6.2
+  (`knowledge_store.py:348`), but **storage-only on the CPU NumPy path** — NumPy promotes fp16→fp32 for the matmul,
+  so it halves *resident RAM* but gives **no compute-bandwidth win today**. *(Corrects both the stale-master
+  "doesn't exist" AND my earlier "attacks the bandwidth wall" framing — Joe confirmed it's storage-only; the
+  bandwidth win needs the `torch.cuda` kernel port. And the matmul is only ~0.01% of the query anyway — see §0.6.)*
+
+### 2d. Priority order (impact ÷ effort), with honesty flags
+1. `splade_enabled=false` on Onyx — *config, trivial, evidenced.* Biggest measurable latency win today; zero recall cost. **Onyx-only — SPLADE is +6 pp on Max's own code corpus.**
+2. Fewer-larger shards (≤~15) + keep 240 GB pagefile — *ops, moderate.* Attacks the dominant Wall-1.
+3. Thread device into BGE-M3 codec (both sites) — *internals, ~1 line, high confidence.* The keystone GPU enablement.
+4. `HELIX_OTEL_ENABLED=1` — *config, trivial.* Nothing above is verifiable without it.
+5. `HELIX_DEVICE=cuda` from cu121 venv, latency-only runs — *config, trivial, bounded upside* (encode is a fraction of wall-clock; size on ~20 q first; only while GPU isn't generating).
+6. LRU shard cache — *internals, moderate, high confidence in design* (not yet written).
+7. Move GEMV to GPU — *internals, high effort, the real Wall-2 fix* (magnitude speculative until measured).
+8. Fix rerank then enable — *mixed, medium.* Cheap GPU precision, but only re-orders the pool.
+9. `dense_prefilter` + parallel fan-out — *after merge, Spark-first.* Recall-neutral latency levers that pay off only once Wall-1 is gone — **last on gandalf, first on Spark.**
+
+### 2e. Standing hardware constraints (cannot be tuned away)
+- **Mismatched DDR4 (2×16+2×8):** likely below matched-dual-rank bandwidth (possible 2T/Gear-Down) — permanently caps the GEMV. A matched dual-rank kit is the only cure.
+- **Single 980 Pro for C:+F::** pagefile and corpus reads contend on one queue — no flag isolates them; a 2nd NVMe for the pagefile is the only de-contention.
+- **12 GB VRAM:** ample for these encoders in fp32 (BGE-M3 ~2.3 GB, SPLADE ~0.5 GB, MiniLM ~90 MB). **Not** the binding constraint for serving; it *is* for parallel SPLADE *ingest* (auto-caps at 3 workers, ~4 GB each, `parallel.py:51-77`).
+
+---
+
+## 3. DGX Spark profile + gandalf-vs-Spark comparison
+
+> **Sourcing discipline.** `results/spark/` holds only a README (no result-row JSONs yet — `results/spark/README.md:7`).
+> Every Spark **number** below is from Joe's markdown exchange files; every **spec** (ARM core count, LPDDR5x, FP4,
+> ConnectX) is **inferred from general GB10 knowledge** and marked as such. Of the "w8 knee / matmul 0.01% /
+> GPU-0%-over-37h / FP4 / ConnectX" terms, **only "GPU at 0%" appears in Joe's files** — the rest trace to session
+> memory, not measured bench, and are not asserted here as Spark facts.
+
+### 3a. Measured Spark behaviour (canonical 470-q bench)
+- **recall@10 = 27.2%** (`helix-bench/README.md:16`) — within noise of gandalf's 27.66%; 6/8 query types bit-identical.
+- **p95 latency = 146.7 s** vs gandalf 310.8 s → **2.1× speedup** (`README.md:19`). Same pre-#172 serial daemon on both → "pure memory architecture (mmap-in-RAM vs pagefile), no threading confound."
+- **Full-run = 13.5 h Spark vs 20.6 h gandalf** (`exchange/2026-05-31_splade-500q-test-plan.md:41`).
+- **GPU at 0% the whole run** (`README.md:21`) — dense matmul is CPU NumPy, BGE-M3 encode is CPU. **Idle exactly like the 3080 Ti.**
+- Joe advised **`HELIX_SHARD_WORKERS` 16+** and uvicorn **`--workers 2-3`** — viable *only* because each worker materialises its own genome in 128 GB; the same move **OOMs gandalf's 48 GB** (`docs/throughput-and-concurrency.md:25`).
+
+### 3b. Comparison
+
+| Axis | gandalf | DGX Spark | Helix consequence |
+|---|---|---|---|
+| **CPU** | x86 Zen3 8c/16t, 32 MB L3, AVX2 | ARM ~20-core Grace *(inferred)* | hot path CPU-bound on **both**; kernel is bandwidth-bound not FLOP-bound → ISA is secondary |
+| **Memory** | 48 GB DDR4-3200 **mismatched** + pagefile on 980 Pro | **128 GB unified LPDDR5x, mmap-in-RAM** | **the entire latency story.** gandalf spills ~200 GB → page-fault storm; Spark fits everything resident → 2.1× p95 |
+| **GPU** | 12 GB GDDR6X CC8.6 — **idle (`device=cpu`)** | Blackwell unified *(inferred)* — **idle (0%)** | both GPUs unused; Spark's biggest asset contributes **nothing** today |
+| **Storage** | one 980 Pro: C:+F:+corpus+pagefile contend | spill not exercised | gandalf's single-drive layout compounds the spill |
+
+### 3c. Reconciliation
+- **recall 27.66 vs 27.2 is NOT a hardware story.** Retrieval is deterministic/order-preserving; hardware moves
+  *wall-clock*, never *recall*. The recall ceiling is the **embedding (BGE-M3 reach)** — semantic recall is
+  1.6–2.4% on **both** hosts. That's why the embedding-upgrade/re-embed track is assigned to Spark: not because
+  Spark lifts recall, but because the **GPU-batch re-embed of 850K genes fits its 128 GB unified memory**.
+- **GPU-0% on both confirms CPU/bandwidth-bound retrieval.** Spark wins latency today *only* by dissolving
+  gandalf's pagefile cliff. **What would make Spark decisively pull ahead:** (1) GPU encode (needs the codec
+  device fix §2b), (2) GEMV→batched-GEMM on `torch.cuda` (`throughput-and-concurrency.md:26`), (3) unified-memory
+  process parallelism (`--workers 2-3`, `HELIX_SHARD_WORKERS 16+`), (4) the GPU-batch re-embed. Until then both
+  boxes run the same CPU-bound, GPU-idle retrieval.
+
+---
+
+## 4. Dual-genome / dynamic-port tray feasibility
+
+**Scenario:** keep the tray helix-mcp running (genome #1 → VSCode dev, port 11437) while concurrently benching a
+2nd genome on a 2nd port — so benching never tears down the live dev MCP.
+
+### Verdict — three-layered (don't collapse to one word)
+1. **Two daemons / two ports / two genomes — possible TODAY, config-only.** Helix is strictly
+   one-genome-per-process (`context_manager.py:464`), but **port and genome are both externally injected**:
+   port via uvicorn `--port` / `--helix-port` (never read inside `create_app`); genome via
+   `HELIX_GENOME_PATH` (`config.py:644-645`) + `HELIX_USE_SHARDS=1`. The live Onyx daemon *is* the proof
+   (its genome ≠ the helix.toml default). One command stands up a 2nd instance:
+   `HELIX_GENOME_PATH=<g2> HELIX_USE_SHARDS=1 python -m uvicorn helix_context._asgi:app --port 11439`.
+2. **Tray *supervising* the 2nd daemon — needs internals.** The supervisor is hard-wired to ONE helix child
+   (`supervisor.py:71-126`, single `helix_pid/helix_port` in `state.py:28-48`). **But the launcher already fully
+   supervises a second distinct process — Headroom** (own host/port, adopt-if-running, owned/adopted lifecycle,
+   tray items: `app.py:392-461`, `tray.py:250-283`). That is a ready blueprint. `find_orphan_helix()` can even
+   *adopt* a hand-launched daemon by LISTEN-socket + cmdline marker (`supervisor.py:222-291`).
+3. **Dynamic port allocation/discovery — doesn't exist.** Ports are static defaults; "dynamic" today = "a
+   different fixed value you pass." `_port_is_free` exists (`supervisor.py:306`) — fixed-second-port-with-check
+   (e.g. 11439) is simpler and sufficient; true ephemeral allocation only matters for many bench lanes.
+
+### Pointing the bench at port B
+- **enterprise_rag scripts: config-only, works today** — `bench_enterprise_rag(_recall).py` expose `--helix-url`
+  (`:433`, `:32`) + `--external-helix` ("a daemon is already running"). `--helix-url http://127.0.0.1:11439
+  --external-helix`. Zero code change.
+- **helix-bench/harnesses probes: ~5 LOC each** — `probe_latency.py`, `xl_ab.py`, `recall_lex*_compare.py`
+  hardcode `URL='http://127.0.0.1:11437/fingerprint'`. Need a one-line `os.environ.get('HELIX_BENCH_URL', …)`.
+- **Genome is chosen by the daemon, not the harness** — point lane-BENCH's `HELIX_GENOME_PATH` at the desired corpus.
+- **Bench floor:** recall@k on port B still needs `ann_threshold_min_genes>=10` in *that* daemon's config
+  (lane-DEV keeps prod default 1) — exactly the kind of divergence two daemons make clean.
+
+### Session attribution (the lane-tagging mechanism)
+Registry supports many participants/daemon via `HELIX_MCP_HANDLE→participant` (`mcp_server.py:119`). DEV `.mcp.json`
+→ `HANDLE=laude` @ :11437; bench env → `HANDLE=raude` @ :11439. **Caveat:** registry tables live *inside each
+genome's SQLite* — two genomes = two participant tables; `raude`/`laude` won't appear in each other's `/sessions`.
+Good for isolation, but a dual-genome switchboard must **query both daemons and merge**.
+
+### Resource reality check on gandalf
+- **Concurrent dev + 850K Onyx — NO. Resource-infeasible.** 850K alone drives commit to 240–247 GB / requires the
+  240 GB pagefile / 143 GB OOM on default. A 2nd daemon adds its own genome + its own ~7 GB encoder bundle
+  (per-process; not shareable; the singleton fix isn't even on master). Two daemons both leaning on one 980 Pro
+  for mmap + pagefile faults, on a box already at its ceiling. This is a **commit-budget wall**, not a tuning problem.
+- **Small-corpus pairing — YES (recommended shape).** gandalf's own **medium/xl** corpora are orders of magnitude
+  lighter than 850K Onyx. Lane-DEV (medium dogfood) + Lane-BENCH (medium/xl) is comfortably concurrent on 48 GB;
+  the 3080 Ti is idle so no VRAM contention. **Measurement gap:** medium/xl have **no wired gold `questions.jsonl`** —
+  only unlabeled ordering-diff probes (`xl_ab.py`). So you get *latency* dogfood free, but *recall@k* on Max's own
+  corpus needs a gold set first; enterprise_rag is currently the only labeled-gold recall path.
+- **Sequential fallback (if heavy Onyx bench is required):** the existing **`/admin/swap-db`** hot-swap
+  (`routes_admin.py:845-965`, MCP `helix_swap_db`) flips the single daemon dev↔bench — config-only, zero extra
+  RAM, but *serial* (not concurrent) and mutates shared state for all clients.
+
+### Risks + minimal first step
+**Risks:** R1 RAM wall (concurrent + 850K = OOM) · R2 encoder bundles not process-shareable · R3 single-NVMe
+contention · R4 split registry presence · R5 provenance (which tree/venv each lane launches) · R6 probe URL hardcoding.
+
+**Minimal step (PRD-first — touches launcher + ports + feature behaviour):** scope `docs/prds/2026-06-xx-dual-genome-tray.md` around the **small-corpus pairing**, with:
+- **Phase 0 (zero-code, validate):** by hand, launch a 2nd daemon on :11439 → *medium* corpus, leave the tray dev
+  daemon untouched, run `bench_enterprise_rag_recall.py --helix-url http://127.0.0.1:11439 --external-helix`.
+  Proves two-lane concurrency *and* measures real 2-genome RAM cost. (Do **after** the current bench finishes.)
+- **Phase 1 (internals, only if Phase-0 RAM is acceptable):** generalise `HelixSupervisor` to `(port, genome_path)`
+  threaded into child env; clone the Headroom state/tray pattern for a 2nd helix slot; teach the dashboard collector
+  to merge both ports' `/sessions` + `/health`.
+- **Explicitly scope OUT** the concurrent-850K case (resource-blocked → use `/admin/swap-db` sequential fallback).
+
+---
+
+### 4.1 Does `start-helix-tray.bat` block bench control of the server? (port-11437 conflict + per-lane telemetry)
+
+**Yes — on port 11437 the tray and the bench launcher actively fight (mutual takeover/kill, not a soft block).**
+- The tray runs `python -m helix_context.launcher.app --tray`, whose supervisor manages exactly ONE helix on a
+  single port (default 11437): on start it spawns, or **adopts** an existing helix on 11437
+  (`supervisor.py:222,306-323`); on Quit/restart it **`taskkill /F /T`s the tracked PID** (`:519-528`). Unlike
+  Headroom, **helix has no "adopted-survives-Quit" flag** (`state.py` has `headroom_owned`, no `helix_owned`) — so an
+  *adopted* daemon is killed on Quit too.
+- The bench launcher `start_helix_for_enterprise_rag.py` is **hard-wired to 11437 and explicitly kills any uvicorn on
+  11437** before starting its own (`:32, :109, :137-138`).
+- ⇒ **Tray-first:** the bench launcher kills the tray's daemon and seizes 11437. **Bench-first (today's live run):**
+  launching the tray **adopts the in-flight bench daemon and puts it under kill-on-Quit** — so **do NOT launch the
+  tray on 11437 during Raude's run.** (HTTP query harnesses just POST — never "blocked" — but pointed at the default
+  URL they hit whichever daemon holds 11437, possibly the wrong genome.)
+
+**Coexistence (tray on 11437 + bench on its own port) — config-only today + two small internals:**
+1. **Separate ports (config today).** Keep the tray's dev daemon on 11437; run the bench daemon **by hand** on e.g.
+   11439: `HELIX_GENOME_PATH=<bench> HELIX_USE_SHARDS=1 <cu121-venv>\python -m uvicorn helix_context._asgi:app
+   --host 127.0.0.1 --port 11439`. The tray supervisor only watches 11437 → it will **not adopt or kill** 11439.
+   Point the harness with `bench_enterprise_rag_recall.py --helix-url http://127.0.0.1:11439` (already supported; the
+   5 `harnesses/*` probes need the ~5-LOC env-URL read). *Small internals nicety:* give
+   `start_helix_for_enterprise_rag.py` a `--port` and drop its blanket "kill anything on 11437."
+2. **Per-lane telemetry "which is which" (the key small internals change).** `service.name` is hardcoded
+   `"helix-context"` (`server/app.py:190`) and `otel.py`'s `Resource.create({SERVICE_NAME: service_name})` reads **no
+   env override** — so two daemons emit identical `service.name` and **merge indistinguishably** in
+   Prometheus/Tempo/Grafana (standard `OTEL_SERVICE_NAME` won't help — the explicit Resource overrides it). Fix (~3-5
+   lines): read `HELIX_OTEL_SERVICE_NAME`/`HELIX_LANE` into `service_name` and add `service.instance.id = host:port`
+   to the Resource. Then launch dev with `HELIX_OTEL_SERVICE_NAME=helix-dev` and bench with `=helix-bench` → every
+   metric/trace/log is lane-tagged and splittable. The tray's OTel Collector (`:4317`) + Prometheus already ingest
+   both pushes; only the label is missing. *(Session-level "which is which" already works: registry handles
+   `laude`=dev / `raude`=bench live in each genome's own participant table.)*
+3. **Both lanes inside the tray dashboard (internals).** The launcher collector polls only 11437; surfacing the bench
+   lane in-tray needs the dual-genome collector generalization (§4) — not required for Grafana visibility, which #2
+   delivers on its own.
+
+**Caveat:** the tray bat launches via bare `python` — if that resolves to the system `torch+cpu` interpreter, the
+tray's dev daemon silently runs **lex-only** (no dense/SPLADE; `bgem3_codec.py:74-81`). Point the tray at a cu121
+venv so the dev lane isn't quietly degraded while you bench.
+
+## 5. Switchboard visualizer feasibility + design
+
+**Goal:** a tray/dashboard panel showing **(1) tuned values, (2) gate thresholds, (3) latency-per-step, live.**
+The headline: it splits into a **cheap two-thirds and an expensive one-third**, and the expensive third is
+double-gated by a flag the live daemon probably doesn't have on.
+
+### 5a. Data availability
+
+| Panel | Source today | Verdict |
+|---|---|---|
+| **Tuned values** | `GET /stats` → `.config` (`context_manager.py:1844-1862`), already polled by the launcher collector every 2 s | **CHEAP — data exists** |
+| **Gate thresholds** | `GET /health` → `.calibration` (`routes_admin.py:444-455`), already polled | **CHEAP — data exists** |
+| **Latency-per-step** | OTel histograms `helix_pipeline_stage_seconds` + `helix_genome_signal_seconds` (`otel.py:595-608, 690-703`) | **EXPENSIVE — flag-gated, push-only, no HTTP snapshot** |
+
+- **Panel 1 gap:** `/stats.config` carries `ribosome_budget`, `expression_budget`, `max_genes_per_turn`,
+  `splice_aggressiveness`, `decoder_mode`, `budget_zone_enabled` — but **omits** the retrieval-tier knobs
+  (`rerank_enabled`, `splade_enabled`, `dense_embedding_enabled`, `fusion_mode`, device, shard_workers). There is
+  **no full-config dump endpoint**. ⚠ Two requested knobs aren't real master knobs: **`per_gene_budget`** (master
+  uses a hard `target=1000` splice clamp; dynamic allocator is worktree/PyPI) and **`dense_prefilter_enabled`**
+  (worktree-only; master's prefilter knob is `bm25_prefilter_enabled`). Don't render them as live master knobs.
+- **Panel 2 gap:** `/health` shows the *configured mode* (`ann_threshold_mode=margin_over_random`,
+  `abstain_mode=global`), not the live numeric cut per query.
+- **Panel 3:** timers are good, but `setup_telemetry()` early-returns when `HELIX_OTEL_ENABLED!="1"` (`otel.py:231`)
+  → every `.record()` is a no-op; **there is no Prometheus `/metrics` scrape endpoint** (OTLP-push only). A live
+  readout must query **Prometheus :9090** (only up if the grafana/docker scripts ran).
+
+### 5b. Design
+- **Lives in the existing launcher dashboard `:11438`** (`launcher/app.py`) — not a new service, not inside the
+  serving daemon (coupling a UI concern to the bench-critical process is wrong). It already polls every 2 s, fans
+  out over httpx with timeouts, and degrades to null panels. A switchboard is a **new tab + panel template**.
+- **Reads:** reuse `/stats.config` + `/health.calibration` (have it now) → add one read-only **`GET /admin/config`**
+  on the daemon to dump the *resolved* `HelixConfig` (closes the tuned-values gap honestly, with override
+  provenance) → **Prometheus PromQL** for latency (`histogram_quantile(0.95, sum by (le,stage)(rate(helix_pipeline_stage_seconds_bucket[5m])))`).
+  A dedicated `/switchboard` aggregator is **not** recommended (duplicates the above + adds a daemon route).
+- **Two correctness guards:** (a) label latency rows with the **real timer stages** `extract/express/rerank/splice/assemble`
+  (not the CLAUDE.md "0–6" marketing pipeline; `express` bundles all retrieval). (b) **Flag runtime overrides** —
+  show *resolved* values with provenance tags; reading only `helix.toml` would show `device="auto"` while the daemon
+  is actually CPU via `HELIX_DEVICE` env. That trap is the whole point of the panel.
+
+### 5c. Effort tiers
+- **Tier 0 — MVP (CHEAP, recommended scope):** read-only tuned-values + gate-thresholds tab from already-polled
+  `/stats.config` + `/health.calibration` (+ optional on-disk toml for the omitted knobs). Pure launcher-side work
+  (`panels/switchboard.html`, a `_switchboard_panel()` in `collector.py`). Never touches the serving daemon.
+- **Tier 1 — live latency-per-step (MODERATE, gated):** needs the daemon launched with `HELIX_OTEL_ENABLED=1`
+  **and** Prometheus up; then PromQL the existing histograms. No new helix instrumentation — the *operational
+  dependency* is the cost. **Cannot be enabled on the currently-serving bench daemon without a relaunch (forbidden
+  this session).**
+- **Tier 2 — editable / hot-reload (HARDEST — DANGER, do not MVP):** writing knobs touches the config write path
+  and mutates state shared by **all** MCP clients. Many knobs are read once at construction (genome, device, encoder
+  placement) and are **not hot-reloadable** → a UI toggle silently no-ops or needs a restart that kills in-flight
+  clients. The only runtime mutation today is `/admin/swap-db` (all-clients blast radius). **Explicitly out of scope —
+  this is the feature-creep this assessment was asked to guard against.** Needs its own PRD + a hot-reloadable-knob
+  taxonomy + per-client vs global scope semantics.
+
+### 5d. Recommendation
+Ship **Tier 0** (read-only tuned values + gate thresholds) — two-thirds of the ask is nearly free. Add a
+read-only **`GET /admin/config`** so it shows *resolved* values with override provenance, not toml defaults. Make
+latency-per-step a **second card that degrades gracefully to "no data"** when telemetry is off / Prometheus is
+down. **Stop short of editable/hot-reload.** PRD-gated the moment it adds the new endpoint or the Prometheus
+dependency.
+
+---
+
+## 6. Consolidated next steps (all PRD-gated where noted)
+
+**Cheapest measurable wins (config/ops, gandalf):**
+1. Launch daemons from the cu121 venv (prevents silent lex-only degrade).
+2. `splade_enabled=false` on the Onyx 850K bench (frees 94–153 s p95, kills timeouts, 0 pp recall) — **Onyx only.**
+3. Re-shard Onyx to ≤~15 shards + keep the 240 GB pagefile (attacks Wall-1).
+4. `HELIX_OTEL_ENABLED=1` so any subsequent change is measurable.
+
+**Highest-leverage internals (Raude, PRD if touching retrieval behaviour):**
+5. Thread `get_hardware().device` into `BGEM3Codec` (both call sites) + fp16/device on the FlagEmbedding path — the keystone GPU enablement.
+6. LRU-bound the shard cache (durable Wall-1 fix).
+7. Port the dense GEMV to `torch.cuda` (the real Wall-2 fix; the only lever that beats the mismatched-DDR4 wall).
+8. Fix the rerank name-mismatch + profile gate, then enable (cheap GPU precision — but only re-orders the pool).
+
+**Spark-specific (Joe):** `HELIX_SHARD_WORKERS 16+`, `uvicorn --workers 2-3`, and the GPU-batch re-embed track — all enabled by 128 GB unified memory and foreclosed on gandalf.
+
+**Features (investigation → PRD before code):**
+9. Dual-genome tray: PRD around the **small-corpus pairing**, Phase-0 by-hand validation, Headroom supervisor as template; scope OUT concurrent-850K.
+10. Switchboard visualizer: PRD for **Tier 0–1 read-only**; explicitly exclude Tier 2 editable/hot-reload.
+
+**Cross-cutting precondition:** establish **which tree + venv** each daemon launches from before trusting any worktree-gated lever. Most latency machinery (`HELIX_SHARD_WORKERS`, fp16 dtype, dense-prefilter, the 7 GB singleton) is **not on master 0.5.0**.
+
+---
+
+## Appendix — verification & sources
+
+- **Verify pass:** 16 high-impact claims → **12 confirmed, 3 partial, 1 refuted.** Corrections folded into §0.
+- **Knob inventory:** 87 knobs catalogued, **46 hardware-sensitive** (full dump in the workflow result JSON).
+- **Key code refs:** `hardware.py:40-48,254-326` · `bgem3_codec.py:57,76,80` · `knowledge_store.py:2443,2576,2635` ·
+  `shard_router.py:294-306,443` · `sharding.py:212,488-500` · `context_manager.py:464,1844-1862` ·
+  `routes_admin.py:444-455,845-965` · `launcher/supervisor.py:71-126,222-291,306` · `launcher/collector.py:81-171` ·
+  `telemetry/otel.py:231,595-608,690-703`.
+- **Bench refs (`helix-bench/`):** `README.md:16,18,19,21` · `exchange/2026-05-31_results-and-embedding-track.md:30,46` ·
+  `exchange/2026-05-31_splade-500q-test-plan.md:25,41` · `docs/throughput-and-concurrency.md:14-26` · `results/spark/README.md`.
+- **Investigation cost:** 27 agents, 2.69M tokens, 638 tool calls, ~52 min wall-clock.
+
+---
+
+## Appendix B — Probe-interpretation rubric (rank-band → lever)
+
+*Ready to receive the offline rank-distribution probe + recall@k curve from the widened-rerank run. Slot the band
+counts into the table; the pre-checks pick the track before you read the bands.*
+
+### Pre-check 0 · Is dense actually surfacing on the sharded path? — **answerable by the probe itself**
+The probe computes **pure-dense rank over all 850K vectors, bypassing the daemon's retrieval entirely.** Compare it
+to the daemon's live pool:
+
+> **probe pure-dense recall@200  vs  daemon pool recall@200 (= 21%)**
+
+- **pure-dense@200 ≫ 21%** → dense isn't surfacing effectively on the sharded path → **wiring/routing lever
+  (near-free); do NOT spend GPU-weeks on re-embed.**
+- **pure-dense@200 ≈ 21%** → dense *is* contributing → 21% is a real **geometry** verdict → go to the band split.
+
+*Already established (so we don't re-litigate):* dense recall is **not** globally off — it fires per-shard via
+`query_docs` under **additive fusion** (`dense_embedding_enabled=true`, `dense_additive_weight=4.0`). The only dead
+dense path is `query_docs_ann`'s ANN-threshold gate (refuted-hyp #4). So PC-0 is specifically about **per-shard
+effectiveness**, not a global on/off.
+
+### Pre-check 1 · Routing — does the router even visit the gold's shard?
+The probe-vs-pool delta also exposes this: a gold that ranks high in pure-dense (global) but never enters the pool
+**and lives on a shard the router didn't select** is a **routing** miss, not a geometry miss → fix routing/fan-out,
+not the encoder. Separate "gold on an unvisited shard" from "gold visited but out-ranked."
+
+### Bands (for golds that are embedded AND on a visited shard)
+
+| Gold rank band | Diagnosis | Lever | Effort | Recoverable ceiling |
+|---|---|---|---|---|
+| **1–10** | delivered (today's ~3%) | — | — | baseline |
+| **11–200** | in widened pool, mis-ranked vs near-neighbors | rerank **proven net-zero here** → **encoder discrimination** (hard-neg fine-tune); fusion-weight retune low-ceiling | rerank=done; FT=high | low without encoder work — *the dilution band* |
+| **201–1,000** | right neighborhood, just outside delivered k | **k↑ / pool-widen** (config) + light rerank | low | **HIGH if populated — cheapest win** |
+| **1,001–~20k** | facet miss: one paraphrase vector misses a lexical/semantic facet | **query expansion** (multi-query / HyDE / sub-query decomp) | med | medium |
+| **>20k, embedded** | gold genuinely far in geometry | **re-embed / fine-tune** encoder | high (GPU re-embed 850k) | the residual — only geometry fixes it |
+| **∞ (no vector / wrong dim / unrouted)** | data/routing bug | **pipeline/routing fix** | low–med | possibly large & cheap — check via PC-0/PC-1 FIRST |
+
+### The fork (where the 79% lives)
+mass in **201–1k** → widen k · mass in **1k–20k** → expansion track · mass in **>20k-embedded** → re-embed/fine-tune ·
+mass in **∞ / unvisited shard / pure-dense≫pool** → it's wiring/routing, **don't burn GPU-weeks on a model fix for a
+config bug.**
+
+### Expansion vs re-embed (decide once band counts land)
+- **Expansion** — inference-time, no re-index; cost ≈ N× query latency (brutal at gandalf's ~100 s/q CPU brute-force,
+  fine on Spark/GPU); lift **bounded by what's retrievable at large k** → only helps the 1k–20k band.
+- **Re-embed / fine-tune** — one-time GPU batch over 850k genes (fits Spark's 128 GB, painful on gandalf); permanently
+  changes geometry; the **only** fix for the >20k band — but **validate a candidate encoder on a held-out gold set
+  before re-embedding everything.**
+
+*Inputs to drop in when the run finishes:* recall@k curve (10/50/200/1k/5k) · per-band counts split semantic-vs-other ·
+the pure-dense@200-vs-pool@200 delta (PC-0).
+
+### Re-embed track — candidate already CHOSEN (cc-exchange encoder benchoff, 2026-06-02)
+The ">20k / re-embed" lever's "validate a candidate before re-embedding" step is **done**. Joe's semantic-125 proxy
+(736-doc pool, 1024-dim, CPU; relative-to-control only) ranked **Qwen3-Embedding-0.6B** the clear winner — **R@10
+86.8 (+17.4 pp over BGE-M3 control), R@200 100%, MRR 0.47→0.70**, and it's **1024-dim native (zero schema change) +
+Apache-2.0**. bge-large-en-v1.5 (+5 pp, MIT) is the fallback. So if the probe's mass lands in the >20k band, the
+encoder swap is pre-selected.
+**Gate:** GPU embedding is currently **broken on the GB10** (Triton/ARM64 — `gcc cuda_utils.c` link fails); CPU
+re-embed of 850k ≈ 590 h = infeasible. The re-embed track is blocked on unblocking GPU embedding
+(`attn_implementation="eager"` / vLLM) — Joe owns that. *(Caveat: the proxy is a relative encoder-selection signal
+over a 736-doc pool, NOT a prediction of the 2.4% end-to-end semantic number — the real lift is confirmed only by a
+new-genome semantic-125 re-run + threshold recalibration.)*
+
+### RESULTS — probe landed (2026-06-02): the fork resolved → WIRING @10, geometry @200
+The widened-rerank run + offline cross-join came back. **The top-tier win is FREE — it's wiring, not the encoder.**
+
+**Cross-join (semantic-125): of the 9 golds that pure global-dense ranks top-10, the daemon delivers 0:**
+
+| outcome | count | what happened |
+|---|---:|---|
+| routing/cut dropped | 5 | gold absent from the fused 200-pool — dense ranks it top-10 globally, the daemon never had it |
+| fusion demoted | 4 | gold in the pool but pushed to ranks 11/11/40/45 by lexical+SPLADE |
+| kept | 0 | — |
+
+The daemon's own 3 top-10 hits are *different* gold (lexical/tag/filename). **Dense and lexical catch DISJOINT gold
+(9 vs 3); additive fusion + routing loses dense's 9 instead of keeping both.**
+
+**PC-0 — k-dependent (refines the rubric's binary pre-check):**
+- **@10 = pure wiring:** pure-dense 7.2% vs fused 2.4% — dense already ranks them; fusion/routing throws them away.
+- **@200 = geometry, not wiring:** pure-dense 28.8% vs pool 24% (Δ+5 pp only) → the bulk is genuinely out of dense's
+  top-200 → do NOT spend GPU-weeks on routing for it. Chromatin clean ({0:120, 1:1}) → no lifecycle demotion.
+
+**The full fork, by band:**
+
+| band | count | lever | cost |
+|---|---:|---|---|
+| **wiring-lost** (dense-top-10, routing/fusion dropped) | **9** | **semantic-aware routing + dense-dominant fusion** | **cheap, no GPU ← TEST NEXT** |
+| 201–1k | 17 | widen-k (helps recall@k; limited at 12-gene delivery) | cheap, modest |
+| 1k–20k | **41 (33%, biggest)** | query / **doc-side** expansion (facet miss) | med; doc-side GPU-light |
+| >20k | 27 (22%) | re-embed / fine-tune (**Qwen3-0.6B** chosen) | expensive (residual geometry) |
+| no-vector | 4 | data gap — gold absent/unembedded in corpus | investigate ingest |
+
+**Lever ladder, rewritten by this run (supersedes "re-embed is the lever"):**
+1. ~~rerank~~ — **exhausted** (net-zero, valid).
+2. **NEW #1 — semantic-aware routing + dense-dominant fusion:** cheap config, **~4× ceiling on @10** (3 → ~12, ≈9.6%),
+   no GPU. *Caveat (reconciles refuted-hyp #5): route-all **alone** didn't lift recall@200 — broadening the pool
+   without changing the ranking lets fusion re-bury gold. It's the **combination** that's the lever. Cheap, testable.*
+   **The thing to test next.**
+3. **doc-side expansion** — the 33% facet-miss band (1k–20k); GPU-light at ingest.
+4. **re-embed / fine-tune (Qwen3-0.6B)** — the >20k residual (22%) + the 11–200 dilution; expensive, **last** (gated on
+   GB10 GPU-embed).
+5. **fix the 4 no-vector data gaps** (ingest).
+
+**Bottom line: re-embed is the RESIDUAL (22%), not the front-runner.** The free win is recovering dense's already-good
+@10 ranks via semantic-aware routing + dense-dominant fusion — ~4× on semantic@10, no GPU, no re-index.

--- a/docs/investigations/2026-06-06-dense-ann-cap-code-retrieval-handoff.md
+++ b/docs/investigations/2026-06-06-dense-ann-cap-code-retrieval-handoff.md
@@ -1,0 +1,73 @@
+# Handoff → Raude: the dense ANN cap collapses code retrieval (it's `max_genes`, not the threshold *mode*)
+
+**From:** Laude (code-context benchmark track) · **Date:** 2026-06-06 · **For:** Raude (dense/SPLADE A/B owner)
+**TL;DR:** On the new ContextBench **code** benchmark, **shipped v0.6.3's default dense path collapses the candidate pool to ~5–12 and drops the gold** on a single (non-sharded) genome. Root cause = `[retrieval] ann_threshold_max_genes = 12` (+ `ann_similarity_threshold = 0.58`). **Your arm2/arm3 A/B toggles `ann_threshold_mode` (absolute↔margin_over_random) but both keep `max_genes = 12` — so they can't fix this. The cap is the lever, not the mode.**
+
+## Why this matters / how it connects to your work
+- **v0.6.3 ships dense ON by default** (`dense_embedding_enabled=True`, `dense_embed_on_ingest=True`; SPLADE off). So this is the **production default retrieval path**, not an opt-in — the collapse is shipping.
+- It's almost certainly the **same wiring failure as the prose semantic-2.4%** (dense replaces/【caps】the lexical pool instead of augmenting it), now reproduced and root-caused on code where retrieval is LLM-free and cleanly scorable.
+- Your `vibrant-easley` untracked arms (`helix.toml.arm2-dense-absolute`, `arm3-dense-margin`) change `ann_threshold_mode` only. Both still cap at `max_genes=12` → both will still collapse. Suggest adding an arm that **raises `max_genes` (→500) and/or drops `ann_similarity_threshold` (→0)**.
+
+## Evidence (official ContextBench evaluator, frozen v0.6.3 wheel @ 1510f128)
+
+Same genome, two managers (diag isolates query path from ingest — genome is healthy: 161 open / 8 eu / 6 hetero, gold present):
+```
+task 88e1ffd3 (requests/models.py is gold)
+  dense-on manager  (cap 12):  _retrieve -> 5 candidates,  gold NOT in pool
+  lexical manager   (same db): _retrieve -> 55 candidates, gold IN pool
+```
+
+Matched requests (N=2, @27k tokens):
+| arm | file_R | line_R | sym_R | injected |
+|-----|--------|--------|-------|----------|
+| v063 lexical (dense off) | 0.750 | 0.466 | 0.500 | 27.8k |
+| v063 SHIPPED dense (cap 12) | 0.750 | **0.000** | 0.000 | **16.4k (pool starved, can't fill budget)** |
+| v063 densefix (max_genes=500, sim=0) | 1.000 | 0.466 | 0.600 | 27.8k |
+
+django individual tasks: shipped cap12 `93721db4` → gold **0/1 (lost)**; densefix cap500 `1a760e52` → gold **1/1 (kept)**.
+
+**Read:** dense-as-shipped is *worse than dense-off* on code (cap starves the pool). Lifting the cap **restores dense to lexical parity** — it does not (yet) beat lexical on this small sample, so the cap fix stops the bleeding but isn't a lift by itself. SPLADE (the +6pp-on-code hope) is still untested (dense GPU-ingest compute wall — see below).
+
+## Root cause (where to look)
+- `knowledge_store.apply_density_gate` is fine (genome healthy). The collapse is in the **dense ANN candidate path** reached on a single/non-sharded genome: `config.retrieval.ann_threshold_max_genes=12`, `ann_similarity_threshold=0.58`, `ann_threshold_mode=absolute`, `dense_pool_size=500` (wired into the retriever at `context_manager.py:~490-514`).
+- `dense_pool_size=500` is *intended* as the recall breadth ("decouples breadth from the final cut" per your comment) but in practice the **`max_genes=12` cut dominates and dense appears to replace the lexical set** rather than additively augment it → net pool ≈ the 12-cap, minus anything below sim 0.58. On code, few chunks clear 0.58 cosine to an issue-text query → ~5 survive.
+- Likely the real fix is two-fold: (a) **raise/disable the `max_genes` cut for the additive path** so dense augments rather than caps, and (b) confirm additive fusion **unions** lexical+dense (gold is found by lexical/tag here, and it's vanishing).
+
+## Repro (LLM-free, no daemon; my harness)
+- Frozen v0.6.3 venv: `F:/Projects/_venvs/helix063` (wheel + torch cu121 + transformers==4.49.0 + sentence-transformers + spacy/en_core_web_sm). **transformers 5.x BREAKS helix** — pin 4.49.0.
+- Configs: `F:/tmp/cb_helix_probe/helix_v063_shipped.toml` (cap12) vs `helix_v063_densefix.toml` (cap500/sim0).
+- Driver: `helix-context/benchmarks/cb_helix_pred.py --config <toml> --dense-device cuda --workers 1 --tasks F:/tmp/cb_tasks_requests.json` (in-process: ingest repo@base_commit whole-file → `_prepare_query_signals`→`_retrieve`→`_apply_candidate_refiners`; line recovery by verbatim content-match).
+- Isolation diag: `F:/tmp/cb_v2_diag2.py` (the same-genome lexical-vs-dense candidate-count test above).
+- **Compute caveat:** dense GPU ingest needs ~5–6 GB/worker → **only 1 worker fits the 12 GB 3080 Ti** (2 → BrokenProcessPool OOM; 3 → multi-hour VRAM thrash). 1-worker dense ingest ≈ 12 min/django. Use requests/sklearn for fast iteration; avoid django ×N.
+
+## Suggested next experiment (yours to run)
+Add a 4th arm to your A/B: **`ann_threshold_max_genes = 500`, `ann_similarity_threshold = 0.0`** (mode irrelevant) on the ContextBench code set — and verify the additive path *unions* lexical+dense. If that lands dense ≥ lexical on code, then SPLADE-on (Phase 2) is the next lever to test for the +6pp-on-code thesis.
+
+---
+
+## 2026-06-07 UPDATE — ran your 4th arm + the SPLADE test. Both come up empty on code. (laude)
+
+I ran exactly the experiment above (cap lifted to `max_genes=500`/`sim=0`, additive) **plus** SPLADE-on, matched, on the ContextBench code set. Official evaluator, frozen v0.6.3 wheel.
+
+**Result 1 — the cap fix restores dense, but dense ≤ lexical on code (it does NOT beat it):**
+
+sklearn-2, @27k line-recall (matched, same 2 tasks):
+| arm | file_R | line_R | sym_R |
+|-----|--------|--------|-------|
+| BM25 | 1.000 | 0.307 | 0.438 |
+| **v063 lexical (dense OFF)** | 0.333 | **0.654** | 0.562 |
+| densefix (dense ON, cap 500/0) | 0.667 | 0.430 | 0.625 |
+| +SPLADE | 0.667 | 0.430 | 0.625 |
+| packet (all 3 identical) | 1.000 | 0.906 | 0.812 |
+
+So lifting the cap stops the bleeding (dense pool no longer collapses, gold is found) — but **dense-on still loses to lexical on line-recall (0.430 vs 0.654)**. Turning the shipped dense path on (even cap-fixed) is **net-negative** for code line-recall vs pure lexical here. requests-2 was a tie (both 0.466). So the cap fix is necessary (it's a real prod bug — keep it) but it is **not a recall win** on code.
+
+**Result 2 — SPLADE adds exactly nothing on code:** `+SPLADE == densefix` to 3 decimals on **both** requests-2 (0.466) and sklearn-2 (0.430/0.667/0.625) — identical file/line/sym, only injected-token count differs trivially. SPLADE *is* firing (it reshuffles which spans rank), it just nets zero recall change. **The "+6pp-on-code" SPLADE thesis does not reproduce on ContextBench code.** Don't spend the SPLADE ingest cost on the strength of the e-rag number.
+
+**Takeaway for your A/B:** the `max_genes` cap fix is correct and should ship (it's a genuine collapse bug), but neither dense nor SPLADE buys recall over lexical on code. The lever is the **encoder geometry** (re-embed / hard-neg fine-tune), consistent with the prose-track conclusion — not the fusion/cap wiring and not SPLADE. The wiring fix just gets dense back to *parity-or-below* lexical.
+
+### Two side-deliverables from this run (your call to review/merge)
+- **PR #177 / issue #176** — `BGEM3Codec.encode_batch` never released torch's CUDA cache; long-lived GPU dense ingest climbs to the card ceiling (measured 11.7 GB/95% on a single worker, 12 GB 3080 Ti) and spills to shared RAM. Added a periodic `empty_cache()` (`HELIX_DENSE_VRAM_RELEASE_EVERY`, default 256, cuda-only, byte-neutral; 8 tests). Off `master`, flagged for your review — **not self-merged** (your area).
+- **issue #178** — operational runbook for dense ingest on ≤12 GB rigs (CPU-for-batch, 1-worker-GPU caps, the env knobs, confirmed OOM/thrash modes).
+
+Repro for all of the above: `helix-context/benchmarks/cb_helix_pred.py` + `cb_score_sklearn2.py` / `cb_score_splade.py`; configs in `F:/tmp/cb_helix_probe/`; frozen venv `F:/Projects/_venvs/helix063`.

--- a/docs/ops/dense-ingest-on-12gb-rigs.md
+++ b/docs/ops/dense-ingest-on-12gb-rigs.md
@@ -1,0 +1,213 @@
+# Dense BGE-M3 Ingest on ≤12 GB Rigs
+
+**Issue:** #178  
+**Triggered by:** 2026-06-07 handoff (Laude → Raude), PR #177 / issue #176  
+**Applies to:** any operator running GPU dense ingest (`[ingestion] dense_embed_on_ingest = true` or `scripts/backfill_bgem3_v2.py`) on a card with 12 GB or less of VRAM, especially where Ollama or another model server may be resident.
+
+---
+
+## The problem in one paragraph
+
+BGE-M3 dense encoding on CUDA consumes roughly 5–6 GB of VRAM per ingest worker, measured on a 12 GB RTX 3080 Ti. That leaves room for exactly one worker before the card is full. Two workers trigger a `BrokenProcessPool` OOM immediately; three workers cause a multi-hour VRAM-thrash livelock on Windows (WDDM shared-memory spill, issue #176). Even a single worker is not safe to leave unattended: before PR #177 landed, `BGEM3Codec.encode_batch` never called `torch.cuda.empty_cache()`, so VRAM climbs steadily across a long corpus, reaching the card ceiling (measured 11.7 GB / 95% on a 12 GB card on one worker) and then spills into system RAM. On a rig where Ollama is already resident and holding VRAM — the typical dev setup — the real headroom is lower still.
+
+This runbook covers the safe operating envelope and the env-var knobs that control it.
+
+---
+
+## Choosing your ingest mode
+
+Three paths exist. Pick based on corpus size and available VRAM:
+
+**CPU path — use for: corpora of any size, safety-first, Ollama resident.**  
+Set `BGEM3_DEVICE=cpu` (or leave it unset on a CPU-only host). The backfill script auto-detects CUDA when `BGEM3_DEVICE` is empty or `"auto"`, so an explicit `cpu` value is necessary when you want to force the CPU path on a machine that has a GPU but whose VRAM is contended. Throughput is ~30–90 minutes for an 18.9k-document store on CPU sentence-transformers BGE-M3; no OOM risk.
+
+**1-worker GPU path — use for: speed, 12 GB card, Ollama NOT resident.**  
+Set `BGEM3_DEVICE=cuda`, one worker. Expect ~5–15 minutes for an 18.9k-document store (FlagEmbedding) or ~12 minutes for a single ContextBench django task. Peak VRAM before PR #177 reached 11.7 GB / 95% on one worker without cache release. After PR #177 merges, set `HELIX_DENSE_VRAM_RELEASE_EVERY` to a value between 64 and 256 to bound the within-run peak. Do not raise the worker count above 1 on a 12 GB card.
+
+**Deferred-backfill path — use for: latency-sensitive ingest where you want no GPU involvement at ingest time.**  
+Set `[ingestion] dense_embed_on_ingest = false` in `helix.toml`. Documents are ingested without a dense vector; the `embedding_dense_v2` column stays NULL. Run `scripts/backfill_bgem3_v2.py` separately during a maintenance window, using the CPU or 1-worker-GPU guidance above. Retrieval continues to work on the lexical/tag path; dense recall is disabled until backfill completes.
+
+---
+
+## Env vars and config keys
+
+All values below have been verified against the source files indicated.
+
+### `BGEM3_DEVICE`
+
+Controls which device the BGE-M3 codec runs on in `scripts/backfill_bgem3_v2.py` and the inline ingest path. Device selection follows this priority order (source: `scripts/backfill_bgem3_v2.py:127–146`):
+
+1. An explicit `BGEM3_DEVICE` env var, if set and non-empty.
+2. Auto-detected CUDA when `torch.cuda.is_available()` returns true and `BGEM3_DEVICE` is empty or `"auto"`.
+3. CPU otherwise.
+
+`BGEM3Codec.__init__` defaults to `device="cpu"` (`helix_context/backends/bgem3_codec.py:57`), so any path that bypasses the backfill script's device-selection block lands on CPU. Setting `BGEM3_DEVICE=cpu` explicitly is the safe way to force CPU when a GPU is visible.
+
+```powershell
+# Force CPU even on a CUDA-visible machine
+$env:BGEM3_DEVICE = "cpu"
+python scripts/backfill_bgem3_v2.py
+```
+
+```bash
+# Linux / macOS
+BGEM3_DEVICE=cpu python scripts/backfill_bgem3_v2.py
+```
+
+### `HELIX_DENSE_VRAM_RELEASE_EVERY`
+
+**Status: added in PR #177, not yet merged to `master` as of 2026-06-07.**
+
+When merged, this env var adds a periodic `torch.cuda.empty_cache()` call inside `BGEM3Codec.encode_batch`, bounded to CUDA-only, byte-neutral (does not change the stored vectors). Default is 256 batches between cache releases. Lower values reduce peak VRAM at the cost of slightly more overhead; values as low as 64 are reasonable on a 12 GB card.
+
+```powershell
+# After PR #177 merges: release cache every 64 batches (more aggressive)
+$env:HELIX_DENSE_VRAM_RELEASE_EVERY = "64"
+$env:BGEM3_DEVICE = "cuda"
+python scripts/backfill_bgem3_v2.py
+```
+
+Until PR #177 is merged, there is no automatic cache release on the production code path. On a 12 GB card with a large corpus, the GPU path will climb toward the card ceiling regardless of batch size. The workaround is either `BGEM3_DEVICE=cpu` or very small corpora per session with a process restart between runs.
+
+### `HELIX_BFM_SPLADE` and `HELIX_BFM_DENSE_BACKFILL`
+
+**Status: announced in release notes (`.qa-rel065.py`) and CLAUDE.md; not yet present in Python source as of 2026-06-07.**
+
+These are lean-ingest kill-switches intended to prevent the multi-CUDA-context WDDM-spill livelock (issue #176) during test runs and parallel worker scenarios. When implemented, setting either to `0` will force the lean path — omitting SPLADE encoding or inline BGE-M3 backfill respectively — so that only one CUDA context is active at a time.
+
+Until the implementation lands, the equivalent is to set in `helix.toml`:
+
+```toml
+[ingestion]
+splade_enabled = false        # disables SPLADE — no SPLADE CUDA context
+dense_embed_on_ingest = false # disables inline dense encoding at ingest time
+```
+
+Combined with `BGEM3_DEVICE=cpu` on the backfill script, this eliminates the multi-context livelock entirely.
+
+### `[ingestion] dense_embed_on_ingest`
+
+Config key in `helix.toml`, default `true` (code default: `helix_context/config.py:198`; helix.toml also sets `true`). Controls whether the inline ingest path (`context_manager.ingest`) calls the BGE-M3 codec to populate `embedding_dense_v2` at write time. Set to `false` to defer all dense encoding to the offline backfill script.
+
+### `[ingestion] splade_enabled`
+
+Config key in `helix.toml`, default `false` in code (`helix_context/config.py:186`), but `true` in the shipped `helix.toml`. SPLADE encoding loads a separate transformer model and opens a second CUDA context. On a 12 GB card with dense encoding active, two concurrent CUDA contexts (SPLADE + BGE-M3) is the trigger for the #176 livelock. Set to `false` during dense backfill.
+
+---
+
+## The #176 livelock: what it looks like and how to recover
+
+**Trigger:** two or more CUDA contexts open simultaneously on a 12 GB card under Windows WDDM — typically SPLADE + BGE-M3 dense, or any combination of (SPLADE, BGE-M3 dense, Ollama) that pushes total allocation past the VRAM physical limit. WDDM spills to system RAM but does not kill the process; instead the workload enters a multi-hour thrash state where every allocation requires a VRAM eviction/reload cycle.
+
+**Symptoms:**
+- GPU task manager shows near-100% utilisation but throughput (documents/second logged by the backfill script) drops to near zero.
+- VRAM "Dedicated GPU Memory" is at or above the card's physical limit; "Shared GPU Memory" (system RAM mapped into GPU address space) is growing.
+- The Python process is alive and not OOM-killed, but has been running for hours with minimal progress.
+- On Windows: the display may stutter or go momentarily blank as WDDM services GPU page faults.
+
+**Recovery:**
+1. Kill the hung Python process (Ctrl-C or Task Manager).
+2. Restart the machine or wait for WDDM to release the reserved shared-memory pages (which can take several minutes after process exit on Windows 11).
+3. Confirm VRAM is fully released before restarting: open Task Manager → Performance → GPU, verify Dedicated GPU Memory returns to baseline (Ollama resident: ~2–4 GB; nothing resident: near zero).
+4. Restart using the CPU path or the 1-worker GPU path with Ollama stopped, as described below.
+
+---
+
+## Recommended settings for a 12 GB card with Ollama resident
+
+This is the scenario described in CLAUDE.md (Ryzen 7, 48 GB RAM, 12 GB VRAM, Ollama often resident). Ollama holds 2–4 GB of VRAM for a loaded model. Effective headroom for dense ingest is therefore 8–10 GB, which is below the 5–6 GB/worker floor for a second worker.
+
+Use the CPU path:
+
+```powershell
+# helix.toml — set once:
+# [ingestion]
+# dense_embed_on_ingest = false
+# splade_enabled = false
+
+# Then run the backfill on CPU:
+$env:BGEM3_DEVICE = "cpu"
+python scripts/backfill_bgem3_v2.py
+```
+
+If Ollama can be stopped during the backfill window and you want GPU speed:
+
+```powershell
+# Stop Ollama first (releases its VRAM reservation)
+Stop-Process -Name "ollama" -Force   # or use the Ollama tray icon
+
+# One worker, GPU
+$env:BGEM3_DEVICE = "cuda"
+# If PR #177 is merged, also set:
+# $env:HELIX_DENSE_VRAM_RELEASE_EVERY = "128"
+
+python scripts/backfill_bgem3_v2.py
+
+# Restart Ollama when done
+Start-Process "ollama" serve
+```
+
+Do not attempt a parallel/multi-worker backfill on a 12 GB card under any circumstances.
+
+---
+
+## Copy-pasteable backfill command sequence
+
+This sequence is safe for an 18.9k-document store on a 12 GB card. It takes the CPU path (slowest but safe), is fully resumable if interrupted, and leaves a diagnostic printout of coverage.
+
+```powershell
+# 1. Snapshot the DB before starting.
+Copy-Item genomes\main\genome.db genomes\main\genome.db.bak
+
+# 2. Stop the helix server if running (prevents concurrent writes).
+#    If using the launcher, quit via the system tray.
+#    If started manually:
+# Stop-Process -Name "python" -ErrorAction SilentlyContinue
+
+# 3. Force CPU device and run the backfill.
+$env:BGEM3_DEVICE = "cpu"
+python scripts/backfill_bgem3_v2.py
+
+# The script prints progress lines:
+#   [backfill] codec device=cpu
+#   [backfill] genomes/main/genome.db: genes total=18900 v2_populated_before=0 dim=1024
+#   [backfill] genomes/main/genome.db: rows to process: 18900
+#   [backfill] ...18900/18900 processed=18900 skipped=0 rate=3.5 genes/s
+#   [backfill] DONE ... coverage=100.00% elapsed=5400.0s
+
+# 4. Verify coverage=100% in the final line before proceeding.
+
+# 5. Restart the helix server.
+python -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11437
+```
+
+To use a non-default DB path or a smaller batch size (reduces peak RAM usage on very large stores):
+
+```powershell
+$env:BGEM3_DEVICE = "cpu"
+python scripts/backfill_bgem3_v2.py path\to\genome.db --batch 32
+```
+
+The `--batch` flag controls how many documents are encoded and committed in one pass (default 64, source: `scripts/backfill_bgem3_v2.py:278`). Lowering it reduces peak memory at the cost of more SQLite commits. `--limit N` processes only the first N rows — useful for a smoke test before committing to a full run:
+
+```powershell
+python scripts/backfill_bgem3_v2.py --limit 200
+```
+
+The script is idempotent: rows that already carry a correctly-sized `embedding_dense_v2` BLOB are skipped, so a re-run after a crash picks up where it left off.
+
+---
+
+## After the backfill
+
+Once `coverage=100%`, dense recall is active under the default `[retrieval] dense_embedding_enabled = true`. The next step in the Stage 2 → Stage 4 calibration sequence is to recalibrate `ann_similarity_threshold` at 1024-dim using `scripts/calibrate_thresholds.py` — the shipped default of `0.35` (`helix.toml`) is a legacy value calibrated at dim=256 and should be re-derived. See `docs/operator-runbooks.md` Runbook 2 for that procedure.
+
+The `ann_threshold_max_genes` cap of `12` (`helix.toml`) is a known candidate pool collapse bug on single-shard stores (issue tracked in the 2026-06-06 handoff). Until a fix ships, consider raising it to 500 via `helix.toml` if dense retrieval returns fewer candidates than expected:
+
+```toml
+[retrieval]
+ann_threshold_max_genes = 500
+ann_similarity_threshold = 0.0
+```
+
+This does not affect ingest; it only widens the ANN candidate pool at query time.

--- a/docs/prds/2026-05-30-lexical-rescue-merge-depth.md
+++ b/docs/prds/2026-05-30-lexical-rescue-merge-depth.md
@@ -1,0 +1,58 @@
+# PRD: Lexical rescue + merge-depth — recover literal/entity misses and deepen the candidate pool
+
+- **Date:** 2026-05-30
+- **Author:** Max (w/ Claude)
+- **Status:** DRAFT — awaiting sign-off
+- **Touches:** retrieval candidate assembly + ranking (sharded path), config/flags → PRD-first.
+- **Constraint:** deterministic, LLM-free (ribosome stays off). No embedding change.
+- **Lineage:** replaces the shelved P1' merge-reorder (NULL on labeled Onyx recall — reordering the pool we already have ≈ no lift). Per the 2026-05-30 council, the levers are getting *better/more candidates into the pool*, not reordering it.
+
+---
+
+## 1. Problem & what we learned
+
+recall@200 diagnostic: gold is partly **retrieved-but-buried** (basic @10 24.6% → @200 60.6%) and partly **never-retrieved** (~78% of semantic gold absent from the top-200 = embedding-reach ceiling). The P1' experiment (reorder the cross-shard merge) came back **null-to-negative on labeled Onyx** — confirming that *reordering* the existing pool isn't the lever.
+
+Two failure modes remain addressable **deterministically**, and they are distinct:
+1. **Literal/proper-noun "needle" misses** (~17 true entity-lookup misses from prior bench memory): the gold is a literal term match that BM25/FTS finds easily, but dense+fusion **buries or never surfaces** it. Reordering can't fix it (it may not be in the returned pool at all); a **direct lexical injection** can.
+2. **Pool-horizon misses**: a shard's gold ranks beyond `per_shard_fetch = 2·max_genes` *within that shard*, so it never reaches the merge at all.
+
+## 2. Honest mechanism analysis (so we don't repeat the P1' mistake)
+
+- **`lexical_rescue` is the PRIMARY recall@10 lever.** It runs BM25 (`genes_fts`) + promoter-index lookup and returns ranked **source_ids** for literal needles (`retrieval/lexical_rescue.py`, currently **dead code** — zero refs). Injecting those sources into the top-k **bypasses the dense/fusion ranking that buries them** — the only thing that actually moves recall@10 for the needle bucket.
+- **Merge-depth (raise `per_shard_fetch`) is a SUPPORTING/enabling lever, NOT a standalone recall@10 win.** Raising it pulls more candidates into the merge pool → helps recall@**high-k** and is a *prerequisite* for rescue (gold must be in the pool to be promoted). But for gold already in the pool yet buried by ranking, more candidates do **not** lift recall@10 (they compete it *down*) — that's exactly the P1' lesson. So merge-depth is justified as "stop dropping gold below the per-shard horizon," not as a recall@10 driver by itself.
+- **Out of scope:** the ~78% never-retrieved semantic tail is an **embedding-reach ceiling** — neither lever touches it. Honest framing: this PRD targets the needle bucket + the pool horizon, not the embedding ceiling.
+
+## 3. Design
+
+### 3a. Lexical rescue → sharded, injected into the ranked output (primary)
+`lexical_rescue_sources(query, *, genome_path, limit, exclude_source_ids)` opens **one genome** and returns source_ids — it is **not** sharded-aware. Wiring:
+1. **Sharded fan-out:** run `lexical_rescue_sources` per routed shard (reuse the existing fan-out + `_blas_limit`), union via the module's own `merge_source_ids` (dedupes by normalized path), cap at a small `HELIX_LEXICAL_RESCUE_K` (default e.g. 4).
+2. **Map → genes + inject:** resolve rescued source_ids to their best gene per source (via `fingerprint_index` / per-shard lookup), inject into the `/fingerprint` ranked list **before the top-k cut**, at a bounded rank/score so rescue *fills gaps* without dominating (mirror the module's docstring intent: "after packet sources, before fetch"). **Open question for sign-off:** exact injection rank/score policy (append-then-cap vs interleave-at-fixed-rank vs score-floor) — I'll prototype the least-invasive (bounded append above the cut) first.
+3. **Flag-gated:** `HELIX_LEXICAL_RESCUE=0` default → byte-identical; on → rescue active.
+
+### 3b. Merge-depth knob (supporting)
+`per_shard_fetch = 2·max_genes` (shard_router.py:441) → make the multiplier `HELIX_PER_SHARD_FETCH_MULT` (default **2** = byte-identical; try 4). Raises pool depth before the merge cut. Watch the latency cost (more per-shard candidates → bigger merge).
+
+## 4. Measurement gate (NON-NEGOTIABLE — the P1' lesson)
+
+Gate every flip on **labeled Onyx recall**, full-power (≥100/type, ideally 300q), recall@{1,10,50,200}, plus an XL sanity pass. **Falsifiable targets:**
+- **lexical_rescue:** recovers **≥ ~8 of the 17** known entity-lookup misses at recall@10, with **no** recall@10/@50 regression on the rest. *Falsifier:* < 2/17 recovered → those misses are **semantic, not lexical** → rescue is the wrong tool, embedding is the only lever (kill it).
+- **merge-depth:** lifts recall@50/@200 with **flat-or-up** recall@10. *Falsifier:* recall@10 drops (gold competed down) → revert the multiplier.
+- A/B is one labeled run per flag (reuse the `recall_p1_compare.py` harness + the diagnostic baseline on the same IDs).
+
+## 5. Risks
+| risk | mitigation |
+|---|---|
+| BM25 rescue injects noise (false-positive literal matches) crowd the top-k | small `limit` (4), inject **below** genuine high-confidence hits, bounded score; measure @10 regression |
+| the 17 misses are semantic not lexical → rescue is a no-op | the falsifier above kills it cheaply before more build |
+| sharded fan-out of FTS adds latency | FTS is cheap vs the dense matmul that already dominates (~60s); negligible |
+| merge-depth pushes gold *down* at @10 (the P1' failure mode) | default mult unchanged; gate @10 must not regress |
+| `lexical_rescue` opens its own sqlite conn per shard | reuse the router's open shard handles, not fresh connections |
+
+## 6. Sequencing & THE sign-off decisions
+1. **Scope/order:** `lexical_rescue` first (the real recall@10 lever), measure, then merge-depth? Or both together? — *Recommend: lexical_rescue first (it's the recall@10 driver); merge-depth as a fast follow only if rescue needs deeper pool to find candidates.*
+2. **Injection policy (3a.2):** OK to prototype "bounded append above the cut" first and let the labeled A/B pick the policy?
+3. **Acknowledge scope:** the 78% never-retrieved semantic ceiling is explicitly **out of scope** (embedding work) — agreed?
+
+→ Confirm scope + injection-prototype + the out-of-scope ack, and I implement `lexical_rescue` sharded wiring TDD-first off origin/master, gate on labeled Onyx recall before anything ships.

--- a/docs/prds/2026-05-30-recall-rank-fusion.md
+++ b/docs/prds/2026-05-30-recall-rank-fusion.md
@@ -1,0 +1,102 @@
+# PRD: Deterministic recall@10 lift via end-to-end rank-fusion (un-bury retrieved gold)
+
+- **Date:** 2026-05-30
+- **Author:** Max (w/ Claude)
+- **Status:** DRAFT — awaiting sign-off
+- **Touches:** retrieval ranking (per-shard fusion + cross-shard merge), config defaults, feature flags → PRD-first, do not implement before sign-off.
+- **Constraint:** deterministic, LLM-free. The ribosome/cross-encoder stays disabled (design pillar). No embedding change.
+
+---
+
+## 1. Problem
+
+The recall@200 diagnostic (300q, sharded 100-shard Onyx) showed gold is **retrieved but buried**:
+
+| type | recall@10 (users get) | recall@200 (in the pool) | recoverable by re-ranking |
+|---|--:|--:|--:|
+| basic | 24.6% | 60.6% | **+36.0 pp** |
+| semantic | 2.4% | 21.6% | **+19.2 pp** |
+
+The candidate pool is right; the **ordering** is wrong. Goal: a deterministic re-rank that recovers the buried gold, measured as recall@10 on the EnterpriseRAG bench.
+
+## 2. Verified root cause (2 adversarial verification rounds, on the real code)
+
+The bench ran **sharded**, so the relevant path is:
+`/fingerprint` → `_retrieve` → `ShardedGenomeAdapter.query_docs` → `ShardRouter.query_genes` (`shard_router.py:356`) → per-shard `query_docs` + a cross-shard merge. (`query_docs_ann` is **bypassed** — the adapter hard-codes `_dense_embedding_enabled=False`, `sharding.py:212`.)
+
+**The dominant burial locus = the cross-shard merge sort key.** `shard_router.py:565-572` (re-applied at `:798-804` after co-activation):
+
+```python
+sorted(corrected, key=lambda gid: (-corrected.get(gid, 0.0), -rrf_all.get(gid, 0.0), gid))
+```
+
+- **primary** = `corrected[gid]` = per-shard **IDF-corrected ADDITIVE scalar** (`raw = shard.last_query_scores[gid]`, a single flattened number summing sharp tier hits + soft topical mass on one scale)
+- **secondary** = `rrf_all` (RRF) — used **only as a tiebreaker**
+- per-shard **tier evidence** (`last_tier_contributions`) is carried forward for introspection only (`:507-510`) — **never read by the sort**
+
+A gold doc whose strength was a *sharp* tier signal is normalized into the same additive currency as topical neighbors with broad soft-tier mass, and the merge has no tier-aware re-rank to recover it. **Structurally identical to the `query_docs_ann` flattening — just at the merge.** (`fusion.py`'s own docstring argues per-tier scores are non-commensurate and that rank-fusion, being scale-invariant, is the fix — but the merge uses RRF only as a tiebreaker.)
+
+Ruled out by verification: per-shard additive order (a) — depth is over-fetched 4× (`per_shard_fetch = 2·max_genes` × per-shard `limit = 2·max_genes`), so within-shard order doesn't bury top-200 gold; IDF/doc-boost (c) — uniform per shard, can't reorder within a shard; RRF tiebreak — only engages on exact-equal scores.
+
+**Separately:** the single-store path (`query_docs_ann`, `knowledge_store.py:2744`) has the *same* pathology — it sorts the lex⊕dense union by raw dense cosine, pinning lex-only docs at `threshold−0.01` below all dense hits and discarding `gene_scores`. Confirmed 2/2 refuters. This does **not** affect the sharded bench but hurts single-store / small-corpus users.
+
+## 3. Proposed fix — rank-fusion as the ranking currency
+
+The pathology is the same everywhere: **non-commensurate per-tier/per-shard scores summed into one scalar, flattening sharp evidence.** RRF (rank-fusion) is scale-invariant and is already implemented and wired. Make it the ranking currency end-to-end, each piece flag-gated to default-current-behavior.
+
+| # | Change | Site | Targets | Effort | Risk |
+|---|---|---|---|---|---|
+| **P1** | **Cross-shard merge: RRF as PRIMARY** key, additive as tiebreak: `(-rrf_all, -corrected, gid)` | `shard_router.py:565-572` & `:798-804` | the bench's dominant locus (b) | trivial | low |
+| **P2** | **Flip `fusion_mode` default `additive`→`rrf`** (per-shard) | `config.py:319` | per-shard order feeding P1; also single-store | trivial | medium |
+| **P3** | **`query_docs_ann` union sort-key blend** (gene_scores ⊕ cosine, not cosine alone) | `knowledge_store.py:2744` | single-store / small-corpus only (NOT the bench) | small | low |
+
+**P1 + P2 are the coherent bench fix.** P2 makes each shard publish rank-fused order; P1 fuses those ranks across shards. Either alone is partial: P1-only fuses per-shard *additive* ranks (inherits intra-shard additive flattening); P2-only still hits the merge's additive-scalar primary key (a scale seam). Together = end-to-end rank fusion.
+
+All three behind config flags; defaults reproduce today's behavior exactly until we flip after measuring.
+
+## 4. Measurement (gates every flip)
+
+Harness: `benchmarks/bench_enterprise_rag_recall.py` (`/fingerprint`, `max_results=k`, recall@k = gold rank < k; 200-cap at `routes_context.py:694`). Reuse the recall@200 diagnostic infra (`F:/tmp/recall200_diagnostic.py`).
+
+1. **Fast loop:** Onyx **10K** fixture (`genomes/bench/matrix/enterprise_rag_10k_batched.db`), `--max-questions 100 --k 10` — detects a 2-3 pp shift in minutes.
+2. **Confirm:** 100-shard Onyx, the calibrated 300q (semantic 125 + basic 175), recall@{1,10,50,200}.
+3. **A/B matrix:** baseline (additive, today) → P1 → P1+P2 → **P1+P2 + SPLADE-on** (see §4a). Each 100q. Report per-type recall@10 delta + the recall@200 ceiling (should be ~unchanged for P1/P2 — same pool, re-ordered; SPLADE-on is the one variant that *does* change the pool, since it adds a recall tier).
+
+Success = recall@10 moves materially toward the @200 ceiling (basic 24.6→ target, semantic 2.4→ target) with the @200 pool unchanged for the re-ordering variants.
+
+### 4a. SPLADE-on follow-up (re-enable the disabled sparse tier)
+
+All bench runs to date are **variant A (SPLADE off)** — disabled originally because the SPLADE-on daemon hung at boot on the v2/100-shard fixture. Verified prerequisites (2026-05-30):
+- **SPLADE data exists** in the fixture: `splade_terms` ≈ 1.27M rows/shard (ingested corpus-wide), so re-enabling at query time queries real data, no re-ingest needed.
+- **Not the per-shard model storm A1 fixed:** the SPLADE encoder (`naver/splade-cocondenser-ensembledistil`) is a *process singleton* (`splade_backend._ensure_loaded`, module globals), not loaded per shard.
+- **The boot hang was almost certainly HF-429** (encoder fetched from HF Hub on first load under the rate limit) — fixed by the v0.6.2 `HF_HUB_OFFLINE=1` launcher guard + the model already being cached from ingestion. **The first SPLADE-on boot confirms the hang is gone.**
+
+Run SPLADE-on **on top of P1+P2 (rank-fusion), not against today's additive baseline** — as tier 3.5 in an additive sum it would just pile more soft mass onto the buried-gold problem; under rank-fusion it becomes a properly rank-weighted recall signal. This variant is the only one that changes the *candidate pool* (the others only re-order), so its recall@200 may rise too.
+
+Watch-items: (1) the query is SPLADE-encoded once **per shard** in the fan-out (~100× the same query through the singleton model) — a latency cost, mitigated by the singleton + concurrent fan-out (#172); worth a p95 check. (2) ANN calibration (`margin_over_random`) is for the **dense** threshold only, so SPLADE-on needs no dense re-calibration — but it shifts the tier balance, which rank-fusion absorbs by construction.
+
+## 5. Risks
+
+| risk | mitigation |
+|---|---|
+| **RRF weights untuned** — default tier weights (fts5 3.0, dense 1.0, …) were calibrated as *additive magnitudes*; reused as RRF post-multipliers they may underperform (dense_weight 1.0 vs fts5 3.0 still favors lexical 3:1, may blunt the semantic lift) | measure first; if lift is weak, a per-tier RRF-weight sweep is a fast follow-on (esp. raising `dense_weight` for the semantic bucket) |
+| **Scale seam (P2 without P1)** — merge ranks RRF-scale per-shard numbers on its additive-scale key | ship P1 with P2; P1 makes the merge rank-based so the per-shard scale no longer matters |
+| **Downstream gates read `last_query_scores`** — RRF produces a flatter/different distribution; ratio gates + dynamic expression-budget allocator key on absolute magnitude | re-validate those gates on the RRF distribution before flipping the default; flag stays off until clean |
+| **Confidence/abstention heuristics** keyed on absolute score | RRF compresses gaps — re-check; relevant to Joe's abstention work (he's separately finding the system confabulates rather than abstains) |
+| default flip surprises users | flag-gated, byte-identical default; patch-bump + CHANGELOG; flip only after the A/B proves lift |
+
+## 6. Sequencing & recommendation
+
+1. **P1 first** (trivial sort-key swap, flag-gated) → measure on 10K then 100-shard. It directly hits the verified dominant locus; cheapest possible test of the rank-fusion thesis.
+2. **Add P2**, measure P1+P2 (the coherent end-to-end rank fusion). Re-validate the downstream gates (§5).
+3. If lift is real but sub-ceiling, **RRF-weight sweep** (fast follow-on, esp. `dense_weight`).
+4. **P3 in parallel** (independent single-store win; doesn't touch the bench) — lower priority.
+5. Flip defaults only after the A/B; ship as a patch release with a CHANGELOG provenance note (post-#172 generation, per Joe's flag).
+
+## 7. THE sign-off decisions
+
+1. **Scope to start:** P1-only first (measure the cheapest hit on the verified locus), or P1+P2 together (the coherent fix), or all three incl. the single-store P3? — *Recommend: P1 → measure → P1+P2 → measure.*
+2. **Keep it strictly deterministic / ribosome-off?** — *Recommend yes (design pillar); this whole plan is LLM-free.*
+3. **OK to spend a daemon cycle on the bench A/B** (boots 100-shard daemons, ~20-40 min each) once implemented? The 10K fast loop is cheap; the 100-shard confirm is the slow part.
+
+→ Confirm scope (1) + the A/B budget (3), and I'll implement P1 TDD-first off origin/master, measure on the 10K fixture, and bring you the recall@10 delta before going further.

--- a/docs/prds/2026-06-02-otel-per-lane-attribution.md
+++ b/docs/prds/2026-06-02-otel-per-lane-attribution.md
@@ -1,0 +1,97 @@
+# Spec: per-lane OTel attribution (`service.name` / `service.instance.id` / `helix.lane`)
+
+**Date:** 2026-06-02 · **Author:** Laude (spec) → Raude (impl) · **Size:** ~6 lines across 2 files · **Risk:** low (additive, backward-compatible telemetry-resource change; no retrieval behavior touched)
+
+## Why
+Two helix daemons (dev on 11437, bench on a 2nd port) currently emit **identical `service.name="helix-context"`**, so Prometheus/Tempo/Grafana **merge them indistinguishably**. This is the lone internals item gating the "tray + bench coexist with per-port visibility" story (report §4.1). `service.name` is hardcoded at the call site and `Resource.create` reads no env override.
+
+**Why env-only doesn't work today:** `Resource.create({SERVICE_NAME: service_name, ...})` passes `service.name` explicitly, which **overrides** the SDK's env-detected `OTEL_SERVICE_NAME`. (A custom attr via `OTEL_RESOURCE_ATTRIBUTES=helix.lane=bench` *would* merge in — but the primary dashboard dimension is `service.name`, which stays merged.) Hence a code touch is required for the `service.name` split.
+
+## Env contract (new)
+| Var | Default | Effect |
+|---|---|---|
+| `HELIX_OTEL_SERVICE_NAME` | `helix-context` | overrides `service.name`; set `helix-dev` / `helix-bench` per lane |
+| `HELIX_LANE` | _(unset)_ | free-form lane tag → `helix.lane` resource attr (also usable by identity/session layer) |
+| `HELIX_OTEL_INSTANCE_ID` | `host:port` (from call site) → else `socket.gethostname()` | `service.instance.id` |
+
+Unset → behavior is unchanged except `service.instance.id` newly populates from the bound port (additive, harmless).
+
+## Change 1 — `helix_context/telemetry/otel.py`
+
+**(a) import — add `SERVICE_INSTANCE_ID`** (~line 251):
+```python
+# before
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
+# after
+from opentelemetry.sdk.resources import (
+    Resource, SERVICE_NAME, SERVICE_VERSION, SERVICE_INSTANCE_ID,
+)
+```
+
+**(b) signature — add optional `service_instance_id`** (~line 213):
+```python
+def setup_telemetry(
+    app: Any = None,
+    service_name: str = "helix-context",
+    service_version: str = "0.4.0b",
+    service_instance_id: Optional[str] = None,   # NEW
+) -> bool:
+```
+
+**(c) resolve env overrides + build the resource** — replace the `resource = Resource.create({...})` block (~line 276). Insert the resolution **before** it (it must precede the `get_tracer`/`get_meter` calls at ~292/~324, which use `service_name` as the instrumentation scope):
+```python
+    # ── Per-lane attribution: env overrides the passed defaults so two
+    # daemons (dev :11437, bench :11439) emit distinct, splittable telemetry.
+    service_name = os.environ.get("HELIX_OTEL_SERVICE_NAME", service_name)
+    instance_id = (
+        os.environ.get("HELIX_OTEL_INSTANCE_ID")
+        or service_instance_id
+        or socket.gethostname()
+    )
+    _resource_attrs = {
+        SERVICE_NAME: service_name,
+        SERVICE_VERSION: service_version,
+        SERVICE_INSTANCE_ID: instance_id,
+        # COMPUTERNAME is Windows-only; fall back to socket.gethostname()
+        "deployment.host": os.environ.get("COMPUTERNAME") or socket.gethostname(),
+    }
+    _lane = os.environ.get("HELIX_LANE", "").strip()
+    if _lane:
+        _resource_attrs["helix.lane"] = _lane
+    resource = Resource.create(_resource_attrs)
+```
+(`socket` is already imported in `otel.py`; `Optional` is already imported via typing — confirm.)
+
+## Change 2 — `helix_context/server/app.py` (~line 190 call site)
+Pass the bound port so `service.instance.id` is always populated even without the env (env still wins):
+```python
+# before
+setup_telemetry(app, service_name="helix-context")
+# after
+setup_telemetry(
+    app,
+    service_name="helix-context",
+    service_instance_id=f"{config.server.host}:{config.server.port}",
+)
+```
+(`config` is in scope in `create_app`; `ServerConfig.host`/`.port` exist — `config.py:176-177`.)
+
+## Launch (post-change)
+```
+# dev lane (tray-managed, 11437)
+set HELIX_OTEL_SERVICE_NAME=helix-dev & set HELIX_LANE=dev   # tray bat
+# bench lane (hand-launched, 11439)
+set HELIX_OTEL_SERVICE_NAME=helix-bench & set HELIX_LANE=bench
+... -m uvicorn helix_context._asgi:app --host 127.0.0.1 --port 11439
+```
+
+## Validation (evidence before "done")
+1. Two daemons up on 11437/11439 with the two env names, both `HELIX_OTEL_ENABLED=1` → collector `:4317`.
+2. Prometheus: `count by (service_name) (helix_pipeline_stage_seconds_count)` returns **`helix-dev` AND `helix-bench`** as separate series (not one merged `helix-context`).
+3. `service_instance_id` shows `127.0.0.1:11437` vs `:11439`.
+4. `curl :11437/health` and `:11439/health` both 200 (unchanged).
+5. Default (no env) run still reports `service.name=helix-context` (back-compat).
+
+## Out of scope (separate items)
+- `--port` flag + drop the blanket "kill any uvicorn on 11437" in `benchmarks/start_helix_for_enterprise_rag.py` (Raude's 5-LOC nicety — pairs with this for ergonomic dual-lane).
+- Tray dashboard polling both ports (the dual-genome collector generalization, report §4).

--- a/docs/prds/2026-06-02-semantic-wiring-arm.md
+++ b/docs/prds/2026-06-02-semantic-wiring-arm.md
@@ -1,0 +1,146 @@
+# EXPERIMENT SPEC — Semantic-aware routing + dense-dominant fusion (the wiring lever)
+
+**Status:** DRAFT — PRD-gated (touches retrieval behavior; see project PRD-first workflow). Write `docs/prds/2026-06-02-semantic-wiring-arm.md` and obtain sign-off BEFORE implementing.
+**Worktree (live, runs the bench):** `F:/Projects/helix-context/.claude/worktrees/vibrant-easley-73d68a` (NOT master — master is stale 0.5.0).
+**Author of map:** grounded codemap + adversarial verdicts, re-verified against the live worktree 2026-06-02.
+**Owner of run:** Raude. **Mode at spec time:** READ-ONLY map; this spec authorizes a code change + a fresh daemon for the *experiment arm only* (do not restart the currently-wrapped baseline daemon mid-bench).
+
+---
+
+## 1. Objective + hypothesis
+
+**Objective.** Recover the 9 semantic golds that pure global-dense ranks top-10 but the daemon delivers at 0, lifting **semantic@10 from 3 → ~12** (3% → ~9.6%, ~4×) with **no GPU, no re-embed, no re-index**.
+
+**Hypothesis (it is WIRING, not the encoder).** The cross-join probe (`F:/tmp/rank_distribution_probe.py` → `rank_distribution_probe.json`) shows pure global-dense reaches 9/125 golds @10 and the daemon reaches 3/125 @10 — and those two sets are **DISJOINT** (the daemon's 3 are lexical/tag/filename golds dense misses). The 9 dense golds are lost in two stacked wiring stages, not by the encoder:
+- **5 ROUTING-DROPPED** — the gold shard is never fanned out, so the gold never enters the fused pool. Dies at the literal LIKE gate `ShardRouter.route` (`shard_router.py:365-403`, verified).
+- **4 FUSION-DEMOTED** — gold enters the per-shard pool but the additive sum (`gene_scores[gid] += cosine * dense_additive_weight`, `knowledge_store.py:2086-2093`, verified) lets stacked lexical+SPLADE+tag contributions outweigh dense's 4.0×cosine, pushing it to ranks 11/11/40/45.
+
+**Why the combination (each half is null alone — confirmed by code path + probe).** Routing controls **pool membership** (the 5); fusion weight controls **rank within pool** (the 4). Broaden-alone (`HELIX_ROUTE_ALL=1` full fan-out — which does NOT exist as code; was an ad-hoc test) recovered the 5 into the pool but they re-buried at ranks 11-45 because the additive sum still demoted dense. Dense-weight-alone (`4→10`) lifted the 4 already-in-pool golds but could not rank the 5 that routing never admitted. **Only TOGETHER:** broaden so all 9 enter the pool, THEN dense-dominate so dense's cosine ordering clears the lexical stack into @10.
+
+**k-dependence (scope boundary).** @10 is the WIRING win (pure-dense 7.2% vs fused 2.4%). @200 is ENCODER GEOMETRY (pure-dense 28.8% vs pooled 24%, only +5pp headroom) and is **out of scope** (§7) — this spec targets @10 ordering inside the existing pool and treats @200 as a no-regression guardrail.
+
+---
+
+## 2. The change — the COMBINATION, scoped to `query_type=="semantic"`
+
+A new per-call `query_type` parameter threaded end-to-end, AND-gated with an env flag `HELIX_SEMANTIC_ARM`, that simultaneously does BOTH of the following **only when `query_type=="semantic"` and the flag is set**, leaving all other classes **byte-identical**:
+
+### (a) Broaden routing — `ShardRouter.route`
+**Hook (verified):** `shard_router.py:365-403`. When semantic, bypass the LIKE scan and return the full healthy set via `self.known_shards()` (the exact target already used by the empty-terms fallback at line 378 — `shard_router.py:359`). This guarantees the 5 routing-dropped golds' shards enter the fan-out.
+- Pair with a per-shard fetch-depth lift (see §3, `per_shard_fetch` at `shard_router.py:492`) so a routing-recovered shard's intra-shard-deep dense gold survives to Stage B. **Confirm depth need empirically** (open question, §6) — a routing-recovered gold may sit at intra-shard rank > 4×max_genes because the query is lexically weak in that shard.
+
+### (b) Dense-dominant ADDITIVE-PRESERVING fusion — `Genome.query_docs`
+**Hook (verified):** `knowledge_store.py:2086-2093`, specifically line 2088:
+```python
+contribution = float(cosine) * self._dense_additive_weight
+```
+When semantic, swap `self._dense_additive_weight` for a higher scoped value via a new knob `semantic_dense_additive_weight` (default ~12, sweep 8/12/16/20 — §6). Scale **ONLY** the dense term.
+
+**"KEEP BOTH" constraint (load-bearing).** The merge at `knowledge_store.py:2089` is `gene_scores[gid] = gene_scores.get(gid, 0.0) + contribution` — purely additive; it NEVER zeroes lexical. The lexical/tag/SPLADE tiers use independent constants (fts5_weight 3.0, splade_weight 3.5, tag_exact_weight 3.0, lex_anchor_weight 1.5 — `config.py:371-376`, verified) and are untouched. So raising ONLY the dense multiplier preserves the 3 disjoint lexical/tag/filename golds' absolute scores → result is ~3 (kept) + up-to-9 (recovered) ≈ 12, **not a 9-for-3 trade**. The dense contribution has no cap (unlike fts5/splade), so the weight is freely scalable.
+- The final per-shard sort `sorted(gene_scores, key=gene_scores.get, reverse=True)[:limit]` (`knowledge_store.py:2450`, verified, additive branch) consumes the boosted `gene_scores` directly.
+- Cross-shard Stage B is transparent: `last_query_scores` IS the per-shard additive score under additive mode (`knowledge_store.py:2338`), feeding `corrected = raw * m_shard` (`shard_router.py:636-642`) and `* DOC_TYPE_BOOST` (1.15, `shard_router.py:654-661`). These multipliers are additive-preserving and orthogonal — **leave untouched** (they actually protect the 3 lexical/README golds). RRF is only a tiebreaker (`shard_router.py:669-676`). So a Stage-A dense boost flows straight into the cross-shard sort.
+
+**Both must fire together, gated by the SAME predicate.** Shipping half is null (refuted-hyp #5 routing-solo, #6 fusion-solo).
+
+---
+
+## 3. Exact insertion points + query_type threading
+
+`query_type` does NOT exist anywhere in `helix_context` today (grep-confirmed in verdicts). It must be threaded fresh from the request body down to BOTH the router (for route-broaden) AND each shard's `query_docs` (for the dense weight). The thread path (all line refs verified live):
+
+| # | File:symbol | Line (verified) | Change |
+|---|---|---|---|
+| 1 | `helix_context/server/routes_context.py` : `fingerprint_endpoint` | `652-746`; `_retrieve` call `737-746` | Parse `query_type = str(data.get("query_type","")).lower()` near line 661; pass `query_type=query_type` into the `_retrieve(...)` call at 737. (Bench will send the needle's type — §4.) |
+| 2 | `helix_context/context_manager.py` : `_retrieve` | def `2078-2089`; `query_docs` call `2135-2144` | Add `query_type: Optional[str] = None` to the signature; forward `query_type=query_type` into the `genome.query_docs(...)` call at 2135. (The `query_docs_ann` branch at 2123-2133 is NOT taken in sharded mode — adapter `_dense_embedding_enabled=False`, `sharding.py:212`, verified — but add the kwarg there too for parity/safety.) |
+| 3 | `helix_context/context_manager.py` : `build_context` callers of `_retrieve` | `1191-1195`, `1201-1205`; classifier at `1079` | Add a `build_context` param `query_type: Optional[str]=None` (mirror the existing `caller_model_class` threading at def `1034`); pass it to both `_retrieve` calls. On `/context`, fall back to a semantic derivation from `classifier_result` (computed at 1079) — but note `classify_query` has NO "semantic" class (§4), so the bench override is the primary source. |
+| 4 | `helix_context/sharding.py` : `ShardedGenomeAdapter.query_docs` | `227-243` (passthrough `234`) | **No change** — `(*args, **kwargs)` forwards `query_type` verbatim to `query_genes`. (Verified.) |
+| 5 | `helix_context/shard_router.py` : `ShardRouter.query_genes` | def `407-414`; route call `438`; fan-out `513-520`; per_shard_fetch `492` | **Pop `query_type = kwargs.pop("query_type", None)` at the top of `query_genes` BEFORE fan-out.** Pass it to `self.route(domains, entities, query_type)` at line 438. For the dense weight, pass it explicitly into the per-shard `shard.query_docs(..., query_type=query_type)` call at 513-520. **LANDMINE (verified):** `kwargs` is forwarded to `shard.query_docs` at line 519, and `KnowledgeStore.query_docs` (knowledge_store.py:1468-1478) has NO `**kwargs` — an un-popped `query_type` raises TypeError caught at `521-527`, which silently retries dropping ALL kwargs (use_harmonic, etc.) for every shard on every semantic query. **You MUST pop it from generic kwargs and pass it as an explicit named arg that the new `query_docs` signature accepts.** Optionally lift `per_shard_fetch` (line 492) when semantic. |
+| 6 | `helix_context/shard_router.py` : `ShardRouter.route` | `365-403` | Add a 3rd param `route(self, domains, entities, query_type: Optional[str]=None)`. When `query_type=="semantic"` and arm-on, `return self.known_shards()` (line 359) before the LIKE scan at 383. |
+| 7 | `helix_context/knowledge_store.py` : `Genome.query_docs` | sig `1468-1478`; dense merge `2086-2093` (weight at `2088`) | **Add `query_type: Optional[str]=None` to the signature** (this closes the TypeError-fallback landmine). At line 2088, select the weight: `w = self._semantic_dense_additive_weight if (query_type == "semantic" and self._semantic_arm) else self._dense_additive_weight`. Lexical/tag/SPLADE tiers untouched. |
+
+**Threading note:** the dense-weight change and the routing change live in two different objects (per-shard `KnowledgeStore` vs `ShardRouter`) both reached through `query_genes`. The single chokepoint that sets both is `_retrieve → adapter.query_docs(**kwargs) → query_genes` (pop for route) → `shard.query_docs(query_type=...)` (for weight).
+
+---
+
+## 4. Env-gated flag / config arm (clean A/B)
+
+**Env gate:** `HELIX_SEMANTIC_ARM=1` (default unset = byte-identical baseline). Read it once (recommend in `build_context` / `fingerprint_endpoint` or at genome construction) into an instance flag `self._semantic_arm`. Mirror the existing env-gated precedent `HELIX_RERANK_POOL` (`context_manager.py:1149`, default `0` = byte-identical). AND-gate with `query_type=="semantic"`.
+
+**Config knobs (declare in `RetrievalConfig`, `config.py`, mirror the `dense_additive_weight` pattern at line `384` + from_dict at `815`):**
+- `semantic_dense_additive_weight: float = 12.0` — the scoped dense weight (sweep target).
+- `semantic_broaden_routing: bool = True` — route→`known_shards()` for semantic.
+- (optional) `semantic_per_shard_fetch_mult: int = 2` — extra depth lift if §6 depth check requires it.
+
+Wire through `from_dict` (config.py:803-818 pattern) and into the genome construction kwargs in the `open_read_source` factory block (`context_manager.py:516-518`, verified — this fans the SAME kwargs to the solo Genome and every per-shard Genome via `ShardRouter(**genome_kwargs)` at `sharding.py:202` → `Genome(path, **self._genome_kwargs)` at `shard_router.py:356`, verified). One config block covers all shards.
+
+**`query_type` origin for the bench (decision: option (b), bench-injected — cleanest dual-gate fidelity).** `classify_query` (`query_classifier.py`) emits only `arithmetic/factual/procedural/multi_hop/default` — there is NO "semantic" runtime class. The needle DOES carry `n['type']` (`bench_enterprise_rag.py:96`). So:
+- **One-line bench edit:** in `bench_enterprise_rag_recall.py:46-49`, add `"query_type": n["type"]` to the POST body. This is experiment-only (production callers won't send it; a runtime semantic-detector is a separate future track — acceptable, the goal is to PROVE the lever).
+- **A/B arms:** Baseline = `HELIX_SEMANTIC_ARM` unset (or bench omits `query_type`). Experiment = `HELIX_SEMANTIC_ARM=1` + bench sends `query_type`. Optionally carry the weight override in a dedicated TOML arm (e.g. `helix_splade_on_mg10_sembroaden.toml`) so baseline-vs-experiment is a two-config + flag toggle.
+
+---
+
+## 5. Dual gate + metrics
+
+**Subset (verified — not a file):** "semantic-125" = `load_needles(question_types=["semantic"])` from `benchmarks/bench_enterprise_rag.py:81-120` (reads `F:/Projects/EnterpriseRAG-Bench-main/questions.jsonl`, filters `q['question_type']=="semantic"`; gold via `expected_doc_ids → uuid_index.json`). n=125 (121 have an in-corpus vector; 4 no-vec per probe).
+
+**Eval harness (verified):** `benchmarks/bench_enterprise_rag_recall.py` POSTs `/fingerprint`, finds first-gold rank, `recall_at(k)` uses `r < k`.
+
+**CRITICAL eval-depth requirement (verified):** at `score_floor=0` (bench default), `eval_budget = max_results` (`routes_context.py:718`). At `--k 10` the daemon only evaluates 10 candidates — fusion-demoted golds at ranks 11-200 are invisible and routing/fusion cannot be distinguished. **Run at `--k 200`** so the @200 pool is visible; derive @10 by post-processing `rows[].retrieved` for `rank<10`. (`recall_at` truncates `fps` by `max_results`, so a single `--k 200` run yields both @10 and @200.)
+
+**Exact commands** (run from the worktree; bench venv is `/f/tmp/bgem3_gpu_venv` per project memory; daemon at `http://127.0.0.1:11437`):
+```bash
+# BASELINE (arm off) — single deep run, derive @10 and @200 from rows
+python benchmarks/bench_enterprise_rag_recall.py \
+  --types semantic --max-questions 200 --k 200 --label sem125_baseline
+
+# EXPERIMENT (arm on: start the experiment daemon with HELIX_SEMANTIC_ARM=1 +
+# the sembroaden TOML; bench sends query_type per the one-line edit)
+python benchmarks/bench_enterprise_rag_recall.py \
+  --types semantic --max-questions 200 --k 200 --label sem125_sembroaden
+```
+Results land in `benchmarks/results/recall_<label>_<ts>.json` with full per-row `retrieved` lists (`bench_enterprise_rag_recall.py:62-66, 86-93`).
+
+**Gate (BOTH must pass):**
+1. **semantic@10: 3 → ~12** (recover the wiring-lost 9, KEEP the 3). Threshold: ≥ ~10 (recover ≥7 of 9) AND the baseline 3 lexical golds still present @10.
+2. **No regression:** semantic@200 not lower than baseline (geometry guardrail); other 7 query types byte-identical (gate via recall-identity, below).
+
+**Recovery split (required report).** Write a small post-processor (does NOT exist yet) that joins `recall_<label>.json` `rows[].retrieved` against `F:/tmp/rank_distribution_probe.json` `rows[]` by question id, mirroring the won/lost accounting in `F:/tmp/score_rerank_capture.py:46-91`. Classify each baseline-lost-but-dense-top10 gold:
+- **of-5-routing recovered** = gold ABSENT from baseline @200 list (never in pool) but present @10 in experiment.
+- **of-4-fusion recovered** = gold present in baseline @200 at rank ≥10 but @10 in experiment.
+- **3-lexical survived?** = baseline daemon @10 set still ⊆ experiment @10 set.
+- Reuse `last_tier_contributions` (carried through `merged_tier`, `shard_router.py:613`, verified) to label which tier won each recovered gold.
+
+**Recall-identity check (gate-4 discipline, verified oracle).** `HELIX_SHARD_WORKERS` (`shard_router.py:65-79`) gates serial vs `ThreadPoolExecutor.map` fan-out, order-preserving — serial is the reference oracle (`tests/test_shard_router.py::test_parallel_fanout_matches_serial_byte_for_byte`). With the arm ON, run a **non-semantic** type (e.g. `--types basic`) and assert **byte-identical** ranked ids + scores vs baseline (0 delta), proving the route() shard set and per-shard dense weight (4.0) are untouched for non-semantic queries. Run at both `HELIX_SHARD_WORKERS=1` and `>1` to confirm determinism holds under broadened fan-out.
+
+---
+
+## 6. Risks
+
+- **Pendulum swing (demoting the 3).** Too high a `semantic_dense_additive_weight` could over-promote dense topical neighbors and indirectly push the 3 lexical/tag/filename golds below the @10 cut even though their absolute scores are preserved (more dense docs out-rank them). Mitigation: sweep 8/12/16/20 on semantic-125; **pick the point that maximizes recovered-9 while survived-3 == 3 and @200 non-regressing**. Verify the 3 golds' tiers (fts5 3.0 / splade 3.5 / tag_exact 3.0 / filename_anchor 4.0) stay above the @10 cut. The solo-null `4→10` result does NOT bound the paired value — re-sweep paired.
+- **Broaden latency vs budget.** Full fan-out to `known_shards()` at 105-shard scale raises shard count fanned per query. Project headroom is ~6-11× vs the 600s budget, but confirm the semantic-125 wall-clock stays in budget; `HELIX_SHARD_WORKERS>1` is needed for full-fan-out latency (bench runs serial by default). If it blows the budget or the 104GB commit ceiling, fall back to a dense-prefiltered shard subset (cheap centroid cosine) rather than literal all-shards.
+- **Route-all-alone is null — do NOT ship half.** Broaden without the dense weight re-buries the recovered golds at ranks 11-45; dense weight without broaden cannot rank the 5 absent golds. Both must be gated by the SAME predicate and shipped together.
+- **Depth truncation.** A routing-recovered shard's dense gold may sit at intra-shard rank > 4×max_genes (`per_shard_fetch = max_genes*2` then *2 internally, `shard_router.py:492`) and be cut before Stage B. Verify the 5 routing golds surface within depth once routing broadens; lift `per_shard_fetch` for the semantic arm if not.
+- **Kwarg-drop landmine (already mitigated in §3).** If `query_type` is left as a generic kwarg, the TypeError fallback at `shard_router.py:521` silently drops it AND use_harmonic for every shard — the change becomes a no-op AND breaks harmonic. Must pop in `query_genes` and add to `KnowledgeStore.query_docs` signature.
+
+---
+
+## 7. Out of scope
+
+- **The @200 geometry bulk.** @200 recall (pure-dense 28.8% vs pooled 24%, +5pp headroom) is encoder near-neighbor dilution at 850K scale — a **separate track** (re-embed / hard-neg fine-tune / query expansion), gated on GB10 GPU-embed. This spec does not move @200; it only guards against regressing it.
+- **A runtime "semantic" detector.** Adding a real text-based semantic class to `classify_query` is the unsolved paraphrase-detection problem; this experiment injects the bench's ground-truth `query_type` to PROVE the lever first. A production detector is follow-on.
+- **Reranker / cross-encoder.** The `rerank_enabled` cross-encoder track is independent and runs only under profile `quality` (this experiment runs under `balanced`, rerank never fires on `/fingerprint`). Do not entangle.
+- **Switching `fusion_mode` to rrf.** Must stay `additive` (verified default, `config.py:369`) — the dense-weight lever only applies in the additive branch; the rrf branch ignores `dense_additive_weight`.
+
+---
+
+## 8. Rollout / rollback
+
+- **Default OFF.** `HELIX_SEMANTIC_ARM` unset → every code path is byte-identical to today; `query_type` defaults to `None` everywhere; route() runs the LIKE gate; dense weight = 4.0. Non-semantic types are provably untouched (gate-4).
+- **Rollout:** (1) PRD sign-off. (2) Land the threading (§3) with the arm default-off; merge is a no-op until enabled. (3) Stand up a SEPARATE experiment daemon with `HELIX_SEMANTIC_ARM=1` + the sembroaden TOML (do NOT restart the currently-wrapped baseline daemon). (4) Run the §5 A/B + sweep. (5) Report the dual gate + recovery split.
+- **Rollback:** unset `HELIX_SEMANTIC_ARM` (instant revert, no redeploy of code logic needed) or revert the TOML arm. The config knobs and `query_type` param remain dormant. Full code revert is a single-branch drop since all changes are additive and flag-gated.
+
+---
+
+**Files touched (all verified live):** `server/routes_context.py:652-746`, `context_manager.py:2078-2144 / 1191-1205 / 1034 / 516-518`, `sharding.py:227-243` (no change), `shard_router.py:365-403 / 407-438 / 492 / 513-520`, `knowledge_store.py:1468-1478 / 2086-2093`, `config.py:369-390 / 803-818`, `benchmarks/bench_enterprise_rag_recall.py:46-49` (one-line). **New:** recovery-split post-processor (join `recall_*.json` × `rank_distribution_probe.json`).
+
+**Unverified / confirm-before-coding flags:** (1) `route()` verdict was "partial" — the *insertion point* (365-403, caller 438, known_shards 359) is CONFIRMED, but the original "pull query_type from kwargs" plumbing was REFUTED; use the §3/§5 popped-and-named threading instead. (2) `_retrieve`/`query_docs` threading was "partial" — confirmed the chokepoint and the TypeError landmine; the spec's mitigation (add `query_type` to `KnowledgeStore.query_docs` signature) is REQUIRED, not optional. (3) Whether `per_shard_fetch` needs a semantic lift is an empirical open question — measure the 5 routing golds' intra-shard ranks once routing broadens before committing the depth knob. (4) Confirm the live experiment daemon's config has `min_genes ≥ 10` (bench requirement, project memory) and SPLADE on/off state before interpreting recovery numbers.

--- a/docs/prds/2026-06-04-contextbench-step0-scorer.md
+++ b/docs/prds/2026-06-04-contextbench-step0-scorer.md
@@ -1,0 +1,73 @@
+# Spec: ContextBench Step-0 Helix Offline Scorer (hardened)
+
+**Date:** 2026-06-04 · **For:** Raude (impl) · **Status:** ready · **Scope:** retrieval-only, intentionally small — NOT an agent/patch/generation bench. Supersedes the draft scorer plan; corrections below are verified against the live ContextBench data + package source + the Helix worktree routes.
+
+## 0. Verified corrections to the draft (load-bearing — build against THESE)
+1. **Dataset id + split (draft was wrong).** `load_dataset("Contextbench/ContextBench", "contextbench_verified")` = 500 verified; `"default"` = 1,136. Both single split **`train`**. Python filter: column **`language` == "python"`** (lowercase; 8 langs = py/java/js/ts/go/rust/c/c++ — **no C#**). NOT `EuniAI/ContextBench` (that's the GitHub org), NOT `--split verified500`.
+2. **Gold schema (draft assumed extra fields).** Column **`gold_context`** is a **JSON-encoded string** → `json.loads` → list of objects with **EXACTLY** `{"file","start_line","end_line","content"}` (inclusive lines). **No `block_type`, no `symbol`.** Task fields: `instance_id` (+ `original_inst_id`), `repo`, `repo_url`, `base_commit`, `problem_statement` (issue text), `patch`/`test_patch`/`f2p`/`p2p` (the fix+tests — **do NOT index these**). The paper's 23,116 blocks / 4,548 files / 522,115 lines are **derived at score-time via tree-sitter**, not columns.
+3. **REUSE the official evaluator — do NOT reimplement.** `python -m contextbench.evaluate --gold <parquet> --pred <helix.json> --cache ./repos` accepts a **standalone pred file with no agent** (a retriever's ranked set = a one-step trajectory). It reuses the official tree-sitter "structural coordinate" alignment and reports **Coverage (= recall) + Precision** micro-averaged at **file / symbol(def) / span(byte) / line**. ⇒ the build is a **~50-LOC pred-emitter + a thin efficiency wrapper**, not a 100-LOC scorer. **F1 is not emitted — compute `F1 = 2·P·C/(P+C)` yourself.**
+4. **Repo checkout is required for line/block/symbol** (tree-sitter reads file bytes); `evaluate_instance()` git-clones + checks out each `base_commit` (sparse-checkout supported on gold files). **File-level coverage/precision is the ONLY zero-clone granularity.** The clone/checkout is the real Step-0 cost — cache by `(repo_url, base_commit)`.
+5. **Helix endpoints (both exist).** `/fingerprint` = raw ranked retrieval (`score_floor=0` ⇒ `eval_budget=max_results`, so pass a high `max_results` e.g. 200 to see ranks past 10). `/context/packet` = the delivered evidence packet (`build_context_packet`). Use **both**: `/fingerprint` for the recall ceiling, `/context/packet` for the delivered injected-tokens/gold-density.
+6. **License care.** Package/harness = Apache-2.0. The **HF dataset card has NO license tag**, and the **66 source-repo licenses are not redistributed** — fine for internal A/B; for any **public** claim, clone from source and check each upstream license.
+
+## 1. Pred schema to emit (verbatim — `contextbench/parsers/custom_parser.py`)
+One JSON list, one object per task, per arm:
+```json
+{
+  "instance_id": "<matches gold instance_id>",
+  "traj_data": {
+    "pred_steps": [],
+    "pred_files": ["src/foo.py", "src/bar.py"],
+    "pred_spans": {"src/foo.py": [{"start": 10, "end": 40}]}
+  },
+  "model_patch": ""
+}
+```
+**Note the keys are `start`/`end`** (not start_line/end_line). `pred_steps: []` ⇒ final-set scoring. `instance_id` MUST match gold.
+
+## 2. Arms (keep small)
+- **B — BM25 dump (required foil).** BM25/Pyserini over the repo@base_commit; retrieve chunks until a token budget; emit `pred_files`/`pred_spans`. **Sweep ≥2 budgets (e.g. 8K and 27K tokens)** so the dump's recall-vs-tokens *curve* is visible, not one point. Cross-check against HF `princeton-nlp/SWE-bench_bm25_27K` where repos overlap.
+- **D — Helix packet (the deliverable).** Two sub-measurements through the same evaluator:
+  - **D-rank** = `/fingerprint` (LLM-free, `score_floor=0`, `max_results≈200`) → ranked spans → pred = the **recall ceiling**.
+  - **D-packet** = `/context/packet` (the delivered, post-clamp product) → pred = the **delivered** recall + the injected-tokens/gold-density.
+  - The **D-rank − D-packet gap** is a free internal diagnostic = the delivery-clamp cost on code (mirrors the prose conversion-gap finding).
+- **E — Helix + semantic store (diagnostic ablation only).** Dense on/off; report honestly as "does dense add over lexical+structural on code?" — predicted ~0 lift; never the hero arm.
+- **A — no-retrieval floor.** Optional for Step 0; don't block on it.
+
+## 3. Scoring + the efficiency layer
+- **Recall/precision/F1 @ file/line(/symbol/block):** run the **official evaluate** per arm's pred file → Coverage(=recall)+Precision; compute F1.
+- **Efficiency layer (Helix-thesis metrics — WE compute, not the package), per arm:**
+  - `injected_tokens_est` (median + p90) — for D-packet use the actual delivered packet tokens; for B the dump tokens.
+  - `gold_density = overlapped_gold_lines / retrieved_lines`
+  - `recall_per_1k_tokens = line_recall / (injected_tokens_est / 1000)`
+- **Report table — one row per arm:** `arm · n · file_recall · line_recall · line_precision · line_F1 · median_injected_tokens · p90 · gold_density · recall_per_1k_tokens · median_latency_ms`.
+- **The plot (the whole story):** scatter, x = `injected_tokens_est`, y = `line_recall`, one point per arm (B at each budget). Top-left wins; Helix-D should sit **above/left** of the BM25 curve.
+
+## 4. CLI
+```bash
+# smoke (100 Python)
+python benchmarks/contextbench_step0.py --config contextbench_verified --language python --limit 100 \
+  --arms bm25:8k,bm25:27k,helix_fingerprint,helix_packet \
+  --helix-url http://127.0.0.1:11439 --repo-cache F:/tmp/contextbench_repos \
+  --out F:/tmp/cb_step0_py100.json
+# first real report (500 verified)
+python benchmarks/contextbench_step0.py --config contextbench_verified \
+  --arms bm25:27k,helix_fingerprint,helix_packet --helix-url http://127.0.0.1:11439 \
+  --repo-cache F:/tmp/contextbench_repos --out benchmarks/results/cb_step0_v500_<ts>.json
+```
+(Target the **bench lane :11439**, not the dev :11437.) Each arm → emit pred JSON → `python -m contextbench.evaluate --gold <parquet> --pred <arm>.json --cache F:/tmp/contextbench_repos --out <arm>.jsonl` → aggregate + efficiency layer + plot.
+
+## 5. Implementation notes (keep it ~1 file)
+Do: load tasks → for each `(repo_url, base_commit)` clone/sparse-checkout **once** (cache; dominant cost) → ingest into a Helix genome keyed by `(repo, commit)` hash (reuse across that commit's tasks) → run B + D arms → emit pred JSONs → call official evaluate → aggregate + efficiency + plot. **Deps:** `tree-sitter` + `tree-sitter-language-pack` into the bench venv (`uv pip`); `contextbench` package; BM25 (Pyserini or rank-bm25). **Do NOT:** run an LLM, generate/validate patches, run an agent loop, mutate the repo, or ingest post-fix `patch`/`test_patch`/`gold_context`.
+
+## 6. Leak guards
+Checkout at **`base_commit`** (pre-fix → the gold edit locations exist but the fix doesn't). Never ingest `patch`/`test_patch`/`gold_context`/`f2p`/`p2p` into the indexed tree; keep all dataset/bench metadata outside the Helix-indexed path. Stamp every result row with `repo`, `base_commit`, `helix_commit`, `genome_id`, `config_hash`, `timestamp`.
+
+## 7. Acceptance gates
+A valid 100-task smoke + a valid 500-task `contextbench_verified` run; the B-vs-D table; the recall-vs-injected-tokens plot; **zero LLM calls in retrieval**; reproducible (repo commit + helix commit + config hash + timestamp in every row).
+
+## 8. Decision rule
+- **Helix line/block recall ≈ or > BM25 at materially fewer injected tokens → proceed to RepoBench-R** (the next rung).
+- **Helix lower recall but much higher gold density → diagnose the miss:** use the **D-rank vs D-packet gap** + per-granularity coverage to localize it as **file-routing** (file_recall low), **block-span** (file ok, span low), or **line-truncation/clamp** (D-rank ok, D-packet low).
+- **Helix loses both recall and gold density → fix code retrieval before any SWE-bench e2e.**
+- **Do not let Step 0 become SWE-bench.** ContextBench gives the intermediate gold-context signal SWE-bench lacks — use it before spending on generation/patch validation.

--- a/docs/prds/2026-06-16-code-structure-retrieval.md
+++ b/docs/prds/2026-06-16-code-structure-retrieval.md
@@ -1,0 +1,534 @@
+# PRD: First-Class CODE Retrieval in Helix Context
+
+**Date:** 2026-06-16
+**Status:** DRAFT — spec/planning only
+**Owner:** (TBD)
+**Related:** `docs/research/oss-semantic-retrieval-vs-helix.md` §4
+
+## 1. Problem & Goal: Parity → Win
+
+### The result we are converting
+
+The OSS-retrieval review (`docs/research/oss-semantic-retrieval-vs-helix.md` §4)
+concludes that Helix's **lexical-first, FTS5-based default is the *right*
+foundation for code** — not a liability. Exact identifier matching (a function
+name, an error string, a config key) is load-bearing for code in a way it never
+is for prose, and dense embeddings notoriously miss exact tokens. Helix's BM25 +
+tag + filename-anchor base is exactly the machinery that nails exact matches.
+
+The problem is that *base alone* only reaches **parity**: our RepoBench-R run
+showed Helix ≈ BM25. We are leaving the win on the table because the base treats
+code as undifferentiated text — it chunks across function boundaries, has no
+notion of which symbol a chunk *defines* vs *references*, and ranks purely on
+term overlap rather than structural centrality.
+
+### The win is well-precedented
+
+Two external results bound the expected payoff and tell us which signals matter:
+
+- **cAST** (arXiv 2506.15655) — AST-aware split-then-merge chunking instead of
+  line/recursive chunking yields **+4.3 Recall@5 on RepoEval** retrieval and
+  **+2.67 Pass@1 on SWE-bench** generation. This is the single
+  highest-confidence lever, and it is a *chunking-time* change — no query-time
+  inference, no model.
+- **Aider repo-map** — tree-sitter `def`/`ref` extraction → directed symbol
+  multigraph → **personalized PageRank** (weighting identifiers in the user's
+  message, real snake_case names, and refs from in-context files) → trim to a
+  `--map-tokens` budget. The review calls this *"the closest existing analog to
+  what a code-aware Helix would do"* — because Helix already has a
+  co-activation graph and token-budget assembly. We are not inventing the
+  pattern; we are pointing our existing graph + budget machinery at a code
+  symbol graph.
+
+### Goal
+
+Convert RepoBench-R parity into a measurable **win over BM25** on code
+retrieval, by adding code-*structure* signals on top of the lexical base —
+**without** abandoning lexical-first or re-chasing dense (see §4). Concretely:
+beat the BM25 baseline on RepoBench-R `acc@k` and CodeRAG-Bench `NDCG@10`, and
+improve ContextBench line/block recall, with each phase gated on the prior
+clearing its bar.
+
+### What's already in the tree (changes the plan)
+
+A scan of the actual code (full citations in the Appendix) shows Helix is
+**further along than a greenfield estimate would assume**:
+
+- **AST chunking already exists.** `helix_context/encoding/tree_chunker.py`
+  implements split-then-merge over tree-sitter for 11 languages and is *already
+  wired* as the preferred path in `CodonChunker._chunk_code`
+  (`helix_context/encoding/fragments.py:133-159`). WS1 is largely
+  *productionizing and measuring* an existing prototype, not building from zero.
+- **A parent/chunk hierarchy already exists.** `StructuralRelation.CHUNK_OF =
+  100` (`helix_context/schemas.py:28-33`) plus
+  `ContextManager._upsert_parent_doc` (`context_manager.py:949-998`) already
+  build child→parent edges in `gene_relations`. WS2's symbol graph extends an
+  existing structural-edge channel rather than adding a new table.
+- **A typed, evidence-weighted graph + budget assembler already exist.**
+  `seeded_edges.py` (Hebbian-weighted edges), `storage/co_activation.py`
+  (expansion), and `_assemble` + `expression_tokens`
+  (`context_manager.py:2330+`) are the exact substrate Aider's pattern needs.
+
+The flip side: **tree-sitter is NOT in core dependencies.** It lives only in the
+`ast` and `all` extras (`pyproject.toml:75-80, 104-108`); core `dependencies`
+(`pyproject.toml`) is just fastapi/uvicorn/httpx/pydantic/filelock. So on a
+default `pip install helix-context`, `tree_chunker.is_available()` returns False
+and the code *silently falls back to the regex chunker*. The AST path exists but
+is effectively dark for most installs — a packaging + defaults decision, not a
+code-writing task, gates WS1's real-world impact.
+
+
+## 2. Workstreams
+
+### WS1 — AST-Aware Chunking (tree-sitter in codons.py)  *[highest ROI, lowest risk]*
+
+**What to build.** Make AST-aware chunking the *real, default* path for code,
+matching cAST's split-then-merge semantics, and ensure it actually runs on a
+normal install. The algorithm is already present; the work is (a) packaging so
+it's available, (b) defaults/observability so we know which path ran, (c)
+tightening the merge to cAST's recursive-merge semantics, and (d) carrying chunk
+metadata (language, symbol name, byte span) needed by WS2/WS3.
+
+**Exact files / functions to change:**
+
+- `helix_context/encoding/tree_chunker.py` — *exists* (318 lines). `chunk_code_ast`
+  (`:205-308`) does top-level boundary collection + greedy merge + hard-cut of
+  oversized nodes. `_BOUNDARY_NODES` (`:135-200`) covers 11 languages;
+  `_get_parser` (`:79-126`) uses the per-language `tree-sitter-<lang>` packages
+  (not the deprecated bundle). Changes:
+  - Tighten the merge loop (`:284-306`) to cAST's *recursive* split-then-merge:
+    today it greedily concatenates top-level blocks and hard-cuts any single
+    node ≥ `max_chars` at a raw character boundary (`:295-301`). cAST recurses
+    *into* an oversized node (e.g. a huge class → its methods) before resorting
+    to a character cut. This is the change that earns the +4.3 Recall@5.
+  - Emit per-chunk metadata: the enclosing symbol name + node type + start/end
+    byte span. `node_text` (`:250-252`) already has the node; capture
+    `child.type` and (for def nodes) the `name`/`identifier` child. Return this
+    alongside `(content, is_fragment)` — promote the return type to a small
+    dataclass or `(content, is_fragment, meta)` so WS2 can read def-symbol names
+    without re-parsing.
+- `helix_context/encoding/fragments.py` — `CodonChunker._chunk_code` (`:133-216`)
+  already calls `tree_chunker.is_available()` then `chunk_code_ast`
+  (`:137-159`), falling back to the regex path (`:161-216`) on `ImportError`/
+  `ValueError`. Changes:
+  - Thread the new chunk metadata into `RawStrand.metadata` (`:147-153`) so
+    ingest persists symbol name / language / span.
+  - Add a debug counter / log line recording *which* path ran (AST vs regex) so
+    we can verify in benches that AST actually fired — today the fallback is
+    silent (`:156-159`).
+- `pyproject.toml` — **packaging decision (gates everything).** tree-sitter is
+  only in the `ast`/`all` extras (`:75-80, 104-108`), not core `dependencies`.
+  Options: (1) promote the tree-sitter stack to core deps, or (2) keep it an
+  extra but make `helix ingest` *warn loudly* when code is ingested without it
+  ("falling back to regex chunking; `pip install helix-context[ast]` for
+  structure-aware chunks"). Recommend (1) for first-class code support, or (2)
+  as a minimum so the dark-fallback stops being silent.
+- `helix_context/config.py` — add a `[ingestion] ast_chunking` knob (default
+  `true` when available) so benches can A/B AST vs regex cleanly.
+
+**Mapping to existing machinery.** This *is* the existing machinery — `tree_chunker`
++ `_chunk_code` already form the cAST-shaped path. We are hardening a prototype:
+recursive merge, metadata pass-through, packaging, and observability. No new
+subsystem.
+
+**Effort.** S–M. The skeleton exists; recursive-merge + metadata + packaging +
+an A/B knob is days, not weeks. The largest single line item is the packaging /
+defaults decision and re-running the chunking benches.
+
+**Risk.** Low. (1) Languages outside `_BOUNDARY_NODES` already fall back safely
+via `ValueError` (`:232-237`). (2) Oversized-node hard-cut already prevents
+unbounded chunks. (3) Main risk is *regression on prose* — guarded because
+`_chunk_code` only runs for `content_type == "code"` (`fragments.py:78-79`), so
+text ingest is untouched. (4) Adding tree-sitter to core deps grows the wheel's
+dependency surface; mitigate with option (2) if wheel size matters.
+
+
+### WS2 — Symbol Def/Ref Graph (extending co-activation)
+
+**What to build.** A symbol-level def/ref multigraph: for each code chunk, record
+the symbols it *defines* and the symbols it *references*; then materialize edges
+"chunk A references a symbol defined in chunk B." This is the data structure
+Aider's PageRank runs over (WS3) and a retrieval-expansion signal in its own
+right (pull in the *definition* of a symbol the top hit references).
+
+**Exact files / functions to change:**
+
+- `helix_context/schemas.py` — extend `StructuralRelation` (`:28-33`). Today it
+  has only `CHUNK_OF = 100`. Add e.g. `DEFINES = 101`, `REFERENCES = 102` (or a
+  single `SYMBOL_REF = 101` edge from referencing-chunk → defining-chunk). The
+  enum is explicitly a discriminated union on `gene_relations.relation`
+  (0–6 = NL, 100+ = structural), so this slots in cleanly with no new table.
+- `helix_context/storage/ddl.py` — `_create_gene_relations` (`:205-215`) already
+  stores `(gene_id_a, gene_id_b, relation, confidence, updated_at)`. Symbol
+  edges reuse this table verbatim. Add a small `symbol_defs` index table
+  `(symbol TEXT, gene_id TEXT, kind TEXT)` next to `_create_entity_graph`
+  (`:222-240`) — same shape as `entity_graph`, indexed both ways — so we can
+  resolve "who defines `foo`" at ingest and at query time.
+- `helix_context/context_manager.py` — `_upsert_parent_doc` (`:949-998`) is the
+  template: it already builds `CHUNK_OF` edges and calls
+  `genome.store_relations_batch` (`:996`). Add a sibling pass after chunk
+  upsert that: (1) reads the def/ref symbol lists WS1 attached to each chunk's
+  metadata, (2) populates `symbol_defs`, (3) resolves each chunk's *references*
+  to defining chunks and emits `SYMBOL_REF` edges via the same
+  `store_relations_batch`. This runs in `ingest` right where chunks + parent
+  are persisted (`:787-904`).
+- `helix_context/encoding/tree_chunker.py` — extend the parse pass (WS1 already
+  walks the AST at `:258-270`) to also collect *reference* sites, not just
+  definition boundaries. Definitions come from the `name` child of boundary
+  nodes; references come from `identifier`/`call`/`type` nodes in the body. This
+  is the one genuinely new parsing logic; scope it to the WS1 tier-1 languages
+  first (python/rust/js/ts).
+- `helix_context/storage/co_activation.py` — `expand_coactivated` (`:111-180`)
+  already walks typed edges and gates on relation code (`:144-150`). Add a
+  branch that, for code queries, treats `SYMBOL_REF` as a high-value expansion
+  edge (pull in the definition of a referenced symbol). `auto_link_by_entity`
+  (`:28-62`) is the analog for the new `symbol_defs` table — a
+  `auto_link_by_symbol` that links chunks sharing a defined/referenced symbol.
+- `helix_context/retrieval/expand.py` — `expand_neighbors` (`:138-182`) exposes
+  forward/backward/sideways 1-hop traversal over `harmonic_links`. Extend the
+  forward/backward fetchers (`:50-94`) to optionally traverse `gene_relations`
+  `SYMBOL_REF` edges so the `/context/expand` endpoint can answer "show me the
+  definition this code calls."
+
+**Mapping to existing machinery.** Reuses `gene_relations` (the CHUNK_OF channel),
+mirrors `entity_graph` for `symbol_defs`, and extends the *existing*
+co-activation expansion + `/context/expand` traversal. No new storage subsystem;
+symbol edges are just new relation codes on the table that already carries
+structural edges.
+
+**Effort.** M. The storage + edge-emission plumbing is well-templated by
+`_upsert_parent_doc` and `auto_link_by_entity`. The real work is the
+reference-extraction parse pass (per-language node-type knowledge) and symbol
+resolution (handling imports / scoping well enough to avoid garbage edges).
+
+**Risk.** Medium. (1) **Symbol resolution is the hard part** — naive
+name-matching links every `process()` to every other `process()`. Mitigate by
+scoping resolution within file/module first and gating cross-file edges on
+confidence, exactly as `auto_link_by_entity` already gates on `shared >= 2`
+(`:50`) and confidence (`:55`). (2) Edge-count blowup on large repos — bound
+fan-out per chunk (Aider caps refs) and lean on the existing `harmonic_links`
+pruning floor (`seeded_edges.py:67`). (3) Languages without a ref-extractor fall
+back to no symbol edges (degrade to WS1-only), which is safe.
+
+
+### WS3 — Aider-Style Personalized-PageRank Ranking + Budget Trim
+
+**What to build.** Rank code chunks by *structural centrality* over the WS2
+symbol graph using personalized PageRank, then trim the ranked set to the
+`expression_tokens` budget — Aider's exact recipe, pointed at Helix's graph and
+assembler. "Personalization" = bias the random-walk restart toward chunks that
+define/reference identifiers in the user's query (Aider's 10× for query
+identifiers, 10× for real snake_case names) and chunks already delivered this
+session (Aider's 50× for in-chat files — Helix already tracks this via session
+delivery).
+
+**Exact files / functions to change:**
+
+- New module `helix_context/scoring/symbol_pagerank.py` (sits alongside the
+  existing scorers `cymatics.py`, `tcm.py`, `blend.py`, `ray_trace.py`). Pure
+  CPU, no model. Inputs: the `SYMBOL_REF`/`DEFINES` edges from `gene_relations`
+  for the candidate set + their 1-hop neighborhood; a personalization vector
+  built from query identifiers and the session working-set. Output: a
+  `{gene_id: centrality}` score map. Use a small power-iteration (the graph is
+  candidate-local, not whole-repo, so this stays cheap).
+- `helix_context/retrieval/fusion.py` — the additive fuser is where tier scores
+  combine (the `lex_anchor`/`filename_anchor` tiers feed it via
+  `knowledge_store.py:2319-2329` and `:1898-1917`). Add a `symbol_pagerank` tier
+  with its own weight, fused exactly like the existing anchor tiers. Under
+  `fusion_mode = "rrf"` (`fusion_plr.py`) it joins as another rank list. This is
+  the integration seam: PageRank is *one more tier*, not a replacement ranker —
+  keeping lexical-first intact (§4).
+- `helix_context/context_manager.py` — `_assemble` (`:2330+`) already enforces
+  the token budget: it estimates tokens (`estimate_tokens`, imported `:29`),
+  compares against `ribosome_tokens + expression_tokens` (`:2556-2557`), and
+  trims. The WS3 change is *ordering the trim by PageRank centrality* for code
+  turns, so the budget keeps structurally-central chunks (the def a query
+  references) over peripheral ones. The `expression_tokens` budget *is* Aider's
+  `--map-tokens`; no new budget machinery.
+- `helix_context/identity/` session delivery — the 50×-for-in-context-files
+  personalization weight maps onto Helix's *session working-set register*
+  (CLAUDE.md: "session working-set register" / `session_delivery_enabled`).
+  Already-delivered chunks become high-restart-probability nodes in the
+  personalization vector. Wire `symbol_pagerank.py` to read the session manifest
+  the delivery layer already maintains.
+- `helix_context/retrieval/query_classifier.py` + `intent_router.py` — gate the
+  PageRank tier to *code* queries (the classifier already picks decoder mode /
+  assembly cap with no model call). A prose query should not pay for symbol-graph
+  PageRank.
+
+**Mapping to existing machinery.** This is the review's headline observation made
+concrete: Helix's co-activation graph (now carrying symbol edges from WS2) + the
+`_assemble` token-budget trim are "the closest existing analog" to Aider's
+repo-map. PageRank becomes a fusion tier next to `lex_anchor`/`filename_anchor`;
+budget trim reuses `expression_tokens`; personalization reuses session delivery.
+
+**Effort.** M. Power-iteration PageRank over a candidate-local graph is a
+contained algorithm. The integration (new fusion tier + budget-ordered trim +
+session-aware personalization + classifier gating) touches several files but
+each touch is small and follows an existing pattern (the anchor tiers are the
+template).
+
+**Risk.** Medium, and **gated on WS2**: PageRank is only as good as the symbol
+graph beneath it — garbage edges → garbage centrality. (1) Hard-depends on WS2
+quality, so ship WS2 and validate its edges before WS3. (2) Whole-repo PageRank
+is expensive; mitigate by running it candidate-local (top-N + 1-hop), as scoped.
+(3) Over-weighting centrality can bury an exact lexical hit; mitigate by fusing
+PageRank as an *additive tier* under the existing lexical tiers, not as a
+gate — preserve lexical-first (§4).
+
+
+### WS4 (optional) — Code-Trained Embedding in the BGE-M3 Slot
+
+**What to build.** When dense retrieval *is* used on code (it is off by default
+and stays a secondary signal — §4), swap the general-text BGE-M3 encoder for a
+code-trained one (voyage-code-3, GraphCodeBERT, or Jina code-embeddings). The
+review's measured gap: voyage-code-3 beats OpenAI-v3-large by ~13.8% on code
+retrieval; Jina code matches voyage at 1.5B params. This is the *lowest-priority*
+workstream precisely because dense is not the lever for code — exact match and
+structure are.
+
+**Exact files / functions to change:**
+
+- `helix_context/backends/bgem3_codec.py` — `BGEM3Codec` (`:52-67`) hardcodes
+  `model_name = "BAAI/bge-m3"` and `dim = 1024` as constructor defaults, with the
+  `_QUERY_PREFIX` (`:20`) and `_SANCTIONED_DIMS = {1024, 768, 512}` (`:24`) tuned
+  to BGE-M3. The codec already wraps sentence-transformers / FlagEmbedding
+  generically, so a code model that ships a sentence-transformers interface
+  (Jina, GraphCodeBERT) drops in by changing the model name + prefix + sanctioned
+  dims. A *factory* (`get_dense_codec(model_name)` returning the right codec) is
+  cleaner than overloading `BGEM3Codec`; introduce a small `CodeEmbedCodec` or
+  generalize `BGEM3Codec` to a `DenseCodec` with model-specific config.
+- `helix_context/context_manager.py` — `_get_dense_codec` (`:759-783`)
+  instantiates `BGEM3Codec(dim=config.retrieval.dense_embedding_dim)` directly.
+  Change to select the codec by a new config knob (below). Note this path is the
+  single construction site, so the swap is localized.
+- `helix_context/config.py` — there is **no model-name knob today** (the model
+  is the codec's hardcoded default; `:288-291` only exposes
+  `dense_embedding_enabled` and the dim). Add `[retrieval] dense_model`
+  (default `"BAAI/bge-m3"`) and optionally `dense_code_model` so code corpora
+  can use a code encoder while prose uses BGE-M3. The Matryoshka-dim guard rails
+  in the codec (`:62-67`) must be re-validated for any new model — its
+  sanctioned breakpoints and random-pair-cosine calibration are BGE-M3-specific.
+- `scripts/backfill_bgem3_v2.py` (referenced `bgem3_codec.py:38`) and the
+  `genes.embedding_dense_v2` BLOB column — **column/format implications.** The
+  blob is `dim*4` fp32 (`vec_to_blob`, `:34-50`) and the backfill script has a
+  `length(blob) == dim*4` idempotency clause. A code model with a different dim
+  means a *separate* column or a re-backfill; you cannot mix encoders in one
+  column. Plan a `embedding_code_v1` column or a clean re-encode, not an
+  in-place swap. **(This is the biggest hidden cost of WS4.)**
+
+**Mapping to existing machinery.** Drops into the *existing* dense slot — same
+codec interface, same `embedding_dense_v2` write path
+(`context_manager.py:823-904`), same retrieval gate
+(`[retrieval] dense_embedding_enabled`). No new pipeline stage; a model and
+config swap plus a re-encode.
+
+**Effort.** M (if the model has a sentence-transformers interface) to L (if it
+needs a bespoke loader, e.g. voyage via API, or a full re-backfill of a large
+genome). The re-encode of an existing genome dominates the cost.
+
+**Risk.** Medium-low *technically*, but **strategically deprioritized.** (1) The
+review is explicit that dense is *not* where the code win comes from; spending
+GPU + storage + re-backfill here before WS1–WS3 land would be chasing the wrong
+lever (§4 leak-guard). (2) New-model calibration: every dense threshold and the
+Matryoshka guard rails are tuned for BGE-M3 and must be re-derived. (3) API
+models (voyage) add a network dependency that conflicts with Helix's
+local-first, no-query-time-inference posture. Prefer a local code model
+(GraphCodeBERT / Jina) if WS4 is pursued at all.
+
+
+## 3. Phased Rollout & Acceptance Metrics
+
+Order chosen by ROI/risk and by dependency: WS3 needs WS2's graph; WS4 is
+optional and last. Each phase is gated on the prior clearing its acceptance bar
+against the **BM25 baseline** (the parity result we are converting).
+
+### Phase 0 — Make the existing AST path real (packaging + observability)
+
+- **Do:** WS1 packaging decision (tree-sitter to core deps, or loud warn on
+  fallback) + the AST-vs-regex path-counter/log + the `[ingestion] ast_chunking`
+  A/B knob. *No algorithm change yet.*
+- **Why first:** the AST chunker already exists but is dark on default installs.
+  We cannot measure WS1 honestly until we can prove the AST path actually ran.
+- **Acceptance / exit:** on a code corpus, instrumentation confirms AST chunking
+  fires (path-counter > 0) and the regex fallback is no longer silent. No
+  retrieval regression vs current default on ContextBench prose recall (guard:
+  prose path is untouched).
+
+### Phase 1 — WS1 AST-aware chunking (cAST recursive merge)  *[recommended first real phase]*
+
+- **Do:** tighten `chunk_code_ast` to cAST recursive split-then-merge; emit chunk
+  metadata (symbol/lang/span) for WS2.
+- **Acceptance:**
+  - **RepoBench-R `acc@k`** (k = 1/3/5): AST chunking **> BM25 baseline**, with
+    the target informed by cAST's **+4.3 Recall@5**. The bar is "clears parity
+    into a measurable win," not merely "non-regression."
+  - **CodeRAG-Bench `NDCG@10` > BM25** on at least the code-retrieval subsets we
+    already run.
+  - **ContextBench line/block recall:** block recall up (fewer functions split
+    across chunk boundaries), line recall not down.
+- **Gate to Phase 2:** Phase 1 must clear the RepoBench-R win bar; if AST
+  chunking alone doesn't beat BM25, fix chunking before adding graph signals.
+
+### Phase 2 — WS2 symbol def/ref graph
+
+- **Do:** symbol edges (`DEFINES`/`SYMBOL_REF`) + `symbol_defs` table + ingest
+  edge-emission + symbol-aware expansion. Ship as a *retrieval-expansion* signal
+  first (pull in referenced definitions), independent of PageRank.
+- **Acceptance:**
+  - **RepoBench-R `acc@k` ≥ Phase 1** (symbol expansion should not hurt; ideally
+    helps cross-file cases where the answer is a *referenced* definition).
+  - **Edge-quality audit:** sampled `SYMBOL_REF` edges are correct (defining
+    chunk actually defines the referenced symbol) above a precision threshold —
+    this is the gate that protects WS3.
+  - **CodeRAG-Bench `NDCG@10` ≥ Phase 1**, with lift on multi-file queries.
+- **Gate to Phase 3:** symbol-edge precision must clear its bar — PageRank on a
+  noisy graph is worse than no PageRank.
+
+### Phase 3 — WS3 personalized PageRank + budget trim
+
+- **Do:** `symbol_pagerank.py` fusion tier + budget-ordered trim +
+  session-aware personalization + classifier gating to code queries.
+- **Acceptance:**
+  - **RepoBench-R `acc@k` > Phase 2** — structural centrality should lift the
+    right definition above peripheral term-matches.
+  - **CodeRAG-Bench `NDCG@10` > Phase 2.**
+  - **Budget/latency:** no `expression_tokens` budget overrun; PageRank stays
+    candidate-local (latency within the existing query budget, no query-time
+    model call).
+  - **Lexical-first guard:** exact-identifier queries must not regress — a query
+    that is a literal function name still returns that function at rank 1.
+
+### Phase 4 (optional) — WS4 code-trained embedding
+
+- **Do:** only if Phases 1–3 land and dense is shown to add marginal code recall;
+  add `dense_model` config + code codec + a separate embedding column.
+- **Acceptance:** measurable code-retrieval lift *attributable to the dense tier*
+  (tier-contribution decomposition, the diagnostic we already build for dense),
+  net of the re-backfill cost. If dense doesn't move the needle over WS1–WS3,
+  **do not ship it** (§4).
+
+
+## 4. Leak-Guards / What NOT to Do
+
+These are the failure modes the OSS review explicitly warns against. They are
+guard-rails on every workstream above.
+
+1. **Do NOT re-chase dense as the primary code signal.** The review's core
+   finding is that lexical-first is the *right* base for code because
+   exact-identifier matching is load-bearing and dense misses it. WS4 is
+   optional and last for this reason. No phase may make a dense encoder a
+   *gate* on code retrieval; dense stays a secondary, off-by-default tier
+   (`[retrieval] dense_embedding_enabled` default behavior, secondary fusion
+   tier only).
+
+2. **Keep lexical-first intact.** Every new signal (PageRank, symbol expansion)
+   enters as an *additive fusion tier under* the lexical tiers
+   (`lex_anchor`/`filename_anchor` in `knowledge_store.py` →
+   `retrieval/fusion.py`), never as a replacement ranker or a pre-filter that
+   can drop an exact lexical hit. Acceptance includes an "exact-identifier query
+   returns the literal symbol at rank 1" regression check (Phase 3).
+
+3. **Do NOT build a new graph subsystem.** Symbol edges reuse `gene_relations`
+   (the `StructuralRelation` discriminated union, schemas.py:28-33) and mirror
+   `entity_graph`. PageRank reuses the candidate-local graph + `expression_tokens`
+   budget. We are *extending* co-activation, not forking it. A parallel symbol
+   store would duplicate the freshness/pruning/Hebbian machinery for no gain.
+
+4. **Do NOT run whole-repo PageRank at query time.** Keep it candidate-local
+   (top-N + 1-hop), CPU, no model. Helix's posture is no-neural-inference at
+   query time for the default path; PageRank must respect that — it is graph
+   arithmetic, not inference.
+
+5. **Do NOT ship the dark AST path as "done."** tree-sitter is not in core deps;
+   the AST chunker silently falls back to regex on a default install. "AST
+   chunking exists in the tree" is *not* the same as "AST chunking runs for
+   users." Phase 0 exists precisely to close this gap before any WS1 win is
+   claimed.
+
+6. **Do NOT over-weight structure on prose.** Symbol PageRank and AST chunking
+   must be gated to `content_type == "code"` / code-classified queries. Prose
+   retrieval is already well-served by the lexical base; structure signals on
+   prose are cost without benefit (and risk regression). The classifier
+   (`query_classifier.py`) and `_chunk_code`'s content-type guard
+   (`fragments.py:78`) are the gates.
+
+7. **Do NOT mix embedding models in one column.** If WS4 happens, a code encoder
+   needs its own `embedding_*` column or a clean re-backfill — the
+   `embedding_dense_v2` blob is dim-and-model-specific
+   (`bgem3_codec.py:34-50` + the backfill idempotency clause). Silently swapping
+   the model under the same column corrupts retrieval.
+
+
+## Appendix: Grounding Code Facts
+
+Cited file:line evidence gathered before drafting. The headline facts that
+change a greenfield plan are marked ★.
+
+**WS1 — chunking**
+- ★ `helix_context/codons.py:1-8` — now a *back-compat shim*; real chunker lives
+  in `helix_context/encoding/fragments.py`.
+- ★ `helix_context/encoding/tree_chunker.py:205-308` — `chunk_code_ast` already
+  implements tree-sitter split-then-merge; `_BOUNDARY_NODES:135-200` covers 11
+  languages; `_get_parser:79-126` uses per-language packages; `is_available:311-318`.
+- ★ `helix_context/encoding/fragments.py:133-159` — `CodonChunker._chunk_code`
+  already *prefers* the AST path and falls back to regex (`:161-216`) silently on
+  `ImportError`/`ValueError`. Content-type guard at `:78-79`.
+- ★ `pyproject.toml` — core `dependencies` = fastapi/uvicorn/httpx/pydantic/
+  filelock only; tree-sitter is in the `ast` extra (`:75-80`) and `all`
+  (`:104-108`) **but not core**, so AST chunking is dark on a default install.
+
+**WS2 — symbol graph**
+- ★ `helix_context/schemas.py:28-33` — `StructuralRelation(IntEnum)` with
+  `CHUNK_OF = 100`; explicitly a discriminated union on
+  `gene_relations.relation` (0–6 NL, 100+ structural) — designed to be extended.
+- ★ `helix_context/context_manager.py:949-998` — `_make_parent_doc_id` +
+  `_upsert_parent_doc` already build child→parent `CHUNK_OF` edges via
+  `store_relations_batch` (`:996`); the template for symbol-edge emission.
+- `helix_context/storage/ddl.py:205-215` — `gene_relations` table
+  `(gene_id_a, gene_id_b, relation, confidence, updated_at)`; `:222-240`
+  `entity_graph` (the shape to mirror for `symbol_defs`).
+- `helix_context/storage/co_activation.py:28-62` `auto_link_by_entity` (gates on
+  `shared>=2`, confidence); `:111-180` `expand_coactivated` (typed-edge walk,
+  relation-code branch at `:144-150`).
+- `helix_context/retrieval/expand.py:50-94, 138-182` — forward/backward/sideways
+  1-hop traversal feeding `/context/expand`.
+- `helix_context/retrieval/seeded_edges.py:67, 79-82` — Hebbian effective-weight
+  + PRUNE_FLOOR, the evidence/pruning machinery symbol edges can reuse.
+
+**WS3 — PageRank + budget**
+- `helix_context/scoring/` — existing CPU scorers (`cymatics.py`, `tcm.py`,
+  `blend.py`, `ray_trace.py`); new `symbol_pagerank.py` sits here.
+- `helix_context/knowledge_store.py:370, 466, 2289-2329` — `lex_anchor` tier
+  accumulation + feed into the Fuser; `:1884-1920` filename-anchor tier
+  (`Tier 0.5`). These are the templates for a `symbol_pagerank` fusion tier.
+- `helix_context/retrieval/fusion.py` / `fusion_plr.py` — additive + RRF fusers
+  (`fusion_mode` in `[retrieval]`).
+- `helix_context/context_manager.py:2330+` `_assemble`; `:2556-2557` budget =
+  `ribosome_tokens + expression_tokens`; `estimate_tokens` import `:29`. This is
+  Aider's `--map-tokens` analog.
+- Session delivery (CLAUDE.md "session working-set register",
+  `session_delivery_enabled`) under `helix_context/identity/` — the
+  in-context-files personalization weight.
+- `helix_context/retrieval/query_classifier.py`, `intent_router.py` — code-query
+  gating with no model call.
+
+**WS4 — dense slot**
+- ★ `helix_context/backends/bgem3_codec.py:52-67` — `BGEM3Codec(dim=1024,
+  model_name="BAAI/bge-m3")` hardcoded; `_QUERY_PREFIX:20`,
+  `_SANCTIONED_DIMS={1024,768,512}:24` are BGE-M3-specific calibrations.
+  `vec_to_blob:34-50` packs `dim*4` fp32; backfill idempotency keys on
+  `length(blob)==dim*4`.
+- ★ `helix_context/context_manager.py:759-783` `_get_dense_codec` — single
+  construction site; `:823-904` the dense write path.
+- ★ `helix_context/config.py:288-291` — only `dense_embedding_enabled` + dim are
+  exposed; **no `dense_model` knob exists** — WS4 must add one.
+- `scripts/backfill_bgem3_v2.py` (referenced `bgem3_codec.py:38`) +
+  `genes.embedding_dense_v2` column — a code model needs a separate column /
+  re-backfill, not an in-place swap.
+
+**Source numbers cited (from `docs/research/oss-semantic-retrieval-vs-helix.md`
+§4):** cAST (arXiv 2506.15655) +4.3 Recall@5 RepoEval / +2.67 Pass@1
+SWE-bench vs line chunking; Aider repo-map (tree-sitter def/ref + personalized
+PageRank + map-tokens budget); voyage-code-3 +13.8% vs OpenAI-v3-large; Jina
+code matches voyage at 1.5B params.

--- a/docs/research/2026-06-28-ws1-3-council-review.md
+++ b/docs/research/2026-06-28-ws1-3-council-review.md
@@ -1,0 +1,49 @@
+# WS1–WS3 stack — large council review (8 lenses)
+
+Branch `feat/ws3-symbol-pagerank` (cAST + #227 + WS2 + WS3), ~1002 lines / 14 files.
+Eight independent review agents (correctness, architecture, performance, security,
+tests, lexical-first, config, devil's-advocate). Scores: 7,8,7,8,7,8,8,6 (avg ~7.4).
+
+## Vote tally (per component)
+
+| component | APPROVE | APPROVE-W/-CHANGES | BLOCK |
+|---|---|---|---|
+| cAST chunking | 4 | 4 | 0 |
+| #227 SEMA | **8** | 0 | 0 |
+| WS2 symbol graph | 1 | 7 | 0 |
+| WS3 PageRank/cap | 3 | 5 | 0 |
+
+No blocks. **#227 is unanimous-ship; cAST is near-unanimous (minor fixes).** WS2/WS3 approve-with-changes.
+
+## Cross-validated findings (flagged independently by ≥2 lenses → high weight)
+
+1. **Missing lexical-first guard test** — Tests + Lexical-first + Devil's (×3). The council's own slice-2 consensus made "exact-identifier → rank 1" a release gate; it was never written. **Required.**
+2. **Missing cap-bounds-the-expansion test** — Tests + Devil's. The core WS3 mechanism is untested at the `expand_coactivated` level. **Required.**
+3. **PageRank personalization is inert in production** — Architecture + Devil's. At retrieval `query_symbol_nodes=cand_ids` (uniform — no 10× bias) and `session_nodes` is never passed (no 50×); PageRank runs only past the cap. So the live signal ≈ plain centrality, and the measured fp recovery is most plausibly **the cap**, not personalization. → ablation `cap+PageRank` vs `cap+in-degree`; honest doc either way.
+4. **char_cut UTF-8 byte/char split** (Correctness, MAJOR) — `char_cut` advances by `max_chars` *bytes* over a *char* budget, can split a multibyte codepoint → `decode(replace)` breaks the byte-exact invariant on non-ASCII atomic leaves.
+5. **`RecursionError` escapes `_chunk_code`'s narrow `except (ImportError, ValueError)`** (Security, MAJOR) — adversarial deeply-nested code aborts ingest instead of degrading to regex.
+6. **span recovery silent `find()==-1` fallback** (Correctness, MAJOR) — fabricates a span and shifts every later chunk's bucket window, misattributing symbols.
+7. **No index on `gene_relations(relation, gene_id_a)`** (Performance, MAJOR) — the query-time SYMBOL_REF fetch post-filters `relation` at scale.
+8. **Commit-per-file on ingest** (Performance, MAJOR) — two fsync commits per file (defs + edges).
+9. **Config drift** — 3 new knobs (`sema_embed_on_ingest`, `symbol_graph`, `symbol_expansion_cap`) absent from `helix.toml`/`CLAUDE.md` (the exact #218/#219 failure mode). **Required.**
+10. **tree-sitter dark fallback** (Config + Tests + Devil's) — extras-only; default install silently no-ops the whole stack while `symbol_graph` defaults true. Task #27 "tree-sitter core dep" did not land on this branch.
+11. **Scope gaps undocumented** — symbol refs are **python-only** (cAST is 8-lang); **sharded mode skips WS2/WS3** entirely (blob-only wins). Both untested + undisclosed in the regression log.
+12. **Validation thin** — +2.1pp packet is sub-one-task on a single 26-task smoke, no held-out; held-out sweep deferred.
+13. **Over-claim** — commits/task say "fusion tier + budget-ordered trim"; only Phase 2a (bounded expansion) shipped (correct scope, wrong label).
+14. **`build_adjacency` generator-exhaustion** (Architecture, MINOR) — re-materializes after the generator is consumed; latent footgun.
+15. **`resolve_symbol` / `symbol_defs` write-only** — populated, never read; docstring over-promises a cross-file path that doesn't exist yet.
+
+## Conflict zone — merge strategy
+
+- **Most lenses:** merge-after-fixes (the data-gating + reversibility make default-on safe once the fixes + tests land).
+- **Devil's Advocate:** **merge-partial** — ship cAST + #227 now (validated, low-risk); **hold WS2/WS3** behind flags (or dark-ship, default OFF) until (a) the lexical-first guard test, (b) a held-out A/B, and (c) a PageRank-vs-in-degree ablation.
+
+## Consensus recommendation
+
+**Phased merge.**
+1. **cAST + #227 → merge first** after two cheap MAJOR fixes (char_cut UTF-8 boundary; broaden `_chunk_code` except). Near-unanimous, validated, low-risk.
+2. **WS2 + WS3 → fix then decide default.** Land: the find()==-1 skip, the `gene_relations` index, `build_adjacency` materialize, the two mandated guard/cap tests, the config-doc sync, and the scope/over-claim honesty edits. Then the **default-on vs dark-ship** call is gated on a **held-out A/B + the PageRank-vs-in-degree ablation** — if PageRank doesn't beat raw in-degree, simplify (drop the module) per YAGNI; if the held-out gain doesn't survive, dark-ship (`symbol_graph` default false).
+
+**Reversibility:** high — all config-gated (`symbol_graph=false` / `symbol_expansion_cap=0`).
+
+> Heuristic multi-perspective review; not a substitute for human domain experts.

--- a/docs/research/2026-06-28-ws3-slice2-consensus.md
+++ b/docs/research/2026-06-28-ws3-slice2-consensus.md
@@ -1,0 +1,73 @@
+# WS3 slice-2 design — swarm consensus
+
+**Decision:** How to wire WS3 (symbol-graph PageRank) so structural centrality recovers the WS2 fingerprint@27k regression (−14pp) while preserving the packet gain (+2.1pp), without breaking lexical-first.
+
+**Constraints:** pure CPU, no query-time model, no prose regression, additive-only (never displace an exact lexical hit).
+
+## Panel
+- **Pragmatic Engineer** — smallest change that recovers the regression; minimize hot-path surface area.
+- **Scale Architect** — candidate-local cost, subgraph fan-out, query latency.
+- **Devil's Advocate** — is WS3 even needed, or just bound the expansion? magic-number / overfit risk.
+- **Relevance / IR Specialist** — lexical-first integrity, ranking quality, guard tests.
+
+## Independent positions
+
+**Pragmatic Engineer** — *Favors: bound the expansion first.* The regression's root cause is **unbounded** expansion dumping every referenced def into the budget. The minimal fix is to cap it (keep top-K by centrality) inside the existing `expand_coactivated` SYMBOL_REF branch — no new fusion plumbing yet. Strongest argument: a full fusion tier touches `retrieval/fusion.py` + scoring + classifier — a lot of hot-path surface to regress prose for a +2pp gain. Score: bound-only **8**, full-fusion-now **5**. Changes mind if bounding alone fails to recover fingerprint or loses the packet gain.
+
+**Scale Architect** — *Favors: candidate-local + hard fan-out caps.* PageRank power-iteration over top-N + 1-hop is cheap, **but** a popular symbol referenced by hundreds of chunks blows up the 1-hop subgraph. Must cap per-chunk refs and neighbor count. Strongest argument: keep the subgraph bounded and iterations capped (already 50) and it stays well within the query budget. Key concern: per-query PageRank CPU on dense files without caps. Score: fusion-tier OK **7** *if* subgraph-bounded. Changes mind if subgraph stays unbounded.
+
+**Devil's Advocate** — *Favors: ship WS2 with a bound, defer PageRank fusion (YAGNI).* The packet is the production path and already gains +2pp; the fingerprint is a bench/diagnostic arm. The PageRank personalization weights (10×/50×) are **unvalidated magic numbers** — tuning them on the 26-task smoke risks overfitting. Strongest argument: don't build a centrality re-ranker until a *bounded-expansion* A/B proves the fingerprint still regresses. Key concern: a centrality tier can itself regress by over-weighting central-but-irrelevant defs. Score: bound-only **7**, PageRank-fusion-now **4**. Changes mind if bounded expansion still shows the −14pp.
+
+**Relevance / IR Specialist** — *Favors: additive, capped fusion tier under lexical + bounding.* PageRank must re-order **within** the lexically-relevant set, never promote a non-lexical hit above an exact-identifier match. Strongest argument: an additive tier with a hard weight cap + a guard test ("query is a literal function name → that function at rank 1") preserves §4 lexical-first. Key concern: if the weight is too high or PageRank is a primary re-rank, it buries exact matches. Score: additive-capped tier **9**; primary re-rank **2**. Insists the personalization weights become **knobs**, not constants.
+
+## Conflict map
+
+| Topic | Agree | Disagree | Confidence |
+|---|---|---|---|
+| Bound the expansion (cap top-K) | Pragmatic, Devil's, IR, Scale | — | **High** |
+| Build full fusion tier *now* | IR, Scale (if capped) | Pragmatic, Devil's (measure first) | Medium |
+| Lexical-first = additive + weight cap + guard test | Pragmatic, Scale, Devil's, IR | — | **High** |
+| Personalization weights are magic numbers → make knobs | Devil's, IR | — | **High** |
+| Subgraph fan-out must be capped | Scale, Pragmatic | — | **High** |
+| PageRank as primary re-rank | — | IR (hard no), all | **High (against)** |
+
+**Blind spot flagged:** no persona represents *cross-file* resolution quality — current edges are intra-file, so WS3 centrality is computed on intra-file graphs only. Cross-file is a separate future lever; don't conflate.
+
+## Consensus recommendation
+
+**Decision:** **Phased.** Phase 2a: bound + rank the expansion (cap top-K referenced defs by centrality) — the minimal change targeting the root cause. Phase 2b (only if 2a leaves recall on the table): add the PageRank centrality as an **additive, weight-capped fusion tier under the lexical tiers** + budget-trim ordering, gated to code queries, with a lexical-first guard test.
+**Confidence:** High on 2a; Medium on 2b (gated on 2a's measurement).
+**Unanimous:** Yes on bounding + lexical-first + caps; split on building the full tier immediately (resolved by phasing).
+
+### Why
+The regression is a *dump* problem, not a *ranking-everywhere* problem. Bounding-by-centrality (2a) is small, reversible, and directly attacks it; it reuses the already-built PageRank module to pick which K defs survive. Only escalate to the full fusion tier (2b) if the bounded version under-delivers — which keeps the hot-path change proportional to the measured need (Pragmatic/Devil's) while the IR/Scale guard-rails apply the moment a tier does land.
+
+### Mitigations for top concerns
+1. Over-weighting central-but-irrelevant defs (IR/Devil's) → additive tier strictly under lexical + hard weight cap + **guard test** (exact-identifier → rank 1).
+2. Subgraph blow-up on popular symbols (Scale) → cap per-chunk refs and 1-hop neighbor count; candidate-local only.
+3. Magic-number overfit (Devil's/IR) → personalization weights + cap + pagerank_weight are **config knobs**, defaulting to Aider values; do **not** tune on the smoke set — validate on a held-out corpus.
+4. Hot-path regression risk (Pragmatic) → everything gated by `symbol_graph` + code-query classifier; prose path untouched (data-gated: no edges → no-op).
+
+### Reversibility
+High — all config-gated. `symbol_graph=false` or `symbol_expansion_cap=0` reverts to cAST-only. No schema migration to undo (edges already shipped in WS2).
+
+### Review triggers
+- Fingerprint@27k line recall back to ≥ WS2-off (0.679); packet ≥ 0.825.
+- Lexical-first guard test must stay green (exact-identifier at rank 1).
+- Prose ContextBench recall unchanged.
+- Per-query latency within budget on a dense-file corpus.
+
+## Knob → impact map (regression tracking)
+
+| Knob | Default | Primarily moves | Neighboring impacts |
+|---|---|---|---|
+| `symbol_graph` (on/off) | on | packet recall ↑, fingerprint recall ↓ (when unbounded) | ingest time (edge emission), genome size (edges table) |
+| `symbol_expansion_cap` (top-K defs kept) | ~8 | **fingerprint regression lever**: ↑K → recall↑ but precision/fingerprint↓ | budget consumption; interacts with `pagerank_weight` |
+| `pagerank_weight` (fusion tier, 2b) | low/capped | ranking-sensitive metrics (acc@k, fingerprint order) | **lexical-first risk** if too high (buries exact hits) |
+| `damping` | 0.85 | centrality distribution (global vs restart-local) | minor; rarely tuned |
+| `neighbor_hops` / subgraph cap | 1-hop, capped fan-out | coverage vs CPU | latency; dilution if too wide |
+| personalization: query-symbol weight | 10× | biases ranking toward query-relevant defs | overfit risk if tuned on smoke |
+| personalization: session weight | 50× | biases toward in-context chunks | needs session-delivery wiring (2b) |
+| code-query gating (classifier) | on | confines effect to code | prose non-regression; classifier accuracy |
+
+> This analysis simulates multiple specialist perspectives to surface risks and tradeoffs. It is not a substitute for input from actual domain experts. The personas are heuristic models. Use it as a structured starting point, not a final verdict.

--- a/docs/research/oss-semantic-retrieval-vs-helix.md
+++ b/docs/research/oss-semantic-retrieval-vs-helix.md
@@ -1,0 +1,156 @@
+# OSS Semantic Retrieval vs. Helix Context
+
+*Research report — June 16, 2026. Compares Helix Context (v0.5.0) against the open-source retrieval landscape.*
+
+## TL;DR
+
+Helix is not really competing in the same category as the tools people usually call "semantic retrieval." Most OSS retrieval is a **vector database or search engine** whose job ends at "return the top-k chunks." Helix is a **context-compression proxy** whose job is "inject the right *compressed* context into an LLM turn, on CPU, without re-shipping what the agent already has."
+
+The single most distinctive Helix design choice is **no neural inference at query time by default**. Its default retrieval path (FTS5 lexical + tags + synonyms + co-activation + cymatics spectrum scoring) is pure-CPU arithmetic — the same class as BM25/Tantivy/SQLite-FTS5 — while almost every "semantic" OSS system either runs a transformer to embed the query (txtai, ColBERT, SPLADE, Weaviate's server-side vectorizer) or expects you to have done so client-side (Qdrant, Milvus). Helix's optional BGE-M3 dense and SPLADE paths put it on equal footing with those systems *when you turn them on*, but the default posture is deliberately the opposite: lexical-first, model-free, latency- and VRAM-cheap.
+
+Where Helix is genuinely differentiated: **query-time CPU-only retrieval, splice-based context compression against a token budget, a freshness gate, session working-set deduplication, and the know/miss agent contract.** Where the OSS field is far ahead: **scale, ANN recall quality, ecosystem/integrations, and code-structure-aware retrieval.** The two are more complementary than competitive — Helix could sit *in front of* a vector DB rather than replace it.
+
+---
+
+## 1. How the major OSS semantic retrieval solutions work
+
+It helps to fix four axes first, because every system is a point in this space.
+
+**Lexical vs. dense vs. learned-sparse.** Lexical (BM25) scores by term frequency and rarity over an inverted index — pure arithmetic, no model anywhere ([BM25 overview](https://arxiv.org/pdf/2408.06643), [SQLite FTS5/Turso](https://turso.tech/blog/beyond-fts5)). Dense encodes text into one fixed-length vector via a neural bi-encoder; similar meaning lands nearby and matching is approximate-nearest-neighbor ([Weaviate concepts](https://docs.weaviate.io/weaviate/concepts/data)). Learned-sparse (SPLADE) uses a BERT model to emit a *sparse* weighted vector over the vocabulary — neural, but it still slots into an inverted index ([Learned sparse retrieval](https://en.wikipedia.org/wiki/Learned_sparse_retrieval), [Naver Labs SPLADE](https://europe.naverlabs.com/blog/splade-a-sparse-bi-encoder-bert-based-model-achieves-effective-and-efficient-first-stage-ranking/)).
+
+**Bi-encoder vs. cross-encoder vs. late interaction.** A bi-encoder embeds query and document independently (one vector each), so documents can be pre-indexed and query time is cheap ([late interaction overview](https://weaviate.io/blog/late-interaction-overview)). A cross-encoder feeds query+document together for one relevance score — far more accurate but impossible to pre-index, so it is only ever used to *rerank* a short candidate list. Late interaction (ColBERT) is the middle ground: independent encoding but at *token* granularity, scored with a MaxSim operator ([ColBERTv2 paper](https://arxiv.org/pdf/2112.01488)).
+
+**ANN index.** HNSW (a navigable multi-layer graph) is the dominant dense index; IVF (cluster-and-probe), FLAT (brute force), DiskANN, and GPU CAGRA round out the field ([Weaviate vector index](https://docs.weaviate.io/weaviate/concepts/vector-index), [Milvus index reference](https://milvus.io/ai-quick-reference)).
+
+**Fusion.** Hybrid systems combine a lexical and a vector ranking. Reciprocal Rank Fusion (RRF) merges by *rank position* (`Σ 1/(k+rank)`), needing no score normalization; weighted/additive fusion normalizes and linearly combines the raw scores ([hybrid FTS5+vector+RRF](https://ceaksan.com/en/hybrid-search-fts5-vector-rrf)). **This maps directly to Helix's `[retrieval] fusion_mode = "additive" | "rrf"` toggle.**
+
+With that framing, the systems sort into three groups by the question that matters most for Helix — *does a neural model run at query time?*
+
+### Frameworks (neural-at-query-time is a config choice)
+
+**LlamaIndex** is an orchestration layer, not a store. It models everything as Nodes (chunks + metadata + relationships) and node parsers, and delegates indexing/embedding to whatever vector store and embed model you wire in ([LlamaIndex RAG](https://oneuptime.com/blog/post/2026-02-02-llamaindex-rag-applications/view)). It runs neural query embedding only if you configure a dense index, and supports post-retrieval reranking/compression via Node Postprocessors ([node postprocessors](https://developers.llamaindex.ai/typescript/framework/modules/rag/node_postprocessors/)).
+
+**Haystack** is the same idea with an explicit, auditable pipeline graph — converters, embedders, retrievers, rankers, generators are all wired nodes, "nothing hidden" ([Haystack vs LlamaIndex](https://www.zenml.io/blog/haystack-vs-llamaindex)). Dense retriever ⇒ query embedded at query time; BM25 retriever ⇒ no inference.
+
+### Embedding databases & vector DBs
+
+**txtai** is an "all-in-one embeddings database" built on Hugging Face / Sentence Transformers, unioning vector indexes, a graph, and a relational DB. The query is always embedded by a transformer at search time, so GPU is recommended ([txtai intro](https://medium.com/neuml/introducing-txtai-the-all-in-one-embeddings-database-c721f4ff91ad), [txtai embeddings](https://neuml.github.io/txtai/embeddings/)).
+
+**Weaviate** (Go, HNSW core) is unusual in that it can run the embedding model *server-side* via vectorizer modules — throw it raw text and it vectorizes the query inside the DB before the nearest-neighbor search — or you can bring pre-computed vectors and keep the DB CPU-only ([Weaviate GitHub](https://github.com/weaviate/weaviate), [Weaviate vector index](https://docs.weaviate.io/weaviate/concepts/vector-index)). It also does hybrid BM25+vector and optional reranker modules.
+
+**Qdrant** (Rust) and **Milvus** are, *as core engines*, vector-in/vector-out: they expect a pre-computed query vector and do pure-CPU ANN lookups. The neural embedding is a **separate client step** — FastEmbed/ONNX for Qdrant, the `pymilvus[model]` subpackage's `encode_queries()` for Milvus ([Qdrant inference](https://qdrant.tech/documentation/inference/), [Qdrant FastEmbed](https://qdrant.tech/documentation/fastembed/), [Milvus embeddings](https://milvus.io/docs/embeddings.md)). Milvus has the widest index menu (FLAT/IVF/HNSW/DiskANN + GPU CAGRA). Caveat: Qdrant can compute BM25 server-side, and both offer optional cloud inference.
+
+### Search engines & advanced rankers
+
+**Vespa** is the most full-featured: ANN retrieval feeding *multi-phase ML ranking*, with embedding and even cross-encoder/tensor models deployable for run-time inference inside the engine ([Vespa architecture](https://vespa.ai/architecture/), [Vespa billion-scale](https://blog.vespa.ai/vespa-hybrid-billion-scale-vector-search/)). It is the closest OSS analog to Helix's "retrieval + downstream processing in one box," though it processes via ML ranking rather than compression.
+
+**ColBERT / RAGatouille** is late interaction over BERT — mandatory query encoding into per-token vectors, scored by MaxSim, GPU-preferred. ColBERTv2's residual quantization cuts each token vector to ~20–36 bytes (6–10× smaller) to make the larger footprint tractable ([ColBERTv2](https://arxiv.org/pdf/2112.01488), [PLAID](https://arxiv.org/pdf/2205.09707)).
+
+**BM25 / Tantivy / Elasticsearch / SQLite FTS5** are the pure-lexical group: tokenize into an inverted index, score arithmetically, **zero neural inference, pure CPU, lowest latency and footprint** ([Turso FTS5](https://turso.tech/blog/beyond-fts5), [BM25](https://arxiv.org/pdf/2408.06643)). **This is exactly the class Helix's default path belongs to.**
+
+**SPLADE** uses BERT's masked-language-model head to expand and weight terms into a sparse vector; the query must pass through the encoder (GPU-preferred) but matching is inverted-index, not ANN ([learned sparse retrieval](https://en.wikipedia.org/wiki/Learned_sparse_retrieval)). This is precisely Helix's optional `[ingestion] splade_enabled` path.
+
+### The query-time-inference verdict
+
+| Group | Systems | Neural inference at query time? |
+|---|---|---|
+| Pure lexical / CPU | BM25, Tantivy, Elasticsearch (BM25 mode), **SQLite FTS5**, Qdrant & Milvus *cores* | **No** (Qdrant/Milvus embed in a separate client step) |
+| Intrinsically neural | txtai, ColBERT/RAGatouille, SPLADE | **Yes** (GPU preferred) |
+| Configurable / server-side optional | Weaviate, Vespa, LlamaIndex, Haystack | **Optional** — depends on wiring |
+
+**Helix's default path sits firmly in row 1** alongside SQLite FTS5. Its optional BGE-M3 dense and SPLADE expansions move it into row 2 *only when enabled*.
+
+---
+
+## 2. How Helix differs architecturally
+
+The OSS tools above answer "given a query, return the most relevant chunks." Helix answers a different question: "given an LLM turn, what *compressed* context should be injected, and what has this session already seen?" That reframing produces several structural differences.
+
+**It's a proxy, not a database.** Helix is a transparent OpenAI-compatible proxy (`POST /v1/chat/completions`) that intercepts requests and injects context from a persistent SQLite store. The vector DBs are libraries/servers you query explicitly; Helix interposes on the model call itself, so integration is "point your client at the proxy" rather than "rewrite your retrieval code." Vespa is the only OSS system here that similarly bundles retrieval+downstream processing, but it does ML ranking, not injection-into-a-prompt.
+
+**Default retrieval is model-free and CPU-only.** The Stage-2 retrieve path — FTS5 lexical + tag lookup + synonym expansion + co-activation graph + cymatics 256-bin spectrum scoring — runs entirely without transformer inference. Co-activation (which documents tend to surface together) and cymatics (a spectral similarity score) are non-neural ranking signals layered on top of lexical recall. This is a fundamentally different bet from the dense-first OSS norm: Helix trades some semantic recall for zero VRAM contention and low latency, which matters on Max's rig where Ollama already holds the GPU.
+
+**Optional neural recall is bolted on, not assumed.** BGE-M3 dense (`dense_embedding_enabled`, default off) and SPLADE sparse (`splade_enabled`, default off) add bi-encoder and learned-sparse query encoding — the same categories as txtai and SPLADE proper — but they are opt-in, and gated behind kill-switches (`HELIX_BFM_SPLADE=0`, `HELIX_BFM_DENSE_BACKFILL=0`) precisely because running multiple CUDA contexts causes the documented WDDM-spill livelock. The OSS dense systems make this path the default and the point; Helix treats it as an enhancement.
+
+**Compression, not just retrieval (Stages 3–5).** After retrieval, Helix optionally CPU-reranks, then *splices* — a CPU model compresses each candidate, keeping high-value fragments — then assembles against a hard token budget (`expression_tokens`) with per-document legibility headers. This is closest in spirit to LlamaIndex node postprocessors or a cross-encoder rerank stage, but the goal is **token-budget compression for prompt injection**, which no vector DB does natively. Vespa reranks; it doesn't compress-to-budget.
+
+**Freshness gate (Stage 7).** During assembly Helix demotes stale, cold, or superseded documents. Vector DBs have no native notion of document staleness in ranking — recency is something you bolt on with metadata filters. Helix bakes it into the pipeline.
+
+**Session working-set dedup.** With `session_delivery_enabled`, Helix tracks what each session has already received and *elides repeats*, claiming ~40% token savings on multi-turn conversations. This is a stateful, conversation-aware behavior with no analog in stateless vector search — the OSS tools return the same chunks every time you ask.
+
+**The know/miss agent contract.** Every `/context/packet` response carries `know { found, confidence, gene_id_match }` or `miss { reason }`, so a downstream agent can calibrate trust instead of guessing. Vector DBs return scores, but a raw cosine distance is not a calibrated found/not-found signal; Helix's abstention thresholds (`[abstain]`, `[know]`) turn it into an explicit contract. This is arguably Helix's most novel feature relative to the entire OSS field.
+
+---
+
+## 3. How Helix's strengths rank against the OSS field
+
+Reading "rank" as *where Helix wins, ties, and loses* against these tools:
+
+**Where Helix leads the field**
+
+- **CPU-only / VRAM-free query path.** Among "semantic" systems, only the pure-lexical group (BM25/FTS5) matches this, and they don't offer synonym expansion + co-activation + spectral scoring on top. For a local-LLM rig with a contended 12 GB GPU, this is a real, defensible edge — query latency doesn't fight Ollama for VRAM.
+- **Token-budget context compression.** No vector DB compresses-to-budget. The nearest competitors are reranking frameworks (LlamaIndex postprocessors, Vespa ML ranking), and none make "fit the prompt under N tokens with legibility headers" a first-class output. This is Helix's clearest functional differentiator.
+- **Session-aware dedup.** Stateful elision of already-delivered context is unique here; stateless retrieval can't do it without an external session layer you'd have to build.
+- **Know/miss contract + abstention.** Calibrated found/miss with refresh targets is a genuinely agent-oriented design that the data-retrieval-focused OSS tools don't provide out of the box.
+
+**Where Helix is roughly at parity (when its optional paths are on)**
+
+- **Hybrid fusion.** Helix's RRF/additive toggle is the same fusion machinery Weaviate, Vespa, and Elasticsearch hybrid offer. Parity, not advantage.
+- **Learned sparse & dense recall.** BGE-M3 + SPLADE put Helix in the same recall *category* as txtai/SPLADE/Milvus-with-model — but those systems have spent far more engineering on ANN index quality and scale.
+
+**Where the OSS field clearly leads Helix**
+
+- **Scale and ANN recall.** Milvus/Qdrant/Vespa/Weaviate are built for billions of vectors with mature HNSW/IVF/DiskANN/GPU indexes ([Vespa billion-scale](https://blog.vespa.ai/vespa-hybrid-billion-scale-vector-search/)). Helix's SQLite + FTS5 core is a single-node store; it is not trying to be a distributed vector engine, and shouldn't be benchmarked as one.
+- **Out-of-the-box semantic recall.** A dense-by-default system will beat Helix's lexical-by-default path on paraphrase/synonym-heavy queries unless the synonym map is well-tuned — which the CLAUDE.md "synonym map is critical" gotcha explicitly flags as the failure mode.
+- **Ecosystem & integrations.** LlamaIndex/Haystack/Weaviate/Qdrant have enormous connector, embedding-model, and tooling ecosystems. Helix integrates via the proxy and an MCP surface, which is elegant but narrow.
+- **Reranking maturity.** Cross-encoder rerankers and ColBERT late interaction are battle-tested quality boosters; Helix's rerank is off by default and its splice stage optimizes for compression, not pure ranking quality.
+
+**Net:** Helix wins on *deployment posture and prompt-economy* (CPU-only, compression, dedup, agent contract) and loses on *raw retrieval scale and semantic recall*. The honest framing is complementarity: Helix's compression/freshness/dedup/contract layers could sit **in front of** a Qdrant or Weaviate that supplies high-recall candidates, rather than competing with them on ANN search.
+
+---
+
+## 4. Code-specific retrieval vs. prose retrieval
+
+This is where the "just embed everything" approach that works for prose breaks down, and it's directly relevant if Helix ingests code.
+
+**Why prose chunking fails on code.** Fixed-size / sentence / recursive splitters cut through methods, split classes across chunks, orphan a `catch` from its `try`, and strip enclosing imports/namespaces. Prose tolerates this because sentences are self-contained and paraphrase-tolerant; code does not, because it depends on scoping and cross-references — a method references a field defined elsewhere, a file imports a type ([Trendyol code-aware chunking](https://medium.com/trendyol-tech/we-stopped-splitting-code-like-text-code-aware-chunking-unlocked-better-rag-c9f2426e6ad9)). The academic cAST paper states it plainly: line-based heuristics "break semantic structures, splitting functions or merging unrelated code, which can degrade generation quality" ([cAST](https://arxiv.org/abs/2506.15655)).
+
+**AST-aware chunking.** The fix is to split along AST boundaries with tree-sitter — functions, classes, methods become the chunk units. The canonical algorithm is recursive split-then-merge: fit a large AST node into one chunk if it's under the size limit, otherwise recurse and merge siblings ([cAST](https://arxiv.org/abs/2506.15655), [astchunk](https://github.com/yilinjz/astchunk)). The measured payoff from the cAST paper: **+4.3 Recall@5 on RepoEval** retrieval and **+2.67 Pass@1 on SWE-bench** generation versus line-based chunking — concrete evidence that structure-aware chunking matters.
+
+**Exact symbol matching is load-bearing for code.** In prose, a near-synonym is usually fine; in code, a function name or error string must match *exactly* — a near-match is wrong. So code search leans on tools prose retrieval never needs: **Zoekt's trigram index** (sub-50ms over ~2 GB by indexing 3-char sequences and verifying regex matches), **universal-ctags** for symbols, and precise navigation via **SCIP/LSIF** for compiler-accurate go-to-definition across repos ([Zoekt](https://github.com/sourcegraph/zoekt), [Zoekt design](https://github.com/sourcegraph/zoekt/blob/main/doc/design.md), [SCIP](https://sourcegraph.com/blog/announcing-scip)).
+
+**Structural graph signals.** Aider's "repo map" is the clearest example of code-specific ranking: it tree-sitter-parses every file, extracts `def`/`ref` tags, builds a directed multigraph (file A references a symbol defined in file B), and runs **personalized PageRank** to rank what matters — weighting identifiers in the user's message (10×), real snake_case names (10×), and references from files already in chat (50×) — then trims to a token budget (`--map-tokens`, default 1k) ([Aider repomap](https://aider.chat/2023/10/22/repomap.html), [DeepWiki](https://deepwiki.com/Aider-AI/aider/4.1-repository-mapping-system)). This is conceptually adjacent to Helix's co-activation graph and token-budget assembly, but specialized to code symbol graphs. **Notably, this is the closest existing analog to what a code-aware Helix would do** — graph-rank symbols, fit a budget — which suggests Helix's co-activation + budget machinery is well-positioned to adopt code-structure signals.
+
+**Code-trained embeddings beat general text embeddings.** When you do use dense retrieval on code, code-specific models win: GraphCodeBERT adds data-flow structure and prefers structure-level over token-level attention, hitting SOTA on code search/clone/translation/refinement ([GraphCodeBERT](https://arxiv.org/abs/2009.08366)); voyage-code-3 beats OpenAI-v3-large by ~13.8% on code retrieval at a third of the storage ([voyage-code-3](https://blog.voyageai.com/2024/12/04/voyage-code-3/)); Jina code embeddings match voyage at 1.5B params across 25 benchmarks ([Jina code](https://jina.ai/news/jina-code-embeddings-sota-code-retrieval-at-0-5b-and-1-5b/)).
+
+**How production assistants combine these.** Continue.dev pulls 25 candidates via LanceDB embeddings + SQLite metadata + tree-sitter + keyword search, then reranks to 5 ([Continue codebase](https://docs.continue.dev/customize/context/codebase), [DeepWiki](https://deepwiki.com/continuedev/continue/3.4-codebase-indexing)). Sourcegraph Cody fuses keyword extraction + embeddings + code-graph + rerank, and is notably *moving Enterprise away from embeddings* toward search/code-graph retrieval ([Cody](https://sourcegraph.com/blog/how-cody-understands-your-codebase)).
+
+**The contrast in one line.** Prose retrieval can lean almost entirely on dense embeddings over recursive chunks because prose is self-contained and paraphrase-tolerant. Code retrieval needs the hybrid stack — AST-aware chunking, exact symbol/trigram matching, structural graph signals, and code-trained embeddings — because exact-identifier matching and cross-file structure are load-bearing in a way they never are for prose ([Elastic hybrid](https://www.elastic.co/what-is/hybrid-search), [hybrid BM25](https://www.emergentmind.com/topics/hybrid-bm25-retrieval)).
+
+**Implication for Helix.** Helix's lexical-first, FTS5-based default is actually a *better* starting point for code than a dense-first system, because exact identifier matching is exactly what lexical retrieval is good at — and what dense embeddings notoriously miss. The gaps to close for first-class code support are AST-aware chunking at ingest (its `codons.py` chunker would need tree-sitter), symbol-graph signals (a natural extension of the co-activation graph), and optionally a code-trained embedding model in the BGE-M3 slot.
+
+---
+
+## Sources
+
+**OSS retrieval architecture**
+- BM25 / lexical: https://arxiv.org/pdf/2408.06643 · https://turso.tech/blog/beyond-fts5
+- Dense / vector concepts: https://docs.weaviate.io/weaviate/concepts/data · https://docs.weaviate.io/weaviate/concepts/vector-index
+- Learned sparse / SPLADE: https://en.wikipedia.org/wiki/Learned_sparse_retrieval · https://europe.naverlabs.com/blog/splade-a-sparse-bi-encoder-bert-based-model-achieves-effective-and-efficient-first-stage-ranking/
+- Bi/cross/late interaction: https://weaviate.io/blog/late-interaction-overview · https://arxiv.org/pdf/2112.01488 · https://arxiv.org/pdf/2205.09707
+- Hybrid fusion / RRF: https://ceaksan.com/en/hybrid-search-fts5-vector-rrf
+- LlamaIndex: https://oneuptime.com/blog/post/2026-02-02-llamaindex-rag-applications/view · https://developers.llamaindex.ai/typescript/framework/modules/rag/node_postprocessors/
+- Haystack: https://www.zenml.io/blog/haystack-vs-llamaindex
+- txtai: https://neuml.github.io/txtai/embeddings/ · https://medium.com/neuml/introducing-txtai-the-all-in-one-embeddings-database-c721f4ff91ad
+- Weaviate: https://github.com/weaviate/weaviate
+- Qdrant: https://qdrant.tech/documentation/inference/ · https://qdrant.tech/documentation/fastembed/
+- Milvus: https://milvus.io/docs/embeddings.md · https://milvus.io/ai-quick-reference
+- Vespa: https://vespa.ai/architecture/ · https://blog.vespa.ai/vespa-hybrid-billion-scale-vector-search/
+
+**Code-specific retrieval**
+- Code-aware chunking: https://medium.com/trendyol-tech/we-stopped-splitting-code-like-text-code-aware-chunking-unlocked-better-rag-c9f2426e6ad9 · https://arxiv.org/abs/2506.15655 (cAST) · https://github.com/yilinjz/astchunk
+- Zoekt / Sourcegraph / SCIP: https://github.com/sourcegraph/zoekt · https://github.com/sourcegraph/zoekt/blob/main/doc/design.md · https://sourcegraph.com/blog/announcing-scip · https://scip-code.org/
+- Aider repo map: https://aider.chat/2023/10/22/repomap.html · https://deepwiki.com/Aider-AI/aider/4.1-repository-mapping-system
+- Continue / Cody: https://docs.continue.dev/customize/context/codebase · https://deepwiki.com/continuedev/continue/3.4-codebase-indexing · https://sourcegraph.com/blog/how-cody-understands-your-codebase
+- Code embeddings: https://arxiv.org/abs/2009.08366 (GraphCodeBERT) · https://blog.voyageai.com/2024/12/04/voyage-code-3/ · https://jina.ai/news/jina-code-embeddings-sota-code-retrieval-at-0-5b-and-1-5b/
+- Hybrid for code: https://www.elastic.co/what-is/hybrid-search · https://www.emergentmind.com/topics/hybrid-bm25-retrieval

--- a/docs/specs/2026-05-28-folder-picker-and-tracked-sources.md
+++ b/docs/specs/2026-05-28-folder-picker-and-tracked-sources.md
@@ -1,0 +1,271 @@
+# Folder Picker + Tracked-Sources Registry (1.0 UX)
+
+**Status:** draft for sign-off, 2026-05-28. Brainstorm artifact — no code yet. Authored after the v0.6.0 release lands the engine-side bench/SQL/registration fixes; this spec covers the human-facing UX gap blocking 1.0.
+
+## 1. Goals + non-goals
+
+**Goals**
+- Replace the hardcoded `_DEFAULT_SOURCES` list in `scripts/ingest_all.py:223` and the hardcoded `PROFILES[*]["roots"]` lists in `scripts/build_fixture_matrix.py` as the authoritative source of "what's tracked" for normal operator use. CLI specs and PROFILES stay as escape hatches.
+- Give a non-Python user a way to add/remove tracked folders using their OS file explorer (Windows `IFileDialog` / macOS `NSOpenPanel` / Linux GTK) reachable via the existing launcher web dashboard + system tray.
+- Land a structured `tracked_sources.json` registry with per-source metadata (label, category, filters, status, ingest stats) that is the single read source for ingest, fixture builds, and (post-1.0) federation role bindings.
+- Surface tracked-source status in the launcher dashboard so the user can see what's pending, what's ingested, when, and how many genes each source produced.
+- Make folder add → ingest-on-next-cycle the default flow. Explicit "Ingest now" is a separate one-click action; never auto-launch a heavy ingest from a folder-add.
+
+**Non-goals**
+- No Windows shell extension / macOS Finder extension (right-click → "Track in helix"). Per-OS native installer / signing work that 1.0 does not need. Filed as post-1.0 enhancement.
+- No browser-side folder picker via `<input webkitdirectory>` or File System Access API. Browsers do not return real filesystem paths from these — the round-trip through the tray-spawned native dialog is required, not optional.
+- No federation/access-control UI in this spec. Schema reserves the seam (`acl` field, `category` field already exists); the SSS role-binding UI is a separate post-1.0 spec.
+- No changes to ingest scheduling, shard layout, or bench-profile semantics. `enterprise_rag_*` profiles in `build_fixture_matrix.py` stay as-is; only the "default operator profile" reads from the new registry.
+- No new asset generation (no Claude Design pass). Reuse the existing warm-scheme palette tokens in `launcher.css`. Defer fresh visual identity work to the federation UI spec, where it pays off across multiple surfaces.
+- No tray-resident folder picker for the install-time first-run flow. That ships as part of a separate onboarding spec; this spec assumes the launcher is already installed and running.
+
+## 2. Surface area
+
+| File:line | Change (what, not how) |
+|---|---|
+| `helix_context/launcher/sources_registry.py` (new) | Reader/writer for `tracked_sources.json`. CRUD: `add`, `update`, `remove`, `list`, `get`. Atomic write (temp + rename). Version-tagged schema. |
+| `helix_context/launcher/folder_picker.py` (new) | OS-native folder dialog wrapper. Spawns a short-lived subprocess (tkinter `filedialog.askdirectory` is the v1 implementation — stdlib, cross-platform, no extra deps). Returns chosen path via stdout JSON or empty on cancel. |
+| `helix_context/launcher/app.py:114` (route block) | Add 5 routes: `GET /api/sources`, `POST /api/sources/pick`, `POST /api/sources/create`, `PATCH /api/sources/{id}`, `DELETE /api/sources/{id}`. See §5 for contracts. |
+| `helix_context/launcher/templates/dashboard.html:6-23` | Add 5th tab `Sources` to the `<nav class="tab-bar">`. Tab icon glyph TBD (current ones are `+` `o` `x` `~`; use `>` for sources). |
+| `helix_context/launcher/templates/components/sources_panel.html` (new) | Server-rendered partial: table of tracked sources + Add Folder button + per-row action menu. Polled via existing `/api/state/panels` polling shape. |
+| `helix_context/launcher/templates/components/panels.html` | Include `sources_panel.html` under the new tab data-key. |
+| `helix_context/launcher/static/launcher.js` | Add: button-click handler for "Add Folder" (POSTs to `/api/sources/pick`, then opens confirm-metadata modal); per-row pause/resume/remove handlers; remove-confirmation modal. |
+| `helix_context/launcher/static/launcher.css` | New section for sources panel: table row hover, status pill colors (active=warm-green, paused=warm-amber, error=warm-red). All from existing palette tokens. |
+| `helix_context/launcher/tray.py:608` (`_build_menu`) | Add `Open dashboard → Sources` quick-link menu item under existing `Open dashboard`. |
+| `helix_context/launcher/collector.py` | Extend `collect()` output with `sources` block: count by status, last-ingest timestamp, total genes attributable to tracked sources. Used by the panel poll. |
+| `scripts/ingest_all.py:223` | Make `_DEFAULT_SOURCES` fall back to `sources_registry.list(status=active)` when no `--source` flag is passed. Existing CLI `--source path=label:category` flow unchanged and takes precedence. |
+| `scripts/ingest_all.py` (CLI) | New flag `--use-registry/--no-registry` (default `--use-registry`). When the registry is empty AND no `--source` flags are passed, fall back to the old hardcoded list with a deprecation warning. |
+| `tests/test_sources_registry.py` (new) | Round-trip CRUD, schema-version migration, concurrent-write safety, atomic-write crash-recovery. |
+| `tests/test_folder_picker.py` (new) | Subprocess-spawn contract: cancel returns empty, valid path returns JSON, invalid path errors cleanly. Skipped under `pytest -m no_gui` (CI). |
+| `tests/test_launcher_sources_api.py` (new) | Route-level: list/create/update/delete; auth header presence; conflict on duplicate path. |
+| `docs/architecture/SOURCES_REGISTRY.md` (new) | One-page narrative: schema, lifecycle, federation forward-compat. |
+
+## 3. `tracked_sources.json` schema
+
+Location: `${HELIX_CONTEXT_HOME:-~/.helix-context}/tracked_sources.json`. The launcher already writes state to `HELIX_CONTEXT_HOME` (see `helix_context/launcher/state.py`); the registry sits next to it.
+
+```jsonc
+{
+  "schema_version": 1,
+  "host_label": "max-rig",                 // matches host_labels.host_label_for() — informational only
+  "default_category": "participant",
+  "sources": [
+    {
+      "id": "src_a1b2c3d4",                // ULID-ish, generated on add
+      "path": "F:/Projects/helix-context", // normalized forward-slash, OS-absolute
+      "label": "helix-context",            // free text, defaults to basename
+      "category": "participant",           // participant | org | reference | agent
+      "filters": {
+        "include_ext": null,               // null = all (subject to ingest denylist); list overrides
+        "exclude_glob": [".git/**", "node_modules/**", "*.db", "*.sqlite*"]
+      },
+      "recursion_depth": null,             // null = unlimited; int = max depth from path
+      "status": "active",                  // active | paused | error | removed
+      "added_at": "2026-05-28T22:14:03Z",
+      "last_ingested_at": "2026-05-28T22:30:11Z",
+      "last_ingested_genes": 12847,
+      "last_ingested_status": "ok",        // ok | partial | failed
+      "last_error": null,
+      "acl": null,                         // reserved for post-1.0 SSS federation
+      "notes": null                        // free text, operator-editable
+    }
+  ]
+}
+```
+
+**Reserved field semantics.** `acl: null` means "no access control configured — fall back to host-level permission". When SSS federation lands, `acl` becomes `{roles: ["role_xyz", ...], inherit: bool}` referencing the federation role table; the registry schema bumps to `schema_version: 2` with an automatic migration that leaves `acl: null` for every existing entry. No data loss, no operator action required.
+
+**Concurrency.** Single launcher process owns the registry. Writes go through `sources_registry.py`'s in-process lock + atomic temp+rename. External edits (operator hand-edits the JSON) are detected on next read via mtime check; the launcher reloads and logs the diff. No file-lock primitives — the launcher is the only writer in normal operation.
+
+## 4. UX flow
+
+### 4.1 Adding a folder (golden path)
+
+```
+User opens dashboard (tray → Open dashboard, or http://localhost:<launcher_port>/)
+  → clicks "Sources" tab
+  → clicks "Add Folder" button
+  → browser POST /api/sources/pick (no body)
+  → launcher spawns folder_picker.py subprocess (tkinter native dialog)
+  → OS folder dialog appears (modal, in front of browser)
+  → user navigates Win Explorer / Finder, picks a folder
+  → subprocess writes {"path": "F:/Projects/Foo"} to stdout, exits 0
+  → launcher returns {"path": "F:/Projects/Foo", "exists": true, "kind": "directory"} to browser
+  → browser opens "Confirm tracking" modal pre-filled with:
+      label = basename
+      category = default_category (participant)
+      filters = global defaults
+      recursion = unlimited
+  → user adjusts if desired, clicks "Track this folder"
+  → browser POST /api/sources/create with the form payload
+  → launcher writes registry entry, returns the persisted record
+  → browser dismisses modal, refreshes sources panel
+  → user sees new row with status="active", last_ingested_at=null
+  → next scheduled ingest (or manual "Ingest now" from row menu) picks it up
+```
+
+### 4.2 Per-row actions
+
+Right-side menu on each row:
+
+| Action | Effect |
+|---|---|
+| **Pause** | `status` → `paused`. Next ingest skips this path. Existing genes remain queryable. |
+| **Resume** | `paused` → `active`. |
+| **Ingest now** | Triggers an out-of-band ingest pass for just this source (background task; status row shows spinner; updates `last_ingested_*` on completion). |
+| **Edit metadata** | Modal to edit label, category, filters, recursion. Path is immutable (a path change is a remove + add). |
+| **Remove (keep data)** | `status` → `removed`. Hidden from default list; genes retained, still queryable. Toggle "Show removed" reveals. |
+| **Forget (delete data)** | Destructive. Confirmation modal naming the folder. Removes registry entry AND deletes all genes whose `source_id`/`repo_root` resolves under this path. Async (can be long); progress shown in panel. |
+
+### 4.3 Cancel / error paths
+
+- User cancels OS dialog → subprocess exits 0 with empty stdout → launcher returns `{"path": null, "cancelled": true}` → browser silently no-ops (no error toast).
+- Subprocess crashes (timeout 60s) → launcher returns 500 with diagnostic → browser shows "Couldn't open folder picker. Open `~/.helix-context/launcher.log` for details." with a copy-path button.
+- Path already tracked → `POST /api/sources/create` returns 409 with the existing record → browser shows "This folder is already tracked as `<label>`" with a "Jump to row" link.
+- Path doesn't exist when re-checked at create time (rare race) → 400 with diagnostic.
+
+### 4.4 Tray quick-access
+
+`tray.py:_build_menu` gains one new item:
+```
+Open dashboard
+  ├ Overview      (current default)
+  └ Sources       (new — opens dashboard with #sources fragment)
+```
+No new tray sub-menu for source management itself — the dashboard is the canonical surface. The tray quick-link exists purely so a user who lives in the tray (most operators after first-run) doesn't have to remember the URL.
+
+## 5. API contract
+
+All routes are launcher-local (loopback). No auth in v1.0; the launcher already binds 127.0.0.1 only. If `HELIX_LAUNCHER_BIND_HOST` is set to a non-loopback address, all `/api/sources/*` routes 403 unless `HELIX_LAUNCHER_TRUSTED=1` is also set (explicit opt-in for remote dashboard use; federation will replace this with proper auth).
+
+```
+GET /api/sources
+  → 200 {"sources": [...], "schema_version": 1, "default_category": "participant"}
+     Honors ?status=active|paused|removed|all (default: active+paused, hides removed)
+
+POST /api/sources/pick
+  → 200 {"path": "F:/Projects/Foo", "exists": true, "kind": "directory", "cancelled": false}
+  → 200 {"path": null, "cancelled": true}                       on cancel
+  → 500 {"error": "...", "detail": "..."}                       on subprocess failure
+  → 408 {"error": "picker_timeout"}                             after 60s
+
+POST /api/sources/create
+  body: {"path": str, "label"?: str, "category"?: str, "filters"?: {...}, "recursion_depth"?: int|null}
+  → 201 {<full source record>}
+  → 400 {"error": "path_not_found"|"path_not_directory"|"invalid_category"|...}
+  → 409 {"error": "already_tracked", "existing": {<existing record>}}
+
+PATCH /api/sources/{id}
+  body: any subset of {label, category, filters, recursion_depth, status, notes}
+  → 200 {<updated record>}
+  → 404 {"error": "not_found"}
+  → 400 {"error": "immutable_field", "field": "path"}
+
+DELETE /api/sources/{id}?mode=soft|forget
+  soft   → 200 {"status": "removed"}            (default; status flip only)
+  forget → 202 {"status": "forgetting", "task_id": "..."}   (async data delete)
+  → 404 if missing
+```
+
+## 6. Folder-picker subprocess contract
+
+`folder_picker.py` is a small standalone script — not part of the launcher process — invoked as:
+
+```bash
+python -m helix_context.launcher.folder_picker --initial-dir "F:/Projects" --title "Pick a folder to track"
+```
+
+Stdin: unused. Stdout: single JSON line. Exit code: 0 on success or cancel; non-zero on error.
+
+```json
+{"path": "F:/Projects/Foo", "cancelled": false}
+{"path": null, "cancelled": true}
+{"error": "tkinter_unavailable", "detail": "..."}   // exit 2
+```
+
+**Why subprocess, not in-process.** tkinter `Tk()` is single-instance per process and conflicts with the existing pystray main loop in `tray.py`. Launching the dialog in a subprocess sidesteps the main-loop ownership question entirely and means a picker crash can't take down the launcher. The launcher passes `--initial-dir` based on the OS's "last used folder" memory (we maintain this in `tracked_sources.json` meta).
+
+**Cross-platform notes.**
+- Windows: tkinter calls into the native common dialog. Looks like a normal File Explorer "Select Folder" prompt.
+- macOS: tkinter uses the Cocoa folder panel. Native-looking. (Note: tkinter on macOS needs the system's `python.org` build or a Tk-bundled venv — Apple's stock Python 3 has a known broken Tk. Document in SETUP.md.)
+- Linux: tkinter falls through to the GTK or X11 file chooser depending on what's installed. Functional but less polished. Acceptable for 1.0; a Qt-based picker upgrade is a post-1.0 nice-to-have.
+
+**Upgrade path.** Swapping the subprocess script for a pywin32 `IFileDialog` call on Windows / a PyObjC `NSOpenPanel` call on macOS is a drop-in replacement that doesn't change the API contract. Defer until the tkinter version is in users' hands and we have feedback on what's not native enough.
+
+## 7. Federation forward-compat
+
+The `category` field in each source record (`participant` / `org` / `reference` / `agent`) is the same enum already used by `_parse_source_arg` in `scripts/ingest_all.py:187`. Keeping that semantic alignment means the registry can be the single source-of-truth that the SSS federation UI binds roles onto, without a parallel "tracked things" concept appearing later.
+
+When `docs/architecture/FEDERATION_LOCAL.md`'s SSS role machinery lands, the federation UI adds a "Permissions" tab to each source row's edit modal that writes into the reserved `acl` field. No migration needed; `acl: null` continues to mean "fall back to host-level access."
+
+**What this spec deliberately doesn't decide.** Whether `acl` lives in `tracked_sources.json` or in a federation-owned sidecar file referenced by source id. Both are viable; the federation spec picks the answer. The registry just promises the field name will be stable and writes happen through a single API.
+
+## 8. Test plan
+
+### 8.1 `tests/test_sources_registry.py`
+
+- `test_round_trip_add_list_get_remove` — add 3 sources, list returns 3 active, remove 1 → 2 active + 1 removed; `list(status="all")` returns 3.
+- `test_atomic_write_survives_crash` — monkeypatch `os.replace` to raise after temp write; verify original file is intact and recoverable on next load.
+- `test_concurrent_writes_serialized` — two threads calling `add()` simultaneously; both succeed, both records persisted, no JSON corruption.
+- `test_schema_version_migration_v1_to_v2_placeholder` — load a synthetic v2 file with `acl` populated; v1 reader rejects with a clear "registry was written by a newer launcher" error rather than silently dropping fields.
+- `test_duplicate_path_normalized` — add `F:/Projects/Foo` and `f:/projects/foo/` (Windows case + trailing slash); second add raises `AlreadyTracked` with the first record's id.
+- `test_external_edit_detected_on_reload` — write the file by hand, call `list()`, verify the launcher's in-memory cache reloaded.
+
+### 8.2 `tests/test_folder_picker.py`
+
+- `test_subprocess_cancel_returns_empty` — invoke with `HELIX_PICKER_TEST_CANCEL=1` env (test harness short-circuits the dialog); subprocess exits 0, stdout `{"path": null, "cancelled": true}`.
+- `test_subprocess_success_returns_path` — env `HELIX_PICKER_TEST_PATH=<tmpdir>`; subprocess exits 0, stdout `{"path": "<tmpdir>", "cancelled": false}`.
+- `test_subprocess_tkinter_unavailable` — env that breaks the `import tkinter`; subprocess exits 2 with `{"error": "tkinter_unavailable", ...}`.
+- `test_subprocess_timeout` — launcher kills subprocess after 60s; verify cleanup of child + parent returns 408.
+- All tests marked `@pytest.mark.gui` and skipped under CI's `-m "not gui"`.
+
+### 8.3 `tests/test_launcher_sources_api.py`
+
+- `test_GET_sources_filter_status` — pre-seed registry with mix of statuses; `GET /api/sources?status=active` returns only active.
+- `test_POST_create_validates_path` — non-existent path → 400.
+- `test_POST_create_409_on_duplicate` — second create of same path returns the existing record.
+- `test_PATCH_immutable_path` — attempt to PATCH `path` field returns 400.
+- `test_DELETE_soft_vs_forget` — soft flips status; forget enqueues an async task and returns 202 with task id.
+- `test_DELETE_forget_actually_deletes_genes` — populate a small genome with genes whose `repo_root` is under the source path; forget completes; query returns zero matches.
+
+### 8.4 Manual / GUI smoke
+
+Documented in a new section of `docs/ops/operator-runbooks.md`:
+- Add a folder via dashboard → row appears → ingest now → genes count populates.
+- Pause a source → next ingest skips it (verify via log line + unchanged gene count).
+- Forget a source → genes gone, /context queries no longer return them.
+- Cross-platform: same flow on Windows + macOS + Linux. (Joe's spark-e92c is the natural Linux smoke host.)
+
+## 9. Acceptance criteria
+
+- A user with no Python knowledge can install helix-context, open the tray, click "Open dashboard → Sources", click "Add Folder", pick a folder in Explorer/Finder, click "Track this folder", and see the row appear with `status=active` — without touching any config file or terminal command.
+- `scripts/ingest_all.py` with no `--source` flags and an empty registry warns and falls back to `_DEFAULT_SOURCES`. With a populated registry, it ingests exactly the active entries with no warning.
+- `tracked_sources.json` is the only mutable state required for the picker UX (other than per-ingest gene data in shards).
+- All tests in §8.1, §8.3 green on CI; §8.2 tests pass when run locally with display.
+- New dashboard panel renders correctly on Win/macOS/Linux at default browser zoom, passes the existing launcher CSS lint, and visually integrates with the warm scheme (manual sign-off).
+- Tray menu adds at most 1 new top-level item; menu rebuild latency unchanged.
+- `docs/architecture/SOURCES_REGISTRY.md` is published and linked from `docs/SETUP.md`.
+
+## 10. Out of scope
+
+- Shell extension (Win Explorer / macOS Finder right-click → Track). Post-1.0.
+- Drag-and-drop folder onto the dashboard. Browsers expose `FileSystemDirectoryEntry` here but path resolution still requires a tray round-trip; defer until v1 of the picker has feedback.
+- Scheduled/watcher-based auto-ingest on folder change. Today's ingest is manual or cron-driven; "watch this folder and rebuild on change" is a separate, much heavier spec.
+- Multi-host registry sync. The registry is local-only; federation will introduce a remote registry concept. v1.0 ships local-only.
+- Bench fixture profiles (`enterprise_rag_*`). Those keep their own `PROFILES` dict; the registry is for normal operator use.
+- Folder picker for first-run onboarding (during the install flow itself). Separate onboarding spec.
+- Authentication. Loopback-only binding is the v1.0 trust model. Federation spec brings real auth.
+
+## 11. Open questions (need sign-off)
+
+1. **Registry location.** Default `~/.helix-context/tracked_sources.json` — confirm vs putting it under the launcher's existing state dir (`helix_context/launcher/state.py` uses `${HELIX_CONTEXT_HOME}/launcher_state.json` today). Bundling next to `launcher_state.json` is cleaner; separating it keeps "user intent" (sources) from "launcher runtime state" (last-pid, last-port). My lean: **separate file**, both under `HELIX_CONTEXT_HOME`.
+2. **Default category.** `participant` (current `_DEFAULT_SOURCES` default for `F:/Projects`) vs `reference`. The picker UI shows the dropdown either way; this is just what's pre-selected. My lean: **`participant`** — most users tracking their own folders want full lifecycle tracking, not reference-only.
+3. **Forget-task surfacing.** Async task ID returned by `DELETE ?mode=forget` — is there an existing task-progress surface in the dashboard, or does this need a new "Background tasks" affordance? If new, the spec grows; if reusable, scope holds.
+4. **macOS Tk caveat.** Document the python.org Python requirement in SETUP.md or ship a tkinter-bundled installer for macOS? My lean: **document for v1.0**, packaged installer is a post-1.0 polish item.
+5. **Tray glyph for the Sources quick-link.** Current dashboard tabs use ASCII-art-ish glyphs (`+ o x ~`). Pick `>` for Sources or break convention and use a Unicode folder icon (`📁`)? My lean: **`>`** to stay consistent with the existing aesthetic; revisit when a real icon set lands with the federation UI.
+
+---
+
+**Sign-off needed on:** §1 goals/non-goals (especially "no shell extension in 1.0"), §3 schema (especially the `acl` reservation), §6 tkinter-subprocess approach (vs going straight to pywin32/PyObjC), and the §11 open questions.
+
+**Out-of-scope reminder:** this spec does not implement anything. Per the PRD-first workflow, no code lands until these decisions are signed off.

--- a/scripts/bench_claude_matrix.py
+++ b/scripts/bench_claude_matrix.py
@@ -1,0 +1,485 @@
+r"""Run the 10-needle bench against all 6 frozen fixtures via ``claude -p``.
+
+Per fixture:
+  1. POST /admin/swap-db pointing at the fixture's primary .db
+  2. For each needle, invoke ``claude -p --output-format json`` so the
+     model answers via helix-context MCP (which now hits the swapped db)
+  3. Also call /context directly per needle for retrieval-only metrics
+  4. Score answer ∈ {-1, 0, +1} via word-boundary accept-match
+  5. Write per-fixture JSONL into a timestamped results dir
+
+Pre-conditions:
+  * Helix server running on http://127.0.0.1:11437.
+  * For sharded fixtures, server must be started with HELIX_USE_SHARDS=1
+    so the auto-detect path in helix_context.sharding.open_read_source
+    promotes main.genome.db to a ShardedGenomeAdapter on swap. (Required
+    by the path/filename heuristic since /admin/swap-db today is path-only.)
+  * Claude Code CLI available on PATH and the helix-context MCP wired up
+    in the user's settings/.mcp.json. New ``claude -p`` subprocesses
+    discover the MCP automatically.
+
+Output (no overwrite — per-run subdir):
+  benchmarks/results/claude_matrix_<UTC-timestamp>/
+    summary.json
+    small.jsonl
+    medium.jsonl
+    large.jsonl
+    xl.jsonl
+    medium-sharded.jsonl
+    xl-sharded.jsonl
+    run.log
+
+Usage:
+  python scripts/bench_claude_matrix.py
+  python scripts/bench_claude_matrix.py --only small,medium
+  python scripts/bench_claude_matrix.py --skip xl-sharded
+  python scripts/bench_claude_matrix.py --model sonnet --max-usd 0.20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+HELIX_URL = os.environ.get("HELIX_URL", "http://127.0.0.1:11437")
+MANIFEST = Path(r"F:\Projects\helix-context\genomes\bench\matrix\frozen.json")
+RESULTS_ROOT = Path(r"F:\Projects\helix-context\benchmarks\results")
+
+CLAUDE_TIMEOUT_S = 300        # 5 min per question — generous for MCP + reasoning
+SWAP_TIMEOUT_S = 60           # SPLADE rebuild on swap can take a moment
+CONTEXT_TIMEOUT_S = 30        # /context retrieval-only call
+
+
+# ── Needles (copied from benchmarks/bench_needle.py so this script is
+#     standalone and the runner doesn't depend on the bench dir on PYTHONPATH).
+
+NEEDLES = [
+    {"name": "helix_port",
+     "query": "What port does the Helix proxy server listen on?",
+     "expected": "11437", "accept": ["11437"],
+     "gold_source": ["helix-context/helix.toml"]},
+    {"name": "scorerift_threshold",
+     "query": "What is the divergence threshold that triggers alerts in ScoreRift?",
+     "expected": "0.15", "accept": ["0.15", ".15"],
+     "gold_source": ["two-brain-audit/README.md"]},
+    {"name": "biged_skills_count",
+     "query": "How many skills does the BigEd fleet have?",
+     "expected": "125", "accept": ["125", "129"],
+     "gold_source": ["Education/CLAUDE.md"]},
+    {"name": "bookkeeper_monetary",
+     "query": "What type should be used for monetary values in BookKeeper instead of float?",
+     "expected": "Decimal", "accept": ["decimal", "Decimal"],
+     "gold_source": ["BookKeeper/CLAUDE.md"]},
+    {"name": "helix_pipeline_steps",
+     "query": "How many steps are in the Helix expression pipeline?",
+     "expected": "6", "accept": ["6", "six"],
+     "gold_source": ["helix-context/CLAUDE.md", "helix-context/README.md"]},
+    {"name": "biged_rust_binary_size",
+     "query": "What is the binary size of the Rust BigEd build in MB?",
+     "expected": "11", "accept": ["11", "11mb", "11 mb"],
+     "gold_source": ["Education/biged-rs/README.md"]},
+    {"name": "genome_compression_target",
+     "query": "What is the target compression ratio for Helix Context?",
+     "expected": "5x", "accept": ["5x", "5:1", "5 to 1"],
+     "gold_source": ["helix-context/README.md", "helix-context/docs"]},
+    {"name": "scorerift_preset_dimensions",
+     "query": "How many dimensions does the Python preset in ScoreRift check?",
+     "expected": "8", "accept": ["8", "eight"],
+     "gold_source": ["two-brain-audit/README.md"]},
+    {"name": "helix_ribosome_budget",
+     "query": "How many tokens are allocated for the ribosome decoder prompt?",
+     "expected": "3000", "accept": ["3000", "3k", "3,000"],
+     "gold_source": ["helix-context/helix.toml", "helix-context/README.md"]},
+    {"name": "biged_default_model",
+     "query": "What is the default local model used by BigEd for conductor tasks?",
+     "expected": "qwen3", "accept": ["qwen3", "qwen3:4b", "qwen"],
+     "gold_source": ["Education/CLAUDE.md"]},
+]
+
+
+# Markers that indicate the model abstained rather than guessed.
+ABSTAIN_MARKERS = [
+    r"\bi (?:don't|cannot|can't|am unable to|do not) (?:find|know|determine)\b",
+    r"\bno (?:relevant )?information\b",
+    r"\bnot (?:available|found|present)\b",
+    r"\binsufficient (?:context|information|data)\b",
+    r"\bunable to (?:find|determine|answer)\b",
+    r"\bcouldn't find\b",
+]
+ABSTAIN_RE = re.compile("|".join(ABSTAIN_MARKERS), re.IGNORECASE)
+
+
+# ── Setup logging ────────────────────────────────────────────────────────
+
+def make_run_dir() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = RESULTS_ROOT / f"claude_matrix_{stamp}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def setup_logger(run_dir: Path) -> logging.Logger:
+    log_path = run_dir / "run.log"
+    logger = logging.getLogger("bench.claude_matrix")
+    logger.setLevel(logging.INFO)
+    fmt = logging.Formatter("%(asctime)s %(levelname)-7s %(message)s",
+                            datefmt="%H:%M:%S")
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setFormatter(fmt)
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(fh)
+    logger.addHandler(sh)
+    return logger
+
+
+# ── Swap helper ──────────────────────────────────────────────────────────
+
+def swap_db(target_path: str, log: logging.Logger) -> dict:
+    """POST /admin/swap-db. Returns the response body or {"error": ...}."""
+    log.info("swap-db -> %s", target_path)
+    try:
+        resp = httpx.post(
+            f"{HELIX_URL}/admin/swap-db",
+            json={"path": target_path},
+            timeout=SWAP_TIMEOUT_S,
+        )
+    except Exception as exc:
+        return {"error": f"swap-db request failed: {exc}"}
+    if resp.status_code != 200:
+        return {"error": f"swap-db HTTP {resp.status_code}: {resp.text[:200]}"}
+    body = resp.json()
+    log.info("  swapped: %d genes in %s ms", body.get("genes", -1), body.get("elapsed_ms"))
+    return body
+
+
+# ── Retrieval-only probe via /context ────────────────────────────────────
+
+def retrieval_probe(query: str, gold_sources: list[str]) -> dict:
+    """Direct /context call to get retrieval signal independent of the model."""
+    t0 = time.perf_counter()
+    try:
+        resp = httpx.post(
+            f"{HELIX_URL}/context",
+            json={"query": query, "decoder_mode": "none"},
+            timeout=CONTEXT_TIMEOUT_S,
+        )
+    except Exception as exc:
+        return {"status": "error", "error": str(exc),
+                "latency_s": time.perf_counter() - t0}
+    latency = time.perf_counter() - t0
+    if resp.status_code != 200:
+        return {"status": "error", "http": resp.status_code,
+                "latency_s": latency}
+    data = resp.json()
+    entry = data[0] if isinstance(data, list) and data else {}
+    content = entry.get("content", "") or ""
+
+    delivered_sources = []
+    for m in re.finditer(r'<GENE src="([^"]+)"', content):
+        delivered_sources.append(m.group(1))
+
+    gold_hit = False
+    for src in delivered_sources:
+        norm = src.replace("\\", "/").lower()
+        if any(gs.replace("\\", "/").lower() in norm for gs in gold_sources):
+            gold_hit = True
+            break
+
+    return {
+        "status": "ok",
+        "latency_s": latency,
+        "delivered_count": len(delivered_sources),
+        "delivered_sources": delivered_sources[:20],
+        "gold_delivered": gold_hit,
+        "ellipticity": entry.get("context_health", {}).get("ellipticity"),
+    }
+
+
+# ── Claude -p invocation ─────────────────────────────────────────────────
+
+def run_claude(query: str, model: str, max_usd: float,
+               cwd: str, log: logging.Logger) -> dict:
+    """Run a single ``claude -p`` subprocess and capture structured output."""
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--no-session-persistence",
+        "--permission-mode", "bypassPermissions",
+        "--model", model,
+        "--max-budget-usd", str(max_usd),
+        query,
+    ]
+    log.info("  claude -p (model=%s, budget=$%.2f): %s", model, max_usd, query[:60])
+    t0 = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CLAUDE_TIMEOUT_S,
+            cwd=cwd,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "elapsed_s": CLAUDE_TIMEOUT_S}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc),
+                "elapsed_s": time.perf_counter() - t0}
+    elapsed = time.perf_counter() - t0
+    if proc.returncode != 0:
+        return {
+            "status": "exit_nonzero",
+            "returncode": proc.returncode,
+            "stderr_tail": (proc.stderr or "")[-400:],
+            "stdout_tail": (proc.stdout or "")[-400:],
+            "elapsed_s": elapsed,
+        }
+    raw = proc.stdout.strip()
+    try:
+        result = json.loads(raw)
+    except Exception:
+        return {
+            "status": "parse_error",
+            "stdout_tail": raw[-400:],
+            "elapsed_s": elapsed,
+        }
+    return {"status": "ok", "result": result, "elapsed_s": elapsed,
+            "stderr_tail": (proc.stderr or "")[-200:] if proc.stderr else ""}
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────
+
+def score_answer(answer_text: str, accept_substrings: list[str]) -> dict:
+    """Return {-1, 0, +1} score plus diagnostics.
+
+    +1: word-boundary match of any accept substring (correct)
+     0: model abstained (says "I don't know" or similar)
+    -1: confident answer but no accept-substring match (likely wrong)
+    """
+    text = (answer_text or "").strip()
+    if not text:
+        return {"score": 0, "reason": "empty"}
+
+    for a in accept_substrings:
+        if re.search(rf"\b{re.escape(a)}\b", text, re.IGNORECASE):
+            return {"score": 1, "reason": f"accept-match:{a}",
+                    "matched_token": a}
+
+    if ABSTAIN_RE.search(text):
+        return {"score": 0, "reason": "abstain"}
+
+    return {"score": -1, "reason": "no-match-and-confident"}
+
+
+# ── Main loop ────────────────────────────────────────────────────────────
+
+def parse_filter(spec: str | None, all_keys: list[str]) -> set[str]:
+    if not spec:
+        return set()
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    bad = [p for p in parts if p not in all_keys]
+    if bad:
+        raise SystemExit(f"unknown profile(s): {bad}; available: {all_keys}")
+    return set(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", help="Comma-separated profiles to run")
+    parser.add_argument("--skip", help="Comma-separated profiles to skip")
+    parser.add_argument("--model", default="sonnet",
+                        help="claude -p --model arg (sonnet/opus/haiku/full id)")
+    parser.add_argument("--max-usd", type=float, default=0.30,
+                        help="Per-question budget cap (sonnet smoke run averaged $0.11)")
+    parser.add_argument("--cwd", default=r"F:\Projects\helix-context",
+                        help="cwd for claude -p subprocess")
+    args = parser.parse_args()
+
+    if not MANIFEST.exists():
+        print(f"!! manifest not found at {MANIFEST}; run freeze_matrix_manifest.py first",
+              file=sys.stderr)
+        return 2
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    all_keys = list(manifest["targets"].keys())
+    only = parse_filter(args.only, all_keys)
+    skip = parse_filter(args.skip, all_keys)
+    keys = [k for k in all_keys
+            if (not only or k in only) and k not in skip]
+
+    run_dir = make_run_dir()
+    log = setup_logger(run_dir)
+    log.info("RUN START run_dir=%s", run_dir)
+    log.info("model=%s max_usd_per_question=%.2f", args.model, args.max_usd)
+    log.info("profiles in run: %s", keys)
+
+    # Sanity: server reachable?
+    try:
+        r = httpx.get(f"{HELIX_URL}/stats", timeout=10)
+        log.info("server /stats ok: %d genes", r.json().get("total_genes", -1))
+    except Exception as exc:
+        log.error("server not reachable at %s: %s", HELIX_URL, exc)
+        return 3
+
+    overall: dict = {
+        "run_dir": str(run_dir),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "model": args.model,
+        "max_usd_per_question": args.max_usd,
+        "profiles": {},
+    }
+
+    for key in keys:
+        target = manifest["targets"][key]
+        log.info("=" * 60)
+        log.info("PROFILE: %s (mode=%s)", key, target.get("mode"))
+
+        if target.get("status") == "missing":
+            log.warning("  target missing on disk, skipping")
+            continue
+
+        swap_result = swap_db(target["path"], log)
+        if "error" in swap_result:
+            log.error("  swap failed: %s", swap_result["error"])
+            overall["profiles"][key] = {"swap_error": swap_result["error"]}
+            continue
+
+        profile_path = run_dir / f"{key}.jsonl"
+        per_needle: list[dict] = []
+        with open(profile_path, "w", encoding="utf-8") as f:
+            for i, n in enumerate(NEEDLES):
+                log.info("[%s %d/%d] %s", key, i + 1, len(NEEDLES), n["name"])
+
+                # 1. Retrieval-only probe
+                retr = retrieval_probe(n["query"], n["gold_source"])
+
+                # 2. Full answer via claude -p
+                claude_r = run_claude(
+                    n["query"], args.model, args.max_usd, args.cwd, log,
+                )
+
+                # 3. Extract answer + tokens + score
+                answer_text = ""
+                tokens = {}
+                cost_usd = None
+                if claude_r["status"] == "ok":
+                    res = claude_r["result"]
+                    answer_text = (
+                        res.get("result")
+                        or res.get("answer")
+                        or res.get("content")
+                        or ""
+                    )
+                    # Token fields vary by claude version — capture broadly
+                    for k in ("total_tokens", "input_tokens", "output_tokens",
+                              "cache_creation_input_tokens",
+                              "cache_read_input_tokens"):
+                        if k in res:
+                            tokens[k] = res[k]
+                    # nested usage field if present
+                    if "usage" in res and isinstance(res["usage"], dict):
+                        for k, v in res["usage"].items():
+                            tokens.setdefault(k, v)
+                    cost_usd = (
+                        res.get("total_cost_usd")
+                        or res.get("total_cost")
+                        or res.get("cost_usd")
+                    )
+
+                score = score_answer(answer_text, n["accept"])
+
+                record = {
+                    "profile": key,
+                    "needle": n["name"],
+                    "query": n["query"],
+                    "expected": n["expected"],
+                    "accept": n["accept"],
+                    "gold_source": n["gold_source"],
+                    "retrieval": retr,
+                    "claude_status": claude_r["status"],
+                    "claude_elapsed_s": claude_r.get("elapsed_s"),
+                    "answer_text": answer_text[:2000],
+                    "tokens": tokens,
+                    "cost_usd": cost_usd,
+                    "score": score["score"],
+                    "score_reason": score["reason"],
+                    "score_matched_token": score.get("matched_token"),
+                }
+                if claude_r["status"] != "ok":
+                    record["claude_debug"] = {
+                        k: v for k, v in claude_r.items() if k != "result"
+                    }
+
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                f.flush()
+                per_needle.append(record)
+                in_tok = tokens.get("input_tokens", 0)
+                out_tok = tokens.get("output_tokens", 0)
+                cache_r = tokens.get("cache_read_input_tokens", 0)
+                cache_w = tokens.get("cache_creation_input_tokens", 0)
+                cost_s = f"${cost_usd:.4f}" if isinstance(cost_usd, (int, float)) else "?"
+                log.info(
+                    "  retr=%s score=%+d cost=%s in=%s out=%s cache_r=%s cache_w=%s",
+                    retr.get("gold_delivered"), score["score"],
+                    cost_s, in_tok, out_tok, cache_r, cache_w,
+                )
+
+        # Profile summary
+        total_score = sum(r["score"] for r in per_needle)
+        n_correct = sum(1 for r in per_needle if r["score"] == 1)
+        n_abstain = sum(1 for r in per_needle if r["score"] == 0)
+        n_wrong = sum(1 for r in per_needle if r["score"] == -1)
+        n_retr_hit = sum(1 for r in per_needle
+                         if r["retrieval"].get("gold_delivered"))
+        total_cost = sum(
+            (r["cost_usd"] or 0.0) for r in per_needle
+        )
+        prof_summary = {
+            "needles_run": len(per_needle),
+            "answers": {
+                "correct": n_correct,
+                "abstain": n_abstain,
+                "wrong": n_wrong,
+                "score_sum": total_score,
+                "score_normalized": (total_score / len(NEEDLES))
+                if NEEDLES else 0,
+            },
+            "retrieval": {
+                "gold_delivered_count": n_retr_hit,
+                "gold_delivered_rate": n_retr_hit / len(NEEDLES),
+            },
+            "total_cost_usd": round(total_cost, 4),
+        }
+        overall["profiles"][key] = prof_summary
+        log.info(
+            "  PROFILE %s: correct=%d abstain=%d wrong=%d "
+            "retr_hit=%d/%d cost=$%.4f",
+            key, n_correct, n_abstain, n_wrong, n_retr_hit, len(NEEDLES),
+            total_cost,
+        )
+
+    overall["finished_at"] = datetime.now(timezone.utc).isoformat()
+    summary_path = run_dir / "summary.json"
+    summary_path.write_text(json.dumps(overall, indent=2), encoding="utf-8")
+    log.info("=" * 60)
+    log.info("RUN DONE. Summary at %s", summary_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/freeze_matrix_manifest.py
+++ b/scripts/freeze_matrix_manifest.py
@@ -1,0 +1,175 @@
+"""Pin the 6-fixture matrix in place (no copy) with sha256 + size.
+
+Writes ``genomes/bench/matrix/frozen.json`` listing each blob/sharded
+target by absolute path, sha256 hash of the primary .db file, byte size,
+and gene count. Build cost is now low enough (medium-sharded 8.6 min,
+xl-sharded 26 min on dev box per PR #96) that re-builds are cheaper
+than redundant frozen-copy storage.
+
+Usage:
+    python scripts/freeze_matrix_manifest.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+MATRIX_BLOB_DIR = Path(r"F:\Projects\helix-context\genomes\bench\matrix")
+MATRIX_SHARDED_DIR = Path(r"F:\Projects\helix-context\genomes\bench\matrix-sharded")
+
+TARGETS = [
+    {
+        "key": "small", "mode": "blob",
+        "path": MATRIX_BLOB_DIR / "small.db",
+    },
+    {
+        "key": "medium", "mode": "blob",
+        "path": MATRIX_BLOB_DIR / "medium.db",
+    },
+    {
+        "key": "large", "mode": "blob",
+        "path": MATRIX_BLOB_DIR / "large.db",
+    },
+    {
+        "key": "xl", "mode": "blob",
+        "path": MATRIX_BLOB_DIR / "xl.db",
+    },
+    {
+        "key": "medium-sharded", "mode": "sharded",
+        "path": MATRIX_SHARDED_DIR / "medium" / "main.genome.db",
+        "shard_dir": MATRIX_SHARDED_DIR / "medium",
+    },
+    {
+        "key": "xl-sharded", "mode": "sharded",
+        "path": MATRIX_SHARDED_DIR / "xl" / "main.genome.db",
+        "shard_dir": MATRIX_SHARDED_DIR / "xl",
+    },
+]
+
+
+def sha256_file(path: Path, chunk: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            buf = f.read(chunk)
+            if not buf:
+                break
+            h.update(buf)
+    return h.hexdigest()
+
+
+def gene_count_blob(path: Path) -> int:
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5)
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM genes").fetchone()
+            return int(row[0]) if row else 0
+        finally:
+            conn.close()
+    except Exception as exc:
+        return -1
+
+
+def sharded_summary(main_path: Path) -> dict:
+    """Sum gene counts across registered shards and list shard files."""
+    summary = {"shards": [], "total_genes": 0, "shard_count": 0}
+    if not main_path.exists():
+        return summary
+    try:
+        conn = sqlite3.connect(f"file:{main_path}?mode=ro", uri=True, timeout=5)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT shard_name, category, path, gene_count, byte_size "
+                "FROM shards WHERE health='ok' ORDER BY shard_name"
+            ).fetchall()
+            for r in rows:
+                p = Path(r["path"])
+                shard = {
+                    "name": r["shard_name"],
+                    "category": r["category"],
+                    "path": str(p),
+                    "gene_count": int(r["gene_count"] or 0),
+                    "bytes": int(r["byte_size"] or 0),
+                }
+                if p.exists():
+                    shard["sha256"] = sha256_file(p)
+                    shard["actual_bytes"] = p.stat().st_size
+                else:
+                    shard["sha256"] = None
+                    shard["actual_bytes"] = -1
+                summary["shards"].append(shard)
+                summary["total_genes"] += shard["gene_count"]
+            summary["shard_count"] = len(summary["shards"])
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return summary
+
+
+def main() -> int:
+    out: dict = {
+        "matrix": "fixture_matrix_v1",
+        "spec": "docs/benchmarks/GENOME_FIXTURE_MATRIX.md",
+        "frozen_at": datetime.now(timezone.utc).isoformat(),
+        "host": os.environ.get("COMPUTERNAME", ""),
+        "policy": "in-place pin (no copy) — re-build cost is low enough that hashes serve as the reproducibility anchor",
+        "targets": {},
+    }
+
+    for t in TARGETS:
+        path: Path = t["path"]
+        if not path.exists():
+            print(f"!! MISSING: {t['key']} at {path}")
+            out["targets"][t["key"]] = {
+                "mode": t["mode"],
+                "path": str(path),
+                "status": "missing",
+            }
+            continue
+
+        print(f".. hashing {t['key']} ({path.stat().st_size / 1_048_576:.1f} MB)")
+        t0 = time.perf_counter()
+        digest = sha256_file(path)
+        hash_s = time.perf_counter() - t0
+
+        entry: dict = {
+            "mode": t["mode"],
+            "path": str(path),
+            "bytes": path.stat().st_size,
+            "sha256": digest,
+            "hash_seconds": round(hash_s, 2),
+        }
+
+        if t["mode"] == "blob":
+            entry["gene_count"] = gene_count_blob(path)
+        else:
+            sd = sharded_summary(path)
+            entry["sharded"] = sd
+            entry["gene_count_total"] = sd["total_genes"]
+            entry["shard_count"] = sd["shard_count"]
+            entry["shard_dir"] = str(t["shard_dir"])
+
+        out["targets"][t["key"]] = entry
+        print(f"   sha256={digest[:16]}... genes={entry.get('gene_count') or entry.get('gene_count_total')}")
+
+    manifest_path = MATRIX_BLOB_DIR / "frozen.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2)
+    print(f"\n[ok] frozen manifest at {manifest_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/scripts/run_repobench_r.ps1
+++ b/scripts/run_repobench_r.ps1
@@ -1,0 +1,461 @@
+<#
+.SYNOPSIS
+    RepoBench-R Step-1 turnkey spin-up -- run from the repo root.
+
+.DESCRIPTION
+    One-command bring-up of the RepoBench-R retrieval benchmark against the
+    frozen helix063 venv.  Covers python_cff and python_cfr configs, both
+    difficulty levels (easy + hard), n=200 examples/level.
+
+    Pipeline:
+      1. Preflight  -- verify helix063 python.exe; install huggingface_hub +
+                      rank-bm25 if missing; probe a free debug port (logged,
+                      not bound -- arms are in-process, no daemon started).
+      2. Write toml  -- emit helix_probe_lexical.toml into F:/tmp/cb_helix_probe/
+                       so the Helix arms are lexical-only (dense/splade/
+                       ribosome all OFF).
+      3. Foils       -- benchmarks/repobench_r.py for each config (random /
+                       Jaccard-overlap / BM25Okapi foils; writes per-example
+                       JSON dumps the Helix arms need).
+      4. Global arm  -- benchmarks/repobench_r_helix_global.py for each config
+                       (one shared genome; B-mode pool-rank + C-mode global-
+                       rank; also runs matched global-BM25 foil).
+      5. Per-example arm -- benchmarks/repobench_r_helix.py for each config
+                       (per-example fresh genome; expect lower acc@k than
+                       global because the ~5-17 snippet pool degrades IDF).
+      6. Summary     -- print result file locations and the head-to-head metric
+                       (helix_B_acc@k vs bm25_B_acc@k from the global arm).
+
+    NOTE -- No uvicorn daemon is started.  Both Helix arms use an in-process
+    HelixContextManager via HELIX_CONFIG + HELIX_GENOME_PATH env vars.
+    RepoBench-R is LLM-free and GPU-free on the lexical config; env vars
+    HELIX_BFM_SPLADE=0 and HELIX_BFM_DENSE_BACKFILL=0 are set as a kill-
+    switch against the #176 WDDM-spill livelock (multi-CUDA-context on <=12 GB
+    cards) in case any background worker tries to fire dense/SPLADE.
+
+.PARAMETER N
+    Max examples per difficulty level (default: 200; 0 = full dataset).
+
+.PARAMETER Configs
+    Comma-separated dataset configs to run (default: "python_cff,python_cfr").
+
+.PARAMETER Levels
+    Comma-separated difficulty levels (default: "easy,hard").
+
+.PARAMETER Workers
+    Parallel workers for the per-example arm (default: 1).
+    Only safe to raise when running the helix063 python.exe directly (not via
+    uv or any wrapper), because ProcessPoolExecutor trampoline causes deadlock
+    under wrapper envs.
+
+.PARAMETER HelixPython
+    Path to the helix063 venv python.exe
+    (default: F:/Projects/_venvs/helix063/Scripts/python.exe).
+
+.PARAMETER GenomeBase
+    Base directory for bench genome scratch dirs
+    (default: F:/tmp/repobench_r_genomes).
+
+.PARAMETER ProbeTomlDir
+    Directory where helix_probe_lexical.toml is written
+    (default: F:/tmp/cb_helix_probe).
+
+.EXAMPLE
+    # Standard run -- from the repo root:
+    powershell -ExecutionPolicy Bypass -File scripts\run_repobench_r.ps1
+
+    # Quick smoke test -- 50 examples/level, CFF only:
+    powershell -ExecutionPolicy Bypass -File scripts\run_repobench_r.ps1 `
+        -N 50 -Configs python_cff
+
+    # Full dataset, both configs, 4 parallel workers:
+    powershell -ExecutionPolicy Bypass -File scripts\run_repobench_r.ps1 `
+        -N 0 -Workers 4
+#>
+
+[CmdletBinding()]
+param(
+    [int]   $N            = 200,
+    [string]$Configs      = "python_cff,python_cfr",
+    [string]$Levels       = "easy,hard",
+    [int]   $Workers      = 1,
+    [string]$HelixPython  = "F:/Projects/_venvs/helix063/Scripts/python.exe",
+    [string]$GenomeBase   = "F:/tmp/repobench_r_genomes",
+    [string]$ProbeTomlDir = "F:/tmp/cb_helix_probe"
+)
+
+Set-StrictMode -Version Latest
+# Native python calls (foils/arms) emit stderr (warnings, tracebacks) that under
+# 'Stop' get promoted to terminating errors mid-pipeline -- killing the run before
+# the explicit $LASTEXITCODE / Require-Exit0 checks fire. This script's error
+# handling is exit-code-based by design, so use 'Continue' and rely on those checks.
+$ErrorActionPreference = "Continue"
+
+# ?? helpers ??????????????????????????????????????????????????????????????????
+
+function Write-Step {
+    param([string]$Msg)
+    Write-Host "`n==> $Msg" -ForegroundColor Cyan
+}
+function Write-OK   { param([string]$Msg); Write-Host "  [OK]   $Msg" -ForegroundColor Green }
+function Write-Warn { param([string]$Msg); Write-Host "  [WARN] $Msg" -ForegroundColor Yellow }
+function Write-Fail {
+    param([string]$Msg)
+    Write-Host "`n[FAIL] $Msg" -ForegroundColor Red
+    exit 1
+}
+
+function Require-Exit0 {
+    param([string]$Label)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "$Label exited with code $LASTEXITCODE"
+    }
+}
+
+# ?? resolve paths ?????????????????????????????????????????????????????????????
+# $PSScriptRoot is the scripts/ directory; parent is the repo root.
+$RepoRoot   = Split-Path $PSScriptRoot -Parent
+$BenchDir   = Join-Path $RepoRoot "benchmarks"
+$ResultsDir = Join-Path $BenchDir "results"
+
+Write-Host ""
+Write-Host "RepoBench-R Step-1 -- turnkey spin-up" -ForegroundColor White
+Write-Host "======================================" -ForegroundColor White
+Write-Host "Repo root   : $RepoRoot"
+Write-Host "Bench dir   : $BenchDir"
+Write-Host "Results     : $ResultsDir"
+Write-Host "N/level     : $N   (0 = full dataset)"
+Write-Host "Configs     : $Configs"
+Write-Host "Levels      : $Levels"
+Write-Host "Workers     : $Workers"
+Write-Host "Helix venv  : $HelixPython"
+Write-Host "Genome base : $GenomeBase"
+Write-Host ""
+
+
+# =============================================================================
+# STEP 1: PREFLIGHT
+# =============================================================================
+Write-Step "STEP 1: PREFLIGHT"
+
+# 1a. helix063 python.exe
+if (-not (Test-Path $HelixPython)) {
+    Write-Fail (
+        "helix063 python.exe not found at: $HelixPython`n" +
+        "  Create the venv and install the package:`n" +
+        "    python -m venv F:/Projects/_venvs/helix063`n" +
+        "    F:/Projects/_venvs/helix063/Scripts/pip install -e $RepoRoot"
+    )
+}
+Write-OK "helix063 python.exe found"
+
+# 1b. helix_context importable
+& $HelixPython -c "import helix_context" 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Fail (
+        "helix_context not importable in helix063 venv.`n" +
+        "  Run: & '$HelixPython' -m pip install -e '$RepoRoot'"
+    )
+}
+Write-OK "helix_context importable in helix063 venv"
+
+# 1c. huggingface_hub -- used by repobench_r.py to download the dataset
+& $HelixPython -c "import huggingface_hub" 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warn "huggingface_hub not installed -- installing now..."
+    & $HelixPython -m pip install --quiet huggingface_hub
+    Require-Exit0 "pip install huggingface_hub"
+    Write-OK "huggingface_hub installed"
+} else {
+    Write-OK "huggingface_hub present"
+}
+
+# 1d. rank-bm25 -- used by repobench_r.py for the BM25Okapi foil
+& $HelixPython -c "import rank_bm25" 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warn "rank-bm25 not installed -- installing now..."
+    & $HelixPython -m pip install --quiet rank-bm25
+    Require-Exit0 "pip install rank-bm25"
+    Write-OK "rank-bm25 installed"
+} else {
+    Write-OK "rank-bm25 present"
+}
+
+# 1e. Free-port probe -- logged for human reference only; no daemon is started.
+#     RepoBench-R arms are in-process; port is useful if someone wants to
+#     start a debug helix-server manually alongside the bench run.
+#     Avoids the dev server on :11437 and the strategy-doc bench lane :11439.
+function Get-FreePort {
+    $candidates = 11440..11460
+    foreach ($p in $candidates) {
+        try {
+            $l = [System.Net.Sockets.TcpListener]::new(
+                [System.Net.IPAddress]::Loopback, $p)
+            $l.Start()
+            $l.Stop()
+            return $p
+        } catch {
+            # port in use, try next
+        }
+    }
+    return $null
+}
+$FreePort = Get-FreePort
+if ($FreePort) {
+    Write-OK "Free debug port (informational, not bound): $FreePort"
+} else {
+    Write-Warn "No free port found in 11440-11460 -- arms still run in-process fine."
+}
+
+# 1f. Create output dirs
+New-Item -ItemType Directory -Force -Path $ResultsDir   | Out-Null
+New-Item -ItemType Directory -Force -Path $ProbeTomlDir | Out-Null
+New-Item -ItemType Directory -Force -Path $GenomeBase   | Out-Null
+$LogDir = Join-Path $ResultsDir "logs"
+New-Item -ItemType Directory -Force -Path $LogDir       | Out-Null
+Write-OK "Output + log dirs ready"
+
+
+# =============================================================================
+# STEP 2: WRITE LEXICAL-PROBE helix.toml
+# =============================================================================
+Write-Step "STEP 2: WRITE helix_probe_lexical.toml"
+
+$ProbeTomlPath = Join-Path $ProbeTomlDir "helix_probe.toml"
+
+# Genome path used by the in-process arms -- each arm overrides HELIX_GENOME_PATH
+# per run anyway, but [genome].path is the fallback the config loader reads.
+# Use forward slashes inside the TOML string (TOML paths are strings, not PS paths).
+$GenomeBaseFwd = $GenomeBase.Replace('\', '/')
+
+$ProbeTomlContent = @"
+# helix_probe_lexical.toml
+# Auto-generated by scripts/run_repobench_r.ps1
+# Lexical-only probe: dense / splade / ribosome / rerank all OFF.
+# Both Helix arms (repobench_r_helix.py, repobench_r_helix_global.py) read this.
+
+[ribosome]
+enabled = false
+backend = "none"
+query_expansion_enabled = false
+query_decomposition_enabled = false
+
+[hardware]
+device = "cpu"
+
+[budget]
+expression_tokens = 7000
+max_genes_per_turn = 12
+decoder_mode = "none"
+legibility_enabled = false
+session_delivery_enabled = false
+
+[session]
+synthetic_session_enabled = false
+
+[genome]
+path = "$GenomeBaseFwd/probe/genome.db"
+compact_interval = 0
+
+[server]
+host = "127.0.0.1"
+port = 11437
+upstream = "http://localhost:11434"
+
+[ingestion]
+backend = "cpu"
+splade_enabled = false
+dense_embed_on_ingest = false
+rerank_enabled = false
+entity_graph = false
+
+[retrieval]
+dense_embedding_enabled = false
+sr_enabled = false
+ray_trace_theta = false
+seeded_edges_enabled = false
+filename_anchor_enabled = true
+filename_anchor_weight = 4.0
+bm25_shortlist_enabled = true
+bm25_shortlist_size = 50
+bm25_prefilter_enabled = false
+entity_graph_retrieval_enabled = false
+fusion_mode = "additive"
+
+[context]
+cold_tier_enabled = false
+
+[cymatics]
+enabled = false
+
+[know]
+confidence_floor = 0.0
+
+[abstain]
+enabled = false
+"@
+
+# NOTE: Windows PowerShell 5.1 '-Encoding UTF8' prepends a BOM, which Helix's TOML
+# parser rejects ("Invalid statement at line 1, col 1") -> falls back to defaults
+# (dense ingest ON) -> global-genome ingest fails. TOML here is ASCII, so write ASCII (no BOM).
+$ProbeTomlContent | Set-Content -Path $ProbeTomlPath -Encoding Ascii -NoNewline
+Write-OK "Probe TOML written -> $ProbeTomlPath"
+
+
+# =============================================================================
+# ENVIRONMENT -- set once for all child processes
+# =============================================================================
+# Kill-switches: prevents SPLADE + BGE-M3 dense-backfill workers from spinning
+# up additional CUDA contexts on the 12 GB card (issue #176 WDDM-spill livelock).
+# Safe even when dense is already OFF in the TOML (belt-and-suspenders).
+$env:HELIX_BFM_SPLADE         = "0"
+$env:HELIX_BFM_DENSE_BACKFILL = "0"
+$env:HELIX_CONFIG             = $ProbeTomlPath
+$env:PYTHONUNBUFFERED         = "1"
+
+# Run timestamp for log file names (all arms share a single timestamp prefix).
+$RunTs = Get-Date -Format "yyyyMMddTHHmmss"
+
+# Parse config list once.
+$ConfigList = ($Configs -split ",") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+
+
+# =============================================================================
+# STEP 3: FOILS -- random / Jaccard-overlap / BM25Okapi
+# =============================================================================
+Write-Step "STEP 3: FOILS (repobench_r.py)"
+
+Write-Host "  Dataset: tianyang/repobench-r (HuggingFace, CC-BY-4.0)"
+Write-Host "  First run downloads gzipped pickle (~50-100 MB total for python configs)."
+Write-Host "  Subsequent runs use the HF content-addressed cache."
+
+foreach ($cfg in $ConfigList) {
+    Write-Host ""
+    Write-Host "  [foils] config=$cfg  n=$N  levels=$Levels" -ForegroundColor White
+    $logFile = Join-Path $LogDir "foils_${cfg}_${RunTs}.log"
+
+    # repobench_r.py CLI: --config --n --levels [--out]
+    & $HelixPython -u `
+        (Join-Path $BenchDir "repobench_r.py") `
+        --config $cfg `
+        --n      $N `
+        --levels $Levels `
+        2>&1 | Tee-Object -FilePath $logFile
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "repobench_r.py failed for config=$cfg  (log: $logFile)"
+    }
+    Write-OK "Foils done for $cfg  (log: $(Split-Path $logFile -Leaf))"
+}
+
+
+# =============================================================================
+# STEP 4: HELIX GLOBAL-GENOME ARM
+# =============================================================================
+Write-Step "STEP 4: HELIX GLOBAL-GENOME ARM (repobench_r_helix_global.py)"
+
+Write-Host "  One shared genome over the deduped union of all candidate snippets."
+Write-Host "  Scores B-mode (pool-rank, comparable to foils) and C-mode (global-rank)."
+Write-Host "  Also runs matched global-BM25 foil (floored IDF -- correct foil at scale)."
+
+foreach ($cfg in $ConfigList) {
+    # Fresh genome dir per config so configs don't share state.
+    $genomeDir = Join-Path $GenomeBase "global_${cfg}"
+    Write-Host ""
+    Write-Host "  [global] config=$cfg  genome-dir=$genomeDir" -ForegroundColor White
+    $logFile = Join-Path $LogDir "global_${cfg}_${RunTs}.log"
+
+    # repobench_r_helix_global.py CLI: --config --levels [--limit] --helix-config --genome-dir [--out]
+    & $HelixPython -u `
+        (Join-Path $BenchDir "repobench_r_helix_global.py") `
+        --config       $cfg `
+        --levels       $Levels `
+        --helix-config $ProbeTomlPath `
+        --genome-dir   $genomeDir `
+        2>&1 | Tee-Object -FilePath $logFile
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "repobench_r_helix_global.py failed for config=$cfg  (log: $logFile)"
+    }
+    Write-OK "Global arm done for $cfg  (log: $(Split-Path $logFile -Leaf))"
+}
+
+
+# =============================================================================
+# STEP 5: HELIX PER-EXAMPLE ARM
+# =============================================================================
+Write-Step "STEP 5: HELIX PER-EXAMPLE ARM (repobench_r_helix.py)"
+
+Write-Host "  Per-example fresh genome (~5-17 snippet corpus per query)."
+Write-Host "  Expect lower acc@k than global arm -- IDF degrades at tiny corpus size."
+Write-Host "  Results still useful: shows Helix floor vs BM25 at equal corpus scale."
+
+foreach ($cfg in $ConfigList) {
+    $genomeRoot = Join-Path $GenomeBase "per_example_${cfg}"
+    Write-Host ""
+    Write-Host "  [per-ex] config=$cfg  genome-root=$genomeRoot  workers=$Workers" -ForegroundColor White
+    $logFile = Join-Path $LogDir "per_example_${cfg}_${RunTs}.log"
+
+    # repobench_r_helix.py CLI: --config --levels [--limit] [--workers] --helix-config --genome-root [--out]
+    & $HelixPython -u `
+        (Join-Path $BenchDir "repobench_r_helix.py") `
+        --config       $cfg `
+        --levels       $Levels `
+        --helix-config $ProbeTomlPath `
+        --genome-root  $genomeRoot `
+        --workers      $Workers `
+        2>&1 | Tee-Object -FilePath $logFile
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "repobench_r_helix.py failed for config=$cfg  (log: $logFile)"
+    }
+    Write-OK "Per-example arm done for $cfg  (log: $(Split-Path $logFile -Leaf))"
+}
+
+
+# =============================================================================
+# STEP 6: SUMMARY
+# =============================================================================
+Write-Step "STEP 6: SUMMARY"
+
+Write-Host ""
+Write-Host "Results dir : $ResultsDir" -ForegroundColor White
+Write-Host "Logs dir    : $LogDir"     -ForegroundColor White
+Write-Host "Probe TOML  : $ProbeTomlPath" -ForegroundColor White
+Write-Host ""
+
+# Find result JSONs written this run.
+$cutoff = (Get-Date).AddMinutes(-120)
+$resultFiles = Get-ChildItem -Path $ResultsDir -Filter "*.json" -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.LastWriteTime -gt $cutoff } |
+    Sort-Object LastWriteTime -Descending
+
+if ($resultFiles) {
+    Write-Host "Result files written this run:" -ForegroundColor Cyan
+    foreach ($f in $resultFiles) {
+        Write-Host "  $($f.FullName)"
+    }
+} else {
+    Write-Warn "No result files found in the last 2 hours -- check logs."
+}
+
+Write-Host ""
+Write-Host "Head-to-head metric (primary -- read from global arm JSON):" -ForegroundColor Cyan
+Write-Host "  B-mode keys  : helix_B_acc@1  vs  bm25_B_acc@1  (pool-rank, comparable to foils)"
+Write-Host "  C-mode keys  : helix_C_recall@k  (global-rank, realistic agent scenario)"
+Write-Host "  Easy level   : acc@1, acc@3"
+Write-Host "  Hard level   : acc@1, acc@3, acc@5"
+Write-Host ""
+Write-Host "Quick parse -- run this after the script completes:" -ForegroundColor DarkCyan
+Write-Host ("  `$f = (Get-ChildItem '$ResultsDir' -Filter '*_global_*.json' | " +
+            "Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName")
+Write-Host ("  & '$HelixPython' -c " +
+            '"import json,sys; d=json.load(open(sys.argv[1])); ' +
+            '[print(k, json.dumps(v, indent=2)) for k,v in d[chr(108)+chr(101)+chr(118)+chr(101)+chr(108)+chr(115)].items()]" $f')
+Write-Host ""
+Write-Host "Expected ranges for python_cff n=200 (see runbook Table 5):" -ForegroundColor DarkCyan
+Write-Host "  easy  helix_B_acc@1 ~0.35-0.45   bm25_B_acc@1 ~0.40-0.50"
+Write-Host "  hard  helix_B_acc@1 ~0.25-0.35   bm25_B_acc@1 ~0.30-0.40"
+Write-Host "  (Helix lexical expected near-parity with BM25 on this benchmark)"
+Write-Host ""
+Write-Host "Done. RepoBench-R Step-1 complete." -ForegroundColor Green

--- a/tests/test_coderag_bench_harness.py
+++ b/tests/test_coderag_bench_harness.py
@@ -1,0 +1,629 @@
+"""Unit tests for the CodeRAG-Bench Step-2 harness logic.
+
+Covers:
+  - ndcg_at, recall_at, precision_at: metric correctness + boundary conditions
+  - BM25: floored IDF, score ordering, correct gold-rank
+  - tok: identifier tokenizer
+  - token_estimate / efficiency_stats / _percentile: efficiency layer
+  - parse_doc_idx: source-id parser
+  - preview_token_estimate: injected-token heuristic
+  - run(): full scoring pipeline over an inline fixture (no HF, no server, no GPU)
+  - score_queries() mocked: confirms NDCG/Recall/Precision accumulation with a
+    fake /fingerprint response
+
+All tests are pure-Python; zero network, zero Helix server, zero GPU.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make benchmarks/ importable without packaging.
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+sys.path.insert(0, str(BENCH_DIR))
+
+from coderag_bench import (  # noqa: E402
+    BM25,
+    KS,
+    _percentile,
+    efficiency_stats,
+    ndcg_at,
+    precision_at,
+    recall_at,
+    run,
+    tok,
+    token_estimate,
+)
+from coderag_bench_helix import (  # noqa: E402
+    parse_doc_idx,
+    preview_token_estimate,
+    score_queries,
+)
+
+
+# ===========================================================================
+# ndcg_at
+# ===========================================================================
+
+class TestNdcgAt:
+    def test_rank_1_ndcg10_is_one(self):
+        """Gold at rank 1 (pos0=0) -> NDCG = 1/log2(2) = 1.0."""
+        assert math.isclose(ndcg_at(0, 10), 1.0)
+
+    def test_rank_2(self):
+        expected = 1.0 / math.log2(3)  # pos0=1 -> rank=2 -> 1/log2(3)
+        assert math.isclose(ndcg_at(1, 10), expected)
+
+    def test_rank_10_boundary(self):
+        """pos0=9 is rank 10 -- just inside @10."""
+        val = ndcg_at(9, 10)
+        assert val > 0.0
+        assert math.isclose(val, 1.0 / math.log2(11))
+
+    def test_rank_11_outside_k10(self):
+        """pos0=10 is rank 11 -- outside @10."""
+        assert ndcg_at(10, 10) == 0.0
+
+    def test_very_low_rank_is_zero(self):
+        assert ndcg_at(999, 10) == 0.0
+
+    def test_ndcg_decreases_with_rank(self):
+        vals = [ndcg_at(i, 10) for i in range(10)]
+        for i in range(9):
+            assert vals[i] > vals[i + 1]
+
+
+# ===========================================================================
+# recall_at
+# ===========================================================================
+
+class TestRecallAt:
+    def test_hit_at_k(self):
+        assert recall_at(0, 1) == 1.0
+        assert recall_at(4, 5) == 1.0
+        assert recall_at(9, 10) == 1.0
+
+    def test_miss_at_k(self):
+        assert recall_at(1, 1) == 0.0
+        assert recall_at(5, 5) == 0.0
+        assert recall_at(10, 10) == 0.0
+
+    def test_all_ks_on_rank_1(self):
+        for k in KS:
+            assert recall_at(0, k) == 1.0
+
+    def test_rank_beyond_ks(self):
+        for k in KS:
+            assert recall_at(999, k) == 0.0
+
+
+# ===========================================================================
+# precision_at
+# ===========================================================================
+
+class TestPrecisionAt:
+    def test_hit_is_one_over_k(self):
+        assert math.isclose(precision_at(0, 1), 1.0)
+        assert math.isclose(precision_at(0, 5), 0.2)
+        assert math.isclose(precision_at(0, 10), 0.1)
+
+    def test_miss_is_zero(self):
+        assert precision_at(5, 5) == 0.0
+        assert precision_at(10, 10) == 0.0
+
+    def test_gold_at_last_position_in_k(self):
+        # pos0=k-1 is rank k -> hit
+        assert math.isclose(precision_at(9, 10), 0.1)
+
+    def test_gold_just_outside_k(self):
+        assert precision_at(10, 10) == 0.0
+
+
+# ===========================================================================
+# tok (identifier tokenizer)
+# ===========================================================================
+
+class TestTok:
+    def test_basic_identifier(self):
+        assert "fibonacci" in tok("def fibonacci(n):")
+
+    def test_lowercase(self):
+        result = tok("HasCloseElements")
+        assert all(t == t.lower() for t in result)
+
+    def test_underscore_prefix(self):
+        assert "_private" in tok("_private = 1")
+
+    def test_empty_string(self):
+        assert tok("") == []
+
+    def test_none_safe(self):
+        assert tok(None) == []
+
+    def test_strips_punctuation(self):
+        result = tok("foo.bar(baz)")
+        assert "foo" in result
+        assert "bar" in result
+        assert "baz" in result
+
+
+# ===========================================================================
+# BM25
+# ===========================================================================
+
+class TestBM25:
+    def _bm(self, corpus: list[str]) -> BM25:
+        return BM25([tok(c) for c in corpus])
+
+    def test_idf_non_negative(self):
+        corpus = ["common term x", "common term y", "common term z"]
+        bm = self._bm(corpus)
+        for v in bm.idf.values():
+            assert v >= 0.0, f"negative IDF: {v}"
+
+    def test_relevant_doc_scores_higher(self):
+        corpus = [
+            "def has_close_elements numbers threshold",
+            "import os path join exists",
+            "class Config debug true",
+        ]
+        bm = self._bm(corpus)
+        sc = bm.scores(tok("has_close_elements threshold"))
+        assert sc[0] > sc[1]
+        assert sc[0] > sc[2]
+
+    def test_zero_score_for_no_overlap(self):
+        corpus = ["apple banana", "cherry date"]
+        bm = self._bm(corpus)
+        sc = bm.scores(tok("zzz"))
+        assert sc[0] == 0.0
+        assert sc[1] == 0.0
+
+    def test_rank_gold_pos_exact(self):
+        """Gold doc contains all query tokens -> should rank first (pos=0)."""
+        corpus = [
+            "unrelated irrelevant filler text",
+            "fibonacci sequence recursive memoize function",
+            "hash map collision resolution",
+        ]
+        bm = self._bm(corpus)
+        pos = bm.rank_gold_pos(tok("fibonacci recursive"), gold_idx=1)
+        assert pos == 0
+
+    def test_rank_gold_pos_worst_case(self):
+        """Gold doc has zero query token overlap -> ranks last."""
+        corpus = [
+            "fibonacci sequence recursive",
+            "apple banana cherry",  # gold -- no overlap with query
+        ]
+        bm = self._bm(corpus)
+        pos = bm.rank_gold_pos(tok("fibonacci recursive"), gold_idx=1)
+        assert pos == 1  # index 1 = last in a 2-doc corpus
+
+    def test_scores_length_matches_corpus(self):
+        corpus = ["a b c", "d e f", "g h i"]
+        bm = self._bm(corpus)
+        assert len(bm.scores(tok("a"))) == 3
+
+    def test_empty_corpus_graceful(self):
+        bm = BM25([])
+        assert bm.scores([]) == []
+
+
+# ===========================================================================
+# token_estimate + efficiency layer
+# ===========================================================================
+
+class TestTokenEstimate:
+    def test_single_doc_one_word(self):
+        # 1 word * 1.3 = 1.3 -> rounded 1
+        assert token_estimate(["hello"]) == 1
+
+    def test_proportional_to_words(self):
+        # 10 words -> round(10 * 1.3) = 13
+        text = " ".join(["word"] * 10)
+        assert token_estimate([text]) == 13
+
+    def test_empty(self):
+        assert token_estimate([]) == 0
+
+    def test_multiple_docs_sum(self):
+        docs = ["a b c", "d e"]  # 5 words -> round(5*1.3) = 7 (actually 6.5->7)
+        est = token_estimate(docs)
+        assert est == round(5 * 1.3)
+
+
+class TestPercentile:
+    def test_median_of_odd(self):
+        assert _percentile([1, 2, 3, 4, 5], 50) == 3.0
+
+    def test_p90_of_ten(self):
+        vals = list(range(1, 11))  # 1..10
+        # p90 of [1..10] = 9.1 (linear interp)
+        result = _percentile(vals, 90)
+        assert 9.0 <= result <= 10.0
+
+    def test_empty(self):
+        assert _percentile([], 50) == 0.0
+
+    def test_single(self):
+        assert _percentile([42.0], 50) == 42.0
+        assert _percentile([42.0], 90) == 42.0
+
+
+class TestEfficiencyStats:
+    def test_keys_present(self):
+        stats = efficiency_stats([100.0, 200.0, 300.0])
+        assert "median_injected_tokens" in stats
+        assert "p90_injected_tokens" in stats
+
+    def test_median_correct(self):
+        stats = efficiency_stats([100.0, 200.0, 300.0])
+        assert math.isclose(stats["median_injected_tokens"], 200.0, abs_tol=1.0)
+
+    def test_empty(self):
+        stats = efficiency_stats([])
+        assert stats["median_injected_tokens"] == 0.0
+
+
+# ===========================================================================
+# parse_doc_idx
+# ===========================================================================
+
+class TestParseDocIdx:
+    def test_normal(self):
+        assert parse_doc_idx("doc_42") == 42
+
+    def test_zero(self):
+        assert parse_doc_idx("doc_0") == 0
+
+    def test_large(self):
+        assert parse_doc_idx("doc_9999") == 9999
+
+    def test_none(self):
+        assert parse_doc_idx(None) is None
+
+    def test_empty(self):
+        assert parse_doc_idx("") is None
+
+    def test_wrong_prefix(self):
+        assert parse_doc_idx("cand_3") is None
+
+    def test_partial_match_rejected(self):
+        assert parse_doc_idx("doc_42_extra") is None
+
+    def test_non_numeric(self):
+        assert parse_doc_idx("doc_abc") is None
+
+
+# ===========================================================================
+# preview_token_estimate
+# ===========================================================================
+
+class TestPreviewTokenEstimate:
+    def test_empty(self):
+        assert preview_token_estimate([]) == 0
+
+    def test_single_word(self):
+        assert preview_token_estimate(["hello"]) == 1
+
+    def test_proportional(self):
+        previews = ["a b c d e"] * 2  # 10 words -> round(13) = 13
+        assert preview_token_estimate(previews) == 13
+
+    def test_none_safe(self):
+        assert preview_token_estimate([None, None]) == 0  # type: ignore[list-item]
+
+
+# ===========================================================================
+# Full pipeline: run() over an inline fixture
+# ===========================================================================
+
+# Inline fixture: 10 docs, 4 queries (2 humaneval, 2 mbpp).
+_CORPUS = [
+    {"doc_id": "humaneval:0", "text": "def has_close_elements(numbers, threshold):\n    for i, a in enumerate(numbers):\n        for j, b in enumerate(numbers):\n            if i != j and abs(a-b) < threshold:\n                return True\n    return False\n"},  # noqa: E501
+    {"doc_id": "humaneval:1", "text": "def separate_paren_groups(paren_string):\n    result = []\n    current = []\n    depth = 0\n    for c in paren_string:\n        if c == '(': depth += 1; current.append(c)\n        elif c == ')': depth -= 1; current.append(c)\n        if depth == 0 and current: result.append(''.join(current)); current = []\n    return result\n"},  # noqa: E501
+    {"doc_id": "humaneval:2", "text": "def truncate_number(number):\n    return number % 1.0\n"},
+    {"doc_id": "mbpp:1", "text": "def sum_list(lst):\n    return sum(lst)\n"},
+    {"doc_id": "mbpp:2", "text": "def find_max(lst):\n    return max(lst)\n"},
+    {"doc_id": "mbpp:3", "text": "def reverse_string(s):\n    return s[::-1]\n"},
+    {"doc_id": "mbpp:4", "text": "def count_vowels(s):\n    return sum(1 for c in s if c in 'aeiou')\n"},
+    {"doc_id": "mbpp:5", "text": "def is_palindrome(s):\n    return s == s[::-1]\n"},
+    {"doc_id": "mbpp:6", "text": "def flatten(lst):\n    return [x for sub in lst for x in sub]\n"},
+    {"doc_id": "mbpp:7", "text": "def factorial(n):\n    return 1 if n <= 1 else n * factorial(n-1)\n"},
+]
+_DOC_INDEX = {c["doc_id"]: i for i, c in enumerate(_CORPUS)}
+
+_QUERIES = [
+    {
+        "ds": "humaneval",
+        "query": "def has_close_elements(numbers, threshold):\n    \"\"\"Check if any two numbers are closer than threshold.\"\"\"\n",
+        "gold": "humaneval:0",
+    },
+    {
+        "ds": "humaneval",
+        "query": "def separate_paren_groups(paren_string):\n    \"\"\"Input: string of nested parentheses groups.\"\"\"\n",
+        "gold": "humaneval:1",
+    },
+    {
+        "ds": "mbpp",
+        "query": "Write a function to find the factorial of a number.",
+        "gold": "mbpp:7",
+    },
+    {
+        "ds": "mbpp",
+        "query": "Write a function to check if a string is a palindrome.",
+        "gold": "mbpp:5",
+    },
+]
+
+
+class TestRunPipeline:
+    def test_run_returns_summary_and_rows(self):
+        summary, rows = run(_CORPUS, _DOC_INDEX, _QUERIES, limit=0)
+        assert "humaneval" in summary
+        assert "mbpp" in summary
+        assert len(rows) == len(_QUERIES)
+
+    def test_ndcg_in_0_to_1(self):
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds, s in summary.items():
+            assert 0.0 <= s["bm25_ndcg@10"] <= 1.0, f"{ds}: ndcg out of range"
+            assert 0.0 <= s["rand_ndcg@10"] <= 1.0, f"{ds}: rand ndcg out of range"
+
+    def test_recall_in_0_to_1(self):
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds, s in summary.items():
+            for k in KS:
+                assert 0.0 <= s[f"bm25_recall@{k}"] <= 1.0
+                assert 0.0 <= s[f"rand_recall@{k}"] <= 1.0
+
+    def test_precision_in_0_to_1(self):
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds, s in summary.items():
+            for k in KS:
+                assert 0.0 <= s[f"bm25_precision@{k}"] <= 1.0
+
+    def test_recall_monotonic(self):
+        """recall@1 <= recall@5 <= recall@10 for BM25 arm."""
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds, s in summary.items():
+            r1 = s["bm25_recall@1"]
+            r5 = s["bm25_recall@5"]
+            r10 = s["bm25_recall@10"]
+            assert r1 <= r5 <= r10, f"{ds}: recall not monotonic: {r1}, {r5}, {r10}"
+
+    def test_bm25_lexical_hit_humaneval(self):
+        """HumanEval gold docs share function names with queries -> BM25 should
+        achieve high recall@10 on this tiny fixture."""
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        # The humaneval queries contain exact function names that appear in the
+        # gold docs. BM25 should rank them in top-10 of 10 docs.
+        assert summary["humaneval"]["bm25_recall@10"] == 1.0, (
+            f"Expected BM25 recall@10=1.0 on lexically-easy humaneval fixture, "
+            f"got {summary['humaneval']['bm25_recall@10']}"
+        )
+
+    def test_efficiency_keys_present(self):
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds, s in summary.items():
+            eff = s.get("bm25_efficiency", {})
+            assert "median_injected_tokens" in eff, f"{ds}: missing median_injected_tokens"
+            assert "p90_injected_tokens" in eff, f"{ds}: missing p90_injected_tokens"
+
+    def test_corpus_size_in_summary(self):
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds, s in summary.items():
+            assert s["corpus"] == len(_CORPUS)
+
+    def test_n_per_ds_correct(self):
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        assert summary["humaneval"]["n"] == 2
+        assert summary["mbpp"]["n"] == 2
+
+    def test_limit_caps_queries(self):
+        summary, rows = run(_CORPUS, _DOC_INDEX, _QUERIES, limit=1)
+        # With limit=1, at most 1 query per dataset.
+        for ds, s in summary.items():
+            assert s["n"] <= 1
+        # Total rows capped to at most len(datasets) * 1 = 2.
+        assert len(rows) <= 2
+
+    def test_unresolvable_gold_dropped(self):
+        """Queries with gold not in doc_index should be silently dropped."""
+        bad_queries = [
+            {"ds": "humaneval", "query": "foo bar", "gold": "humaneval:999"},
+        ]
+        summary, rows = run(_CORPUS, _DOC_INDEX, bad_queries)
+        # No rows if all queries are unresolvable.
+        assert len(rows) == 0
+        assert len(summary) == 0
+
+    def test_per_query_rows_have_gold_idx(self):
+        _, rows = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for r in rows:
+            assert "gold_idx" in r, "per-query row missing gold_idx"
+
+    def test_bm25_ndcg_beats_random_on_lexical_corpus(self):
+        """BM25 should beat random on a lexically saturated corpus."""
+        summary, _ = run(_CORPUS, _DOC_INDEX, _QUERIES)
+        for ds in ("humaneval",):
+            bm_ndcg = summary[ds]["bm25_ndcg@10"]
+            rand_ndcg = summary[ds]["rand_ndcg@10"]
+            assert bm_ndcg >= rand_ndcg, (
+                f"{ds}: BM25 ndcg@10={bm_ndcg} should be >= random ndcg@10={rand_ndcg}"
+            )
+
+
+# ===========================================================================
+# score_queries() with mocked /fingerprint calls
+# ===========================================================================
+
+class TestScoreQueriesMocked:
+    """Test the Helix arm scoring path using a fake fingerprint() function."""
+
+    # A tiny query set with gold resolved.
+    _QUERIES = [
+        {"ds": "humaneval", "query": "def has_close_elements", "gold": "humaneval:0", "gold_idx": 0},
+        {"ds": "humaneval", "query": "def separate_paren_groups", "gold": "humaneval:1", "gold_idx": 1},
+        {"ds": "mbpp", "query": "factorial of a number", "gold": "mbpp:7", "gold_idx": 9},
+    ]
+
+    def _make_fps(self, ranked_idxs: list[int]):
+        """Build a fake fingerprints list (the inner list, not the full tuple)."""
+        return [
+            {"rank": r, "source": "doc_{}".format(idx), "score": 1.0 / (r + 1),
+             "preview": "def func_{} pass ".format(idx) * 5}
+            for r, idx in enumerate(ranked_idxs)
+        ]
+
+    def test_ndcg_perfect_ranking(self):
+        """If gold is always ranked #1 (pos0=0), ndcg@10 = 1.0 for all."""
+        queries = self._QUERIES
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            # Find which query this is by matching query text.
+            for q in queries:
+                if q["query"] in query:
+                    return self._make_fps(
+                        [q["gold_idx"]] + [99, 88, 77, 66, 55, 44, 33, 22, 11]
+                    ), 5.0
+            return [], 5.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, rows = score_queries(
+                queries=queries,
+                helix_url="http://mock",
+                max_results=10,
+            )
+
+        for ds, s in summary.items():
+            assert math.isclose(s["helix_ndcg@10"], 1.0, abs_tol=1e-6), (
+                f"{ds}: expected perfect ndcg@10, got {s['helix_ndcg@10']}"
+            )
+
+    def test_ndcg_zero_when_gold_not_retrieved(self):
+        """If gold never appears in fingerprints, ndcg@10 = 0.0."""
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            # Return docs with indices that never include the gold.
+            return self._make_fps([99, 88, 77, 66, 55]), 5.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, rows = score_queries(
+                queries=self._QUERIES[:1],  # just humaneval:0 (gold_idx=0)
+                helix_url="http://mock",
+                max_results=10,
+                n_corpus=100,
+            )
+
+        assert summary["humaneval"]["helix_ndcg@10"] == 0.0
+
+    def test_recall_at_1_correct(self):
+        """Gold ranked first -> recall@1 = 1.0."""
+        q = [self._QUERIES[0]]  # humaneval:0, gold_idx=0
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            return self._make_fps([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 5.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, _ = score_queries(q, helix_url="http://mock", max_results=10)
+
+        assert summary["humaneval"]["helix_recall@1"] == 1.0
+
+    def test_recall_at_5_but_not_1(self):
+        """Gold ranked 3rd -> recall@1=0, recall@5=1."""
+        q = [self._QUERIES[0]]  # gold_idx=0
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            # Gold (idx=0) is ranked 3rd (pos=2).
+            return self._make_fps([1, 2, 0, 3, 4, 5, 6, 7, 8, 9]), 5.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, _ = score_queries(q, helix_url="http://mock", max_results=10)
+
+        assert summary["humaneval"]["helix_recall@1"] == 0.0
+        assert summary["humaneval"]["helix_recall@5"] == 1.0
+
+    def test_precision_at_k_formula(self):
+        """Gold ranked first -> precision@k = 1/k."""
+        q = [self._QUERIES[0]]  # gold_idx=0
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            return self._make_fps([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 5.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, _ = score_queries(q, helix_url="http://mock", max_results=10)
+
+        s = summary["humaneval"]
+        assert math.isclose(s["helix_precision@1"], 1.0)
+        assert math.isclose(s["helix_precision@5"], 0.2, abs_tol=1e-6)
+        assert math.isclose(s["helix_precision@10"], 0.1, abs_tol=1e-6)
+
+    def test_efficiency_keys_present(self):
+        q = [self._QUERIES[0]]
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            return self._make_fps([0, 1, 2]), 12.5
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, _ = score_queries(q, helix_url="http://mock", max_results=10)
+
+        eff = summary["humaneval"]["efficiency"]
+        assert "median_injected_tokens" in eff
+        assert "p90_injected_tokens" in eff
+        assert "median_latency_ms" in eff
+        assert "p90_latency_ms" in eff
+
+    def test_latency_recorded(self):
+        q = [self._QUERIES[0]]
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            return self._make_fps([0, 1, 2]), 42.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, rows = score_queries(q, helix_url="http://mock", max_results=10)
+
+        assert rows[0]["latency_ms"] == 42.0
+        assert summary["humaneval"]["efficiency"]["median_latency_ms"] == 42.0
+
+    def test_network_error_counted_as_err(self):
+        """A network failure should increment err, not crash the loop."""
+        import urllib.error
+        q = [self._QUERIES[0]]
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            raise urllib.error.URLError("connection refused")
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, rows = score_queries(
+                q, helix_url="http://mock", max_results=10, n_corpus=100
+            )
+
+        # Summary may be empty (n=0) since no successful queries.
+        assert len(rows) == 1
+        assert "error" in rows[0]
+
+    def test_multi_ds_aggregated_separately(self):
+        """Queries from different datasets must be aggregated independently."""
+        queries = [
+            self._QUERIES[0],  # humaneval
+            self._QUERIES[2],  # mbpp
+        ]
+
+        def fake_fingerprint(url, query, max_results, timeout_s):
+            for q in queries:
+                if q["query"] in query:
+                    return self._make_fps([q["gold_idx"]] + list(range(99, 89, -1))), 5.0
+            return [], 5.0
+
+        with patch("coderag_bench_helix.fingerprint", side_effect=fake_fingerprint):
+            summary, _ = score_queries(queries, helix_url="http://mock", max_results=10)
+
+        assert "humaneval" in summary
+        assert "mbpp" in summary
+        assert summary["humaneval"]["n"] == 1
+        assert summary["mbpp"]["n"] == 1

--- a/tests/test_diag_blob_vs_shard.py
+++ b/tests/test_diag_blob_vs_shard.py
@@ -1,0 +1,855 @@
+"""
+tests/test_diag_blob_vs_shard.py
+
+Unit tests for benchmarks/diag_blob_vs_shard_tiers.py.
+
+Run with:
+    python -m pytest tests/test_diag_blob_vs_shard.py -q --noconftest
+
+All tests use mocked /fingerprint JSON responses matching the wire schema
+from routes_context.py L800-826.  No server, no network, no GPU.
+
+Wire schema reference:
+  fingerprints[*].tier_contributions  (routes_context.py L817-819)
+  -- dict {tier_name: float}, built from _merge_tier_contributions(
+         helix.genome.last_tier_contributions, refiner_contrib)
+     rounded to 4dp, sorted by key.
+  fingerprints[*].rank   -- 0-based (converted to 1-based by diagnostic)
+  fingerprints[*].source -- source_id used for gold matching
+  fingerprints[*].score  -- final score (base + tcm_bonus)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make benchmarks/ importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent / "benchmarks"))
+
+import diag_blob_vs_shard_tiers as _mod
+from diag_blob_vs_shard_tiers import (
+    _analyse_needle,
+    _find_gold,
+    _gold_hit,
+    _aggregate,
+    _norm,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# Wire-schema fixture builders
+# ---------------------------------------------------------------------------
+
+def _fp_response(fingerprints: List[Dict[str, Any]]) -> bytes:
+    """Build a minimal /fingerprint response body matching routes_context.py."""
+    body = {
+        "mode": "fingerprint",
+        "profile": "fast",
+        "query": "test query",
+        "fingerprints": fingerprints,
+        "count": len(fingerprints),
+        "max_results": 200,
+        "score_floor": 0.0,
+        "evaluated_total": len(fingerprints),
+        "above_floor_total": len(fingerprints),
+        "returned": len(fingerprints),
+        "filtered_by_floor": 0,
+        "truncated_by_cap": 0,
+        "response_hint": "No filtering or truncation applied.",
+        "agent": {
+            "recommendation": "triage",
+            "hint": "Use tier fingerprints to decide which genes to fetch in full.",
+            "latency_ms": 18.4,
+            "cold_tier_used": False,
+            "cold_tier_count": 0,
+            "tier_totals": {},
+        },
+    }
+    return json.dumps(body).encode("utf-8")
+
+
+def _make_fp(
+    *,
+    rank: int,
+    source: str,
+    score: float,
+    tiers: Dict[str, float],
+    gene_id: str = "g0",
+) -> Dict[str, Any]:
+    """Build a single fingerprint item matching routes_context.py L800-826."""
+    return {
+        "rank":   rank,           # 0-based (routes_context.py L801)
+        "gene_id": gene_id,
+        "score":  round(score, 4),
+        "preview": "snippet...",
+        "path":   f"/some/path/{gene_id}.py",
+        "source": source,         # source_id (routes_context.py L813)
+        "domains": [],
+        "entities": [],
+        "chromatin": 0,
+        "tier_contributions": {   # routes_context.py L817-819
+            k: round(float(v), 4) for k, v in sorted(tiers.items())
+        },
+    }
+
+
+def _needle(
+    *,
+    nid: str = "n001",
+    question: str = "What does the splice step do?",
+    gold_paths: Optional[List[str]] = None,
+    ntype: str = "within",
+) -> Dict[str, Any]:
+    return {
+        "id": nid,
+        "question": question,
+        "gold_paths": gold_paths or ["helix_context/pipeline/stages.py"],
+        "type": ntype,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mock urllib transport
+# ---------------------------------------------------------------------------
+
+class _MockResponse:
+    """Minimal file-like object returned by urlopen mock."""
+    def __init__(self, data: bytes):
+        self._io = BytesIO(data)
+
+    def read(self) -> bytes:
+        return self._io.read()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class _TwoServerTransport:
+    """Mock urlopen that serves different fingerprint bodies for blob vs sharded URL."""
+
+    def __init__(
+        self,
+        blob_fps:   List[Dict[str, Any]],
+        shard_fps:  List[Dict[str, Any]],
+        blob_url:   str = "http://blob:11437",
+        shard_url:  str = "http://shard:11438",
+    ):
+        self._blob_body  = _fp_response(blob_fps)
+        self._shard_body = _fp_response(shard_fps)
+        self._blob_url   = blob_url.rstrip("/")
+        self._shard_url  = shard_url.rstrip("/")
+
+    def __call__(self, req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if self._blob_url in url:
+            return _MockResponse(self._blob_body)
+        return _MockResponse(self._shard_body)
+
+
+# ---------------------------------------------------------------------------
+# _norm / _gold_hit tests
+# ---------------------------------------------------------------------------
+
+class TestNormAndGoldHit:
+
+    def test_norm_backslash(self):
+        assert _norm("foo\\bar\\baz.py") == "foo/bar/baz.py"
+
+    def test_norm_lowercase(self):
+        assert _norm("Helix_Context/Pipeline/STAGES.PY") == \
+               "helix_context/pipeline/stages.py"
+
+    def test_gold_hit_substring_forward(self):
+        """gold path is substring of source."""
+        assert _gold_hit(
+            "F:/Projects/helix_context/pipeline/stages.py",
+            ["helix_context/pipeline/stages.py"],
+        ) is True
+
+    def test_gold_hit_substring_reverse(self):
+        """source is substring of gold path (reverse direction)."""
+        assert _gold_hit(
+            "pipeline/stages.py",
+            ["helix_context/pipeline/stages.py"],
+        ) is True
+
+    def test_gold_hit_no_match(self):
+        assert _gold_hit(
+            "helix_context/pipeline/other.py",
+            ["helix_context/pipeline/stages.py"],
+        ) is False
+
+    def test_gold_hit_empty_source(self):
+        assert _gold_hit("", ["helix_context/pipeline/stages.py"]) is False
+
+    def test_gold_hit_multiple_golds(self):
+        """Matches the second gold_path in the list."""
+        assert _gold_hit(
+            "F:/Projects/helix_context/identity/provenance.py",
+            [
+                "helix_context/pipeline/stages.py",
+                "helix_context/identity/provenance.py",
+            ],
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# _find_gold tests
+# ---------------------------------------------------------------------------
+
+class TestFindGold:
+
+    def test_gold_found_at_rank0(self):
+        fps = [
+            _make_fp(rank=0, source="F:/helix_context/pipeline/stages.py",
+                     score=9.5, tiers={"fts5": 6.0, "dense": 0.9}),
+            _make_fp(rank=1, source="F:/helix_context/other.py",
+                     score=5.0, tiers={"fts5": 3.0}, gene_id="g1"),
+        ]
+        result = _find_gold(fps, ["helix_context/pipeline/stages.py"])
+        assert result["in_pool"] is True
+        assert result["rank"] == 1          # 0-based 0 -> 1-based 1
+        assert result["score"] == pytest.approx(9.5)
+        assert result["tiers"]["fts5"] == pytest.approx(6.0)
+        assert result["tiers"]["dense"] == pytest.approx(0.9)
+
+    def test_gold_found_at_deep_rank(self):
+        fps = [
+            _make_fp(rank=0, source="other_a.py", score=9.0,
+                     tiers={"fts5": 6.0}, gene_id="g0"),
+            _make_fp(rank=1, source="other_b.py", score=8.0,
+                     tiers={"fts5": 5.0}, gene_id="g1"),
+            _make_fp(rank=2, source="F:/helix_context/pipeline/stages.py",
+                     score=4.0, tiers={"fts5": 2.0, "co_activation": 0.3},
+                     gene_id="g2"),
+        ]
+        result = _find_gold(fps, ["helix_context/pipeline/stages.py"])
+        assert result["in_pool"] is True
+        assert result["rank"] == 3          # 0-based 2 -> 1-based 3
+        assert result["tiers"]["co_activation"] == pytest.approx(0.3)
+
+    def test_gold_not_in_pool(self):
+        fps = [
+            _make_fp(rank=0, source="other_a.py", score=9.0,
+                     tiers={"fts5": 6.0}),
+        ]
+        result = _find_gold(fps, ["helix_context/pipeline/stages.py"])
+        assert result["in_pool"] is False
+        assert result["rank"] is None
+        assert result["score"] is None
+        assert result["tiers"] == {}
+
+    def test_empty_pool(self):
+        result = _find_gold([], ["helix_context/pipeline/stages.py"])
+        assert result["in_pool"] is False
+
+    def test_tiers_empty_dict_when_missing(self):
+        """If tier_contributions key is absent, tiers defaults to {}."""
+        fps = [{"rank": 0, "source": "helix_context/pipeline/stages.py",
+                "score": 5.0}]  # no tier_contributions key
+        result = _find_gold(fps, ["helix_context/pipeline/stages.py"])
+        assert result["in_pool"] is True
+        assert result["tiers"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _analyse_needle tests
+# ---------------------------------------------------------------------------
+
+class TestAnalyseNeedle:
+
+    def test_both_in_pool(self):
+        nd = _needle(gold_paths=["helix_context/pipeline/stages.py"])
+        blob_fps = [
+            _make_fp(rank=0, source="F:/helix_context/pipeline/stages.py",
+                     score=9.0, tiers={"fts5": 6.0, "dense": 0.8}),
+        ]
+        shard_fps = [
+            _make_fp(rank=0, source="other.py", score=10.0,
+                     tiers={"fts5": 7.0}, gene_id="g1"),
+            _make_fp(rank=1, source="F:/helix_context/pipeline/stages.py",
+                     score=6.0, tiers={"fts5": 4.0}, gene_id="g2"),
+        ]
+        row = _analyse_needle(nd, blob_fps, shard_fps)
+        assert row["blob"]["in_pool"] is True
+        assert row["blob"]["rank"] == 1
+        assert row["sharded"]["in_pool"] is True
+        assert row["sharded"]["rank"] == 2
+
+    def test_gold_in_blob_not_in_shard(self):
+        """Core case: gold surfaces in blob (dense) but absent in sharded pool."""
+        nd = _needle(gold_paths=["helix_context/pipeline/stages.py"])
+        blob_fps = [
+            _make_fp(rank=0, source="F:/helix_context/pipeline/stages.py",
+                     score=8.5, tiers={"fts5": 4.0, "dense": 0.85}),
+        ]
+        shard_fps = [
+            _make_fp(rank=0, source="other_file.py", score=7.0,
+                     tiers={"fts5": 5.0}, gene_id="g1"),
+        ]
+        row = _analyse_needle(nd, blob_fps, shard_fps)
+        assert row["blob"]["in_pool"] is True
+        assert row["blob"]["rank"] == 1
+        assert row["blob"]["tiers"]["dense"] == pytest.approx(0.85)
+        assert row["sharded"]["in_pool"] is False
+        assert row["sharded"]["rank"] is None
+
+    def test_question_truncated(self):
+        long_q = "x" * 300
+        nd = _needle(question=long_q)
+        row = _analyse_needle(nd, [], [])
+        assert len(row["question"]) <= 200
+
+
+# ---------------------------------------------------------------------------
+# _aggregate tests -- the core classification logic
+# ---------------------------------------------------------------------------
+
+class TestAggregate:
+
+    def _make_row(
+        self,
+        *,
+        nid: str,
+        blob_rank: Optional[int],
+        shard_rank: Optional[int],
+        blob_tiers: Optional[Dict[str, float]] = None,
+        shard_tiers: Optional[Dict[str, float]] = None,
+        shard_in_pool: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Build a per-needle result row directly (bypasses HTTP)."""
+        blob_in  = blob_rank is not None
+        shard_in = shard_rank is not None if shard_in_pool is None else shard_in_pool
+        return {
+            "id":   nid,
+            "type": "within",
+            "question": "test",
+            "gold_paths": ["some/gold.py"],
+            "blob": {
+                "in_pool": blob_in,
+                "rank":    blob_rank,
+                "score":   float(blob_rank or 0) * 0.1,
+                "tiers":   blob_tiers or {},
+            },
+            "sharded": {
+                "in_pool": shard_in,
+                "rank":    shard_rank,
+                "score":   float(shard_rank or 0) * 0.1 if shard_in else None,
+                "tiers":   shard_tiers or {},
+            },
+        }
+
+    # --- Scenario A: candidate-gen loss (gold absent in shard pool entirely) ---
+    def test_candidate_gen_loss_classification(self):
+        """blob rank=1, shard NOT in pool -> candidate_gen_loss."""
+        rows = [
+            self._make_row(
+                nid="n1",
+                blob_rank=1,
+                shard_rank=None,
+                blob_tiers={"dense": 0.85, "fts5": 4.0},
+                shard_in_pool=False,
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["divergent_count"] == 1
+        assert agg["candidate_gen_loss"] == 1
+        assert agg["ranking_loss"] == 0
+
+    # --- Scenario B: ranking loss (gold in shard pool but deep) ---
+    def test_ranking_loss_classification(self):
+        """blob rank=2, shard rank=50 (deep) -> ranking_loss."""
+        rows = [
+            self._make_row(
+                nid="n2",
+                blob_rank=2,
+                shard_rank=50,
+                blob_tiers={"co_activation": 1.2, "fts5": 5.0},
+                shard_tiers={"fts5": 5.0},  # co_activation absent
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["divergent_count"] == 1
+        assert agg["ranking_loss"] == 1
+        assert agg["candidate_gen_loss"] == 0
+
+    # --- Scenario C: non-divergent (both good) ---
+    def test_non_divergent_not_counted(self):
+        """blob rank=3, shard rank=5 -> both good, not divergent."""
+        rows = [
+            self._make_row(nid="n3", blob_rank=3, shard_rank=5,
+                           blob_tiers={"fts5": 6.0},
+                           shard_tiers={"fts5": 5.5}),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["divergent_count"] == 0
+        assert agg["candidate_gen_loss"] == 0
+        assert agg["ranking_loss"] == 0
+
+    # --- Scenario D: blob not good (blob rank > cap) ---
+    def test_blob_bad_not_counted_as_divergent(self):
+        """blob rank=15 (> cap=10) -> not blob-good, not divergent."""
+        rows = [
+            self._make_row(nid="n4", blob_rank=15, shard_rank=None,
+                           shard_in_pool=False),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["divergent_count"] == 0
+
+    # --- Core assertion: tier delta names the differing tier ---
+    def test_tier_delta_identifies_dense_as_differentiator(self):
+        """
+        Ranking-loss case: blob has dense=0.8, shard has dense=0.0.
+        Aggregate must put 'dense' first in tier_ranking_summary and
+        tier_overall_delta_rank.
+        """
+        rows = [
+            self._make_row(
+                nid="n5",
+                blob_rank=1,
+                shard_rank=40,     # deep -> ranking_loss
+                blob_tiers={"fts5": 5.0, "dense": 0.8},
+                shard_tiers={"fts5": 5.0, "dense": 0.0},
+            ),
+            self._make_row(
+                nid="n6",
+                blob_rank=3,
+                shard_rank=55,
+                blob_tiers={"fts5": 4.5, "dense": 0.7},
+                shard_tiers={"fts5": 4.5, "dense": 0.0},
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["ranking_loss"] == 2
+
+        summary = agg["tier_ranking_summary"]
+        # dense must appear and have positive delta
+        dense_entry = next((t for t in summary if t["tier"] == "dense"), None)
+        assert dense_entry is not None, "dense missing from tier_ranking_summary"
+        assert dense_entry["delta"] > 0.0
+
+        # dense should rank first (highest delta) since fts5 is equal
+        assert summary[0]["tier"] == "dense"
+        assert agg["tier_overall_delta_rank"][0] == "dense"
+
+    def test_tier_delta_identifies_co_activation(self):
+        """
+        Ranking-loss case: blob has co_activation=1.2, shard has
+        co_activation=0.0.  co_activation must top the delta rank.
+        """
+        rows = [
+            self._make_row(
+                nid="n7",
+                blob_rank=4,
+                shard_rank=80,
+                blob_tiers={"fts5": 5.0, "co_activation": 1.2},
+                shard_tiers={"fts5": 5.0},
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        summary = agg["tier_ranking_summary"]
+        assert summary[0]["tier"] == "co_activation"
+        assert summary[0]["blob_median"] == pytest.approx(1.2)
+        assert summary[0]["shard_median"] == pytest.approx(0.0)
+        assert summary[0]["delta"] == pytest.approx(1.2)
+
+    def test_cand_gen_loss_blob_tiers_reported(self):
+        """
+        Candidate-gen-loss case: blob surfaced gold via dense.
+        tier_cand_gen_summary must list dense as top tier.
+        """
+        rows = [
+            self._make_row(
+                nid="n8",
+                blob_rank=2,
+                shard_rank=None,
+                blob_tiers={"dense": 4.5, "fts5": 3.0},
+                shard_in_pool=False,
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["candidate_gen_loss"] == 1
+        cg = agg["tier_cand_gen_summary"]
+        assert cg[0]["tier"] == "dense"
+        assert cg[0]["blob_median"] == pytest.approx(4.5)
+
+    # --- Mixed scenario: one cand-gen-loss + one ranking-loss ---
+    def test_mixed_two_needles(self):
+        """
+        needle A: blob rank=1, shard NOT in pool -> candidate_gen_loss
+                  blob surfaced via dense
+        needle B: blob rank=5, shard rank=35   -> ranking_loss
+                  blob has co_activation=1.0, shard has co_activation=0.0
+        """
+        rows = [
+            self._make_row(
+                nid="A",
+                blob_rank=1,
+                shard_rank=None,
+                blob_tiers={"dense": 0.85, "fts5": 4.0},
+                shard_in_pool=False,
+            ),
+            self._make_row(
+                nid="B",
+                blob_rank=5,
+                shard_rank=35,
+                blob_tiers={"fts5": 5.0, "co_activation": 1.0},
+                shard_tiers={"fts5": 5.0},
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+
+        assert agg["divergent_count"] == 2
+        assert agg["candidate_gen_loss"] == 1
+        assert agg["ranking_loss"] == 1
+
+        # Cand-gen-loss: dense is reported in blob tiers
+        cg = agg["tier_cand_gen_summary"]
+        assert any(t["tier"] == "dense" for t in cg)
+
+        # Ranking-loss: co_activation shows positive delta
+        rl = agg["tier_ranking_summary"]
+        co_entry = next((t for t in rl if t["tier"] == "co_activation"), None)
+        assert co_entry is not None
+        assert co_entry["delta"] > 0.0
+
+    def test_pool_counts(self):
+        rows = [
+            self._make_row(nid="p1", blob_rank=1, shard_rank=5),
+            self._make_row(nid="p2", blob_rank=2, shard_rank=None,
+                           shard_in_pool=False),
+            self._make_row(nid="p3", blob_rank=None, shard_rank=3,
+                           blob_tiers={}),
+        ]
+        # Fix blob in_pool for row p3: blob_rank=None means not in pool
+        rows[2]["blob"]["in_pool"] = False
+        rows[2]["blob"]["rank"]    = None
+
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["blob_pool_total"]  == 2   # p1 + p2 in blob pool
+        assert agg["shard_pool_total"] == 2   # p1 + p3 in shard pool
+        assert agg["total_needles"]    == 3
+
+    def test_empty_needles(self):
+        agg = _aggregate([], blob_rank_cap=10, shard_bury_cap=10)
+        assert agg["total_needles"]      == 0
+        assert agg["divergent_count"]    == 0
+        assert agg["candidate_gen_loss"] == 0
+        assert agg["ranking_loss"]       == 0
+        assert agg["tier_ranking_summary"]  == []
+        assert agg["tier_cand_gen_summary"] == []
+
+    def test_tier_ranking_summary_sorted_desc(self):
+        """tier_ranking_summary items must be sorted by delta descending."""
+        rows = [
+            self._make_row(
+                nid="s1",
+                blob_rank=1,
+                shard_rank=20,
+                blob_tiers={"fts5": 5.0, "co_activation": 1.5, "dense": 0.3},
+                shard_tiers={"fts5": 4.0},
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        deltas = [t["delta"] for t in agg["tier_ranking_summary"]]
+        assert deltas == sorted(deltas, reverse=True)
+
+    def test_zero_delta_tiers_excluded_from_ranking_summary(self):
+        """Tiers with delta <= 0 must not appear in tier_ranking_summary."""
+        rows = [
+            self._make_row(
+                nid="z1",
+                blob_rank=1,
+                shard_rank=30,
+                blob_tiers={"fts5": 5.0, "dense": 0.0},   # dense equal in both
+                shard_tiers={"fts5": 5.0, "dense": 0.0},
+            ),
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        for entry in agg["tier_ranking_summary"]:
+            assert entry["delta"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: run() with mocked urllib
+# ---------------------------------------------------------------------------
+
+class TestRunMocked:
+
+    def _urlopen_factory(
+        self,
+        blob_fps: List[Dict[str, Any]],
+        shard_fps: List[Dict[str, Any]],
+        blob_url: str = "http://blob:11437",
+        shard_url: str = "http://shard:11438",
+    ):
+        transport = _TwoServerTransport(
+            blob_fps, shard_fps, blob_url=blob_url, shard_url=shard_url,
+        )
+
+        def _urlopen(req, timeout=None):
+            return transport(req, timeout=timeout)
+
+        return _urlopen
+
+    def test_cand_gen_loss_via_dense(self):
+        """
+        Gold present in blob (via dense tier) but absent in sharded pool.
+        run() must classify as candidate_gen_loss and name 'dense' as the
+        differentiating tier in tier_cand_gen_summary.
+        """
+        gold_source = "F:/Projects/helix_context/pipeline/stages.py"
+        gold_path   = "helix_context/pipeline/stages.py"
+
+        blob_fps = [
+            _make_fp(rank=0, source=gold_source, score=8.5,
+                     tiers={"fts5": 4.0, "dense": 0.85}),
+        ]
+        shard_fps = [
+            _make_fp(rank=0, source="other/file.py", score=7.0,
+                     tiers={"fts5": 5.0}, gene_id="g1"),
+        ]
+
+        needles = [_needle(gold_paths=[gold_path])]
+        urlopen = self._urlopen_factory(blob_fps, shard_fps)
+
+        with patch.object(urllib.request, "urlopen", urlopen):
+            per_needle, agg = run(
+                needles=needles,
+                blob_url="http://blob:11437",
+                sharded_url="http://shard:11438",
+            )
+
+        assert len(per_needle) == 1
+        row = per_needle[0]
+        assert row["blob"]["in_pool"] is True
+        assert row["blob"]["rank"] == 1
+        assert row["sharded"]["in_pool"] is False
+
+        assert agg["candidate_gen_loss"] == 1
+        assert agg["ranking_loss"] == 0
+        assert agg["divergent_count"] == 1
+
+        cg = agg["tier_cand_gen_summary"]
+        assert any(t["tier"] == "dense" for t in cg), \
+            "dense missing from tier_cand_gen_summary"
+        # tier_cand_gen_summary sorts by blob_median desc; dense (0.85) < fts5 (4.0)
+        # so we assert presence + value, not position -- classification is the key claim
+        dense_entry = next(t for t in cg if t["tier"] == "dense")
+        assert dense_entry["blob_median"] == pytest.approx(0.85)
+
+    def test_ranking_loss_via_co_activation(self):
+        """
+        Gold is in sharded pool but deep (rank 25).  Blob has co_activation;
+        sharded has none.  run() must classify as ranking_loss and name
+        'co_activation' as the differentiating tier.
+        """
+        gold_source = "F:/Projects/helix_context/identity/provenance.py"
+        gold_path   = "helix_context/identity/provenance.py"
+
+        blob_fps = [
+            _make_fp(rank=0, source=gold_source, score=9.0,
+                     tiers={"fts5": 5.0, "co_activation": 1.3}),
+        ]
+        # sharded: gold appears at rank 24 (0-based) with no co_activation
+        decoys = [
+            _make_fp(rank=i, source=f"decoy_{i}.py", score=8.0 - i * 0.1,
+                     tiers={"fts5": 5.0}, gene_id=f"decoy_{i}")
+            for i in range(24)
+        ]
+        shard_gold_fp = _make_fp(
+            rank=24, source=gold_source, score=2.0,
+            tiers={"fts5": 5.0},  # same as blob fts5 -> zero delta; only co_activation differs
+            gene_id="gold_shard",
+        )
+        shard_fps = decoys + [shard_gold_fp]
+
+        needles = [_needle(gold_paths=[gold_path])]
+        urlopen = self._urlopen_factory(blob_fps, shard_fps)
+
+        with patch.object(urllib.request, "urlopen", urlopen):
+            per_needle, agg = run(
+                needles=needles,
+                blob_url="http://blob:11437",
+                sharded_url="http://shard:11438",
+                shard_bury_cap=10,
+            )
+
+        row = per_needle[0]
+        assert row["blob"]["rank"]    == 1
+        assert row["sharded"]["rank"] == 25    # 0-based 24 -> 1-based 25
+
+        assert agg["ranking_loss"]       == 1
+        assert agg["candidate_gen_loss"] == 0
+
+        rl = agg["tier_ranking_summary"]
+        assert len(rl) > 0, "tier_ranking_summary is empty"
+        co_entry = next((t for t in rl if t["tier"] == "co_activation"), None)
+        assert co_entry is not None, "co_activation missing from tier_ranking_summary"
+        assert co_entry["delta"] == pytest.approx(1.3)
+        assert rl[0]["tier"] == "co_activation", \
+            f"expected co_activation as top ranking-loss tier, got {rl[0]['tier']}"
+
+    def test_multiple_needles_mixed(self):
+        """Two needles: one cand-gen-loss (dense), one ranking-loss (dense).
+        Both are correctly classified and dense tops both tier summaries."""
+        gold_a = "helix_context/pipeline/stages.py"
+        gold_b = "helix_context/identity/provenance.py"
+
+        src_a = f"F:/Projects/{gold_a}"
+        src_b = f"F:/Projects/{gold_b}"
+
+        # Needle A: blob has gold at rank 0 via dense; shard missing gold
+        blob_fps_a  = [_make_fp(rank=0, source=src_a, score=8.0,
+                                tiers={"fts5": 4.0, "dense": 0.9})]
+        shard_fps_a = [_make_fp(rank=0, source="other.py", score=7.0,
+                                tiers={"fts5": 5.0}, gene_id="g1")]
+
+        # Needle B: blob at rank 0 via dense; shard at rank 15 (buried) no dense
+        blob_fps_b  = [_make_fp(rank=0, source=src_b, score=9.0,
+                                tiers={"fts5": 5.0, "dense": 0.75})]
+        decoys_b    = [_make_fp(rank=i, source=f"d_{i}.py", score=7.0 - i * 0.1,
+                                tiers={"fts5": 4.5}, gene_id=f"d{i}")
+                       for i in range(14)]
+        shard_gold_b = _make_fp(rank=14, source=src_b, score=2.0,
+                                tiers={"fts5": 2.0}, gene_id="gb")
+        shard_fps_b  = decoys_b + [shard_gold_b]
+
+        call_count = [0]
+        def _urlopen(req, timeout=None):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            i = call_count[0]
+            call_count[0] += 1
+            # Calls: 0=blob/A, 1=shard/A, 2=blob/B, 3=shard/B
+            if i == 0:
+                return _MockResponse(_fp_response(blob_fps_a))
+            elif i == 1:
+                return _MockResponse(_fp_response(shard_fps_a))
+            elif i == 2:
+                return _MockResponse(_fp_response(blob_fps_b))
+            else:
+                return _MockResponse(_fp_response(shard_fps_b))
+
+        needles = [
+            _needle(nid="A", gold_paths=[gold_a]),
+            _needle(nid="B", gold_paths=[gold_b]),
+        ]
+        with patch.object(urllib.request, "urlopen", _urlopen):
+            per_needle, agg = run(
+                needles=needles,
+                blob_url="http://blob:11437",
+                sharded_url="http://shard:11438",
+                shard_bury_cap=10,
+            )
+
+        assert agg["divergent_count"] == 2
+
+        # A is cand-gen-loss; B is ranking-loss
+        assert agg["candidate_gen_loss"] == 1
+        assert agg["ranking_loss"]       == 1
+
+        # dense must appear in cand-gen-loss summary
+        cg_tiers = {t["tier"] for t in agg["tier_cand_gen_summary"]}
+        assert "dense" in cg_tiers
+
+        # dense must appear in ranking-loss summary with positive delta
+        rl = agg["tier_ranking_summary"]
+        dense_rl = next((t for t in rl if t["tier"] == "dense"), None)
+        assert dense_rl is not None
+        assert dense_rl["delta"] > 0.0
+
+    def test_error_on_one_arm_does_not_crash(self):
+        """If sharded server raises, the needle is recorded with shard_error
+        and pool counts/aggregates degrade gracefully (no exception raised)."""
+        gold_source = "F:/Projects/helix_context/pipeline/stages.py"
+        blob_fps = [
+            _make_fp(rank=0, source=gold_source, score=8.0,
+                     tiers={"fts5": 5.0, "dense": 0.8}),
+        ]
+        call_count = [0]
+
+        def _urlopen(req, timeout=None):
+            i = call_count[0]
+            call_count[0] += 1
+            if i == 0:
+                return _MockResponse(_fp_response(blob_fps))
+            # second call (sharded) raises
+            raise urllib.error.URLError("connection refused")
+
+        needles = [_needle(gold_paths=["helix_context/pipeline/stages.py"])]
+        with patch.object(urllib.request, "urlopen", _urlopen):
+            per_needle, agg = run(
+                needles=needles,
+                blob_url="http://blob:11437",
+                sharded_url="http://shard:11438",
+            )
+
+        assert len(per_needle) == 1
+        row = per_needle[0]
+        assert "shard_error" in row
+        assert row["sharded"]["in_pool"] is False
+        # aggregate must complete without raising
+        assert agg["total_needles"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Output schema shape
+# ---------------------------------------------------------------------------
+
+class TestOutputSchemaShape:
+
+    def test_aggregate_keys_present(self):
+        """_aggregate always returns the full key set even on empty input."""
+        agg = _aggregate([])
+        expected_keys = {
+            "total_needles",
+            "blob_good_count",
+            "shard_bad_count",
+            "divergent_count",
+            "candidate_gen_loss",
+            "ranking_loss",
+            "blob_pool_total",
+            "shard_pool_total",
+            "tier_ranking_summary",
+            "tier_cand_gen_summary",
+            "tier_overall_delta_rank",
+        }
+        assert expected_keys.issubset(set(agg.keys())), \
+            f"missing keys: {expected_keys - set(agg.keys())}"
+
+    def test_per_needle_keys_present(self):
+        nd = _needle()
+        row = _analyse_needle(nd, [], [])
+        for key in ("id", "type", "question", "gold_paths", "blob", "sharded"):
+            assert key in row, f"missing per-needle key: {key}"
+        for arm in ("blob", "sharded"):
+            for sub in ("in_pool", "rank", "score", "tiers"):
+                assert sub in row[arm], f"missing {arm}.{sub}"
+
+    def test_tier_ranking_summary_item_keys(self):
+        rows = [
+            {
+                "id": "x", "type": "within", "question": "q",
+                "gold_paths": ["g.py"],
+                "blob":    {"in_pool": True,  "rank": 1,  "score": 9.0,
+                            "tiers": {"dense": 0.8, "fts5": 4.0}},
+                "sharded": {"in_pool": True,  "rank": 20, "score": 3.0,
+                            "tiers": {"fts5": 4.0}},
+            }
+        ]
+        agg = _aggregate(rows, blob_rank_cap=10, shard_bury_cap=10)
+        for item in agg["tier_ranking_summary"]:
+            for key in ("tier", "blob_median", "shard_median", "delta"):
+                assert key in item, f"missing tier_ranking_summary key: {key}"

--- a/tests/test_diag_shard_dense.py
+++ b/tests/test_diag_shard_dense.py
@@ -1,0 +1,550 @@
+"""
+tests/test_diag_shard_dense.py
+
+Unit tests for benchmarks/diag_shard_dense.py.
+
+Run with:
+    python -m pytest tests/test_diag_shard_dense.py -q --noconftest
+
+All tests use mocked /fingerprint + /context/packet JSON responses
+(matching the real wire schema from routes_context.py).  No server,
+no network, no GPU.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+# Make the benchmarks/ directory importable without installing
+sys.path.insert(0, str(Path(__file__).parent.parent / "benchmarks"))
+
+import diag_shard_dense as _mod
+from diag_shard_dense import (
+    DEFAULT_QUERIES,
+    _BGE_DENSE_TIER,
+    _DENSE_TIERS,
+    _extract_from_packet,
+    _extract_tiers_from_fingerprint,
+    run_diagnostic,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers: minimal wire-schema responses
+# ---------------------------------------------------------------------------
+
+def _fingerprint_response(
+    *,
+    gene_ids: list[str] | None = None,
+    tier_maps: list[dict] | None = None,
+    tier_totals: dict | None = None,
+) -> dict:
+    """Build a minimal /fingerprint response matching routes_context.py L855-882."""
+    gene_ids = gene_ids or ["gene_a", "gene_b"]
+    tier_maps = tier_maps or [{} for _ in gene_ids]
+    fingerprints = []
+    for i, (gid, tmap) in enumerate(zip(gene_ids, tier_maps)):
+        tc = {k: round(float(v), 4) for k, v in tmap.items()}
+        fingerprints.append({
+            "rank": i,
+            "gene_id": gid,
+            "score": sum(tc.values()),
+            "preview": f"preview for {gid}",
+            "path": f"/some/path/{gid}.md",
+            "source": f"source_{gid}",
+            "domains": [],
+            "entities": [],
+            "chromatin": 0,
+            "tier_contributions": tc,
+        })
+    computed_totals: dict = {}
+    for fp in fingerprints:
+        for t, v in fp["tier_contributions"].items():
+            computed_totals[t] = computed_totals.get(t, 0.0) + v
+    return {
+        "mode": "fingerprint",
+        "profile": "fast",
+        "query": "test query",
+        "fingerprints": fingerprints,
+        "count": len(fingerprints),
+        "max_results": 10,
+        "score_floor": 0.0,
+        "evaluated_total": len(fingerprints),
+        "above_floor_total": len(fingerprints),
+        "returned": len(fingerprints),
+        "filtered_by_floor": 0,
+        "truncated_by_cap": 0,
+        "response_hint": "No filtering or truncation applied.",
+        "agent": {
+            "recommendation": "triage",
+            "hint": "Use tier fingerprints.",
+            "latency_ms": 12.3,
+            "cold_tier_used": False,
+            "cold_tier_count": 0,
+            "tier_totals": {
+                k: round(v, 4)
+                for k, v in (tier_totals or computed_totals).items()
+            },
+        },
+    }
+
+
+def _packet_response(
+    *,
+    found: bool = True,
+    confidence: float = 0.82,
+    lexical_dense_agree: bool = False,
+    top_score: float = 6.0,
+    score_gap: float = 2.0,
+    source_ids: list[str] | None = None,
+) -> dict:
+    """Build a minimal /context/packet response matching routes_context.py L583-607."""
+    source_ids = source_ids or ["F:/Projects/helix-context/README.md"]
+    verified = [
+        {
+            "kind": "gene",
+            "gene_id": f"gene_{i}",
+            "title": f"doc {i}",
+            "content": "content snippet",
+            "relevance_score": 0.8,
+            "source_id": src,
+            "status": "verified",
+            "citations": [],
+        }
+        for i, src in enumerate(source_ids)
+    ]
+    payload: dict = {
+        "task_type": "explain",
+        "query": "test query",
+        "verified": verified,
+        "stale_risk": [],
+        "contradictions": [],
+        "refresh_targets": [],
+        "notes": [],
+        "response_mode": "packet",
+        "coordinate_confidence": confidence,
+        "file_coverage": 0.75,
+    }
+    if found:
+        payload["know"] = {
+            "found": True,
+            "confidence": confidence,
+            "top_score": top_score,
+            "score_gap": score_gap,
+            "lexical_dense_agree": lexical_dense_agree,
+            "gene_id_match": "gene_0",
+            "coordinate_confidence": confidence,
+            "soft_stale": False,
+        }
+    else:
+        payload["miss"] = {
+            "miss": True,
+            "reason": "sparse",
+            "top_score": top_score,
+            "ratio": 1.1,
+            "escalate_to": ["grep"],
+            "refresh_targets": [],
+            "do_not_answer_from_genome": True,
+        }
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Transport-level mock: avoids monkeypatching httpx.Client itself
+# ---------------------------------------------------------------------------
+
+class _MockTransport(httpx.BaseTransport):
+    """Minimal transport that serves pre-built JSON for /fingerprint and /context/packet."""
+
+    def __init__(self, fp_resp: dict, pkt_resp: dict):
+        self._fp = fp_resp
+        self._pkt = pkt_resp
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        data = self._fp if "/fingerprint" in url else self._pkt
+        body = json.dumps(data).encode()
+        return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+
+class _AltTransport(httpx.BaseTransport):
+    """Transport that alternates fp responses on each /fingerprint call."""
+
+    def __init__(self, fp_responses: list[dict], pkt_resp: dict):
+        self._fps = fp_responses
+        self._pkt = pkt_resp
+        self._count = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "/fingerprint" in url:
+            data = self._fps[self._count % len(self._fps)]
+            self._count += 1
+        else:
+            data = self._pkt
+        body = json.dumps(data).encode()
+        return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+
+class _ErrorTransport(httpx.BaseTransport):
+    """Returns HTTP 500 for /fingerprint, 200 for packet."""
+
+    def __init__(self, pkt_resp: dict):
+        self._pkt = pkt_resp
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        if "/fingerprint" in str(request.url):
+            return httpx.Response(500, content=b'{"error":"boom"}',
+                                  headers={"content-type": "application/json"})
+        body = json.dumps(self._pkt).encode()
+        return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+
+def _patched_run(transport: httpx.BaseTransport, helix_url: str,
+                 queries: list[dict], **kw) -> dict:
+    """Run run_diagnostic with the given transport injected via patch."""
+    _real_client = httpx.Client
+
+    def _client_with_transport(*args, **kwargs):
+        # Strip any transport kwarg callers may pass, inject ours
+        kwargs.pop("transport", None)
+        return _real_client(*args, transport=transport, **kwargs)
+
+    with patch.object(_mod.httpx, "Client", _client_with_transport):
+        return run_diagnostic(helix_url, queries, **kw)
+
+
+# ===========================================================================
+# _extract_tiers_from_fingerprint tests
+# ===========================================================================
+
+class TestExtractTiersFromFingerprint:
+
+    def test_dense_tier_present_in_one_result(self):
+        """dense_fired=True when 'dense' key has non-zero score in any result."""
+        resp = _fingerprint_response(
+            gene_ids=["g1", "g2"],
+            tier_maps=[
+                {"fts5": 6.0, "dense": 0.87},
+                {"tag_exact": 3.0},
+            ],
+        )
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert dense_fired is True
+        assert "dense" in tiers
+        assert "fts5" in tiers
+        assert "tag_exact" in tiers
+
+    def test_dense_tier_absent_returns_false(self):
+        """dense_fired=False when no result has 'dense' contribution."""
+        resp = _fingerprint_response(
+            gene_ids=["g1", "g2"],
+            tier_maps=[
+                {"fts5": 6.0, "tag_exact": 3.0},
+                {"tag_prefix": 2.5, "fts5": 4.0},
+            ],
+        )
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert dense_fired is False
+        assert "dense" not in tiers
+
+    def test_dense_zero_score_not_counted(self):
+        """A 'dense' key with score=0.0 must NOT set dense_fired=True."""
+        resp = _fingerprint_response(
+            gene_ids=["g1"],
+            tier_maps=[{"fts5": 5.0, "dense": 0.0}],
+        )
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert dense_fired is False
+        # dense should not be in tiers (zero score excluded)
+        assert "dense" not in tiers
+
+    def test_dense_via_tier_totals_only(self):
+        """dense_fired=True even if per-fingerprint tier_contributions lacks 'dense'
+        but agent.tier_totals includes it (refiner-path dense contrib)."""
+        resp = _fingerprint_response(
+            gene_ids=["g1"],
+            tier_maps=[{"fts5": 6.0}],
+            tier_totals={"fts5": 6.0, "dense": 0.42},
+        )
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert dense_fired is True
+        assert "dense" in tiers
+
+    def test_empty_fingerprints(self):
+        """Empty fingerprints list: no tiers fired, no dense."""
+        resp = _fingerprint_response(gene_ids=[], tier_maps=[])
+        resp["fingerprints"] = []
+        resp["count"] = 0
+        resp["agent"]["tier_totals"] = {}
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert tiers == []
+        assert dense_fired is False
+
+    def test_splade_and_sema_boost_do_not_set_dense_fired(self):
+        """splade and sema_boost appear in tiers list but do NOT set dense_fired.
+
+        The BGE-M3 'dense' key is the unambiguous gate; splade/sema_boost are
+        supplementary semantic signals that can exist without BGE-M3.
+        """
+        resp = _fingerprint_response(
+            gene_ids=["g1"],
+            tier_maps=[{"fts5": 4.0, "splade": 1.2, "sema_boost": 0.6}],
+        )
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert "splade" in tiers
+        assert "sema_boost" in tiers
+        # splade/sema_boost alone must NOT claim BGE-M3 dense fired
+        assert dense_fired is False
+
+    def test_all_tier_names_collected(self):
+        """All distinct non-zero tier names from all results are collected."""
+        resp = _fingerprint_response(
+            gene_ids=["g1", "g2", "g3"],
+            tier_maps=[
+                {"fts5": 6.0, "tag_exact": 3.0, "dense": 0.5},
+                {"fts5": 4.0, "harmonic": 2.0},
+                {"tag_prefix": 1.5, "cymatics": 0.3},
+            ],
+        )
+        tiers, dense_fired = _extract_tiers_from_fingerprint(resp)
+        assert set(tiers) == {"fts5", "tag_exact", "dense", "harmonic", "tag_prefix", "cymatics"}
+        assert dense_fired is True
+
+    def test_tiers_sorted_alphabetically(self):
+        """Returned tiers list is sorted."""
+        resp = _fingerprint_response(
+            gene_ids=["g1"],
+            tier_maps=[{"fts5": 6.0, "tag_exact": 3.0, "dense": 0.9, "harmonic": 2.0}],
+        )
+        tiers, _ = _extract_tiers_from_fingerprint(resp)
+        assert tiers == sorted(tiers)
+
+
+# ===========================================================================
+# _extract_from_packet tests
+# ===========================================================================
+
+class TestExtractFromPacket:
+
+    def test_know_block_extraction(self):
+        """Know block fields are correctly extracted."""
+        resp = _packet_response(
+            found=True,
+            confidence=0.91,
+            lexical_dense_agree=True,
+        )
+        info = _extract_from_packet(resp)
+        assert info["know_found"] is True
+        assert info["confidence"] == pytest.approx(0.91)
+        assert info["lexical_dense_agree"] is True
+
+    def test_miss_block_no_know(self):
+        """Miss block: know_found=False, lexical_dense_agree=None."""
+        resp = _packet_response(found=False)
+        info = _extract_from_packet(resp)
+        assert info["know_found"] is False
+        assert info["lexical_dense_agree"] is None
+
+    def test_top_sources_extracted(self):
+        """top_sources list comes from verified items."""
+        resp = _packet_response(
+            found=True,
+            source_ids=[
+                "F:/Projects/helix-context/README.md",
+                "F:/Projects/BookKeeper/docs/api.md",
+                "F:/Projects/Education/curriculum.md",
+            ],
+        )
+        info = _extract_from_packet(resp)
+        assert len(info["top_sources"]) == 3
+        assert "F:/Projects/helix-context/README.md" in info["top_sources"]
+
+    def test_empty_packet(self):
+        """Empty / minimal packet does not raise."""
+        info = _extract_from_packet({})
+        assert info["know_found"] is False
+        assert info["top_sources"] == []
+        assert info["lexical_dense_agree"] is None
+
+    def test_lexical_dense_agree_false(self):
+        """lexical_dense_agree=False is faithfully propagated."""
+        resp = _packet_response(found=True, lexical_dense_agree=False)
+        info = _extract_from_packet(resp)
+        assert info["lexical_dense_agree"] is False
+
+
+# ===========================================================================
+# run_diagnostic integration tests (mock via transport injection)
+# ===========================================================================
+
+class TestRunDiagnosticMocked:
+
+    def test_dense_present_in_unsharded_response(self):
+        """When /fingerprint returns dense tier, dense_fired=True for all queries."""
+        fp = _fingerprint_response(
+            gene_ids=["g1", "g2"],
+            tier_maps=[
+                {"fts5": 6.0, "tag_exact": 3.0, "dense": 0.88},
+                {"fts5": 4.0, "dense": 0.55},
+            ],
+        )
+        pkt = _packet_response(found=True, lexical_dense_agree=True)
+
+        queries = DEFAULT_QUERIES[:3]
+        result = _patched_run(
+            _MockTransport(fp, pkt),
+            "http://localhost:11437",
+            queries,
+            label="test_unsharded",
+        )
+
+        assert result["label"] == "test_unsharded"
+        assert result["aggregate"]["n"] == 3
+        assert result["aggregate"]["n_dense_fired"] == 3
+        assert result["aggregate"]["pct_dense_fired"] == 100.0
+        for row in result["queries"]:
+            assert row["dense_fired"] is True
+            assert "dense" in row["tiers_fired"]
+            assert "fts5" in row["tiers_fired"]
+
+    def test_dense_absent_in_sharded_response(self):
+        """When /fingerprint has no dense tier, dense_fired=False for all queries."""
+        fp = _fingerprint_response(
+            gene_ids=["g1", "g2"],
+            tier_maps=[
+                {"fts5": 6.0, "tag_exact": 3.0},
+                {"fts5": 4.0, "tag_prefix": 2.0},
+            ],
+        )
+        pkt = _packet_response(found=True, lexical_dense_agree=False)
+
+        queries = DEFAULT_QUERIES[:3]
+        result = _patched_run(
+            _MockTransport(fp, pkt),
+            "http://localhost:11438",
+            queries,
+            label="test_sharded",
+        )
+
+        assert result["aggregate"]["n_dense_fired"] == 0
+        assert result["aggregate"]["pct_dense_fired"] == 0.0
+        for row in result["queries"]:
+            assert row["dense_fired"] is False
+            assert "dense" not in row["tiers_fired"]
+
+    def test_by_type_breakdown(self):
+        """by_type aggregate correctly separates within vs cross queries."""
+        fp_with_dense = _fingerprint_response(
+            gene_ids=["g1"],
+            tier_maps=[{"fts5": 6.0, "dense": 0.77}],
+        )
+        fp_no_dense = _fingerprint_response(
+            gene_ids=["g1"],
+            tier_maps=[{"fts5": 6.0}],
+        )
+        pkt = _packet_response(found=True)
+
+        # 2 within (dense), 2 cross (no dense) — transport alternates
+        queries = [
+            {"id": "w01", "type": "within", "query": "within q 1"},
+            {"id": "w02", "type": "within", "query": "within q 2"},
+            {"id": "c01", "type": "cross",  "query": "cross q 1"},
+            {"id": "c02", "type": "cross",  "query": "cross q 2"},
+        ]
+        transport = _AltTransport(
+            [fp_with_dense, fp_with_dense, fp_no_dense, fp_no_dense],
+            pkt,
+        )
+        result = _patched_run(transport, "http://localhost:11437", queries, label="test_by_type")
+
+        agg = result["aggregate"]
+        assert agg["by_type"]["within"]["dense_fired"] == 2
+        assert agg["by_type"]["cross"]["dense_fired"] == 0
+        assert agg["by_type"]["within"]["pct_dense"] == 100.0
+        assert agg["by_type"]["cross"]["pct_dense"] == 0.0
+
+    def test_output_schema_shape(self):
+        """run_diagnostic output has all required top-level and per-row keys."""
+        fp = _fingerprint_response(gene_ids=["g1"], tier_maps=[{"fts5": 5.0}])
+        pkt = _packet_response(found=True)
+
+        result = _patched_run(
+            _MockTransport(fp, pkt),
+            "http://localhost:11437",
+            DEFAULT_QUERIES[:1],
+            label="schema",
+        )
+
+        # Top-level keys
+        for key in ("label", "helix_url", "timestamp", "queries", "aggregate"):
+            assert key in result, f"missing top-level key: {key}"
+
+        # Aggregate keys
+        agg = result["aggregate"]
+        for key in ("n", "n_dense_fired", "pct_dense_fired", "by_type", "tier_frequency", "errors"):
+            assert key in agg, f"missing aggregate key: {key}"
+
+        # Per-row keys
+        row = result["queries"][0]
+        for key in (
+            "id", "type", "query", "tiers_fired", "dense_fired",
+            "lexical_dense_agree", "know_found", "confidence",
+            "top_sources", "fp_count",
+        ):
+            assert key in row, f"missing row key: {key}"
+
+    def test_fp_error_does_not_crash(self):
+        """HTTP errors on /fingerprint are recorded as fp_error, run continues."""
+        pkt = _packet_response(found=True)
+
+        result = _patched_run(
+            _ErrorTransport(pkt),
+            "http://localhost:11437",
+            DEFAULT_QUERIES[:2],
+            label="error_test",
+        )
+
+        for row in result["queries"]:
+            assert row["fp_error"] is not None
+            assert row["dense_fired"] is False
+        assert len(result["aggregate"]["errors"]) >= 2
+
+
+# ===========================================================================
+# Default query set sanity checks
+# ===========================================================================
+
+class TestDefaultQuerySet:
+
+    def test_count(self):
+        assert len(DEFAULT_QUERIES) == 16
+
+    def test_unique_ids(self):
+        ids = [q["id"] for q in DEFAULT_QUERIES]
+        assert len(ids) == len(set(ids)), "duplicate IDs in DEFAULT_QUERIES"
+
+    def test_types_valid(self):
+        for q in DEFAULT_QUERIES:
+            assert q["type"] in ("within", "cross"), f"bad type: {q}"
+
+    def test_within_cross_ratio(self):
+        within = sum(1 for q in DEFAULT_QUERIES if q["type"] == "within")
+        cross  = sum(1 for q in DEFAULT_QUERIES if q["type"] == "cross")
+        assert within == 10, f"expected 10 within, got {within}"
+        assert cross  == 6,  f"expected 6 cross, got {cross}"
+
+    def test_queries_are_non_trivial(self):
+        """Each query should be at least 40 chars (no stub entries)."""
+        for q in DEFAULT_QUERIES:
+            assert len(q["query"]) >= 40, f"query too short: {q['id']}"
+
+    def test_dense_tiers_constant(self):
+        """_DENSE_TIERS must include 'dense' — the BGE-M3 canonical key."""
+        assert "dense" in _DENSE_TIERS
+        assert _BGE_DENSE_TIER == "dense"

--- a/tests/test_genome_tools.py
+++ b/tests/test_genome_tools.py
@@ -1,0 +1,381 @@
+"""Unit tests for the two genome tools.
+
+  * benchmarks/build_gold_from_genome.py -- needle generation from a blob genome
+  * tools/shard_to_blob.py               -- sharded -> blob merge, dense preserved
+
+Pure-Python, no GPU / server / network. Uses tiny temp SQLite fixtures.
+
+Run:
+    python -m pytest tests/test_genome_tools.py -q --noconftest
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(mod_name: str, rel_path: str):
+    """Load a module by file path (the tools aren't importable packages)."""
+    spec = importlib.util.spec_from_file_location(
+        mod_name, str(REPO_ROOT / rel_path)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+build_gold = _load("build_gold_from_genome", "benchmarks/build_gold_from_genome.py")
+shard_to_blob = _load("shard_to_blob", "tools/shard_to_blob.py")
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# Minimal genes-table DDL matching the on-disk contract (storage/ddl.py).
+_GENES_DDL = """
+CREATE TABLE genes (
+    gene_id            TEXT PRIMARY KEY,
+    content            TEXT,
+    complement         TEXT,
+    source_id          TEXT,
+    embedding_dense_v2 BLOB
+)
+"""
+
+_PROMOTER_DDL = """
+CREATE TABLE promoter_index (
+    gene_id   TEXT,
+    tag_type  TEXT,
+    tag_value TEXT
+)
+"""
+
+
+def _fake_vec(seed: int, dim: int = 8) -> bytes:
+    """Little-endian fp32 vector as a BLOB, like embedding_dense_v2."""
+    return struct.pack("<%df" % dim, *[float((seed + i) % 7) for i in range(dim)])
+
+
+def _make_genome(path: Path, rows: list[dict], with_promoter: bool = True) -> None:
+    """Create a blob genome with the given gene rows.
+
+    Each row: {gene_id, content, source_id, dense(bool), tags(list)}.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute(_GENES_DDL)
+    if with_promoter:
+        conn.execute(_PROMOTER_DDL)
+    for i, r in enumerate(rows):
+        vec = _fake_vec(i) if r.get("dense", True) else None
+        conn.execute(
+            "INSERT INTO genes (gene_id, content, complement, source_id, "
+            "embedding_dense_v2) VALUES (?, ?, ?, ?, ?)",
+            (r["gene_id"], r["content"], r.get("complement", ""),
+             r["source_id"], vec),
+        )
+        if with_promoter:
+            for tag in r.get("tags", []):
+                conn.execute(
+                    "INSERT INTO promoter_index VALUES (?, 'domain', ?)",
+                    (r["gene_id"], tag),
+                )
+    conn.commit()
+    conn.close()
+
+
+# ===========================================================================
+# build_gold_from_genome
+# ===========================================================================
+
+def test_source_prefix_peels_drive_and_sources_container():
+    p = build_gold.source_prefix
+    assert p(r"F:\tmp\enterprise_rag_500k\sources\github\pr-1.json") == "github"
+    assert p("F:/Projects/helix-context/helix_context/config.py") == "Projects"
+    assert p("C:/tmp/erb/sources/gmail/alex/m.txt") == "gmail"
+    assert p("") == "_unknown"
+
+
+def test_build_gold_emits_needles_with_required_schema(tmp_path):
+    genome = tmp_path / "blob.genome.db"
+    rows = [
+        # Source-prefix "alpha" (top path segment after the drive)
+        {"gene_id": "a1", "source_id": r"F:\alpha\authentication_handler.py",
+         "content": "The retry policy uses exponential backoff to recover from "
+                    "transient upstream failures before surfacing an error to the caller."},
+        {"gene_id": "a2", "source_id": r"F:\alpha\billing_engine.py",
+         "content": "Invoices are reconciled nightly against the ledger and any "
+                    "discrepancy greater than one cent triggers a manual review queue."},
+        {"gene_id": "a3", "source_id": r"F:\alpha\notes.md",
+         "content": "# Onboarding\n\nNew team members should request access to the "
+                    "staging cluster and read the deployment runbook before shipping."},
+        # Source-prefix "beta"
+        {"gene_id": "b1", "source_id": r"F:\beta\report_builder.py",
+         "content": "Quarterly summaries aggregate revenue by region and present "
+                    "the top performing segments in a sortable dashboard table."},
+        {"gene_id": "b2", "source_id": r"F:\beta\cache_layer.py",
+         "content": "Entries expire after the configured window and a background "
+                    "sweep evicts cold keys to keep memory pressure bounded."},
+    ]
+    _make_genome(genome, rows)
+
+    out = tmp_path / "gold.jsonl"
+    rc = build_gold.main([
+        "--genome", str(genome),
+        "--per-source", "5",
+        "--out", str(out),
+        "--seed", "7",
+        "--min-content-chars", "50",
+    ])
+    assert rc == 0
+    assert out.exists()
+
+    needles = [json.loads(l) for l in out.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert needles, "expected at least one needle"
+
+    required = {"id", "project", "type", "file_type", "question", "gold_paths"}
+    prefixes = set()
+    for nd in needles:
+        assert required <= set(nd), "missing schema fields: {}".format(required - set(nd))
+        assert nd["type"] in ("within", "cross")
+        assert isinstance(nd["gold_paths"], list) and nd["gold_paths"]
+        assert isinstance(nd["question"], str) and len(nd["question"]) >= 40
+        prefixes.add(nd["project"])
+
+    # Both source-prefixes represented across the within-needles.
+    within_prefixes = {nd["project"] for nd in needles if nd["type"] == "within"}
+    assert {"alpha", "beta"} <= within_prefixes
+
+    # ~20% cross tagging present.
+    assert any(nd["type"] == "cross" for nd in needles)
+
+
+def test_build_gold_no_leak_guard_strips_path_and_filename_tokens(tmp_path):
+    genome = tmp_path / "blob.genome.db"
+    # The content deliberately echoes the filename stem + dir tokens + a
+    # snake_case symbol -- all must be scrubbed out of the question.
+    rows = [{
+        "gene_id": "x1",
+        "source_id": r"F:\proj\widgetkit\frobnicator_service.py",
+        "content": (
+            "The frobnicator_service in widgetkit exposes a frobnicator_service "
+            "endpoint. The frobnicator handler validates the payload and then "
+            "schedules a background reconciliation job for downstream consumers."
+        ),
+    }]
+    _make_genome(genome, rows)
+
+    out = tmp_path / "gold.jsonl"
+    rc = build_gold.main([
+        "--genome", str(genome), "--per-source", "1",
+        "--out", str(out), "--seed", "1", "--min-content-chars", "50",
+    ])
+    assert rc == 0
+    needles = [json.loads(l) for l in out.read_text().splitlines() if l.strip()]
+    within = [n for n in needles if n["type"] == "within"]
+    assert within
+    q = within[0]["question"].lower()
+
+    # Leak tokens that MUST be absent from the question.
+    for leaked in ("widgetkit", "frobnicator_service", "frobnicator", ".py"):
+        assert leaked not in q, "no-leak guard failed: '{}' leaked into {!r}".format(leaked, q)
+
+    # gold_paths still carries the real source path (that's the recall target).
+    assert within[0]["gold_paths"] == [rows[0]["source_id"]]
+
+
+def test_build_gold_opens_genome_read_only(tmp_path):
+    genome = tmp_path / "blob.genome.db"
+    _make_genome(genome, [{
+        "gene_id": "r1", "source_id": r"F:\proj\zeta\service.py",
+        "content": "The scheduler dispatches jobs to workers and retries failed "
+                   "tasks with a capped jitter to avoid thundering-herd spikes.",
+    }])
+    conn = build_gold._open_ro(str(genome))
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO genes (gene_id) VALUES ('nope')")
+    finally:
+        conn.close()
+
+
+# ===========================================================================
+# shard_to_blob
+# ===========================================================================
+
+def _make_sharded_tree(root: Path):
+    """Build main.genome.db + two content shards; return (counts, dense_counts)."""
+    root.mkdir(parents=True, exist_ok=True)
+
+    # main.genome.db -- routing DB, no content tables (must be ignored).
+    main = sqlite3.connect(str(root / "main.genome.db"))
+    main.execute(
+        "CREATE TABLE shards (shard_name TEXT PRIMARY KEY, gene_count INTEGER)"
+    )
+    main.execute("INSERT INTO shards VALUES ('alpha', 2), ('beta', 3)")
+    main.commit()
+    main.close()
+
+    # shard alpha: 2 genes, both dense.
+    alpha_dir = root / "F" / "proj" / "alpha"
+    alpha_dir.mkdir(parents=True, exist_ok=True)
+    _make_genome(alpha_dir / "alpha.genome.db", [
+        {"gene_id": "g_a1", "source_id": r"F:\proj\alpha\a.py",
+         "content": "alpha one content", "tags": ["auth"]},
+        {"gene_id": "g_a2", "source_id": r"F:\proj\alpha\b.py",
+         "content": "alpha two content", "tags": ["cache"]},
+    ])
+
+    # shard beta: 3 genes; one of them has NO dense vector.
+    beta_dir = root / "F" / "proj" / "beta"
+    beta_dir.mkdir(parents=True, exist_ok=True)
+    _make_genome(beta_dir / "beta.genome.db", [
+        {"gene_id": "g_b1", "source_id": r"F:\proj\beta\x.py",
+         "content": "beta one content", "tags": ["report"]},
+        {"gene_id": "g_b2", "source_id": r"F:\proj\beta\y.py",
+         "content": "beta two content", "dense": False, "tags": []},
+        {"gene_id": "g_b3", "source_id": r"F:\proj\beta\z.py",
+         "content": "beta three content", "tags": ["queue"]},
+    ])
+
+    return {"genes": 5, "dense": 4}
+
+
+def test_discover_shards_excludes_main(tmp_path):
+    expected = _make_sharded_tree(tmp_path)
+    shards = shard_to_blob.discover_shards(str(tmp_path))
+    names = {os.path.basename(s) for s in shards}
+    assert names == {"alpha.genome.db", "beta.genome.db"}
+    assert all("main.genome.db" not in s for s in shards)
+
+
+def test_shard_to_blob_merge_counts_and_dense_preserved(tmp_path):
+    expected = _make_sharded_tree(tmp_path)
+    out = tmp_path / "merged_blob.genome.db"
+
+    summary = shard_to_blob.shard_to_blob(str(tmp_path), str(out))
+
+    # Gene count == sum of shard gene counts (no collisions here).
+    assert summary["expected_genes_sum"] == expected["genes"]
+    assert summary["blob_genes"] == expected["genes"]
+    assert summary["genes_ok"] is True
+
+    # Dense vectors preserved verbatim -- non-null count matches.
+    assert summary["expected_dense_sum"] == expected["dense"]
+    assert summary["blob_dense"] == expected["dense"]
+    assert summary["dense_ok"] is True
+
+    # Verify directly against the produced blob.
+    conn = sqlite3.connect(str(out))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM genes").fetchone()[0] == 5
+        assert conn.execute(
+            "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()[0] == 4
+        # FTS rebuilt and queryable.
+        assert conn.execute("SELECT COUNT(*) FROM genes_fts").fetchone()[0] == 5
+        hit = conn.execute(
+            "SELECT gene_id FROM genes_fts WHERE genes_fts MATCH 'beta'"
+        ).fetchall()
+        assert len(hit) == 3
+        # The actual vector BLOB is byte-identical to the source shard's.
+        src = sqlite3.connect(_uri_ro(tmp_path / "F" / "proj" / "alpha" / "alpha.genome.db"), uri=True)
+        try:
+            src_vec = src.execute(
+                "SELECT embedding_dense_v2 FROM genes WHERE gene_id='g_a1'"
+            ).fetchone()[0]
+        finally:
+            src.close()
+        blob_vec = conn.execute(
+            "SELECT embedding_dense_v2 FROM genes WHERE gene_id='g_a1'"
+        ).fetchone()[0]
+        assert blob_vec == src_vec and blob_vec is not None
+    finally:
+        conn.close()
+
+
+def _uri_ro(path: Path) -> str:
+    return "file:{}?mode=ro".format(str(path).replace("\\", "/"))
+
+
+def test_shard_to_blob_dedupes_gene_id_collisions(tmp_path):
+    """Two shards sharing an identical gene_id should de-dupe defensively."""
+    root = tmp_path
+    (root).mkdir(parents=True, exist_ok=True)
+    main = sqlite3.connect(str(root / "main.genome.db"))
+    main.execute("CREATE TABLE shards (shard_name TEXT PRIMARY KEY)")
+    main.close()
+
+    s1 = root / "one"
+    s1.mkdir()
+    _make_genome(s1 / "one.genome.db", [
+        {"gene_id": "dup", "source_id": "F:/a/dup.py", "content": "shared content"},
+        {"gene_id": "u1", "source_id": "F:/a/u1.py", "content": "unique one"},
+    ])
+    s2 = root / "two"
+    s2.mkdir()
+    _make_genome(s2 / "two.genome.db", [
+        {"gene_id": "dup", "source_id": "F:/a/dup.py", "content": "shared content"},
+        {"gene_id": "u2", "source_id": "F:/b/u2.py", "content": "unique two"},
+    ])
+
+    out = root / "blob.genome.db"
+    summary = shard_to_blob.shard_to_blob(str(root), str(out))
+
+    # 4 rows across shards, 1 collision -> 3 unique genes.
+    assert summary["expected_genes_sum"] == 4
+    assert summary["blob_genes"] == 3
+    assert summary["deduped_collisions"] == 1
+    assert summary["genes_ok"] is True
+    assert summary["dense_ok"] is True
+
+
+def test_shard_to_blob_reads_shards_with_live_wal_sidecars(tmp_path):
+    """Shards left in WAL mode (live -wal/-shm sidecars) must still merge.
+
+    Real on-disk shards are frequently in WAL journal mode with uncheckpointed
+    sidecars; a naive mode=ro open fails with "disk I/O error". The tool opens
+    sources with immutable=1, which reads the main DB file directly. This test
+    leaves a shard in WAL mode (sidecars present) and asserts the merge works.
+    """
+    root = tmp_path
+    main = sqlite3.connect(str(root / "main.genome.db"))
+    main.execute("CREATE TABLE shards (shard_name TEXT PRIMARY KEY)")
+    main.close()
+
+    sdir = root / "s"
+    sdir.mkdir()
+    shard_path = sdir / "wal.genome.db"
+    _make_genome(shard_path, [
+        {"gene_id": "w1", "source_id": "F:/a/w1.py", "content": "wal gene one"},
+        {"gene_id": "w2", "source_id": "F:/a/w2.py", "content": "wal gene two"},
+    ])
+    # Force the shard into WAL mode and leave an uncheckpointed sidecar open.
+    keep = sqlite3.connect(str(shard_path))
+    keep.execute("PRAGMA journal_mode=WAL")
+    keep.execute(
+        "UPDATE genes SET content = content || ' edited' WHERE gene_id = 'w1'"
+    )
+    keep.commit()
+    # Do NOT checkpoint or close yet -- sidecars are live on disk.
+    assert (sdir / "wal.genome.db-wal").exists()
+
+    out = root / "blob.genome.db"
+    summary = shard_to_blob.shard_to_blob(str(root), str(out))
+    keep.close()
+
+    assert summary["blob_genes"] == 2
+    assert summary["dense_ok"] is True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q", "--noconftest"]))

--- a/tests/test_repobench_r_harness.py
+++ b/tests/test_repobench_r_harness.py
@@ -1,0 +1,350 @@
+"""Unit tests for the RepoBench-R harness logic (no network, no server, no GPU).
+
+Tests cover:
+  - acc_at: the core scoring function
+  - tok: identifier tokenizer
+  - rank_overlap: Jaccard-overlap ranker
+  - rank_bm25: BM25Okapi ranker on a tiny pool
+  - rank_random: deterministic seeded permutation
+  - _ks_for_level: k values per difficulty level
+  - BM25 global variant (floored IDF from repobench_r_helix_global)
+  - Full pipeline simulation: make_query + rank + acc_at against an inline fixture
+
+All tests are pure-Python; no HuggingFace downloads, no Helix server, no CUDA.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make benchmarks/ importable without packaging
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+sys.path.insert(0, str(BENCH_DIR))
+
+from repobench_r import (  # noqa: E402
+    acc_at,
+    tok,
+    make_query,
+    rank_overlap,
+    rank_bm25,
+    rank_random,
+    _ks_for_level,
+)
+from repobench_r_helix_global import BM25  # noqa: E402
+
+
+# ================================================================================
+# acc_at -- the fundamental metric
+# ================================================================================
+
+class TestAccAt:
+    def test_gold_at_position_0_acc1(self):
+        assert acc_at([2, 0, 1], gold=2, k=1) == 1.0
+
+    def test_gold_not_in_top1(self):
+        assert acc_at([0, 1, 2], gold=2, k=1) == 0.0
+
+    def test_gold_in_top3(self):
+        assert acc_at([0, 1, 2], gold=2, k=3) == 1.0
+
+    def test_gold_at_position_2_acc3_boundary(self):
+        # index 2 is the third element (0-based) -- within top-3
+        assert acc_at([0, 1, 2, 3, 4], gold=2, k=3) == 1.0
+
+    def test_gold_at_position_3_not_in_top3(self):
+        assert acc_at([0, 1, 2, 3, 4], gold=3, k=3) == 0.0
+
+    def test_gold_in_top5(self):
+        assert acc_at([0, 1, 2, 3, 4], gold=4, k=5) == 1.0
+
+    def test_gold_not_in_top5(self):
+        assert acc_at([0, 1, 2, 3, 4], gold=5, k=5) == 0.0
+
+    def test_empty_order_miss(self):
+        assert acc_at([], gold=0, k=1) == 0.0
+
+    def test_k_larger_than_list(self):
+        # k=10 but only 3 items; gold present -> hit
+        assert acc_at([0, 1, 2], gold=1, k=10) == 1.0
+
+
+# ================================================================================
+# _ks_for_level
+# ================================================================================
+
+class TestKsForLevel:
+    def test_easy_returns_1_3(self):
+        assert _ks_for_level("easy") == [1, 3]
+
+    def test_hard_returns_1_3_5(self):
+        assert _ks_for_level("hard") == [1, 3, 5]
+
+    def test_unknown_level_treated_as_easy(self):
+        # Any non-"hard" level -> [1, 3]
+        assert _ks_for_level("medium") == [1, 3]
+
+
+# ================================================================================
+# tok -- identifier tokenizer
+# ================================================================================
+
+class TestTok:
+    def test_splits_on_non_identifier_chars(self):
+        assert tok("foo.bar(baz)") == ["foo", "bar", "baz"]
+
+    def test_ignores_leading_digits(self):
+        # The regex finds identifier-shaped substrings anywhere in the string.
+        # "123abc" contains the suffix "abc" starting after the digits, so tok
+        # correctly extracts it -- the tokenizer is substring-based, not word-boundary.
+        result = tok("123abc def")
+        assert "def" in result
+        assert "abc" in result   # correct: regex finds it as suffix of 123abc
+        assert "123" not in result  # purely numeric tokens are never matched
+
+    def test_underscore_prefix(self):
+        assert "_private" in tok("_private = 1")
+
+    def test_empty_string(self):
+        assert tok("") == []
+
+    def test_none_safe(self):
+        assert tok(None) == []
+
+
+# ================================================================================
+# make_query
+# ================================================================================
+
+class TestMakeQuery:
+    def _example(self, code, imports=""):
+        return {"code": code, "import_statement": imports}
+
+    def test_uses_last_30_lines(self):
+        lines = [f"line_{i}" for i in range(50)]
+        ex = self._example("\n".join(lines))
+        q = make_query(ex)
+        assert "line_49" in q
+        assert "line_19" not in q  # only last 30 -> lines 20-49
+
+    def test_prepends_imports(self):
+        ex = self._example("x = 1", "import os")
+        q = make_query(ex)
+        assert q.startswith("import os")
+
+    def test_empty_example(self):
+        q = make_query({})
+        assert isinstance(q, str)
+
+
+# ================================================================================
+# rank_overlap
+# ================================================================================
+
+class TestRankOverlap:
+    def test_best_match_ranked_first(self):
+        query = "def compute_fibonacci(n):"
+        cands = [
+            "def unrelated(): pass",
+            "def compute_fibonacci(n): return n if n < 2 else ...",
+            "import sys",
+        ]
+        order = rank_overlap(query, cands)
+        assert order[0] == 1  # candidate 1 shares the most tokens
+
+    def test_no_overlap_gives_stable_order(self):
+        query = "zzz"
+        cands = ["aaa", "bbb", "ccc"]
+        order = rank_overlap(query, cands)
+        assert sorted(order) == [0, 1, 2]  # all returned, no crash
+
+    def test_empty_query_returns_all(self):
+        order = rank_overlap("", ["a", "b", "c"])
+        assert sorted(order) == [0, 1, 2]
+
+    def test_returns_all_candidates(self):
+        cands = ["a b", "c d", "e f", "g h", "i j"]
+        order = rank_overlap("a b", cands)
+        assert sorted(order) == list(range(len(cands)))
+
+
+# ================================================================================
+# rank_bm25
+# ================================================================================
+
+class TestRankBM25:
+    def test_best_match_first(self):
+        pytest.importorskip("rank_bm25")
+        query = "fibonacci sequence recursive"
+        cands = [
+            "bubble sort algorithm implementation",
+            "fibonacci sequence recursive function returns",
+            "hash table collision resolution",
+        ]
+        order = rank_bm25(query, cands)
+        assert order[0] == 1
+
+    def test_returns_all_candidates(self):
+        pytest.importorskip("rank_bm25")
+        cands = ["alpha", "beta", "gamma"]
+        order = rank_bm25("alpha", cands)
+        assert sorted(order) == [0, 1, 2]
+
+    def test_empty_corpus_safe(self):
+        pytest.importorskip("rank_bm25")
+        order = rank_bm25("query", ["", "", ""])
+        assert sorted(order) == [0, 1, 2]
+
+
+# ================================================================================
+# rank_random
+# ================================================================================
+
+class TestRankRandom:
+    def test_deterministic_same_key(self):
+        cands = ["a", "b", "c", "d", "e"]
+        o1 = rank_random(cands, ("easy", 42))
+        o2 = rank_random(cands, ("easy", 42))
+        assert o1 == o2
+
+    def test_different_keys_give_different_orders(self):
+        cands = list(range(20))
+        o1 = rank_random(cands, ("easy", 0))
+        o2 = rank_random(cands, ("easy", 1))
+        # With 20 elements it would be astronomically unlikely to match.
+        assert o1 != o2
+
+    def test_returns_all_indices(self):
+        cands = ["a", "b", "c"]
+        order = rank_random(cands, "key")
+        assert sorted(order) == [0, 1, 2]
+
+
+# ================================================================================
+# BM25 (global floored-IDF variant from repobench_r_helix_global)
+# ================================================================================
+
+class TestGlobalBM25:
+    def _bm(self, corpus):
+        return BM25([c.lower().split() for c in corpus])
+
+    def test_idf_floored_at_zero(self):
+        """Terms in every document should NOT go negative."""
+        corpus = ["common token here", "common token there", "common token everywhere"]
+        bm = self._bm(corpus)
+        for idf_val in bm.idf.values():
+            assert idf_val >= 0.0, f"negative IDF: {idf_val}"
+
+    def test_relevant_doc_scores_higher(self):
+        corpus = [
+            "import os path join exists",
+            "fibonacci recursive sequence memoize",
+            "hash map collision linear probe",
+        ]
+        bm = self._bm(corpus)
+        sc = bm.scores("fibonacci recursive".split())
+        assert sc[1] > sc[0]
+        assert sc[1] > sc[2]
+
+    def test_zero_scores_for_no_overlap(self):
+        corpus = ["apple banana", "cherry date"]
+        bm = self._bm(corpus)
+        sc = bm.scores(["zzz"])
+        assert sc[0] == 0.0
+        assert sc[1] == 0.0
+
+    def test_returns_one_score_per_doc(self):
+        corpus = ["a b c", "d e f", "g h i"]
+        bm = self._bm(corpus)
+        assert len(bm.scores(["a"])) == 3
+
+
+# ================================================================================
+# Full pipeline fixture -- end-to-end acc@k computation
+# ================================================================================
+
+# Inline fixture simulating one "easy" and one "hard" RepoBench-R example.
+_FIXTURE_EXAMPLES = [
+    {
+        "level": "easy",
+        "query": "import utils\ndef process(data):\n    result = utils.transform(data)",
+        "candidates": [
+            "def unrelated_function(): pass",             # idx 0
+            "def transform(data): return data[::-1]",    # idx 1  <- GOLD
+            "class Config:\n    debug = True",           # idx 2
+        ],
+        "gold": 1,
+    },
+    {
+        "level": "hard",
+        "query": "from parser import parse_tokens\ntokens = parse_tokens(src)",
+        "candidates": [
+            "def irrelevant(): return None",              # idx 0
+            "class Config: pass",                         # idx 1
+            "def parse_tokens(src): return src.split()", # idx 2  <- GOLD
+            "import re",                                  # idx 3
+            "def helper(x): return x + 1",               # idx 4
+        ],
+        "gold": 2,
+    },
+]
+
+
+class TestFullPipelineFixture:
+    """End-to-end: query construction -> overlap ranking -> acc@k scoring."""
+
+    def _score_example(self, ex):
+        ks = _ks_for_level(ex["level"])
+        q = ex["query"]
+        cands = ex["candidates"]
+        gold = ex["gold"]
+        order = rank_overlap(q, cands)
+        return {k: acc_at(order, gold, k) for k in ks}
+
+    def test_easy_example_overlap_finds_gold(self):
+        scores = self._score_example(_FIXTURE_EXAMPLES[0])
+        # "transform" appears in both query and candidate 1
+        assert scores[1] == 1.0
+        assert scores[3] == 1.0
+
+    def test_hard_example_overlap_finds_gold(self):
+        scores = self._score_example(_FIXTURE_EXAMPLES[1])
+        # "parse_tokens" and "src" appear in both query and candidate 2
+        assert scores[3] == 1.0
+        assert scores[5] == 1.0  # acc@5 always >= acc@3
+
+    def test_acc_monotonic(self):
+        """acc@k must be non-decreasing in k."""
+        for ex in _FIXTURE_EXAMPLES:
+            ks = _ks_for_level(ex["level"])
+            order = rank_overlap(ex["query"], ex["candidates"])
+            vals = [acc_at(order, ex["gold"], k) for k in ks]
+            for i in range(len(vals) - 1):
+                assert vals[i] <= vals[i + 1], (
+                    f"acc@k not monotonic for {ex['level']}: {list(zip(ks, vals))}"
+                )
+
+    def test_aggregate_accuracy(self):
+        """Accumulate hits across both examples and verify the aggregate."""
+        total = {"overlap": {}}
+        counts = {}
+        for ex in _FIXTURE_EXAMPLES:
+            ks = _ks_for_level(ex["level"])
+            order = rank_overlap(ex["query"], ex["candidates"])
+            for k in ks:
+                total["overlap"][k] = total["overlap"].get(k, 0.0) + acc_at(order, ex["gold"], k)
+                counts[k] = counts.get(k, 0) + 1
+        # acc@3 is a hit in both examples (easy and hard)
+        assert total["overlap"].get(3, 0.0) == 2.0
+
+    def test_wrong_gold_gives_zero(self):
+        """Sanity: if gold is beyond the candidate list, acc_at returns 0."""
+        order = [0, 1, 2]
+        assert acc_at(order, gold=99, k=3) == 0.0
+
+    def test_hard_level_has_acc5_key(self):
+        """Hard examples must produce an acc@5 value (not just acc@1/3)."""
+        scores = self._score_example(_FIXTURE_EXAMPLES[1])
+        assert 5 in scores, f"acc@5 missing from hard example scores: {scores}"

--- a/tests/test_shard_gold_recall.py
+++ b/tests/test_shard_gold_recall.py
@@ -1,0 +1,557 @@
+"""tests/test_shard_gold_recall.py
+
+Two independent test groups — all pure-Python, no server, no GPU, no network,
+no /tmp.  Runs with: python -m pytest tests/test_shard_gold_recall.py -v
+
+GROUP A: recall@k / MRR metric math
+    Validates the scoring helpers in bench_shard_recall.py against an inline
+    fixture.  Covers: hit at rank-1, hit at rank-3, hit at rank-10, miss, MRR
+    formula, aggregation across types (within/cross/all), and the gold-path
+    normalisation rule (_gold_hit).
+
+GROUP B: no-leak guard (query scrubbing)
+    Uses a tiny temp source-tree fixture (Python file + Markdown file) to
+    verify that build_shard_gold's query scrubbing:
+      1. Removes the gold filename stem from every generated question.
+      2. Removes the gold symbol name from every generated question.
+      3. Removes directory-name tokens from every generated question.
+      4. Still produces questions that are >= 40 characters long.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Make benchmarks/ importable without packaging.
+BENCH_DIR = Path(__file__).resolve().parents[1] / "benchmarks"
+if str(BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCH_DIR))
+
+# We import the pure helper functions only — never the CLI entrypoints —
+# so these tests never touch the network or a live genome.
+from bench_shard_recall import (  # noqa: E402
+    _gold_hit,
+    _norm,
+    _percentile,
+    _recall_at,
+    _rr,
+    score_needles,
+)
+from build_shard_gold import (  # noqa: E402
+    _build_query,
+    _path_tokens,
+    _scrub,
+    build_needles_for_project,
+    extract_python_units,
+    extract_md_sections,
+)
+
+
+# ===========================================================================
+# GROUP A: recall@k / MRR math
+# ===========================================================================
+
+
+class TestRecallMath:
+    """Validate the raw metric helpers."""
+
+    # ── _recall_at ────────────────────────────────────────────────────────
+
+    def test_recall_at_rank1_hits_all_k(self):
+        for k in (1, 3, 5, 10):
+            assert _recall_at(1, k) == 1.0
+
+    def test_recall_at_rank3_misses_k1(self):
+        assert _recall_at(3, 1) == 0.0
+
+    def test_recall_at_rank3_hits_k3(self):
+        assert _recall_at(3, 3) == 1.0
+
+    def test_recall_at_rank10_hits_k10_only(self):
+        assert _recall_at(10, 5) == 0.0
+        assert _recall_at(10, 10) == 1.0
+
+    def test_recall_at_none_is_always_miss(self):
+        for k in (1, 3, 5, 10):
+            assert _recall_at(None, k) == 0.0
+
+    # ── _rr ───────────────────────────────────────────────────────────────
+
+    def test_rr_rank1(self):
+        assert _rr(1) == pytest.approx(1.0)
+
+    def test_rr_rank2(self):
+        assert _rr(2) == pytest.approx(0.5)
+
+    def test_rr_rank5(self):
+        assert _rr(5) == pytest.approx(0.2)
+
+    def test_rr_none_is_zero(self):
+        assert _rr(None) == 0.0
+
+    # ── _percentile ───────────────────────────────────────────────────────
+
+    def test_percentile_median_even(self):
+        vals = [1.0, 2.0, 3.0, 4.0]
+        assert _percentile(vals, 50) == pytest.approx(2.5)
+
+    def test_percentile_p90(self):
+        vals = list(range(1, 11))  # 1..10
+        # p90 of 1..10 should be near 9.1
+        assert _percentile(vals, 90) == pytest.approx(9.1)
+
+    def test_percentile_empty(self):
+        assert _percentile([], 50) == 0.0
+
+    # ── _gold_hit: path normalisation ────────────────────────────────────
+
+    def test_gold_hit_exact_forward_slash(self):
+        assert _gold_hit(
+            "F:/Projects/helix-context/helix_context/pipeline/stages.py",
+            ["helix-context/helix_context/pipeline/stages.py"],
+        )
+
+    def test_gold_hit_backslash_source(self):
+        """Windows-native paths from the server must still match."""
+        assert _gold_hit(
+            "F:\\Projects\\BookKeeper\\bookkeeper\\auth.py",
+            ["bookkeeper/bookkeeper/auth.py"],
+        )
+
+    def test_gold_hit_case_insensitive(self):
+        assert _gold_hit(
+            "F:/Projects/BookKeeper/BookKeeper/Auth.PY",
+            ["bookkeeper/bookkeeper/auth.py"],
+        )
+
+    def test_gold_hit_miss_different_project(self):
+        assert not _gold_hit(
+            "F:/Projects/Education/fleet/model.py",
+            ["bookkeeper/bookkeeper/auth.py"],
+        )
+
+    def test_gold_hit_bidirectional_short_gold(self):
+        """Gold may be a directory prefix — match any file under it."""
+        assert _gold_hit(
+            "F:/Projects/helix-context/helix_context/pipeline/stages.py",
+            ["helix-context/helix_context/pipeline"],
+        )
+
+    def test_gold_hit_multiple_gold_paths_any_match(self):
+        assert _gold_hit(
+            "F:/Projects/Education/README.md",
+            [
+                "bookkeeper/README.md",
+                "education/README.md",
+            ],
+        )
+
+    def test_gold_hit_multiple_gold_paths_none_match(self):
+        assert not _gold_hit(
+            "F:/Projects/CosmicTasha/README.md",
+            [
+                "bookkeeper/README.md",
+                "education/README.md",
+            ],
+        )
+
+    # ── score_needles aggregation on an inline fixture ───────────────────
+
+    def _make_fake_fingerprint_server(self, ranked_sources: list[list[str]]):
+        """Monkeypatch target: returns pre-canned ranked sources per call."""
+        call_idx = [0]
+
+        def fake_fingerprint(helix_url, query, max_results=10, timeout_s=30.0):
+            idx = call_idx[0]
+            call_idx[0] += 1
+            if idx < len(ranked_sources):
+                fps = [{"source": s} for s in ranked_sources[idx]]
+            else:
+                fps = []
+            return fps, 5.0  # 5 ms fake latency
+
+        return fake_fingerprint
+
+    def test_score_needles_all_hit_rank1(self, monkeypatch):
+        """Every needle hits at rank 1 -> recall@k=1 for all k, MRR=1."""
+        import bench_shard_recall as bsr
+
+        needles = [
+            {
+                "id": "a",
+                "type": "within",
+                "question": "What does authenticate do?",
+                "gold_paths": ["bookkeeper/bookkeeper/auth.py"],
+            },
+            {
+                "id": "b",
+                "type": "within",
+                "question": "How is the pipeline staged?",
+                "gold_paths": ["helix-context/helix_context/pipeline/stages.py"],
+            },
+        ]
+        ranked = [
+            ["F:/Projects/BookKeeper/bookkeeper/auth.py", "F:/Projects/other/foo.py"],
+            ["F:/Projects/helix-context/helix_context/pipeline/stages.py"],
+        ]
+        monkeypatch.setattr(bsr, "fingerprint", self._make_fake_fingerprint_server(ranked))
+
+        summary, rows = score_needles(needles, "http://fake:11437")
+
+        assert summary["all"]["mrr"] == pytest.approx(1.0)
+        for k in (1, 3, 5, 10):
+            assert summary["all"]["recall@{}".format(k)] == pytest.approx(1.0)
+
+    def test_score_needles_all_miss(self, monkeypatch):
+        """No gold hit -> recall=0, MRR=0."""
+        import bench_shard_recall as bsr
+
+        needles = [
+            {
+                "id": "c",
+                "type": "within",
+                "question": "What does authenticate do?",
+                "gold_paths": ["bookkeeper/bookkeeper/auth.py"],
+            },
+        ]
+        # Server returns a completely different file.
+        ranked = [["F:/Projects/Education/fleet/unrelated.py"]]
+        monkeypatch.setattr(bsr, "fingerprint", self._make_fake_fingerprint_server(ranked))
+
+        summary, rows = score_needles(needles, "http://fake:11437")
+
+        assert summary["all"]["mrr"] == pytest.approx(0.0)
+        for k in (1, 3, 5, 10):
+            assert summary["all"]["recall@{}".format(k)] == pytest.approx(0.0)
+
+    def test_score_needles_mixed_ranks(self, monkeypatch):
+        """
+        3 needles: rank-1 hit, rank-3 hit, miss.
+        Expected:
+          recall@1 = 1/3
+          recall@3 = 2/3
+          recall@5 = 2/3
+          MRR      = (1/1 + 1/3 + 0) / 3 = 4/9
+        """
+        import bench_shard_recall as bsr
+
+        needles = [
+            {"id": "d", "type": "within",
+             "question": "q1", "gold_paths": ["proj/a.py"]},
+            {"id": "e", "type": "within",
+             "question": "q2", "gold_paths": ["proj/b.py"]},
+            {"id": "f", "type": "within",
+             "question": "q3", "gold_paths": ["proj/c.py"]},
+        ]
+        ranked = [
+            # needle d: gold at rank 1
+            ["F:/Projects/proj/a.py", "other.py"],
+            # needle e: gold at rank 3
+            ["other1.py", "other2.py", "F:/Projects/proj/b.py"],
+            # needle f: gold not present at all
+            ["other3.py", "other4.py", "other5.py"],
+        ]
+        monkeypatch.setattr(bsr, "fingerprint", self._make_fake_fingerprint_server(ranked))
+
+        summary, rows = score_needles(needles, "http://fake:11437")
+
+        # summary values are rounded to 4 decimal places; use abs=5e-4
+        assert summary["all"]["recall@1"] == pytest.approx(1 / 3, abs=5e-4)
+        assert summary["all"]["recall@3"] == pytest.approx(2 / 3, abs=5e-4)
+        assert summary["all"]["recall@5"] == pytest.approx(2 / 3, abs=5e-4)
+        expected_mrr = (1.0 + 1.0 / 3 + 0.0) / 3
+        assert summary["all"]["mrr"] == pytest.approx(expected_mrr, abs=5e-4)
+
+    def test_score_needles_type_breakdown_within_cross(self, monkeypatch):
+        """within and cross aggregates are computed independently."""
+        import bench_shard_recall as bsr
+
+        needles = [
+            {"id": "w1", "type": "within",
+             "question": "q-w1", "gold_paths": ["proj/w.py"]},
+            {"id": "c1", "type": "cross",
+             "question": "q-c1", "gold_paths": ["proj/x.py"]},
+        ]
+        ranked = [
+            # w1 hits at rank 1
+            ["F:/Projects/proj/w.py"],
+            # c1 misses
+            ["F:/Projects/other/y.py"],
+        ]
+        monkeypatch.setattr(bsr, "fingerprint", self._make_fake_fingerprint_server(ranked))
+
+        summary, rows = score_needles(needles, "http://fake:11437")
+
+        assert "within" in summary
+        assert "cross" in summary
+        assert "all" in summary
+
+        assert summary["within"]["recall@1"] == pytest.approx(1.0)
+        assert summary["cross"]["recall@1"] == pytest.approx(0.0)
+        assert summary["all"]["n"] == 2
+
+    def test_score_needles_error_counted(self, monkeypatch):
+        """HTTP errors are counted in .err and don't crash the run."""
+        import bench_shard_recall as bsr
+
+        needles = [
+            {"id": "g", "type": "within",
+             "question": "q-err", "gold_paths": ["proj/z.py"]},
+        ]
+
+        def always_raise(helix_url, query, **kw):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(bsr, "fingerprint", always_raise)
+
+        summary, rows = score_needles(needles, "http://fake:11437")
+        # n=0 because the error was counted, not a scored needle.
+        assert summary.get("all", {}).get("n", 0) == 0
+        assert rows[0]["error"] is not None
+
+
+# ===========================================================================
+# GROUP B: no-leak guard (query scrubbing)
+# ===========================================================================
+
+
+class TestNoLeakGuard:
+    """Verify that build_shard_gold never echoes filename/symbol/path in query."""
+
+    @pytest.fixture()
+    def temp_project(self, tmp_path):
+        """Build a tiny source tree with known scrub targets."""
+        root = tmp_path / "MyFakeProject"
+        src = root / "src" / "auth"
+        src.mkdir(parents=True)
+
+        # Python file: class AuthHandler with docstring that does NOT
+        # contain the symbol or file name — simulates real code where the
+        # docstring explains behaviour without repeating the name.
+        py_file = src / "auth_handler.py"
+        py_file.write_text(
+            textwrap.dedent("""\
+                class AuthHandler:
+                    \"\"\"Verifies incoming tokens against the credential store
+                    and raises a permission error when validation fails.
+                    Delegates revocation tracking to the session registry.
+                    Supports both bearer and cookie based schemes.
+                    \"\"\"
+
+                    def authenticate(self, token: str) -> bool:
+                        \"\"\"Checks whether token is valid and not expired,
+                        returning True on success and False on failure.
+                        Queries the underlying database for the token record.
+                        This method is the main entry point for all authentication.
+                        \"\"\"
+                        return True
+                """),
+            encoding="utf-8",
+        )
+
+        # Markdown file: section about deployment
+        md_file = root / "docs" / "deploy_guide.md"
+        md_file.parent.mkdir(parents=True)
+        md_file.write_text(
+            textwrap.dedent("""\
+                # Deployment Overview
+
+                This section describes the rollout process and environment
+                prerequisites.  Services must be started in dependency order
+                and health checks should pass before traffic is routed.
+                Containerised builds use multi-stage images to keep size minimal.
+
+                ## Configuration Reference
+
+                Environment variables control all runtime behaviour.
+                The primary knobs are connection pool size, log verbosity,
+                and the upstream endpoint address.
+                """),
+            encoding="utf-8",
+        )
+
+        return root
+
+    # ── Python extractor ────────────────────────────────────────────────
+
+    def test_python_extractor_finds_class_docstring(self, temp_project):
+        py_file = temp_project / "src" / "auth" / "auth_handler.py"
+        units = extract_python_units(py_file)
+        assert len(units) >= 1
+        symbols = [u["symbol"] for u in units]
+        assert "AuthHandler" in symbols
+
+    def test_python_extractor_finds_method_docstring(self, temp_project):
+        py_file = temp_project / "src" / "auth" / "auth_handler.py"
+        units = extract_python_units(py_file)
+        symbols = [u["symbol"] for u in units]
+        assert "authenticate" in symbols
+
+    # ── Markdown extractor ──────────────────────────────────────────────
+
+    def test_md_extractor_finds_sections(self, temp_project):
+        md_file = temp_project / "docs" / "deploy_guide.md"
+        sections = extract_md_sections(md_file)
+        assert len(sections) >= 1
+        titles = [s["symbol"] for s in sections]
+        assert "Deployment Overview" in titles
+
+    # ── _path_tokens detects all leak surfaces ──────────────────────────
+
+    def test_path_tokens_includes_filename_stem(self, temp_project):
+        py_file = temp_project / "src" / "auth" / "auth_handler.py"
+        tokens = _path_tokens(temp_project, py_file)
+        # stem "auth_handler" should produce subtokens "auth" and "handler"
+        assert "handler" in tokens or "auth_handler" in tokens
+
+    def test_path_tokens_includes_directory_names(self, temp_project):
+        py_file = temp_project / "src" / "auth" / "auth_handler.py"
+        tokens = _path_tokens(temp_project, py_file)
+        # "src" and "auth" are directory components
+        # (they may be filtered as too-short / boring, but check at least one deeper one)
+        assert "auth" in tokens or "src" in tokens
+
+    def test_path_tokens_includes_project_root_name(self, temp_project):
+        py_file = temp_project / "src" / "auth" / "auth_handler.py"
+        tokens = _path_tokens(temp_project, py_file)
+        # project root name is "MyFakeProject" -> lower -> "myfakeproject"
+        # after camelCase split: "my", "fake", "project"
+        assert "fake" in tokens or "myfakeproject" in tokens
+
+    # ── _scrub removes forbidden tokens ─────────────────────────────────
+
+    def test_scrub_removes_exact_token(self):
+        text = "The auth_handler validates the session."
+        result = _scrub(text, {"auth_handler"})
+        assert "auth_handler" not in result.lower()
+
+    def test_scrub_removes_case_insensitively(self):
+        text = "AuthHandler processes the request pipeline."
+        result = _scrub(text, {"authhandler"})
+        assert "authhandler" not in result.lower()
+
+    def test_scrub_collapses_whitespace(self):
+        text = "The  handler   processes  tokens."
+        result = _scrub(text, {"handler"})
+        assert "  " not in result
+
+    def test_scrub_preserves_non_forbidden_content(self):
+        text = "Verifies incoming tokens against the credential store."
+        result = _scrub(text, {"auth_handler"})
+        # The forbidden token is not present, so text should be mostly intact.
+        assert "credential" in result.lower()
+        assert "tokens" in result.lower()
+
+    # ── End-to-end: build_needles_for_project no-leak property ──────────
+
+    def test_no_filename_stem_in_query(self, temp_project):
+        """The filename stem must not appear in any generated question."""
+        import random as _random
+        rng = _random.Random(0)
+        needles = build_needles_for_project(temp_project, n=50, rng=rng)
+        # For Python needles from auth_handler.py
+        py_needles = [
+            n for n in needles
+            if "auth_handler.py" in (n.get("gold_paths") or [""])[0]
+        ]
+        for nd in py_needles:
+            q = nd["question"].lower()
+            assert "auth_handler" not in q, (
+                "filename stem 'auth_handler' leaked into question: {!r}".format(q)
+            )
+
+    def test_no_symbol_name_in_query(self, temp_project):
+        """The function/class name must not appear verbatim in the question."""
+        import random as _random
+        rng = _random.Random(0)
+        needles = build_needles_for_project(temp_project, n=50, rng=rng)
+        for nd in needles:
+            q = nd["question"].lower()
+            for sym in nd.get("gold_symbols", []):
+                assert sym.lower() not in q, (
+                    "symbol {!r} leaked into question for {}: {!r}".format(
+                        sym, nd.get("gold_paths"), q
+                    )
+                )
+
+    def test_no_directory_name_in_query(self, temp_project):
+        """Directory-component tokens must not appear in generated questions.
+
+        We specifically test that the project root name's sub-tokens
+        (e.g. 'fake' from 'MyFakeProject') are absent.
+        """
+        import random as _random
+        rng = _random.Random(0)
+        needles = build_needles_for_project(temp_project, n=50, rng=rng)
+        for nd in needles:
+            q = nd["question"].lower()
+            # "myfakeproject" split -> "fake", "project" are forbidden
+            assert "myfakeproject" not in q, (
+                "project root name leaked into question: {!r}".format(q)
+            )
+
+    def test_questions_are_long_enough(self, temp_project):
+        """After scrubbing, every question must still be >= 40 characters."""
+        import random as _random
+        rng = _random.Random(0)
+        needles = build_needles_for_project(temp_project, n=50, rng=rng)
+        assert len(needles) > 0, "expected at least one needle from the fixture"
+        for nd in needles:
+            assert len(nd["question"]) >= 40, (
+                "question too short after scrubbing: {!r}".format(nd["question"])
+            )
+
+    def test_needles_have_required_schema_fields(self, temp_project):
+        """Every needle must have the mandatory JSONL schema fields."""
+        import random as _random
+        rng = _random.Random(0)
+        needles = build_needles_for_project(temp_project, n=50, rng=rng)
+        required = {"project", "file_type", "question", "gold_paths", "gold_lines"}
+        for nd in needles:
+            missing = required - nd.keys()
+            assert not missing, "needle missing fields {}: {!r}".format(missing, nd)
+            assert isinstance(nd["gold_paths"], list)
+            assert len(nd["gold_paths"]) >= 1
+            assert isinstance(nd["gold_lines"], list)
+            assert len(nd["gold_lines"]) == 2
+
+    def test_gold_paths_are_project_relative_forward_slash(self, temp_project):
+        """gold_paths entries must be '<project_name>/...' with forward slashes."""
+        import random as _random
+        rng = _random.Random(0)
+        needles = build_needles_for_project(temp_project, n=50, rng=rng)
+        for nd in needles:
+            for gp in nd["gold_paths"]:
+                assert "/" in gp, "gold_path should use forward slashes: {!r}".format(gp)
+                assert not gp.startswith("/"), (
+                    "gold_path should be relative, not absolute: {!r}".format(gp)
+                )
+                # Should start with the project name.
+                assert gp.startswith(temp_project.name + "/"), (
+                    "gold_path should start with project name {!r}: {!r}".format(
+                        temp_project.name, gp
+                    )
+                )
+
+    # ── _build_query directly ────────────────────────────────────────────
+
+    def test_build_query_returns_none_when_too_short_after_scrub(self):
+        # If the entire doc is just the forbidden token, query should be None.
+        result = _build_query("auth_handler", {"auth_handler"})
+        assert result is None
+
+    def test_build_query_preserves_behaviour_prose(self):
+        doc = (
+            "Verifies incoming tokens against the credential store and raises "
+            "a permission error when validation fails.  Supports both bearer "
+            "and cookie based authentication schemes."
+        )
+        result = _build_query(doc, {"auth_handler", "authenticate", "handler"})
+        assert result is not None
+        assert len(result) >= 40
+        assert "auth_handler" not in result.lower()
+        assert "authenticate" not in result.lower()

--- a/tests/test_sharded_adapter_parity.py
+++ b/tests/test_sharded_adapter_parity.py
@@ -144,6 +144,13 @@ ADAPTER_ONLY_DIFFERENCES_WHITELIST = frozenset({
     # upsert_doc is a no-op, so it never encodes.
     "_encode_dense_v2_blob",
 
+    # #182 cross-shard global-IDF lexical re-score. Per-shard helpers the
+    # ShardRouter calls DIRECTLY on each Genome (not through the adapter):
+    # the router aggregates global N/df across shards, then asks each shard
+    # to recompute its candidates' BM25 lexical sub-score with the injected
+    # global IDF. No adapter fan-out — they operate on one .db's FTS index.
+    "rescore_lexical_global_idf", "_ensure_fts_vocab",
+
     # Dense recall — per-shard, no cross-shard fan-out in V1.
     "query_docs_dense_recall", "query_genes_dense_recall",
 

--- a/tools/shard_to_blob.py
+++ b/tools/shard_to_blob.py
@@ -1,0 +1,426 @@
+"""shard_to_blob.py -- Merge a SHARDED genome into a single BLOB genome.db.
+
+This is the *reverse* of the usual blob -> sharded split. We take a sharded
+knowledge-store tree:
+
+    <sharded-root>/
+      main.genome.db                 # routing + fingerprint_index (NOT merged)
+      .../<name>.genome.db           # per-shard content DBs (merged)
+      .../<name2>.genome.db
+      ...
+
+and produce one flat ``genome.db`` that a normal (non-sharded) Helix server can
+open with dense retrieval fully working -- because we copy ``embedding_dense_v2``
+(and every other column) VERBATIM. We never re-embed.
+
+WHY THIS IS CAREFUL
+-------------------
+The user has only ever gone blob -> sharded before. Going the other direction,
+the failure modes are:
+  - gene_id collisions across shards (gene_id is a content hash, so duplicates
+    are byte-identical -- we de-dupe defensively with INSERT OR IGNORE on the
+    PK).
+  - losing the dense vector by going through any text/JSON round-trip
+    (we copy the raw BLOB column directly, no decode).
+  - a stale / partial FTS5 index after the bulk copy (we DROP + rebuild
+    genes_fts over the merged content so search works).
+
+ALGORITHM
+---------
+1. Discover all non-``main`` ``*.genome.db`` files under ``--sharded-root``
+   (recursive).
+2. Create a fresh blob ``--out`` with the *same per-shard schema* by copying
+   the DDL of one shard (``sqlite_master``), so column order / types match
+   exactly -- including ``embedding_dense_v2 BLOB``.
+3. For each shard: ``ATTACH`` it and ``INSERT OR IGNORE INTO blob.<table>
+   SELECT * FROM shard.<table>`` for every content table that exists in both
+   (``genes`` plus tags / edges / graph tables). ``OR IGNORE`` handles PK
+   collisions (identical content-hashed rows) without aborting.
+4. DROP + recreate ``genes_fts`` and repopulate it from the merged ``genes``
+   (source_id + promoter tags + content), matching the ingest-time FTS layout.
+5. VERIFY: blob gene-count == sum of shard gene-counts minus de-duped
+   collisions, and non-NULL ``embedding_dense_v2`` count is preserved.
+
+CLI
+---
+python tools/shard_to_blob.py \\
+    --sharded-root genomes/bench/matrix-sharded/enterprise_rag_500k \\
+    --out genomes/bench/erb_blob.genome.db
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from typing import Iterable
+
+# Per-shard content tables we merge (best-effort: skipped if absent in a
+# given shard). The FTS5 shadow tables (genes_fts*) are intentionally NOT in
+# this list -- we rebuild the FTS index from scratch after the merge.
+CONTENT_TABLES = [
+    "genes",
+    "promoter_index",
+    "entity_graph",
+    "path_key_index",
+    "filename_index",
+    "gene_relations",
+    "harmonic_links",
+    "splade_terms",
+    "genome_calibration",
+    "health_log",
+]
+
+# Substrings that mark a DB filename as the routing DB (never merged as a shard).
+_MAIN_MARKERS = ("main.genome.db",)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def discover_shards(sharded_root: str) -> list[str]:
+    """Return all non-main ``*.genome.db`` files under *sharded_root* (recursive)."""
+    out: list[str] = []
+    for dirpath, _dirnames, filenames in os.walk(sharded_root):
+        for fn in filenames:
+            if not fn.endswith(".genome.db"):
+                continue
+            if fn in _MAIN_MARKERS:
+                continue
+            # Skip SQLite sidecars (handled implicitly by the .db match anyway).
+            out.append(os.path.join(dirpath, fn))
+    out.sort()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Read-only shard access
+# ---------------------------------------------------------------------------
+
+def _ro_uri(path: str) -> str:
+    # immutable=1 (not mode=ro): real shards on disk often carry live
+    # -wal / -shm sidecars, and a plain mode=ro connection then fails with
+    # "disk I/O error" because it cannot lock/replay the WAL. immutable=1
+    # tells SQLite the file will not change, so it reads the main DB file
+    # directly and ignores the WAL -- correct for a read-only merge source.
+    return "file:{}?immutable=1".format(os.path.abspath(path).replace("\\", "/"))
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+
+
+def _shard_ddl(conn: sqlite3.Connection) -> list[str]:
+    """Return CREATE statements for all non-FTS, non-sqlite tables + indexes.
+
+    We skip:
+      - sqlite internal tables (sqlite_*)
+      - FTS5 virtual table + its shadow tables (genes_fts*) -- rebuilt later
+    """
+    stmts: list[str] = []
+    rows = conn.execute(
+        "SELECT type, name, sql FROM sqlite_master "
+        "WHERE sql IS NOT NULL AND type IN ('table', 'index') "
+        "ORDER BY (type='index'), name"
+    ).fetchall()
+    for typ, name, sql in rows:
+        if name.startswith("sqlite_"):
+            continue
+        if name.startswith("genes_fts"):
+            continue
+        stmts.append(sql)
+    return stmts
+
+
+# ---------------------------------------------------------------------------
+# Blob construction
+# ---------------------------------------------------------------------------
+
+def create_blob_schema(blob_path: str, template_shard: str) -> None:
+    """Create *blob_path* fresh with the schema copied from *template_shard*."""
+    if os.path.exists(blob_path):
+        os.remove(blob_path)
+    for sidecar in ("-wal", "-shm"):
+        if os.path.exists(blob_path + sidecar):
+            os.remove(blob_path + sidecar)
+
+    src = sqlite3.connect(_ro_uri(template_shard), uri=True)
+    try:
+        ddl = _shard_ddl(src)
+    finally:
+        src.close()
+
+    blob = sqlite3.connect(blob_path)
+    try:
+        blob.execute("PRAGMA journal_mode=WAL")
+        for stmt in ddl:
+            try:
+                blob.execute(stmt)
+            except sqlite3.OperationalError as exc:
+                # Index referencing a column/table not present is non-fatal.
+                print("  [warn] DDL skipped: {} ({})".format(
+                    stmt.split("\n")[0][:70], exc), file=sys.stderr)
+        blob.commit()
+    finally:
+        blob.close()
+
+
+def _common_columns(
+    blob: sqlite3.Connection, shard: sqlite3.Connection, table: str
+) -> list[str]:
+    """Columns present in *both* blob and shard for *table* (preserves blob order)."""
+    blob_cols = [r[1] for r in blob.execute(f"PRAGMA table_info({table})")]
+    shard_cols = {r[1] for r in shard.execute(f"PRAGMA table_info({table})")}
+    return [c for c in blob_cols if c in shard_cols]
+
+
+def merge_shard(
+    blob: sqlite3.Connection, shard_path: str, tables: Iterable[str]
+) -> dict[str, int]:
+    """ATTACH *shard_path*, copy each content table into the blob.
+
+    Uses INSERT OR IGNORE so PK collisions (identical content-hashed genes) are
+    de-duped rather than aborting. Returns per-table inserted-row deltas.
+    """
+    blob.execute("ATTACH DATABASE ? AS shard", (_ro_uri(shard_path),))
+    deltas: dict[str, int] = {}
+    try:
+        shard_tables = {
+            r[0]
+            for r in blob.execute(
+                "SELECT name FROM shard.sqlite_master WHERE type='table'"
+            )
+        }
+        blob_tables = _table_names(blob)
+        # Reflect column intersection via a temporary connection view: we can
+        # PRAGMA on attached DB with the schema-qualified name.
+        for table in tables:
+            if table not in shard_tables or table not in blob_tables:
+                continue
+            cols = _common_columns_attached(blob, table)
+            if not cols:
+                continue
+            col_list = ", ".join(cols)
+            before = blob.execute(
+                f"SELECT COUNT(*) FROM main.{table}"
+            ).fetchone()[0]
+            blob.execute(
+                f"INSERT OR IGNORE INTO main.{table} ({col_list}) "
+                f"SELECT {col_list} FROM shard.{table}"
+            )
+            after = blob.execute(
+                f"SELECT COUNT(*) FROM main.{table}"
+            ).fetchone()[0]
+            deltas[table] = after - before
+        blob.commit()
+    finally:
+        blob.execute("DETACH DATABASE shard")
+    return deltas
+
+
+def _common_columns_attached(blob: sqlite3.Connection, table: str) -> list[str]:
+    """Columns present in both main.<table> and shard.<table> (main order)."""
+    main_cols = [r[1] for r in blob.execute(f"PRAGMA main.table_info({table})")]
+    shard_cols = {r[1] for r in blob.execute(f"PRAGMA shard.table_info({table})")}
+    return [c for c in main_cols if c in shard_cols]
+
+
+def _shard_gene_count(shard_path: str) -> int:
+    conn = sqlite3.connect(_ro_uri(shard_path), uri=True)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        conn.close()
+
+
+def _shard_dense_count(shard_path: str) -> int:
+    conn = sqlite3.connect(_ro_uri(shard_path), uri=True)
+    try:
+        return conn.execute(
+            "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# FTS5 rebuild
+# ---------------------------------------------------------------------------
+
+def rebuild_fts(blob: sqlite3.Connection) -> int:
+    """DROP + recreate genes_fts over the merged content. Returns row count.
+
+    Mirrors the ingest-time FTS layout (storage/ddl._create_fts5 and
+    storage/indexes.sync_fts5): the indexed ``content`` column is
+    ``source_id + ' ' + promoter-tags + ' ' + content``.
+    """
+    blob.execute("DROP TABLE IF EXISTS genes_fts")
+    blob.execute(
+        "CREATE VIRTUAL TABLE genes_fts USING fts5("
+        "gene_id, content, complement)"
+    )
+    has_promoter = "promoter_index" in _table_names(blob)
+    if has_promoter:
+        tag_sub = (
+            "COALESCE((SELECT GROUP_CONCAT(pi.tag_value, ' ') "
+            "FROM promoter_index pi WHERE pi.gene_id = g.gene_id), '')"
+        )
+    else:
+        tag_sub = "''"
+    blob.execute(
+        "INSERT INTO genes_fts(gene_id, content, complement) "
+        "SELECT g.gene_id, "
+        "  COALESCE(g.source_id,'') || ' ' || " + tag_sub + " || ' ' || "
+        "  COALESCE(g.content,''), "
+        "  COALESCE(g.complement,'') "
+        "FROM genes g"
+    )
+    blob.commit()
+    return blob.execute("SELECT COUNT(*) FROM genes_fts").fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def shard_to_blob(sharded_root: str, out_path: str) -> dict:
+    """Merge all shards under *sharded_root* into a blob at *out_path*.
+
+    Returns a summary dict with verification fields.
+    """
+    shards = discover_shards(sharded_root)
+    if not shards:
+        raise FileNotFoundError(
+            "No non-main *.genome.db shards found under {}".format(sharded_root)
+        )
+
+    # Expected totals (read-only probe of every shard before we touch the blob).
+    shard_gene_counts = {s: _shard_gene_count(s) for s in shards}
+    shard_dense_counts = {s: _shard_dense_count(s) for s in shards}
+    expected_genes_sum = sum(shard_gene_counts.values())
+    expected_dense_sum = sum(shard_dense_counts.values())
+
+    print("[shard_to_blob] {} shard(s) under {}".format(len(shards), sharded_root))
+    for s in shards:
+        print("    {:6d} genes ({:6d} dense)  {}".format(
+            shard_gene_counts[s], shard_dense_counts[s],
+            os.path.relpath(s, sharded_root)))
+
+    out_dir = os.path.dirname(os.path.abspath(out_path))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    # Schema from the first shard that actually has a genes table.
+    template = next((s for s in shards if shard_gene_counts[s] >= 0), shards[0])
+    create_blob_schema(out_path, template)
+
+    blob = sqlite3.connect(out_path, uri=True)
+    # Allow ATTACH of file: URIs (the shard sources use immutable=1 URIs).
+    blob.execute("PRAGMA busy_timeout=30000")
+    try:
+        total_inserted = 0
+        for s in shards:
+            deltas = merge_shard(blob, s, CONTENT_TABLES)
+            total_inserted += deltas.get("genes", 0)
+
+        blob_genes = blob.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
+        blob_dense = blob.execute(
+            "SELECT COUNT(*) FROM genes WHERE embedding_dense_v2 IS NOT NULL"
+        ).fetchone()[0]
+
+        fts_rows = rebuild_fts(blob)
+    finally:
+        blob.close()
+
+    dupes = expected_genes_sum - blob_genes
+    summary = {
+        "sharded_root": sharded_root,
+        "out": out_path,
+        "n_shards": len(shards),
+        "expected_genes_sum": expected_genes_sum,
+        "blob_genes": blob_genes,
+        "deduped_collisions": dupes,
+        "expected_dense_sum": expected_dense_sum,
+        "blob_dense": blob_dense,
+        "fts_rows": fts_rows,
+        # Dense preservation holds when the blob's non-null dense count equals
+        # the sum of shard dense counts MINUS the de-duped collisions (a deduped
+        # row that had a vector removes one from both totals symmetrically).
+        "genes_ok": blob_genes == expected_genes_sum - dupes,
+        "dense_ok": blob_dense == expected_dense_sum - _dense_dupes(
+            shards, dupes
+        ) if dupes else blob_dense == expected_dense_sum,
+    }
+    return summary
+
+
+def _dense_dupes(shards: list[str], total_dupes: int) -> int:
+    """Conservative estimate of how many de-duped genes carried a dense vector.
+
+    For the verify check we don't need the exact split; when there are no
+    collisions (the common, globally-unique-gene_id case) this returns 0 and
+    the strict equality ``blob_dense == expected_dense_sum`` is used instead.
+    We bound it by total_dupes so the check never under-counts.
+    """
+    return total_dupes
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Merge a sharded genome (main.genome.db + per-shard "
+            "*.genome.db files) into a single blob genome.db, preserving "
+            "embedding_dense_v2 verbatim so a non-sharded Helix server can "
+            "serve dense retrieval. Does NOT re-embed."
+        )
+    )
+    ap.add_argument(
+        "--sharded-root", required=True, dest="sharded_root",
+        help="Directory containing main.genome.db + per-shard *.genome.db.",
+    )
+    ap.add_argument("--out", required=True, help="Output blob genome.db path.")
+    args = ap.parse_args(argv)
+
+    t0 = time.time()
+    try:
+        summary = shard_to_blob(args.sharded_root, args.out)
+    except FileNotFoundError as exc:
+        print("ERROR: {}".format(exc), file=sys.stderr)
+        return 1
+
+    print()
+    print("=" * 60)
+    print("  shard -> blob merge complete")
+    print("=" * 60)
+    print("  shards merged:        {}".format(summary["n_shards"]))
+    print("  expected gene sum:    {}".format(summary["expected_genes_sum"]))
+    print("  blob gene count:      {}".format(summary["blob_genes"]))
+    print("  deduped collisions:   {}".format(summary["deduped_collisions"]))
+    print("  expected dense sum:   {}".format(summary["expected_dense_sum"]))
+    print("  blob dense (non-null):{}".format(summary["blob_dense"]))
+    print("  FTS5 rows rebuilt:    {}".format(summary["fts_rows"]))
+    print("  gene-count OK:        {}".format(summary["genes_ok"]))
+    print("  dense preserved OK:   {}".format(summary["dense_ok"]))
+    print("  elapsed:              {:.1f}s".format(time.time() - t0))
+    print("  -> {}".format(args.out))
+
+    if not (summary["genes_ok"] and summary["dense_ok"]):
+        print("WARNING: verification FAILED -- inspect counts above.",
+              file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Salvaged from the pre-master-switch working-tree snapshot (3b2822c on feat/telemetry-hv-prebase). The ContextBench/RepoBench-R/CodeRAG harnesses, runbooks, and probe config that the regression log and the 2026-07-01 run plan reference existed only as untracked rig files - this makes the bench setup reproducible from the repo.

## Contents
- benchmarks/: cb_helix_pred + step-0 scorers, RepoBench-R + CodeRAG runners/adapters, shard-vs-blob diag scripts, gold builders (22 files)
- docs/benchmarks/: both runbooks, helix_probe_lexical.toml, benchmark strategy + step-0 result docs
- docs/: councils, decisions, investigations (incl. 0027 + #165 notes, moved from repo root), prds (incl. the code-structure-retrieval PRD), WS1-3 council review + consensus + OSS-retrieval research
- scripts/tools/tests: repobench runner ps1, matrix freezer, harness + diag test suites
- .gitignore: local data/cache dirs; contextbench gold parquets stay untracked pending the upstream dataset-license question

## Verification
227 passed, 3 skipped (data-gated) on the salvaged test suites against current master.

## Deliberately excluded
test_shard_score_debug + test_global_idf_rescore - they test an unlanded shard_router iteration (score-breakdown introspection + newer global-IDF behavior) preserved on the snapshot branch; they should land with that feature, not this salvage.