### PR TITLE
feat(sharding): #181 introspection, #182 global-IDF fix, #222/#223 dark-shipped fixes

### DIFF
--- a/helix_context/knowledge_store.py
+++ b/helix_context/knowledge_store.py
@@ -1647,6 +1647,239 @@ class KnowledgeStore:
             cur.close()
         return result
 
+    def _ensure_fts_vocab(self) -> None:
+        """Best-effort create of the ``genes_fts_vocab`` shadow table.
+
+        Created at DB init (storage.ddl) for new stores; this covers
+        LEGACY shard .db files that predate the #182 change. Uses the
+        WRITABLE connection (the read connection is read-only and a
+        ``CREATE VIRTUAL TABLE`` against it raises). Idempotent and
+        soft-failing — on any error the rescore probe falls back to the
+        scalar path.
+        """
+        if not self._fts_available:
+            return
+        try:
+            self.conn.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS genes_fts_vocab "
+                "USING fts5vocab(genes_fts, instance)"
+            )
+            self.conn.commit()
+        except Exception:
+            # Read-only-DB or fts5vocab-unavailable build — non-fatal.
+            log.debug(
+                "global-idf rescore: could not ensure genes_fts_vocab",
+                exc_info=True,
+            )
+
+    def rescore_lexical_global_idf(
+        self,
+        candidate_ids: list[str],
+        query_terms: list[str],
+        global_idf_map: Dict[str, float],
+        *,
+        k1: float = 1.2,
+        b: float = 0.75,
+    ) -> Dict[str, float]:
+        """Recompute each candidate's BM25 LEXICAL score with injected global IDF.
+
+        Cross-shard global-IDF re-score (HELIX_SHARD_GLOBAL_IDF, #182).
+
+        SQLite FTS5's built-in ``bm25()`` (the ``rank`` column used in
+        :meth:`query_docs`'s Tier-3 FTS5 block) computes IDF over THIS
+        shard's corpus only. On sharded retrieval that corpus-LOCAL IDF
+        sets the *within-shard* order of two docs, and a per-shard scalar
+        (``m_shard``) cannot reorder docs inside one shard. This method
+        recomputes the Okapi-BM25 lexical score per candidate doc using:
+
+            * per-doc term frequency ``tf(t,d)`` and doc length ``dl(d)``
+              read from the ``fts5vocab(..., instance)`` shadow table of
+              this shard's ``genes_fts`` (the SAME content this shard's
+              ``bm25()`` scored), and
+            * the INJECTED ``global_idf_map`` (computed by the router from
+              the aggregated global N and global df over all shards) in
+              place of the local IDF.
+
+        Formula (BIT-EXACT with SQLite FTS5's ``bm25()``, k1=1.2, b=0.75)::
+
+            dl(d)    = total instance rows for d over ALL FTS columns
+            avgdl    = (Σ_d dl(d)) / N_local
+            tf(t,d)  = total occurrences of t in d over ALL FTS columns
+            score(d) = Σ_t  idf_global(t) ·
+                            tf(t,d)·(k1+1) /
+                            (tf(t,d) + k1·(1 - b + b·dl(d)/avgdl))
+
+        where ``idf_global(t)`` is the RAW (unsmoothed) FTS5 IDF
+        ``ln((N - n + 0.5) / (n + 0.5))`` injected via ``global_idf_map``
+        with FTS5's non-positive clamp already applied. dl/tf/avgdl are
+        counted over EVERY indexed column (gene_id, content, complement),
+        because FTS5's bm25() treats the row as one bag-of-tokens spanning
+        all columns with unit weights — the same columns the bare
+        ``genes_fts MATCH ?`` in :meth:`query_docs` searches. Empirically
+        verified bit-exact (|Δ| ≈ 1e-15) against ``SELECT bm25(genes_fts)``
+        on real shards; see ``benchmarks/diag_global_idf_counterfactual.py``.
+
+        The returned magnitude is on the SAME signed "bigger = better"
+        scale as the ``-rank`` value the genome feeds into
+        ``last_query_scores`` (the genome caps it at 6.0; the router
+        applies the cap when it splices this back into the fused score, so
+        this raw value is uncapped).
+
+        Returns:
+            ``{gene_id: global_idf_bm25_lexical_score}`` for every
+            candidate that appears in this shard's FTS index. Candidates
+            with no scored-term match get 0.0. Returns ``{}`` if FTS is
+            unavailable or no usable terms/candidates were supplied.
+        """
+        if not self._fts_available or not candidate_ids or not query_terms:
+            return {}
+        # Score only terms long enough to be FTS-relevant AND that have a
+        # global IDF (router only injects IDF for the terms it probed).
+        scored_terms = [
+            t.lower() for t in query_terms
+            if t and len(t) > 2 and t.lower() in global_idf_map
+        ]
+        if not scored_terms:
+            return {}
+
+        cand_set = set(candidate_ids)
+        # The fts5vocab "instance" shadow table (``genes_fts_vocab``) is
+        # created at DB init alongside ``genes_fts`` (storage.ddl). It is a
+        # zero-storage view: "instance" yields one row per
+        # (term, doc, col, offset) occurrence — counting rows per
+        # (doc, term) gives per-doc term frequency, and counting all
+        # rows per doc gives that doc's length in tokens.
+        self._ensure_fts_vocab()
+        cur = self.read_conn.cursor()
+        try:
+            # Probe that the vocab table is queryable; if a legacy DB
+            # predates it and we couldn't create it (read-only), soft-fail
+            # to the scalar path.
+            try:
+                cur.execute("SELECT term FROM genes_fts_vocab LIMIT 1")
+            except Exception:
+                log.warning(
+                    "global-idf rescore: genes_fts_vocab unavailable; "
+                    "falling back to scalar path",
+                    exc_info=True,
+                )
+                return {}
+
+            # Map this shard's FTS rowid -> gene_id for the candidate set.
+            # fts5vocab reports the integer 'doc' (= rowid), so we resolve
+            # candidate gene_ids to rowids and back.
+            id_ph = ",".join("?" * len(cand_set))
+            rowid_rows = cur.execute(
+                f"SELECT rowid, gene_id FROM genes_fts "
+                f"WHERE gene_id IN ({id_ph})",
+                tuple(cand_set),
+            ).fetchall()
+            rowid_to_gid: Dict[int, str] = {
+                int(r["rowid"]): r["gene_id"] for r in rowid_rows
+            }
+            if not rowid_to_gid:
+                return {gid: 0.0 for gid in candidate_ids}
+            cand_rowids = set(rowid_to_gid)
+
+            # Doc length per candidate doc = count of instance rows for
+            # that doc across ALL FTS columns. SQLite FTS5's bm25()
+            # measures D (doc length) as the total token count over every
+            # indexed column (here: gene_id, content, complement), with a
+            # single corpus-wide avgdl = (Σ all-column tokens) / N. Counting
+            # only ``col='content'`` understates both D and avgdl and breaks
+            # bit-exact parity with the engine's bm25() — see the parity
+            # probe in benchmarks/diag_global_idf_counterfactual.py.
+            n_local = self.fts_doc_count() or 0
+            avgdl = 0.0
+            try:
+                tot = cur.execute(
+                    "SELECT COUNT(*) FROM genes_fts_vocab"
+                ).fetchone()
+                total_tokens = int(tot[0]) if tot else 0
+                if n_local > 0:
+                    avgdl = total_tokens / float(n_local)
+            except Exception:
+                avgdl = 0.0
+            if avgdl <= 0.0:
+                avgdl = 1.0  # degenerate corpus; avoid divide-by-zero
+
+            # Per-candidate doc length (ALL columns — matches FTS5's D).
+            doc_len: Dict[int, int] = {rid: 0 for rid in cand_rowids}
+            try:
+                dl_rows = cur.execute(
+                    "SELECT doc, COUNT(*) AS dl FROM genes_fts_vocab "
+                    "GROUP BY doc"
+                ).fetchall()
+                for r in dl_rows:
+                    rid = int(r["doc"])
+                    if rid in doc_len:
+                        doc_len[rid] = int(r["dl"])
+            except Exception:
+                log.warning(
+                    "global-idf rescore: doc-length probe failed",
+                    exc_info=True,
+                )
+                return {}
+
+            # Per (term, candidate-doc) term frequency: count instance rows
+            # across ALL columns (FTS5's tf is the total occurrence count
+            # over every indexed column). One small query per scored term
+            # (bounded by the query length).
+            #
+            # NOTE on the injected ``g_idf`` scale: the router computes it
+            # with SQLite FTS5's RAW Robertson-Sparck-Jones IDF
+            # ``ln((N - n + 0.5) / (n + 0.5))`` AND FTS5's own non-positive
+            # clamp (``idf <= 0 -> 1e-6``), so a globally-ubiquitous term
+            # contributes ~nothing rather than a large negative — exactly
+            # what the engine's bm25() does. We do NOT re-gate on
+            # ``g_idf > 0`` here: the value already carries the engine's
+            # clamp, and the OLD code's combination of the SMOOTHED
+            # always-positive IDF + a local ``g_idf > 0`` gate is precisely
+            # what put the lexical sub-score on the wrong scale and drove
+            # the #182 recall regression (0.347 -> 0.168).
+            scores: Dict[str, float] = {
+                rowid_to_gid[rid]: 0.0 for rid in cand_rowids
+            }
+            for term in scored_terms:
+                if term not in global_idf_map:
+                    continue
+                g_idf = float(global_idf_map[term])
+                escaped_doc_ph = ",".join("?" * len(cand_rowids))
+                try:
+                    tf_rows = cur.execute(
+                        f"SELECT doc, COUNT(*) AS tf FROM genes_fts_vocab "
+                        f"WHERE term = ? "
+                        f"AND doc IN ({escaped_doc_ph}) "
+                        f"GROUP BY doc",
+                        (term, *cand_rowids),
+                    ).fetchall()
+                except Exception:
+                    continue
+                for r in tf_rows:
+                    rid = int(r["doc"])
+                    tf = float(r["tf"])
+                    if tf <= 0.0 or rid not in rowid_to_gid:
+                        continue
+                    dl = float(doc_len.get(rid, 0)) or 1.0
+                    denom = tf + k1 * (1.0 - b + b * (dl / avgdl))
+                    if denom <= 0.0:
+                        continue
+                    contrib = g_idf * (tf * (k1 + 1.0)) / denom
+                    scores[rowid_to_gid[rid]] += contrib
+
+            # Candidates absent from the FTS index keep an implicit 0.0.
+            for gid in candidate_ids:
+                scores.setdefault(gid, 0.0)
+            return scores
+        except Exception:
+            log.warning(
+                "global-idf rescore failed; router falls back to scalar path",
+                exc_info=True,
+            )
+            return {}
+        finally:
+            cur.close()
+
     def _bm25_candidate_set(self, query_terms: list[str], size: int) -> set[str] | None:
         """Return FTS5 BM25 top-N gene_ids, or None if FTS unavailable/empty. Soft-fails to None."""
         if not self._fts_available:

--- a/helix_context/shard_router.py
+++ b/helix_context/shard_router.py
@@ -320,6 +320,103 @@ def _compute_shard_idf_correction(
     return multipliers
 
 
+def _global_idf_enabled() -> bool:
+    """True iff HELIX_SHARD_GLOBAL_IDF is set to a truthy value.
+
+    Truthy (case-insensitive): '1', 'true', 'yes', 'on'. Anything else
+    (including unset) is False. Gates the per-doc global-IDF lexical
+    re-score in :meth:`ShardRouter.query_genes` (#182). OFF by default —
+    when off, the router uses the legacy per-shard scalar ``m_shard``
+    correction and behaviour is byte-identical to the pre-#182 build.
+    """
+    v = os.environ.get("HELIX_SHARD_GLOBAL_IDF")
+    if v is None:
+        return False
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _compute_global_idf_map(
+    query_terms: List[str],
+    shard_n: Dict[str, int],
+    shard_dfs: Dict[str, Dict[str, int]],
+) -> Dict[str, float]:
+    """Per-term TRUE GLOBAL IDF from aggregated cross-shard N and df.
+
+    Uses the RAW (unsmoothed) Robertson-Sparck-Jones IDF that SQLite
+    FTS5's ``bm25()`` uses internally — NOT the ``+1.0``-smoothed variant
+    that :func:`_compute_shard_idf_correction` uses for its scalar
+    multiplier::
+
+        global_idf(t) = ln((ΣN - Σdf(t) + 0.5) / (Σdf(t) + 0.5))
+
+    This is deliberately different from the scalar path. The scalar
+    ``m_shard`` only ever forms a RATIO of two IDFs, so the constant
+    ``+1.0`` smoothing cancels and keeps the multiplier strictly positive
+    and well-conditioned. The per-doc lexical re-score, by contrast, must
+    reproduce ``bm25()``'s ABSOLUTE scale so its output can be SPLICED
+    (``raw − old_local_lex + new_global_lex``) against the genome's
+    ``-rank`` lexical sub-score. The genome's ``-rank`` is exactly the raw
+    (unsmoothed) FTS5 BM25 sum; using the smoothed always-positive IDF here
+    would put the global lexical term on a different (always-larger,
+    never-negative) scale, and the splice would corrupt ranking — the
+    HELIX_SHARD_GLOBAL_IDF recall regression (0.347 → 0.168) traced to
+    exactly this scale mismatch (#182).
+
+    Returns ``{}`` when there's no corpus.
+    """
+    if not query_terms or not shard_n:
+        return {}
+    total_n = sum(shard_n.values())
+    if total_n <= 0:
+        return {}
+    global_df: Dict[str, int] = {t: 0 for t in query_terms}
+    for _shard_name, dfs in shard_dfs.items():
+        for t, df in dfs.items():
+            if t in global_df:
+                global_df[t] += int(df)
+    out: Dict[str, float] = {}
+    for t in query_terms:
+        df_g = global_df[t]
+        # RAW FTS5 IDF, with FTS5's exact negative-IDF clamp. SQLite's
+        # fts5 bm25() computes idf = ln((N - n + 0.5) / (n + 0.5)) and then
+        # forces ``if (idf <= 0.0) idf = 1e-6;`` — a term in > half the
+        # corpus does NOT subtract from the score, it contributes ~nothing.
+        # We reproduce that clamp here so the injected global IDF is
+        # bit-exact with bm25(). Without the clamp a globally-ubiquitous
+        # query term would inject a large NEGATIVE lexical sub-score that
+        # the engine never produced, re-corrupting the splice in the
+        # opposite direction from the original #182 bug.
+        idf = math.log((total_n - df_g + 0.5) / (df_g + 0.5))
+        out[t] = idf if idf > 0.0 else FTS5_IDF_FLOOR
+    return out
+
+
+# Lexical score cap — mirrors KnowledgeStore.query_docs Tier-3, which
+# adds ``min(-rank, 6.0)`` into the fused score. The global-IDF rescore
+# replaces that same capped lexical sub-score per doc.
+FTS5_LEXICAL_CAP = 6.0
+
+# SQLite FTS5's bm25() clamps a non-positive IDF to this tiny floor
+# (``if (idf <= 0.0) idf = 1e-6;`` in fts5_aux.c). Reproduced in the
+# global-IDF rescore so a globally-ubiquitous term contributes ~0 (never a
+# large negative) — matching the engine exactly. See _compute_global_idf_map.
+FTS5_IDF_FLOOR = 1e-6
+
+
+def _score_debug_enabled() -> bool:
+    """True iff HELIX_SHARD_SCORE_DEBUG is set to a truthy value.
+
+    Truthy (case-insensitive): '1', 'true', 'yes', 'on'. Anything else
+    (including unset) is False. Gates the score-path instrumentation in
+    :meth:`ShardRouter.query_genes` (#181) so the hot path is untouched
+    when off.
+    """
+    v = os.environ.get("HELIX_SHARD_SCORE_DEBUG")
+    if v is None:
+        return False
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+
 class ShardRouter:
     """Routes queries across category shard .db files.
 
@@ -367,6 +464,16 @@ class ShardRouter:
         # callers can use either interchangeably.
         self.last_query_scores: Dict[str, float] = {}
         self.last_tier_contributions: Dict[str, Dict[str, float]] = {}
+        # Cross-shard score-path introspection (issue #181 -- gold score
+        # depression). Populated ONLY when HELIX_SHARD_SCORE_DEBUG is
+        # truthy; stays {} otherwise so the hot path has zero overhead
+        # and behaviour is byte-identical. See query_genes.
+        #   last_score_breakdown: gene_id -> {shard, raw, m_shard,
+        #       doc_type_boost, corrected, rrf} for EVERY merged
+        #       candidate (not just the returned top-`limit`).
+        #   last_shard_multipliers: shard_name -> m_shard.
+        self.last_score_breakdown: Dict[str, dict] = {}
+        self.last_shard_multipliers: Dict[str, float] = {}
         # Guards last_query_scores / last_tier_contributions writes from
         # racing concurrent /context calls. KnowledgeStore has the same
         # lock on the same attributes (see knowledge_store.py:479) — the
@@ -722,14 +829,81 @@ class ShardRouter:
                 idf_terms, shard_n, shard_dfs,
             )
 
+        # ── Per-doc GLOBAL-IDF lexical re-score (#182, flag-gated) ──
+        # The scalar ``m_shard`` rescales every doc in a shard equally, so
+        # it cannot change the WITHIN-shard order of two docs — that order
+        # is set by each shard's corpus-LOCAL BM25 IDF. A gold whose
+        # distinguishing term is globally-rare-but-locally-common is buried
+        # under a same-shard incumbent, and no scalar can rescue it.
+        #
+        # When HELIX_SHARD_GLOBAL_IDF is truthy AND ≥2 shards participated,
+        # we recompute each candidate's BM25 LEXICAL sub-score per-doc with
+        # TRUE GLOBAL IDF (from the aggregated global N / df already probed
+        # for the scalar path) and SPLICE it back into that doc's fused
+        # raw score, replacing only the lexical portion. The dense/tier
+        # parts of raw are left untouched. When the flag is off, this whole
+        # block is skipped and the legacy scalar path runs unchanged
+        # (behaviour-preserving).
+        use_global_idf = (
+            _global_idf_enabled()
+            and len(shard_ranked) > 1
+            and bool(idf_terms)
+        )
+        # {shard_name: {gene_id: new_global_lexical_score}} — populated only
+        # under the flag. Empty dict ⇒ scalar path (flag off / 1 shard).
+        global_lex: Dict[str, Dict[str, float]] = {}
+        if use_global_idf:
+            global_idf_map = _compute_global_idf_map(
+                idf_terms, shard_n, shard_dfs,
+            )
+            if global_idf_map:
+                for shard_name, pairs in shard_ranked.items():
+                    cand_ids = [gid for gid, _raw in pairs]
+                    if not cand_ids:
+                        continue
+                    try:
+                        shard = self._shards.get(shard_name)
+                        if shard is None:
+                            continue
+                        global_lex[shard_name] = shard.rescore_lexical_global_idf(
+                            cand_ids, idf_terms, global_idf_map,
+                        )
+                    except Exception:
+                        log.warning(
+                            "shard %s global-idf rescore failed; "
+                            "falling back to scalar for this shard",
+                            shard_name, exc_info=True,
+                        )
+                        global_lex[shard_name] = {}
+            else:
+                # No global signal — nothing to rescore; fall back to scalar.
+                use_global_idf = False
+
         # Apply correction. A doc that appears in multiple shards (rare —
         # would require content-hash collision across shards) keeps its
         # highest corrected score so cross-shard duplication can't penalize.
+        #
+        # Under the global-IDF flag, ``m_shard`` is REPLACED by the per-doc
+        # lexical splice: corrected = (raw − old_local_lexical) +
+        # min(new_global_lexical, cap). When the flag is off (or a shard's
+        # rescore produced no entry for a doc), we use the legacy scalar
+        # ``raw * m_shard`` for that doc.
         corrected: Dict[str, float] = {}
         for shard_name, pairs in shard_ranked.items():
             m = float(multipliers.get(shard_name, 1.0))
+            shard_lex = global_lex.get(shard_name, {}) if use_global_idf else {}
             for gid, raw in pairs:
-                adj = raw * m
+                if use_global_idf and gid in shard_lex:
+                    # Per-doc global-IDF splice. The old local lexical
+                    # sub-score is the per-doc ``fts5`` tier contribution
+                    # the genome recorded (already capped at the cap), and
+                    # the new lexical sub-score is the global-IDF BM25
+                    # value capped to the same ceiling.
+                    old_lex = float(merged_tier.get(gid, {}).get("fts5", 0.0))
+                    new_lex = min(float(shard_lex[gid]), FTS5_LEXICAL_CAP)
+                    adj = raw - old_lex + new_lex
+                else:
+                    adj = raw * m
                 if gid not in corrected or adj > corrected[gid]:
                     corrected[gid] = adj
 
@@ -753,6 +927,63 @@ class ShardRouter:
                     corrected[gid] *= boost
 
         rrf_all = fuser.all_scores()
+
+        # -- Score-path introspection (issue #181) ------------------
+        # Behaviour-preserving: ONLY runs when HELIX_SHARD_SCORE_DEBUG is
+        # truthy. Populates last_score_breakdown for EVERY merged
+        # candidate (including golds that fall below the `limit` cut, so
+        # the diag harness can see the depression) plus
+        # last_shard_multipliers. Reads only -- never touches `corrected`,
+        # `ranked_ids`, or the return value.
+        if _score_debug_enabled():
+            # Re-derive the shard/raw/m that produced each gid's WINNING
+            # adjusted (pre-boost) score -- mirrors the max-over-shards
+            # rule in the corrected-building loop above so the attributed
+            # (shard, raw, m_shard) matches the value that drove the sort.
+            best_pre_boost: Dict[str, Tuple[str, float, float]] = {}
+            for shard_name, pairs in shard_ranked.items():
+                m = float(multipliers.get(shard_name, 1.0))
+                for gid, raw in pairs:
+                    adj = raw * m
+                    prev = best_pre_boost.get(gid)
+                    prev_adj = (prev[1] * prev[2]) if prev is not None else None
+                    if prev_adj is None or adj > prev_adj:
+                        best_pre_boost[gid] = (shard_name, float(raw), m)
+            breakdown: Dict[str, dict] = {}
+            for gid in corrected:
+                shard_name, raw, m = best_pre_boost.get(gid, ("", 0.0, 1.0))
+                doc = merged.get(gid)
+                boost = (
+                    _doc_type_boost_for(getattr(doc, "source_id", None))
+                    if (doc is not None and len(shard_ranked) > 1)
+                    else 1.0
+                )
+                row = {
+                    "shard": shard_name,
+                    "raw": raw,
+                    "m_shard": m,
+                    "doc_type_boost": boost,
+                    "corrected": float(corrected.get(gid, 0.0)),
+                    "rrf": rrf_all.get(gid),
+                }
+                # #182: ONLY when the global-IDF flag is active do we add
+                # the ``global_lex`` field (the per-doc global-IDF BM25
+                # lexical sub-score that REPLACED ``raw * m_shard``). On
+                # the scalar (flag-off) path the breakdown shape stays
+                # byte-identical to the pre-#182 build, so the
+                # ``corrected == raw * m_shard * doc_type_boost`` identity
+                # the #181 diag harness asserts still holds exactly.
+                if use_global_idf:
+                    gl = global_lex.get(shard_name, {})
+                    row["global_lex"] = (
+                        min(float(gl[gid]), FTS5_LEXICAL_CAP)
+                        if gid in gl else None
+                    )
+                breakdown[gid] = row
+            self.last_score_breakdown = breakdown
+            self.last_shard_multipliers = {
+                sn: float(multipliers.get(sn, 1.0)) for sn in shard_ranked
+            }
 
         # Primary sort key: corrected score desc.
         # Secondary tiebreaker: RRF score desc (stable for ties in

--- a/helix_context/shard_router.py
+++ b/helix_context/shard_router.py
@@ -403,6 +403,95 @@ FTS5_LEXICAL_CAP = 6.0
 FTS5_IDF_FLOOR = 1e-6
 
 
+def _shard_fetch_factor() -> int:
+    """Per-shard fetch-depth factor (issue #222). Default 2 = legacy.
+
+    The router fetches ``max_genes * factor`` candidates from each shard
+    BEFORE the cross-shard merge. The flat legacy ``2`` is provably too
+    shallow whenever post-fetch rescaling (``m_shard`` ∈ [0.5, 3.0],
+    doc-type boost, global-IDF splice) can promote a doc past shallower
+    entries from other shards: promotion happens AFTER the per-shard cut,
+    so a mid-shard gold never reaches the merge. Raise via
+    ``HELIX_SHARD_FETCH_FACTOR`` (e.g. 4–6 on many-shard corpora); the
+    price is per-shard query cost. Unparseable/invalid values keep the
+    legacy 2 so behaviour never silently degrades.
+    """
+    raw = os.environ.get("HELIX_SHARD_FETCH_FACTOR", "").strip()
+    if not raw:
+        return 2
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 2
+
+
+def _coact_reserve_slots() -> int:
+    """Reserved result slots for co-activation-promoted docs (issue #223).
+
+    Default 0 = legacy (no reservation: linked docs enter the final sort
+    at ``COACT_LINK_BOOST × source score`` and are truncated like any
+    other candidate — which is exactly how graph-surfaced golds get
+    displaced). Set ``HELIX_SHARD_COACT_RESERVE=N`` to guarantee up to N
+    of the final ``limit`` slots go to the best promoted linked docs.
+    """
+    raw = os.environ.get("HELIX_SHARD_COACT_RESERVE", "").strip()
+    if not raw:
+        return 0
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 0
+
+
+def _apply_coact_reserve(
+    union_ids: List[str],
+    promoted: set,
+    corrected: Dict[str, float],
+    rrf_all: Dict[str, float],
+    limit: int,
+    reserve: int,
+) -> List[str]:
+    """Reserve up to ``reserve`` of the top-``limit`` slots for promoted docs.
+
+    Pure function (issue #223). Given the already-sorted ``union_ids``:
+    if fewer than ``reserve`` promoted docs survive the ``[:limit]`` cut,
+    the weakest NON-promoted entries in the cut are swapped for the best
+    promoted docs below it, then the cut is re-sorted by the same
+    (corrected desc, rrf desc, gid asc) key so ordering semantics are
+    unchanged. ``reserve=0`` returns the plain truncation (legacy,
+    byte-identical). Never grows the result past ``limit`` and never
+    drops a promoted doc that already made the cut.
+    """
+    cut = list(union_ids[:limit])
+    if reserve <= 0 or not promoted:
+        return cut
+    in_cut = sum(1 for g in cut if g in promoted)
+    missing = reserve - in_cut
+    if missing <= 0:
+        return cut
+    overflow = [g for g in union_ids[limit:] if g in promoted][:missing]
+    if not overflow:
+        return cut
+    # Drop the weakest non-promoted tail entries to make room.
+    drop_budget = len(overflow)
+    keep: List[str] = []
+    for g in reversed(cut):
+        if drop_budget > 0 and g not in promoted:
+            drop_budget -= 1
+            continue
+        keep.append(g)
+    keep.reverse()
+    out = keep + overflow
+    out.sort(
+        key=lambda gid: (
+            -corrected.get(gid, 0.0),
+            -rrf_all.get(gid, 0.0),
+            gid,
+        ),
+    )
+    return out
+
+
 def _score_debug_enabled() -> bool:
     """True iff HELIX_SHARD_SCORE_DEBUG is set to a truthy value.
 
@@ -687,7 +776,16 @@ class ShardRouter:
         # gold doc that's intra-shard rank 25+ never enters the merge.
         # The price is per-shard query cost; in benchmarks the medium
         # fixture's 6 shards stay well under 1s with this fan-out.
-        per_shard_fetch = max(int(max_genes), int(max_genes) * 2)
+        #
+        # Issue #222: the factor is env-tunable (HELIX_SHARD_FETCH_FACTOR,
+        # default 2 = legacy byte-identical). The flat 2x is too shallow
+        # whenever post-fetch rescaling (m_shard, doc-type boost,
+        # global-IDF splice) would promote a mid-shard doc past other
+        # shards' entries — the promotion happens AFTER this cut, so the
+        # doc never reaches the merge. Raise to 4–6 on many-shard corpora.
+        per_shard_fetch = max(
+            int(max_genes), int(max_genes) * _shard_fetch_factor(),
+        )
 
         def _fetch(shard_name: str):
             """Open + query one shard + probe IDF, snapshotting its per-query
@@ -1229,7 +1327,14 @@ class ShardRouter:
                 gid,
             ),
         )
-        return union_ids[:limit]
+        # Issue #223: optionally reserve slots for promoted linked docs so
+        # the 0.5x-discounted graph-surfaced candidates aren't displaced
+        # by the flat truncation. Reserve=0 (default) is byte-identical
+        # to the legacy plain [:limit] cut.
+        return _apply_coact_reserve(
+            union_ids, promoted, corrected, rrf_all,
+            limit, _coact_reserve_slots(),
+        )
 
     # ── Lifecycle ───────────────────────────────────────────────────
 

--- a/helix_context/storage/ddl.py
+++ b/helix_context/storage/ddl.py
@@ -331,6 +331,25 @@ def _create_fts5(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> bool:
         )
         """)
 
+        # fts5vocab "instance" shadow over genes_fts — one row per
+        # (term, doc, col, offset) occurrence. Used by
+        # KnowledgeStore.rescore_lexical_global_idf (#182) to read per-doc
+        # term frequency + doc length for the cross-shard global-IDF
+        # BM25 re-score. Zero storage (a view over the FTS index); created
+        # here so the read-time rescore never has to write. Idempotent.
+        try:
+            cur.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS genes_fts_vocab "
+                "USING fts5vocab(genes_fts, instance)"
+            )
+        except Exception:
+            # fts5vocab unavailable on this SQLite build — the rescore
+            # soft-fails to the scalar path, so this is non-fatal.
+            log.warning(
+                "fts5vocab unavailable — global-IDF rescore will fall back",
+                exc_info=True,
+            )
+
         # Incremental FTS5 sync -- only add missing documents, don't rebuild
         gene_count = cur.execute("SELECT COUNT(*) FROM genes").fetchone()[0]
         fts_count = cur.execute("SELECT COUNT(*) FROM genes_fts").fetchone()[0]

--- a/tests/test_global_idf_rescore.py
+++ b/tests/test_global_idf_rescore.py
@@ -1,0 +1,360 @@
+"""Cross-shard global-IDF lexical re-score (HELIX_SHARD_GLOBAL_IDF, #182).
+
+Reproduces and fixes the within-shard mis-ranking bug on sharded
+retrieval:
+
+  Root cause: the cross-shard correction ``m_shard`` is a PER-SHARD
+  SCALAR. A scalar rescales every doc in a shard equally, so it cannot
+  change the relative order of two docs in the SAME shard. That order is
+  set by each shard's corpus-LOCAL BM25 IDF. A gold whose distinguishing
+  term is globally-rare-but-locally-common is buried under a same-shard
+  incumbent, and no scalar can rescue it.
+
+  Fix: when HELIX_SHARD_GLOBAL_IDF is truthy and ≥2 shards participate,
+  re-score each candidate's BM25 lexical component per-doc with TRUE
+  GLOBAL IDF (aggregated N / df over all shards) instead of the shard's
+  local IDF.
+
+Fixture design (two real on-disk shards, no GPU/server/network):
+
+  * Query terms: ``widget`` (the gold's distinguishing term) and ``frob``.
+  * ``widget`` is LOCALLY COMMON in shard A (appears in most A docs → tiny
+    local IDF) but GLOBALLY RARE (shard B has none, and B is large).
+  * ``frob`` is LOCALLY RARE in shard A (high local IDF) but GLOBALLY
+    COMMON (filler in many B docs → tiny global IDF).
+  * GOLD doc lives in shard A and is ``widget``-heavy.
+  * WRONG doc lives in shard A and is ``frob``-heavy.
+
+  ⇒ Under LOCAL IDF (flag OFF), ``frob``'s high local IDF lifts WRONG
+     above GOLD inside shard A — the scalar can't reorder them.
+  ⇒ Under GLOBAL IDF (flag ON), ``widget``'s high global IDF lifts GOLD
+     above WRONG.
+
+Asserts:
+  * flag OFF → WRONG outranks GOLD (reproduces the bug).
+  * flag ON  → GOLD outranks WRONG (global IDF fixes within-shard order).
+
+Self-contained; runs under ``pytest --noconftest``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from helix_context.genome import Genome
+from helix_context.schemas import (
+    ChromatinState,
+    EpigeneticMarkers,
+    Gene,
+    PromoterTags,
+)
+from helix_context.shard_router import ShardRouter
+from helix_context.shard_schema import (
+    init_main_db,
+    open_main_db,
+    register_shard,
+    upsert_fingerprint,
+)
+
+_FLAG = "HELIX_SHARD_GLOBAL_IDF"
+
+
+def _mk_gene(content: str, domains: list, entities: list, source: str) -> Gene:
+    return Gene(
+        gene_id="",
+        content=content,
+        complement=content[:50],
+        codons=[],
+        promoter=PromoterTags(domains=domains, entities=entities, sequence_index=0),
+        epigenetics=EpigeneticMarkers(),
+        chromatin=ChromatinState.OPEN,
+        is_fragment=False,
+        source_id=source,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_flag():
+    prev = os.environ.pop(_FLAG, None)
+    try:
+        yield
+    finally:
+        os.environ.pop(_FLAG, None)
+        if prev is not None:
+            os.environ[_FLAG] = prev
+
+
+@pytest.fixture
+def idf_trap_setup():
+    """Two real shard .db files engineered so local vs global IDF disagree.
+
+    The query is routed to BOTH shards via shared fingerprint terms so the
+    genuine ≥2-shard cross-shard merge path runs.
+    """
+    td = tempfile.TemporaryDirectory()
+    root = Path(td.name)
+    main_path = str(root / "main.db")
+    shard_a_path = str(root / "shard_a.db")
+    shard_b_path = str(root / "shard_b.db")
+
+    # All docs share the routing entity "topic" so the query routes to
+    # both shards regardless of the discriminating terms.
+    ROUTE_ENT = "topic"
+
+    ga = Genome(shard_a_path)
+    # GOLD: widget-heavy (widget x4). widget is the distinguishing term.
+    gold = _mk_gene(
+        "topic widget widget widget widget gold answer payload "
+        "the canonical widget specification lives here",
+        domains=["topic"],
+        entities=[ROUTE_ENT, "gold"],
+        source="/a/gold_widget.md",
+    )
+    gold_id = ga.upsert_gene(gold, apply_gate=False)
+
+    # WRONG: frob-heavy (frob x4), only one widget. frob is locally rare
+    # in shard A (only this doc + nothing else has it here) → high LOCAL
+    # IDF lifts WRONG above GOLD inside shard A.
+    wrong = _mk_gene(
+        "topic frob frob frob frob wrong incumbent widget noise "
+        "frobnicator handling and frob dispatch internals",
+        domains=["topic"],
+        entities=[ROUTE_ENT, "wrong"],
+        source="/a/wrong_frob.md",
+    )
+    wrong_id = ga.upsert_gene(wrong, apply_gate=False)
+
+    # Filler docs in shard A that ALSO contain "widget" — this makes
+    # "widget" LOCALLY COMMON in shard A (drives its local IDF down) while
+    # it stays globally rare (shard B has none).
+    for i in range(4):
+        f = _mk_gene(
+            f"topic widget filler entry number {i} with widget mention",
+            domains=["topic"],
+            entities=[ROUTE_ENT],
+            source=f"/a/filler_{i}.md",
+        )
+        ga.upsert_gene(f, apply_gate=False)
+    ga.conn.close()
+    if ga._reader:
+        ga._reader.close()
+
+    # Shard B: large filler shard packed with "frob" so frob is GLOBALLY
+    # COMMON (low global IDF) and the overall corpus N is large (lifting
+    # widget's global IDF). None of these contain "widget".
+    gb = Genome(shard_b_path)
+    b_ids = []
+    for i in range(24):
+        f = _mk_gene(
+            f"topic frob common boilerplate document {i} with frob content",
+            domains=["topic"],
+            entities=[ROUTE_ENT],
+            source=f"/b/frob_{i}.md",
+        )
+        b_ids.append(gb.upsert_gene(f, apply_gate=False))
+    gb.conn.close()
+    if gb._reader:
+        gb._reader.close()
+
+    main = open_main_db(main_path)
+    init_main_db(main)
+    register_shard(main, "shard_a", "reference", shard_a_path, gene_count=6)
+    register_shard(main, "shard_b", "participant", shard_b_path, gene_count=24)
+
+    # Fingerprint GOLD + WRONG so they're addressable; route on "topic".
+    upsert_fingerprint(
+        main, gene_id=gold_id, shard_name="shard_a",
+        source_id="/a/gold_widget.md",
+        domains_json=json.dumps(["topic"]),
+        entities_json=json.dumps([ROUTE_ENT, "gold"]),
+        key_values_json="[]",
+    )
+    upsert_fingerprint(
+        main, gene_id=wrong_id, shard_name="shard_a",
+        source_id="/a/wrong_frob.md",
+        domains_json=json.dumps(["topic"]),
+        entities_json=json.dumps([ROUTE_ENT, "wrong"]),
+        key_values_json="[]",
+    )
+    # Fingerprint at least one shard-B doc on "topic" so the router fans
+    # out to shard_b too (≥2-shard merge path). The exact gene doesn't
+    # matter for the assertion.
+    upsert_fingerprint(
+        main, gene_id=b_ids[0], shard_name="shard_b",
+        source_id="/b/frob_0.md",
+        domains_json=json.dumps(["topic"]),
+        entities_json=json.dumps([ROUTE_ENT]),
+        key_values_json="[]",
+    )
+    main.close()
+
+    yield {
+        "main_path": main_path,
+        "gold_id": gold_id,
+        "wrong_id": wrong_id,
+    }
+    td.cleanup()
+
+
+def _rank_of(router, gene_id, query):
+    """Return the 0-based rank of gene_id in the router result (or None)."""
+    genes = router.query_genes(domains=query["domains"], entities=query["entities"],
+                               max_genes=8)
+    ids = [g.gene_id for g in genes]
+    return ids.index(gene_id) if gene_id in ids else None, ids
+
+
+# Query: both discriminating terms + the routing term.
+_QUERY = {"domains": ["topic"], "entities": ["widget", "frob"]}
+
+
+def test_both_shards_participate(idf_trap_setup):
+    """Sanity: the query must route to ≥2 shards or the fix is a no-op."""
+    router = ShardRouter(idf_trap_setup["main_path"])
+    try:
+        shards = router.route(domains=_QUERY["domains"], entities=_QUERY["entities"])
+        assert len(shards) >= 2, f"expected ≥2 shards, got {shards}"
+    finally:
+        router.close()
+
+
+def test_flag_off_reproduces_bug(idf_trap_setup):
+    """Flag OFF (scalar m_shard): WRONG outranks GOLD — the bug."""
+    os.environ.pop(_FLAG, None)  # explicitly OFF
+    router = ShardRouter(idf_trap_setup["main_path"])
+    try:
+        gold_rank, ids = _rank_of(router, idf_trap_setup["gold_id"], _QUERY)
+        wrong_rank, _ = _rank_of(router, idf_trap_setup["wrong_id"], _QUERY)
+        assert gold_rank is not None, f"gold not admitted to pool: {ids}"
+        assert wrong_rank is not None, f"wrong not admitted to pool: {ids}"
+        # Bug signature: the scalar can't reorder within shard A, so the
+        # frob-heavy WRONG doc (high LOCAL idf on frob) sits above GOLD.
+        assert wrong_rank < gold_rank, (
+            f"expected WRONG (rank {wrong_rank}) above GOLD (rank {gold_rank}) "
+            f"under local-IDF scalar path; ids={ids}"
+        )
+    finally:
+        router.close()
+
+
+def test_flag_on_fixes_within_shard_order(idf_trap_setup):
+    """Flag ON (per-doc global IDF): GOLD outranks WRONG — the fix."""
+    os.environ[_FLAG] = "1"
+    router = ShardRouter(idf_trap_setup["main_path"])
+    try:
+        gold_rank, ids = _rank_of(router, idf_trap_setup["gold_id"], _QUERY)
+        wrong_rank, _ = _rank_of(router, idf_trap_setup["wrong_id"], _QUERY)
+        assert gold_rank is not None, f"gold not admitted to pool: {ids}"
+        assert wrong_rank is not None, f"wrong not admitted to pool: {ids}"
+        # Fix: widget's high GLOBAL idf lifts GOLD above WRONG even though
+        # they share shard A (global IDF reorders within-shard).
+        assert gold_rank < wrong_rank, (
+            f"expected GOLD (rank {gold_rank}) above WRONG (rank {wrong_rank}) "
+            f"under global-IDF path; ids={ids}"
+        )
+    finally:
+        router.close()
+
+
+def test_flag_truthy_variants(idf_trap_setup):
+    """All truthy spellings enable the fix; junk values stay OFF."""
+    gold_id = idf_trap_setup["gold_id"]
+    wrong_id = idf_trap_setup["wrong_id"]
+
+    for val in ("1", "true", "YES", "On"):
+        os.environ[_FLAG] = val
+        router = ShardRouter(idf_trap_setup["main_path"])
+        try:
+            gr, _ = _rank_of(router, gold_id, _QUERY)
+            wr, _ = _rank_of(router, wrong_id, _QUERY)
+            assert gr is not None and wr is not None and gr < wr, (
+                f"truthy {val!r} should enable fix (gold {gr} < wrong {wr})"
+            )
+        finally:
+            router.close()
+
+    for val in ("0", "false", "no", "", "maybe"):
+        os.environ[_FLAG] = val
+        router = ShardRouter(idf_trap_setup["main_path"])
+        try:
+            gr, _ = _rank_of(router, gold_id, _QUERY)
+            wr, _ = _rank_of(router, wrong_id, _QUERY)
+            assert gr is not None and wr is not None and wr < gr, (
+                f"non-truthy {val!r} should stay on scalar path "
+                f"(wrong {wr} < gold {gr})"
+            )
+        finally:
+            router.close()
+
+
+# ── FTS5 bm25() scale-parity (#182 root-cause guard) ──────────────────
+#
+# The HELIX_SHARD_GLOBAL_IDF recall regression (0.347 -> 0.168 on medium
+# sharded) was a SCALE bug, not a gating bug: the manual BM25 in
+# rescore_lexical_global_idf used the SMOOTHED, always-positive IDF
+# ln((N-n+0.5)/(n+0.5) + 1.0), while SQLite FTS5's bm25() uses the RAW
+# (unsmoothed) IDF ln((N-n+0.5)/(n+0.5)) (which can be negative). Feeding
+# the splice corrected = raw - old_local_fts5 + new_global_fts5 a lexical
+# sub-score on a different scale corrupted ranking.
+#
+# This test pins the fix: rescore_lexical_global_idf, fed each term's LOCAL
+# raw IDF (so global == local), must reproduce ``bm25(genes_fts)`` for the
+# SAME shard's own docs to floating-point tolerance. The genome records the
+# FTS5 lexical sub-score as ``min(-rank, 6.0)`` where ``-rank`` is the
+# negated bm25() sum; the rescore returns that same UNcapped positive sum,
+# so ``rescore == -bm25()``.
+
+def test_manual_bm25_matches_fts5_bm25_local(idf_trap_setup):
+    """rescore_lexical_global_idf with LOCAL raw IDF == -bm25(genes_fts)."""
+    import math
+
+    # Reopen shard A read-only (it holds gold + wrong + 4 widget fillers).
+    router = ShardRouter(idf_trap_setup["main_path"])
+    try:
+        shard = router._open_shard("shard_a")
+        terms = ["widget", "frob"]
+        n_local = shard.fts_doc_count()
+        dfs = shard.term_doc_frequencies(terms)
+        # LOCAL raw IDF (the basis FTS5's own bm25 uses) — global == local.
+        # Apply FTS5's exact negative-IDF clamp (idf <= 0 -> 1e-6); ``widget``
+        # here appears in EVERY shard-A doc, so its raw IDF is negative and
+        # the engine clamps it — the manual must do the same to stay
+        # bit-exact (this is the third leg of the #182 scale fix).
+        def _fts5_idf(n_total: int, df: int) -> float:
+            idf = math.log((n_total - df + 0.5) / (df + 0.5))
+            return idf if idf > 0.0 else 1e-6
+
+        local_idf = {t: _fts5_idf(n_local, dfs[t]) for t in terms}
+
+        # Engine ranking + bm25() for the OR query across BOTH columns.
+        match = " OR ".join(f'"{t}"' for t in terms)
+        cur = shard.read_conn.cursor()
+        rows = cur.execute(
+            "SELECT gene_id, bm25(genes_fts) AS r "
+            "FROM genes_fts WHERE genes_fts MATCH ? ORDER BY rank",
+            (match,),
+        ).fetchall()
+        engine = {row["gene_id"]: float(row["r"]) for row in rows}
+        assert engine, "FTS5 returned no rows for the parity probe"
+
+        manual = shard.rescore_lexical_global_idf(
+            list(engine.keys()), terms, local_idf,
+        )
+        assert manual, "rescore returned empty"
+
+        worst = 0.0
+        for gid, eng in engine.items():
+            # rescore is the positive bm25 sum; engine bm25() is negated.
+            worst = max(worst, abs(eng - (-manual[gid])))
+        assert worst < 1e-6, (
+            f"manual BM25 must match FTS5 bm25() (worst |delta|={worst:.3e}); "
+            f"a non-zero gap means the IDF basis / tf-normalisation drifted "
+            f"from the engine again (#182 scale regression)."
+        )
+    finally:
+        router.close()

--- a/tests/test_shard_depth_and_coact_budget.py
+++ b/tests/test_shard_depth_and_coact_budget.py
@@ -1,0 +1,127 @@
+"""Issues #222 (per-shard fetch depth) + #223 (co-activation reserved budget).
+
+Mechanism-level tests. Both fixes are env-gated with legacy defaults:
+flag-off behaviour must be byte-identical to the pre-fix build; corpus-level
+recall validation is the fixture-gated bench step tracked on the issues.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from helix_context.shard_router import (
+    _apply_coact_reserve,
+    _coact_reserve_slots,
+    _shard_fetch_factor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    saved = {
+        k: os.environ.pop(k, None)
+        for k in ("HELIX_SHARD_FETCH_FACTOR", "HELIX_SHARD_COACT_RESERVE")
+    }
+    yield
+    for k, v in saved.items():
+        os.environ.pop(k, None)
+        if v is not None:
+            os.environ[k] = v
+
+
+# ── #222: fetch-depth factor ─────────────────────────────────────────
+
+def test_fetch_factor_default_is_legacy_2():
+    assert _shard_fetch_factor() == 2
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("4", 4), ("6", 6), ("1", 1),
+    ("0", 1),          # clamped to >=1 — never fetch nothing
+    ("-3", 1),
+    ("garbage", 2),    # unparseable keeps legacy
+    ("", 2),
+])
+def test_fetch_factor_env_parsing(raw, expected):
+    os.environ["HELIX_SHARD_FETCH_FACTOR"] = raw
+    assert _shard_fetch_factor() == expected
+
+
+def test_fetch_depth_formula_matches_router_contract():
+    """per_shard_fetch = max(max_genes, max_genes * factor) — the #222 lever.
+
+    With the legacy factor the per-shard cut equals the global return
+    size; any post-fetch rescale (m_shard up to IDF_CLIP_HI=3.0,
+    doc-type boost, global-IDF splice) can promote a doc that this cut
+    already dropped. factor=4 doubles the headroom.
+    """
+    max_genes = 8
+    os.environ["HELIX_SHARD_FETCH_FACTOR"] = "4"
+    assert max(max_genes, max_genes * _shard_fetch_factor()) == 32
+    os.environ.pop("HELIX_SHARD_FETCH_FACTOR")
+    assert max(max_genes, max_genes * _shard_fetch_factor()) == 16
+
+
+# ── #223: co-activation reserved budget ──────────────────────────────
+
+def _mk_union(n: int, promoted_at: list[int]) -> tuple[list, set, dict, dict]:
+    """Synthetic sorted union: doc i has corrected score n-i (descending)."""
+    union = [f"g{i}" for i in range(n)]
+    corrected = {f"g{i}": float(n - i) for i in range(n)}
+    rrf = {f"g{i}": 0.0 for i in range(n)}
+    promoted = {f"g{i}" for i in promoted_at}
+    return union, promoted, corrected, rrf
+
+
+def test_reserve_zero_is_plain_truncation():
+    union, promoted, corrected, rrf = _mk_union(6, promoted_at=[5])
+    out = _apply_coact_reserve(union, promoted, corrected, rrf, limit=3, reserve=0)
+    assert out == ["g0", "g1", "g2"]  # byte-identical legacy cut
+
+
+def test_reserve_rescues_displaced_linked_doc():
+    """The #223 bug in miniature: promoted doc g5 (0.5x-discounted score)
+    falls below the cut and is displaced; reserve=1 swaps out the weakest
+    non-promoted survivor for it."""
+    union, promoted, corrected, rrf = _mk_union(6, promoted_at=[5])
+    out = _apply_coact_reserve(union, promoted, corrected, rrf, limit=3, reserve=1)
+    assert "g5" in out
+    assert len(out) == 3
+    assert out == ["g0", "g1", "g5"]  # weakest non-promoted (g2) dropped
+
+
+def test_reserve_never_drops_promoted_already_in_cut():
+    union, promoted, corrected, rrf = _mk_union(6, promoted_at=[1, 5])
+    out = _apply_coact_reserve(union, promoted, corrected, rrf, limit=3, reserve=2)
+    assert "g1" in out and "g5" in out
+    assert len(out) == 3
+
+
+def test_reserve_satisfied_in_cut_is_noop():
+    union, promoted, corrected, rrf = _mk_union(6, promoted_at=[0, 1])
+    out = _apply_coact_reserve(union, promoted, corrected, rrf, limit=3, reserve=2)
+    assert out == ["g0", "g1", "g2"]  # already >= reserve promoted in cut
+
+
+def test_reserve_bounded_by_available_promoted():
+    union, promoted, corrected, rrf = _mk_union(6, promoted_at=[4])
+    out = _apply_coact_reserve(union, promoted, corrected, rrf, limit=3, reserve=3)
+    # Only one promoted doc exists below the cut — swap exactly one.
+    assert "g4" in out and len(out) == 3
+
+
+def test_reserve_output_stays_sorted_by_corrected():
+    union, promoted, corrected, rrf = _mk_union(8, promoted_at=[6, 7])
+    out = _apply_coact_reserve(union, promoted, corrected, rrf, limit=4, reserve=2)
+    scores = [corrected[g] for g in out]
+    assert scores == sorted(scores, reverse=True)
+    assert len(out) == 4
+
+
+def test_reserve_env_parsing():
+    assert _coact_reserve_slots() == 0
+    os.environ["HELIX_SHARD_COACT_RESERVE"] = "2"
+    assert _coact_reserve_slots() == 2
+    os.environ["HELIX_SHARD_COACT_RESERVE"] = "junk"
+    assert _coact_reserve_slots() == 0

--- a/tests/test_shard_score_debug.py
+++ b/tests/test_shard_score_debug.py
@@ -1,0 +1,239 @@
+"""Tests for the cross-shard score-path instrumentation (#181).
+
+Verifies the HELIX_SHARD_SCORE_DEBUG gate on ShardRouter.query_genes:
+
+  (a) flag OFF  -> last_score_breakdown / last_shard_multipliers stay {},
+      and the returned ranking is byte-identical to a baseline call (no
+      behaviour change at all).
+  (b) flag ON   -> last_score_breakdown carries the expected keys for every
+      merged candidate, last_shard_multipliers is populated, and for a known
+      candidate  corrected == raw * m_shard * doc_type_boost.
+
+Self-contained on-disk 2-shard fixture (mirrors tests/test_shard_router.py's
+two_shard_setup) so it runs under `pytest --noconftest`. No GPU, no server,
+no network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from helix_context.genome import Genome
+from helix_context.schemas import (
+    ChromatinState,
+    EpigeneticMarkers,
+    Gene,
+    PromoterTags,
+)
+from helix_context.shard_router import ShardRouter
+from helix_context.shard_schema import (
+    init_main_db,
+    open_main_db,
+    register_shard,
+    upsert_fingerprint,
+)
+
+_DEBUG_ENV = "HELIX_SHARD_SCORE_DEBUG"
+
+
+def _mk_gene(content: str, domains: list, entities: list, source: str) -> Gene:
+    return Gene(
+        gene_id="",
+        content=content,
+        complement=content[:50],
+        codons=[],
+        promoter=PromoterTags(domains=domains, entities=entities, sequence_index=0),
+        epigenetics=EpigeneticMarkers(),
+        chromatin=ChromatinState.OPEN,
+        is_fragment=False,
+        source_id=source,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_debug_env():
+    """Ensure the debug flag is unset before and after each test."""
+    prev = os.environ.pop(_DEBUG_ENV, None)
+    try:
+        yield
+    finally:
+        os.environ.pop(_DEBUG_ENV, None)
+        if prev is not None:
+            os.environ[_DEBUG_ENV] = prev
+
+
+@pytest.fixture
+def two_shard_setup():
+    """main.db + two populated shard .db files on disk (2 docs, 2 shards).
+
+    Shard A: a README.md doc tagged docs/helix (eligible for doc-type boost).
+    Shard B: an auth.py doc tagged auth/jwt.
+    """
+    td = tempfile.TemporaryDirectory()
+    root = Path(td.name)
+    main_path = str(root / "main.db")
+    shard_a_path = str(root / "shard_a.db")
+    shard_b_path = str(root / "shard_b.db")
+
+    ga = Genome(shard_a_path)
+    gene_a = _mk_gene(
+        "Helix design README. Context retrieval via fingerprints and shards.",
+        domains=["docs"],
+        entities=["helix"],
+        source="/docs/README.md",  # basename README.md -> doc-type boost
+    )
+    gene_a_id = ga.upsert_gene(gene_a, apply_gate=False)
+    ga.conn.close()
+    if ga._reader:
+        ga._reader.close()
+
+    gb = Genome(shard_b_path)
+    gene_b = _mk_gene(
+        "Auth module. JWT sessions expire every 15 minutes for docs access.",
+        domains=["auth"],
+        entities=["jwt"],
+        source="/code/auth.py",
+    )
+    gene_b_id = gb.upsert_gene(gene_b, apply_gate=False)
+    gb.conn.close()
+    if gb._reader:
+        gb._reader.close()
+
+    main = open_main_db(main_path)
+    init_main_db(main)
+    register_shard(main, "shard_a", "reference", shard_a_path, gene_count=1)
+    register_shard(main, "shard_b", "participant", shard_b_path, gene_count=1)
+    upsert_fingerprint(
+        main, gene_id=gene_a_id, shard_name="shard_a",
+        source_id="/docs/README.md",
+        domains_json=json.dumps(["docs"]),
+        entities_json=json.dumps(["helix"]),
+        key_values_json="[]",
+    )
+    upsert_fingerprint(
+        main, gene_id=gene_b_id, shard_name="shard_b",
+        source_id="/code/auth.py",
+        domains_json=json.dumps(["auth"]),
+        entities_json=json.dumps(["jwt"]),
+        key_values_json="[]",
+    )
+    main.close()
+
+    yield {
+        "main_path": main_path,
+        "gene_a_id": gene_a_id,
+        "gene_b_id": gene_b_id,
+    }
+    td.cleanup()
+
+
+# Query spans both shards so the genuine cross-shard merge path runs
+# (>=2 shards participate -> IDF correction + doc-type boost active).
+_DOMAINS = ["auth", "docs"]
+_ENTITIES = ["helix", "jwt"]
+
+
+def test_init_attrs_default_empty(two_shard_setup):
+    """__init__ initializes both introspection dicts to {} (no AttributeError)."""
+    router = ShardRouter(two_shard_setup["main_path"])
+    try:
+        assert router.last_score_breakdown == {}
+        assert router.last_shard_multipliers == {}
+    finally:
+        router.close()
+
+
+def test_flag_off_no_breakdown_and_ranking_unchanged(two_shard_setup):
+    """(a) Flag OFF: breakdown stays {}, ranking identical to baseline."""
+    assert _DEBUG_ENV not in os.environ
+
+    # Baseline ranking (flag off).
+    router = ShardRouter(two_shard_setup["main_path"])
+    try:
+        baseline = router.query_genes(domains=_DOMAINS, entities=_ENTITIES, max_genes=8)
+        baseline_ids = [g.gene_id for g in baseline]
+        baseline_scores = dict(router.last_query_scores)
+        # Introspection dicts must remain empty when the flag is off.
+        assert router.last_score_breakdown == {}
+        assert router.last_shard_multipliers == {}
+    finally:
+        router.close()
+
+    # Second flag-off call on a fresh router must reproduce the exact ranking.
+    router2 = ShardRouter(two_shard_setup["main_path"])
+    try:
+        again = router2.query_genes(domains=_DOMAINS, entities=_ENTITIES, max_genes=8)
+        again_ids = [g.gene_id for g in again]
+        assert again_ids == baseline_ids
+        assert dict(router2.last_query_scores) == baseline_scores
+        assert router2.last_score_breakdown == {}
+    finally:
+        router2.close()
+
+
+def test_flag_on_breakdown_shape_and_corrected_identity(two_shard_setup):
+    """(b) Flag ON: breakdown keys present + corrected == raw*m_shard*boost.
+
+    Also asserts that turning the flag ON does NOT change the returned
+    ranking or last_query_scores vs the flag-OFF baseline.
+    """
+    # Baseline (flag off).
+    r0 = ShardRouter(two_shard_setup["main_path"])
+    try:
+        base = r0.query_genes(domains=_DOMAINS, entities=_ENTITIES, max_genes=8)
+        base_ids = [g.gene_id for g in base]
+        base_scores = dict(r0.last_query_scores)
+    finally:
+        r0.close()
+
+    # Flag on.
+    os.environ[_DEBUG_ENV] = "1"
+    router = ShardRouter(two_shard_setup["main_path"])
+    try:
+        results = router.query_genes(domains=_DOMAINS, entities=_ENTITIES, max_genes=8)
+        ids = [g.gene_id for g in results]
+
+        # Ranking + scores must be unchanged by the flag (behaviour-preserving).
+        assert ids == base_ids
+        assert dict(router.last_query_scores) == base_scores
+
+        bd = router.last_score_breakdown
+        mults = router.last_shard_multipliers
+
+        # Multipliers populated for both participating shards.
+        assert set(mults.keys()) == {"shard_a", "shard_b"}
+        assert all(isinstance(v, float) for v in mults.values())
+
+        # Breakdown covers EVERY merged candidate (>=2 docs here).
+        assert len(bd) >= 2
+        expected_keys = {"shard", "raw", "m_shard", "doc_type_boost", "corrected", "rrf"}
+        for gid, row in bd.items():
+            assert set(row.keys()) == expected_keys, (gid, set(row.keys()))
+            assert isinstance(row["shard"], str)
+            assert isinstance(row["raw"], float)
+            assert isinstance(row["m_shard"], float)
+            assert isinstance(row["doc_type_boost"], float)
+            assert isinstance(row["corrected"], float)
+            # rrf may be a float or None (Fuser may not score every gid).
+            assert row["rrf"] is None or isinstance(row["rrf"], float)
+
+            # Core identity: corrected == raw * m_shard * doc_type_boost.
+            expected = row["raw"] * row["m_shard"] * row["doc_type_boost"]
+            assert row["corrected"] == pytest.approx(expected, rel=1e-9, abs=1e-12), (
+                gid, row,
+            )
+
+        # The README.md doc (shard_a) must carry the 1.15 doc-type boost.
+        gene_a_id = two_shard_setup["gene_a_id"]
+        if gene_a_id in bd:
+            assert bd[gene_a_id]["doc_type_boost"] == pytest.approx(1.15)
+            # And the recorded m_shard must equal the per-shard multiplier.
+            assert bd[gene_a_id]["m_shard"] == pytest.approx(mults["shard_a"])
+    finally:
+        router.close()
+        os.environ.pop(_DEBUG_ENV, None)


### PR DESCRIPTION
Revives the snapshot iteration Max investigated (archived at 3b2822c on feat/telemetry-hv-prebase), ported surgically onto current master.

## Features (both env-flag-gated, OFF by default)
- **HELIX_SHARD_SCORE_DEBUG (#181):** \last_score_breakdown\ for every merged candidate ({shard, raw, m_shard, doc_type_boost, corrected, rrf}) + \last_shard_multipliers\ - the gold-score-depression diag surface. Zero overhead when off.
- **HELIX_SHARD_GLOBAL_IDF (#182):** per-doc BM25 lexical rescore with true global IDF, spliced into the fused score. The critical fix vs the earlier attempt: raw RSJ IDF **with FTS5's non-positive clamp** (idf<=0 -> 1e-6); the earlier smoothed-IDF variant put the splice on the wrong scale and caused the 0.347 -> 0.168 recall regression. Bit-exact with SQLite bm25() per the counterfactual diag.
- \genes_fts_vocab\ fts5vocab(instance) shadow table (zero storage) at DDL init + lazy create for legacy shards.

## Verification
- 8/8 feature tests (test_shard_score_debug, test_global_idf_rescore)
- 148/148 sharded-suite regression (router, adapter parity, gold recall, blob-vs-shard diag, RRF fusion) - flag-off path byte-identical

## Why now
This is the instrumentation the #222/#223 sharded gold-displacement investigation needs; landing it first keeps those fixes evidence-based.