### PR TITLE
fix(bench): revive body_has_answer metric + un-censor big-model rungs; commit bench_chain harness (#221)

### DIFF
--- a/benchmarks/_citations.py
+++ b/benchmarks/_citations.py
@@ -137,21 +137,69 @@ def parse_legacy_gene_blocks(content: str) -> list[tuple[str, str]]:
 
 
 # Modern legibility header (see helix_context/encoding/legibility.py):
-#   [gene=abc12345... ◆ fired=harmonic:2.3,lex_anchor:1.1 1200→320c]
-# The trailing chars in the gene_id may include any non-bracket chars; the
-# id field stops at the first space (legibility writes ``[gene={short} {symbol}``).
+#   [gene=abc12345abc1 ◆ fired=harmonic:2.3,lex_anchor:1.1 1200→320c]
+# The captured id is ``gene_id[:12]`` — a plain prefix of the full
+# citation gene_id (id_width=12 in both format_gene_header and the
+# session-delivery elision stub). The id field stops at the first space.
 LEGIBILITY_HEADER_RE = re.compile(r"\[gene=([^\s\]]+)[^\]]*\]", re.DOTALL)
+
+# Gene ids are sha256 hexdigest[:16] (knowledge_store.py), so a real
+# header short-id is 8-16 lowercase hex chars. Doc prose quoting the
+# header shape (e.g. "[gene=... ◆ fired=...]" examples in api docs) must
+# not be misparsed as a header — a bogus short-id would strip the
+# block's first line and poison the id join (review 2026-07-05).
+_HEX_SHORT_ID_RE = re.compile(r"[0-9a-f]{8,16}", re.IGNORECASE)
+
+# Session-delivery elision stubs are all-header lines:
+#   [gene=abc12345abc1 ↻ delivered 3 queries ago / 45s — see earlier response]
+# Their text must never be used as a body: bare integers in the stub
+# word-boundary-match numeric accepts ("delivered 16 queries ago" vs
+# accept "16"), silently inflating body_has_answer (review 2026-07-05).
+_ELISION_STUB_MARKER = "see earlier response"
+
+# Wrapper emitted by context_manager around the assembled blocks. The
+# live /context ``content`` is ALWAYS the wrapped string — splitting on
+# the block separator leaves the open tag glued to the FIRST block, so
+# it must be stripped before header matching (2026-07-04: unstripped, it
+# made the first block unpairable and shifted every citation→body pair
+# by one, flat-lining body_has_answer across all sike_bedsweep runs).
+_EXPRESSED_OPEN = "<expressed_context>"
+_EXPRESSED_CLOSE = "</expressed_context>"
+
+
+def _strip_expressed_wrapper(content: str) -> str:
+    text = (content or "").strip()
+    if text.startswith(_EXPRESSED_OPEN):
+        text = text[len(_EXPRESSED_OPEN):]
+    if text.endswith(_EXPRESSED_CLOSE):
+        text = text[: -len(_EXPRESSED_CLOSE)]
+    return text.strip("\n")
 
 
 def extract_block_bodies(payload: Any) -> list[tuple[str, str, str]]:
     """Return (source, gene_id, body) tuples for every delivered document.
 
     For modern responses, the content blob is the assembled splice
-    output -- one legibility header line followed by spliced text, blocks
-    separated by ``\\n---\\n``. We split on ``---``, strip the header
-    from each block, and pair each body with the matching
-    ``agent.citations`` entry (by order, which is the contract: the
-    renderer writes citations in delivery order).
+    output wrapped in ``<expressed_context>`` tags -- one legibility
+    header line followed by spliced text, blocks separated by
+    ``\\n---\\n``. Pairing strategy, in order of trust:
+
+    1. Id join: a block's ``[gene={id[:12]} ...]`` header (8-16 hex
+       chars) is a prefix of exactly one citation's full gene_id.
+       Survives citations dropped by the server's row-lookup miss
+       (routes_context ``continue``s on a missing row, so citations can
+       be FEWER than blocks).
+    2. Positional, count-guarded: headerless blocks (e.g. a bench
+       config with ``legibility_enabled = false``) pair by index ONLY
+       when their count equals the count of citations left unmatched by
+       the id join. On any mismatch (dropped citation, a Markdown
+       horizontal rule ``\\n---\\n`` inside a body inflating the block
+       count) pairing is ambiguous and the affected bodies are returned
+       as ``""`` — fail closed rather than silently mispair.
+
+    Elision stubs (session working-set) pair by id like any block but
+    always yield ``body=""``: their text ("delivered 16 queries ago")
+    would otherwise word-boundary-match numeric accept strings.
 
     For legacy responses, falls back to ``<GENE src=...>...</GENE>``
     block extraction with empty gene_ids.
@@ -164,29 +212,74 @@ def extract_block_bodies(payload: Any) -> list[tuple[str, str, str]]:
     entry = _coerce_top_entry(payload)
     content = _extract_content(entry)
 
-    if citations:
-        # Split content on the per-block separator. Some prefix material
-        # (e.g. an outer ``<expressed_context>`` wrapper) may precede the
-        # first block; ignore blocks whose body doesn't start with a
-        # legibility header, since they cannot be confidently paired.
-        raw_blocks = (content or "").split("\n---\n")
-        paired: list[tuple[str, str, str]] = []
-        body_iter = iter(raw_blocks)
-        for cit_obj in citations:
-            source = str(cit_obj.get("source") or "")
-            gene_id = str(cit_obj.get("gene_id") or "")
-            body = ""
-            for raw in body_iter:
-                stripped = raw.lstrip()
-                if LEGIBILITY_HEADER_RE.match(stripped):
-                    # Remove the header line from the body.
-                    body = LEGIBILITY_HEADER_RE.sub("", stripped, count=1).lstrip("\n")
-                    break
-            paired.append((source, gene_id, body))
-        return paired
+    if not citations:
+        # Legacy fallback: gene_id was never in the markup.
+        return [(src, "", body) for src, body in parse_legacy_gene_blocks(content)]
 
-    # Legacy fallback: gene_id was never in the markup.
-    return [(src, "", body) for src, body in parse_legacy_gene_blocks(content)]
+    inner = _strip_expressed_wrapper(content)
+    raw_blocks = inner.split("\n---\n") if inner else []
+
+    # Parse blocks into (header_short_id | None, body). A header is only
+    # trusted when its captured id is hex-shaped; otherwise the block is
+    # treated as headerless with its FULL text (a doc example like
+    # "[gene=... ◆ ...]" quoted at line start must not be stripped).
+    parsed: list[tuple[str | None, str]] = []
+    for raw in raw_blocks:
+        stripped = raw.strip()
+        m = LEGIBILITY_HEADER_RE.match(stripped)
+        if m and _HEX_SHORT_ID_RE.fullmatch(m.group(1)):
+            if _ELISION_STUB_MARKER in m.group(0) or "↻" in m.group(0):
+                # Elision stub: pairs by id, but never contributes body
+                # text (numeric accept collision — see marker comment).
+                parsed.append((m.group(1), ""))
+            else:
+                body = LEGIBILITY_HEADER_RE.sub("", stripped, count=1).lstrip("\n")
+                parsed.append((m.group(1), body))
+        else:
+            parsed.append((None, stripped))
+
+    # Pass 1 — id join: header short-id is a prefix of the citation's
+    # full gene_id. Each block is claimed at most once.
+    assigned: dict[int, int] = {}  # citation index -> block index
+    unclaimed = list(range(len(parsed)))
+    for ci, cit_obj in enumerate(citations):
+        gid = str(cit_obj.get("gene_id") or "")
+        if not gid:
+            continue
+        for bi in unclaimed:
+            short = parsed[bi][0]
+            if short and gid.startswith(short):
+                assigned[ci] = bi
+                unclaimed.remove(bi)
+                break
+
+    # Pass 2 — positional fallback, count-guarded. Positional pairing
+    # assumes blocks:citations are 1:1 in delivery order; that breaks
+    # when the server drops a citation (row-lookup miss) or a headerless
+    # body contains "\n---\n" (Markdown hr) and inflates the block
+    # count. Only pair when the counts line up exactly; otherwise leave
+    # bodies empty — an empty body is a visible measurement gap, a
+    # mispaired body is a silent lie. Never hand out an unmatched
+    # HEADERED block positionally: it belongs to a different document.
+    unmatched = [ci for ci in range(len(citations)) if ci not in assigned]
+    if assigned:
+        candidates = [bi for bi in unclaimed if parsed[bi][0] is None]
+    else:
+        candidates = unclaimed
+    fallback_blocks = candidates if len(candidates) == len(unmatched) else []
+    fallback_iter = iter(fallback_blocks)
+
+    paired: list[tuple[str, str, str]] = []
+    for ci, cit_obj in enumerate(citations):
+        source = str(cit_obj.get("source") or "")
+        gene_id = str(cit_obj.get("gene_id") or "")
+        if ci in assigned:
+            body = parsed[assigned[ci]][1]
+        else:
+            bi = next(fallback_iter, None)
+            body = parsed[bi][1] if bi is not None else ""
+        paired.append((source, gene_id, body))
+    return paired
 
 
 def normalize_sources(sources: Iterable[str]) -> list[str]:

--- a/benchmarks/bench_needle.py
+++ b/benchmarks/bench_needle.py
@@ -758,11 +758,16 @@ def find_needle(client, needle):
     """Try to find a specific needle in the genome."""
     t0 = time.time()
 
-    # Step 1: Context query
+    # Step 1: Context query. ignore_delivered opts out of the session
+    # working-set register: production defaults keep session delivery +
+    # synthetic sessions ON (300s same-IP window), so a 50-needle battery
+    # would otherwise get elision stubs instead of gold bodies for any
+    # document retrieved twice (CLAUDE.md bench guidance; review 2026-07-05).
     try:
         resp = client.post(f"{HELIX_URL}/context", json={
             "query": needle["query"],
             "decoder_mode": "none",
+            "ignore_delivered": True,
         })
     except Exception:
         return {
@@ -822,24 +827,33 @@ def find_needle(client, needle):
         n_gold_blocks = 0
         n_delivered_blocks = len(parse_delivered_genes_from_response(data))
 
-    # Step 2: Full proxy query for answer accuracy
+    # Step 2: Full proxy query for answer accuracy. Guarded: an
+    # answer-step failure (e.g. a slow local model outliving the
+    # caller's client timeout) must NOT destroy the Step-1 retrieval
+    # fields — callers aggregate gold_delivered over returned rows, so
+    # a raised exception here silently shrinks that denominator
+    # (review 2026-07-05).
     t1 = time.time()
     model = os.environ.get("HELIX_MODEL", "qwen3:8b")
-    proxy_resp = client.post(f"{HELIX_URL}/v1/chat/completions", json={
-        "model": model,
-        "messages": [{"role": "user", "content": needle["query"]}],
-        "stream": False,
-        "options": {"temperature": 0, "num_predict": 256},
-    })
-    proxy_latency = time.time() - t1
-
     answer_correct = False
     answer_text = ""
-    if proxy_resp.status_code == 200:
-        choices = proxy_resp.json().get("choices", [])
-        if choices:
-            answer_text = choices[0].get("message", {}).get("content", "")
-            answer_correct = any(a.lower() in answer_text.lower() for a in accept)
+    try:
+        proxy_resp = client.post(f"{HELIX_URL}/v1/chat/completions", json={
+            "model": model,
+            "messages": [{"role": "user", "content": needle["query"]}],
+            "stream": False,
+            "options": {"temperature": 0, "num_predict": 256},
+        })
+        if proxy_resp.status_code == 200:
+            choices = proxy_resp.json().get("choices", [])
+            if choices:
+                answer_text = choices[0].get("message", {}).get("content", "")
+                answer_correct = any(
+                    a.lower() in answer_text.lower() for a in accept
+                )
+    except Exception:
+        answer_text = ""
+    proxy_latency = time.time() - t1
 
     return {
         "name": needle["name"],

--- a/benchmarks/sweep_dense_additive_weight.py
+++ b/benchmarks/sweep_dense_additive_weight.py
@@ -94,7 +94,9 @@ def _eval_arm(genome, queries: list[dict], topk: int) -> dict:
     per_query = []
     t0 = time.monotonic()
 
-    for q in queries:
+    for _qi, q in enumerate(queries):
+        if _qi and _qi % 25 == 0:
+            print(f"[sweep]   ..{_qi}/{n} queries", flush=True)
         query_text = q["query"]
         gold = set(q["gold_ids"])
         # Use query_docs through the high-level path (same path /context uses).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,124 @@
+# Helix Roadmap
+
+> Canonical forward-planning doc. Created 2026-07-03 from a full repo/issue/bench triage.
+> Supersedes scattered planning in: [2026-06-09 next-steps-evidence](audits/2026-06-09-next-steps-evidence.md),
+> [2026-06-10 test-tuning-roadmap](audits/2026-06-10-test-tuning-roadmap.md),
+> [2026-07-01 next-bench-wave-consensus](research/2026-07-01-next-bench-wave-consensus.md),
+> [2026-07-01 external-bench-run-plan](benchmarks/2026-07-01-external-bench-run-plan.md) — those remain the
+> detailed specs; this doc is the sequencing layer on top.
+
+## Status snapshot (2026-07-03 evening)
+
+- **Version:** 0.7.1 on master (`pyproject.toml`). Docs claiming v0.5.0 are stale (see Docs refresh below).
+- **Bench chain (external wave) is RUNNING** — do not disturb until `benchmarks/logs/chain_status.json` reads `COMPLETE-FINAL` (est. July 4 morning).
+- **Open PRs:** #230 (WS2 symbol graph), #231 (WS3 PageRank, stacked on #230). Both CI-green/clean but **gated on the bench results** per the external-bench run plan's council rules.
+- **Open issues:** 12 — triaged below; 2 are closable now (#203, #206), the rest are scheduled or bench-gated.
+
+## The bench gate (everything sequences around this)
+
+Currently running: **S2 SIKE 50-needle bed-sweep** (#221), third attempt, launched 15:56 by the
+`s2_rerun_after_203.ps1` watcher. Beds: xl → enterprise_rag_10k → enterprise_rag_50k.
+Corpus verified correct this time (46,517 genes on xl; the 07-02 and 07-03_0104 attempts served a stub corpus).
+
+- Results land in `benchmarks/results/sike_bedsweep_<bed>_2026-07-03_1556.json` (written only at run end).
+- Live status: `benchmarks/logs/chain_status.json`; logs in `benchmarks/logs/s2_*_2026-07-03_1556.log`.
+- `claude -p --model sonnet` auth **verified working 2026-07-03 ~19:00** (the 0104 run's Sonnet rung failed 50/50 on a 401 signature; no preflight exists in the script).
+- **Invalid results to quarantine after the run:** `sike_bedsweep_{xl,enterprise_rag_10k,enterprise_rag_50k}_2026-07-03_0104.json` and the 07-02_1252 attempt — wrong corpus, 0.0 gold delivery, 100% Claude-rung errors. Never quote these as #221 numbers.
+- Already-valid from this chain: **S3b' dense-weight sweeps** (n=100 real ERB queries, done 07-03 15:55) — recall@10 monotone in `dense_additive_weight`: erb10k 0.58(w0)→0.64(w6), erb50k 0.47→0.56, zero gold evictions. This closes #203.
+- Known chain defects to follow up: S1's AST assertion failed (586 regex-fallback chunk lines — arm B/C ContextBench comparison is suspect until explained); ~~28/153 HTTP-500 ollama ReadTimeouts in the current xl ladder~~ **root-caused 2026-07-05** (proxy `upstream_timeout=180s` < CPU-offloaded gemma generation time; fixed via `HELIX_SERVER_UPSTREAM_TIMEOUT=600` in the sweep — see [2026-07-05 issue-resolutions](benchmarks/2026-07-05-sike-bedsweep-issue-resolutions.md)); S4 (ERB-500q scored, #93) was skipped and still needs its own run.
+
+### Decision rules (from the run plan; read results in this order)
+
+1. **Arm B (master-cAST) vs BM25 foil:** if B ≤ BM25 → halt all code-track merges (including #230/#231).
+2. **Arm C (ws2+ws3 symbol graph) vs +1pp threshold:** C ≥ +1pp on either external bench → merge #230 then #231 with default-on; C regresses on both → WS2/WS3 stays dark permanently (flip `symbol_graph` default to False or park the PRs).
+3. PageRank-vs-in-degree ablation decides whether `symbol_pagerank.py` survives or simplifies (council flagged personalization as inert in the live path).
+
+## Merge queue (in order, post-bench)
+
+1. **PR #230** (WS2 symbol graph, +447/−5, CI green, CLEAN, no rebase needed) — merge iff arm C passes; record the arm-C number in the PR thread. If dark-shipping instead, flip `config.py` `symbol_graph` default to False first (currently True, which contradicts the "stays dark" rule).
+2. **PR #231** (WS3 PageRank, stacked on #230) — after #230 squash-merges: rebase onto master, retarget to master (**this triggers CI for the first time** — the 5 ws3-only commits have zero CI coverage because ci.yml only runs on PRs targeting master), then merge per the same gate. Branch already dark-ships `symbol_graph=false` (17f275d) with an in-degree ablation knob.
+3. **Bench harness commit:** untracked `scripts/bench_chain/` (incl. the 07-03 13:10 fixes), `docs/benchmarks/helix_probe_symbol.toml` (fix its stale header comment saying `helix_probe_lexical.toml`), and the 3-line progress-print diff in `benchmarks/sweep_dense_additive_weight.py`.
+4. Neither PR has a recorded review — get one on record before merging (ingest-path changes are load-bearing).
+
+## Issue board (triaged 2026-07-03)
+
+| # | Title (short) | State | Action |
+| --- | --- | --- | --- |
+| #203 | dense_additive_weight sweep | **CLOSED 2026-07-03** | Done: sweep table posted (erb10k 0.58→0.64, erb50k 0.47→0.56, medium 0.23→0.40, zero evictions); no flip, 4.0 stands, raise-to-6 deferred to #205. Still owed in the harness commit: refresh stale comment block at `config.py:430-438`. |
+| #206 | Fate of dense-latency PRs #158/#160 | **CLOSED 2026-07-03** | Done: decision comment posted (#158 re-landed via #172+#218; #160 superseded-by-evidence). Still owed: mark "closed by decision" in test-tuning-roadmap:179 during the docs pass; Wall-1 issue only if ~60s/query at 850K is unacceptable. |
+| #221 | SIKE scale-sweep re-baseline | **in progress (running now)** | Validate xl JSON tonight (genes ~46.5K, delivery > 0, Sonnet errors 0). After COMPLETE-FINAL: comment results, commit harness, schedule the missing 829K/100-shard 4th bed, re-admit numbers to README. |
+| #222 | Per-shard fetch depth | done-but-open (dark in #235) | Post-bench: confirmatory factor 2-vs-4 A/B on medium+xl; expected null (twice-measured) → close with "shipped dark, default stays 2". |
+| #223 | Cross-shard co-act reserve | partially-done (dark in #235) | Post-bench: fixture A/B with graph-surfaced golds (`diag_blob_vs_shard_tiers.py`), pick reserve N, promote env var to config key, flip default, close. |
+| #219 | Config unification epic | partially-done (2/5 slices) | Update body: check Slice 2 (3aa6c5c/#220). Then Slice 5 (dark-feature decision — cheapest, unblocks doc honesty), Slice 4 (config-reference generated from dataclasses + ratchet), Slice 3 (serve-lean MCP profile). |
+| #209 | genai_telemetry module | partially-done (phases 1-2 landed) | Rewrite body to the remaining slice: implement `genai_telemetry.py` (OTel GenAI conventions), light up the 15 phantom `helix_genai_*` dashboard queries (or pull the dashboard), flip the 4 "planned" stubs in OBSERVABILITY.md. |
+| #205 | Retrieval profiles 3-layer | in-progress (groundwork only) | Unblocked by #203 result (all beds prefer w=6 → Layer-3 per-class values). Update body checklist; implement after merge wave. |
+| #93 | EnterpriseRAG-Bench adoption | partially-done | Rescope body to 3 items: full-480 rerun on 829K fixture (post-bench, ~8h rig), scored Q&A vs Onyx leaderboard (= the skipped S4), declare blob-vs-sharded answered-by-construction. |
+| #204 | SPLADE scale curve | outstanding (deferred by consensus) | Comment: reuse #221 beds as the "on" twins; schedule twin builds + sweep next rig-free window after the external wave. |
+| #207 | De-hardcoding wave 2 | partially-done (item 8 only) | Update body: check item 8; next slice = items 1-3 (model-ID knobs, citation root-stripping, truncation caps) — they block air-gap deploys. |
+| #208 | SNOW-2 nav benchmark re-spec | blocked (on #205 ← #203/#204) | Spec done and reaffirmed 07-01; comment status, re-date after #205 lands. No respec. |
+
+## Housekeeping checklist (ALL post-`COMPLETE-FINAL` — nothing while the bench runs)
+
+Full forensic inventory (branch↔PR SHA matching) done 2026-07-03; summary:
+
+- [ ] **Branches — delete 61 merged** (tip SHA == squash-merged PR head; needs `-D`): full list in the 2026-07-03 triage; includes all release/*, fix/*, feat/* through #220. 8 are checked out in worktrees — remove worktrees first.
+- [ ] **Branches — delete 17 superseded** (closed PRs ported to master via #162/#172/#112/#113/#234 etc.).
+- [ ] **Branches — review 4 before deciding:** `perf/dense-prefilter-via-splade-candidates` (#160 closed; Onyx v0.6.3 validation kit + codex runner not on master), `feat/onyx-full-v2-build-bundle` (`enterprise_rag_onyx_full_2` bench profile may still be needed for Onyx 500q), `bench/int-5fixture` (verify 977924b claude-p stdio fix landed elsewhere), `fix/dense-fusion-composite-sort` (tip says "do not merge"; salvage H10 investigation docs first).
+- [ ] **Worktrees — remove 13 stale** (incl. `F:/Projects/helix-retrieval-upgrade`, `F:/tmp/helix-release-064`, codex scratch, 2 locked agent worktrees on merged branches — unlock then remove), then `git worktree prune`. **Keep:** `.worktrees/ws2-symbol-graph`, `.worktrees/ws3-pagerank` until PRs resolve.
+- [ ] **Stashes — drop all 8** (0-6 superseded by merged PRs; glance at stash@{7}'s 90-line token-count helper first).
+- [ ] **Remote:** `git push origin --delete docs/external-review-gemini` (merged as #236).
+- [ ] **Quarantine invalid bench results** (07-02_1252 + 07-03_0104 sike_bedsweep JSONs).
+- [ ] **Root runtime clutter** (git-ignored): root-level `genome.db{,-shm,-wal}` (canonical store is `genomes/main/` — verify nothing points at the root copy), `metrics.json`, `logs/`, `overnight_logs/`, `cwola_export/`, `dist/`, caches.
+- [ ] **Commit the bench harness** (`scripts/bench_chain/`, probe toml, sweep diff) — see merge queue item 3.
+
+## Docs refresh (the "fresh baseline" pass — do together with the new bench numbers)
+
+- [ ] `CLAUDE.md:3` — v0.5.0 → v0.7.1 (or drop the hardcoded version).
+- [ ] `CLAUDE.md` Stage-2 text — `dense_embedding_enabled` and `splade_enabled` are **default ON** (config.py:355/:214), not off; drop the "no neural inference at query time" claim for the default path.
+- [ ] `README.md:138` — phantom `[know]` keys `confidence_floor, margin_threshold` → real keys `emit_floor, betas, s_ref, g_ref, stale_after_days`.
+- [ ] Test count in 3 places (README badge + Testing section, CLAUDE.md): "~1950" → ~2,650 (2,643 `def test_` across 184 files; get exact collected count post-bench).
+- [ ] `[ribosome]` backend lists (README:125 + CLAUDE.md): honored values are only `litellm`/`deberta`; drop `claude`/`ollama` or mark legacy.
+- [ ] Package count "16" → 15 (README:191 + CLAUDE.md).
+- [ ] README "Proof (30 seconds)" table + `docs/benchmarks/BENCHMARKS.md` (last updated 2026-05-28) — refresh from the #221 re-baseline once valid. **License caveat:** ContextBench/CodeRAG numbers stay internal until cleared.
+- [ ] Commit/reconstruct `helix_probe_nosema.toml` (referenced by code-track-regression-log.md, absent from tree).
+- [ ] Minor: README `[ingestion]` add `hybrid`; note `[mem_sync]` is consumed out-of-band; document `[vault]`/`[hardware]`.
+
+## Sequenced plan
+
+**Phase 0 — tonight (bench running, hands off the rig):**
+
+1. ~~Verify `claude -p` Sonnet auth~~ ✅ verified 2026-07-03.
+2. ~~Close #203 and #206 with decision comments~~ ✅ done 2026-07-03.
+3. ~~Update issues: #219 (slice-2 box checked + comment), #209 (scope note prepended to body), #207/#222/#223/#204/#208/#93 (status comments)~~ ✅ done 2026-07-03.
+4. When `sike_bedsweep_xl_*_1556.json` lands (~23:00-01:00): sanity-check genes/delivery/Sonnet-errors before beds 2-3 start their Claude pass.
+
+**Phase 1 — July 4, after COMPLETE-FINAL:**
+
+1. Validate all three bed JSONs; comment results on #221; quarantine invalid runs.
+2. Read the gate: arm B vs BM25, arm C vs +1pp → merge/dark-ship/park #230 then #231 per the decision rules; commit bench harness.
+3. ~~Investigate the S1 AST-assertion failure and the ollama ReadTimeout cluster.~~ ReadTimeout cluster **done 2026-07-05** (upstream_timeout root cause + fix in the harness PR); S1 AST assertion still open.
+
+**Phase 1b — bench validity wave (added 2026-07-05, from the bedsweep review):**
+
+Detail + numbers: [docs/benchmarks/2026-07-05-sike-bedsweep-issue-resolutions.md](benchmarks/2026-07-05-sike-bedsweep-issue-resolutions.md).
+The 1556 results are the only valid run AND still mismeasure retrieval (dead
+`body_has_answer` parser — fixed; 6/4/3 false-neg + 7/14/15 false-pos needles
+per bed; 260 echo genes + 43 worktree-dupe genes contaminating xl; probe-TOML
+no-op keys incl. `[abstain] enabled` and the arm-C `symbol_graph` keys that
+don't exist on master). **Hold README re-admission of #221 numbers until Run 1
+(clean baseline) reproduces them on decontaminated beds.** Sequence: Run 1
+(harness+bed validity) → Run 2 (fts5_candidate_depth × additive/RRF A/B on xl)
+→ Run 3 (know recalibration + production-profile arm; arm-C only after its
+fail-fast capability assert).
+
+**Phase 2 — fresh baseline (same week):**
+
+1. Housekeeping sweep (branches/worktrees/stashes/remote/clutter) — checklist above.
+2. Docs refresh pass (checklist above) + README bench-number re-admission.
+3. Tag the result — candidate 0.8.0 baseline: post-merge master, clean tree, honest docs, valid 3-bed scale curve.
+
+**Phase 3 — next wave (re-dated per the 07-01 consensus):**
+
+1. #221's missing 829K/100-shard bed; S4/#93 scored Q&A run (auth preflight now in place).
+2. #223 reserve-N A/B → default flip; #222 confirmatory null → close.
+3. #219 slices 5→4→3; #207 items 1-3; then #205 profiles (now data-fed by #203/#204) → unblocks #208 SNOW-2 build.

--- a/docs/benchmarks/2026-07-05-sike-bedsweep-issue-resolutions.md
+++ b/docs/benchmarks/2026-07-05-sike-bedsweep-issue-resolutions.md
@@ -1,0 +1,199 @@
+# SIKE Bedsweep (#221): Issue → Resolution Log + Bench-Validity Plan
+
+> 2026-07-05. Companion detail doc to `docs/ROADMAP.md` (sequencing layer).
+> Covers: the two anomalies found in the 2026-07-03_1556 bedsweep results, their
+> root causes and fixes (PR `fix/bench-body-metric-and-upstream-timeout`), the
+> adversarial review of those fixes (21-agent workflow, 11 confirmed defects,
+> 28 gaps), and the next-3-runs experiment sequence.
+>
+> Valid data: `benchmarks/results/sike_bedsweep_{xl,enterprise_rag_10k,enterprise_rag_50k}_2026-07-03_1556.json`
+> — the ONLY valid run of this suite. The 07-02_1252 and 07-03_0104 attempts are
+> poisoned (stub corpus / Sonnet 401; `n_gold_blocks=0` on all 300 rows) and must
+> never be quoted.
+
+## 1. Headline numbers from the valid run (what we can and cannot trust)
+
+| Bed | Genes | gold_delivered_rate | body_has_answer_rate | claude:sonnet correct/answered | best-local |
+| --- | --- | --- | --- | --- | --- |
+| xl | 46,517 | **0.64** (32/50) | 0.0 (dead metric) | 32/35 (91.4%) | gemma4:26b-a4b 25/38 |
+| enterprise_rag_10k | 15,889 | **0.80** | 0.0 (dead metric) | 30/32 (93.8%) | gemma4:26b 25/33 |
+| enterprise_rag_50k | 80,363 | **0.82** | 0.0 (dead metric) | 29/31 (93.5%) | gemma4:26b 24/36 |
+
+Trustworthy: `gold_delivered_rate` per-needle booleans (citation-based), consumer
+answer scoring on rows with `status=ok`, Sonnet cost (~$1.79/bed).
+**Not trustworthy:**
+
+- `body_has_answer_rate` — flat 0.0 across all 150 needle-checks; the parser was
+  dead (Anomaly 1). Historically 0.0–0.02 in every prior run: the metric has
+  never produced signal.
+- The three big-gemma rungs (26b-a4b / 31b / 26b) — 11–16 needles per bed
+  recorded as `http_error` at ~181–182 s (Anomaly 2): ~25–30 % of their samples
+  are censored, so their coverage (0.66–0.78) and correctness stats
+  (n≈33–39, survivorship-biased toward fast queries) understate/misstate them.
+- The headline rates themselves mismeasure retrieval in both directions
+  (§4, A1): 6/4/3 false-negative needles per bed (marked miss, yet ≥5/10
+  consumers answered correctly) and 7/14/15 false-positive needles (marked
+  delivered, yet 0/10 consumers correct).
+
+## 2. Anomaly 1 — `body_has_answer_rate = 0.0` (dead metric)
+
+**Root cause A (this run):** the bench servers were launched with
+`docs/benchmarks/helix_probe_lexical.toml` (`s2_sike_bed_sweep.ps1` 2026-07-03
+GPU-contention fix), which sets `legibility_enabled = false`. Without
+`[gene=...]` headers, `benchmarks/_citations.py::extract_block_bodies` paired
+every citation with `body=""` — a word-boundary match on 150 empty strings.
+
+**Root cause B (all runs, latent):** live `/context` content is wrapped as
+`<expressed_context>\n[gene=...` (`context_manager.py:2722`); the parser split
+on `\n---\n` and required each block to START with a header, so the wrapper
+glued to block 1 → first body (the top-ranked document) silently dropped and
+every citation→body pairing shifted by one. The existing test fixture omitted
+the wrapper, which is why tests stayed green while production was broken.
+
+**Resolution (this PR):** `extract_block_bodies` rewritten — strip the wrapper;
+join blocks to citations by the `gene_id[:12]` hex header prefix; positional
+fallback for headerless configs **count-guarded** (pair only when unmatched
+citations == candidate blocks, else fail closed to empty bodies); elision
+stubs pair by id but always yield `body=""`; non-hex bracketed text (doc
+examples) treated as body, not header. 14 new regression tests using the real
+wrapped shape, including an end-to-end `check_gold_delivery` case.
+
+## 3. Anomaly 2 — big-gemma `http_error` clusters (censored rungs)
+
+**Root cause:** proxy default `upstream_timeout = 180.0`
+(`helix_context/config.py:197`) < generation time of CPU-offloaded gemma4
+26b-class models (observed 67 % CPU / 33 % GPU). Server-side
+`httpx.ReadTimeout` at 180 s → 5xx → bench rows at ~181 s. Same failure mode
+as the documented 2026-05-02 bump (120→180 for gemma4:e4b); the ladder outgrew
+180 s. This also explains the "28/153 HTTP-500 ollama ReadTimeouts" chain
+defect flagged in ROADMAP (bench-gate section).
+
+**Resolution (this PR):** `HELIX_SERVER_UPSTREAM_TIMEOUT=600` set per-bed in
+`s2_sike_bed_sweep.ps1` (env override already existed, `config.py:832`);
+runner client timeouts raised above it (660 s) so the server side decides;
+`http` status / `error` body now persisted in per-needle rows.
+
+**Open (Run 3 / #205-adjacent):** consider promoting the timeout fix from bench
+env to shipped config with a granular `httpx.Timeout(connect=10, read=...)` —
+any user proxying big local models hits the same wall.
+
+## 4. Adversarial review of the first-pass fix (what round 2 fixed)
+
+The 21-agent review confirmed 11 defects; all are fixed in this PR:
+
+| # | Defect (confirmed) | Fix |
+| --- | --- | --- |
+| 1 | Positional fallback mispaired bodies whenever headerless blocks ≠ citations (dropped citation; Markdown `\n---\n` inside a body — 2,318/46,777 xl genes contain one, 909 in the first 500 chars) | count-guard; fail closed to empty bodies |
+| 2 | Elision-stub text kept as body: "delivered **16** queries ago" word-boundary-matches numeric accepts (`16` = helix_subpackages_count; `1` matches "1.2h") on default configs (session delivery + synthetic sessions ON) | stubs always yield `body=""`; `find_needle` and `_fetch_context` now send `ignore_delivered: true` |
+| 3 | Timeout inversion regression: Pass-1 `httpx.Client(timeout=300)` < new 600 s server timeout; find_needle's unguarded Step-2 answer call raised → recall row dropped → denominator shrank silently | client 660 s; Step 2 wrapped in try/except so Step-1 retrieval fields survive |
+| 4 | Pass-2 `coverage` divided by `len(recall_rows)` (could exceed 1.0 after Pass-1 drops) | denominator = full needle set |
+| 5 | No circuit breaker: a wedged rung burns 50 × 600 s ≈ 8.3 h of identical errors (~225 h theoretical bound per sweep) | abort rung after 5 consecutive non-ok rows; `rung_aborted` recorded |
+| 6 | Literal `[gene=...]` doc examples misparsed as headers | header id must be 8–16 hex chars |
+| 7 | Claude-rung failures lost `rc`/`stderr`/`stdout_tail`; ollama `http_error` rows lost the response body; `_fetch_context` failure indistinguishable from empty retrieval | all persisted (`rc`, `stderr`, `stdout_tail`, `error`, `ctx_chars`, `ctx_fetch_failed`) |
+| — | `HELIX_CONFIG` leaked into the caller's shell after the sweep | added to end-of-run `Remove-Item` |
+
+## 5. Gap analysis (28 gaps; the ones that change conclusions)
+
+### Tier A — the current numbers are wrong (fix before quoting #221)
+
+- **A1 Metric mismeasurement** (§1 above). Post-fix, make
+  answer-string-in-delivered-body the primary retrieval metric.
+- **A2 Bed contamination — two independent corruptions of xl's 0.64:**
+  (a) **260 echo genes** in xl.db (285 in erb50k): Stage-6 persisted
+  query/response exchanges from prior runs that verbatim-match needle queries
+  (`content LIKE 'User query:%' AND source_id IS NULL`); for
+  `helix_headroom_port` the top-8 FTS5 hits are ALL echoes (bm25 −30.1…−28.0)
+  and can never count as gold. (b) **worktree/clone duplicates**: 9 gold files
+  have 43 competitor genes under `_worktrees/...`/sibling paths whose
+  source_ids can never substring-match `gold_source` (helix.toml ×6,
+  README.md ×5). Purge + rebuild beds; serve with Stage-6 persist disabled;
+  do NOT loosen `src_matches`.
+- **A3 Probe-config no-ops — the bench didn't run its intended config:**
+  `[abstain] enabled = false` is a nonexistent key (real switch:
+  `budget.abstain_enabled`, default True → abstain tier was ACTIVE);
+  `[know] confidence_floor` → real key `emit_floor`; no `[synonyms]` section →
+  synonym expansion was a no-op for all 50 needles;
+  `helix_probe_symbol.toml` sets `symbol_graph` / `symbol_expansion_cap` which
+  **do not exist on master** — if arm C is served from master it is
+  byte-identical to the lexical arm and would falsely dark-ship WS2/WS3 under
+  the ≥+1pp gate (ROADMAP decision rule 2). Fix TOMLs; harden the config
+  loader to warn on unknown scalar keys; add a fail-fast capability assert to
+  the arm-C script.
+- **A4 FTS5 candidate-pool starvation:** depth hard-coupled to max_genes
+  (`knowledge_store.py:2291`, LIMIT limit*2 = 48 at max_genes_per_turn=12).
+  7/18 missed xl needles' golds never enter retrieval (gold FTS ranks:
+  helix_cold_start_threshold 63, mek_version 78, helix_headroom_port 86,
+  helix_calibration_staleness 118, helix_dense_encoder 158;
+  helix_expression_budget / helix_pipeline_steps absent from top-200 —
+  'helix' alone matches ~36 k genes). Add a `fts5_candidate_depth` knob (or
+  wire up the set-but-unused `bm25_shortlist_size`).
+- **A5 know-confidence is anti-signal:** misses score HIGHER than hits on
+  every bed — xl hit-mean 0.327 vs miss-mean 0.421 (AUC 0.352), 10k 0.321 vs
+  0.418 (0.383), 50k 0.328 vs 0.384 (0.442); biged_complex_model rc=0.74 with
+  0/30 correct. Recalibrate (`scripts/calibrate_know_confidence.py`); track
+  hit/miss AUC with a >0.7 gate before agents rely on the know contract.
+
+### Tier B — diagnosis & transfer
+
+- **B1 No baseline:** 1556 is the only valid run; add a write-time validity
+  gate (`sum(n_gold_blocks)==0` → reject) and rerun for variance bands.
+- **B2 In-pool rank loss:** 11/18 xl misses have gold at FTS rank 7–42,
+  squeezed out of ~5 delivered blocks by echoes/near-dupes; FTS5 additive cap
+  6.0 flattens the head while tag_exact is uncapped → A/B additive vs RRF
+  post-decontamination.
+- **B3 Dead needles / splice suspects:** all-bed dead: biged_complex_model,
+  biged_max_workers, helix_expression_budget (0/30 each), biged_thermal_target
+  (4/30) — 6/8 all-bed misses are biged_* (tagging/synonym hole). Separately,
+  the delivered-but-unanswerable cluster (13 needles ≤2/30: e.g.
+  bookkeeper_ocr_confidence, cosmictasha_auth_library,
+  genome_compression_target 0/30) points at Stage-4 splice compressing out the
+  value-bearing fragment — needs a body dump post-parser-fix.
+- **B4 Stale gold paths:** 4/63 `gold_source` paths stale (mek_version,
+  biged_audit_dimensions, helix_expression_budget, helix_subpackages_count) —
+  ANY-of matching means no needle is fully starved (attribute those misses to
+  rank, not missing gold); fix paths + add a min-resolved threshold to
+  `sike_bed_ingest.py`.
+
+### Tier C — backlog
+
+xl-only regression set (7 needles: biged_ram_ceiling, biged_rust_binary_size,
+bookkeeper_dashboard_port, helix_calibration_staleness,
+helix_cold_start_threshold, helix_pipeline_steps, mek_version); answering
+ceiling tracked separately from retrieval (sonnet 65/93 on the 31-needle
+gold-delivered intersection; locals lose 45–65 %); needle staleness audit
+(helix_pipeline_steps expects "6", docs now describe 7 stages); dense-weight
+sweep winner w=6 sits on the swept boundary with mean_rank degrading
+(2.10→2.71) — extend to {8,10,12}; `sema_embed_on_ingest=false` in probe
+TOMLs; UTF-8 bench logs; flip `legibility_enabled=true` in the probes now
+that the parser is robust either way.
+
+## 6. Next-3-runs experiment sequence
+
+**Run 1 — clean baseline (no ranking changes).** This PR's fixes + probe-TOML
+corrections (A3) + bed decontamination (A2) + stale gold paths (B4) + validity
+gate (B1). Expect: `body_has_answer_rate` 0.0 → nonzero ≈ tracking
+gold_delivered; xl gold_delivered 0.64 → **≥0.75** (echo/dupe removal alone
+should rescue helix_headroom_port, helix_dense_encoder, bookkeeper_monetary
+and the biged_* false negatives); recall_rows n == 50 on every bed; big-gemma
+errors ≈ 0 (600 s headroom, breaker as backstop).
+
+**Run 2 — candidate depth + fusion A/B (decontaminated xl only).**
+`fts5_candidate_depth` sweep 48 → 200 → 500 × `fusion_mode` additive vs RRF
+(2×3 arms, retrieval-only scoring). Expect: the 7 deep-rank golds enter the
+pool at 500; RRF outperforms additive on the 11 rank-7–42 squeeze-outs
+(immune to the 6.0 cap); guardrail: mean_rank_of_gold on already-hit needles
+degrades <0.5. The 7 xl-only needles are the regression set.
+
+**Run 3 — calibration + production-profile arm.** Recalibrate `[know]` betas
+against Run-1/2 per-needle data (gate: hit/miss AUC >0.7); one
+production-profile arm (dense + SPLADE + cymatics + entity_graph ON) on the
+decontaminated xl bed to quantify the neural contribution to the
+distractor-density failure mode; extend the dense-weight sweep to {8,10,12}
+on erb50k (report recall@10 + MRR side by side). Only after Run 3 do arm-C
+symbol-graph numbers get recorded, behind the A3 fail-fast assert.
+
+**Sequencing rationale:** Run 1 must precede everything — every tuning
+conclusion from the 1556 files is polluted by dead parsers, contaminated beds,
+and config no-ops. Run 2 targets the largest attributable retrieval loss
+(pool starvation + rank squeeze = 18/18 diagnosed xl misses). Run 3 spends the
+then-trustworthy data on calibration and the production-transfer question.

--- a/docs/benchmarks/helix_probe_symbol.toml
+++ b/docs/benchmarks/helix_probe_symbol.toml
@@ -1,0 +1,75 @@
+# helix_probe_symbol.toml
+# -------------------------------------------------------------------------
+# Symbol-graph probe profile (external-bench arm C: WS2 #230 + WS3 #231).
+# Identical to helix_probe_lexical.toml except the symbol graph is ON
+# ([ingestion] symbol_graph = true, [retrieval] symbol_expansion_cap).
+# All other neural/GPU paths remain OFF: pure FTS5 + tag lookup +
+# synonym expansion + BM25 shortlist + symbol-edge expansion.
+# LLM-free, GPU-free.
+#
+# Pass explicitly via --helix-config / HELIX_CONFIG when serving the
+# arm-C comparison; the lexical probe stays the default for
+# benchmarks/repobench_r_helix.py and repobench_r_helix_global.py.
+# -------------------------------------------------------------------------
+
+[ribosome]
+enabled = false
+backend = "none"
+query_expansion_enabled = false
+query_decomposition_enabled = false
+
+[hardware]
+device = "cpu"
+
+[budget]
+expression_tokens = 7000
+max_genes_per_turn = 12
+decoder_mode = "none"
+legibility_enabled = false
+session_delivery_enabled = false
+
+[session]
+synthetic_session_enabled = false
+
+[genome]
+path = "genomes/probe/genome.db"
+compact_interval = 0
+
+[server]
+host = "127.0.0.1"
+port = 11437
+upstream = "http://localhost:11434"
+
+[ingestion]
+symbol_graph = true
+backend = "cpu"
+splade_enabled = false
+dense_embed_on_ingest = false
+rerank_enabled = false
+entity_graph = false
+
+[retrieval]
+symbol_expansion_cap = 8
+dense_embedding_enabled = false
+sr_enabled = false
+ray_trace_theta = false
+seeded_edges_enabled = false
+filename_anchor_enabled = true
+filename_anchor_weight = 4.0
+bm25_shortlist_enabled = true
+bm25_shortlist_size = 50
+bm25_prefilter_enabled = false
+entity_graph_retrieval_enabled = false
+fusion_mode = "additive"
+
+[context]
+cold_tier_enabled = false
+
+[cymatics]
+enabled = false
+
+[know]
+confidence_floor = 0.0
+
+[abstain]
+enabled = false

--- a/helix_context/config.py
+++ b/helix_context/config.py
@@ -427,15 +427,17 @@ class RetrievalConfig:
     # before entering the gene_scores accumulator. BM25-comparable
     # (tag_exact_weight is 3.0). Unused under RRF.
     #
-    # Issue #138 (tracked): the H10q investigation on EnterpriseRAG-Bench
-    # 10K observed gold eviction at the shipped 4.0 weight on
-    # adversarial prose queries (per-query dense tier totals ran 9-28 vs
-    # tag-exact ~3 per doc). The smoke sweep harness at
-    # ``benchmarks/sweep_dense_additive_weight.py`` covers
-    # {0.0, 2.0, 3.0, 4.0, 6.0} including the dense-off arm; ship the
-    # winning value once an enterprise-class question set is wired in.
-    # ``0.0`` flips dense additively-off without disabling the dense
-    # write path or RRF participation.
+    # Issue #203 (closed 2026-07-03): the real-query sweep
+    # (``benchmarks/sweep_dense_additive_weight.py``, n=100 ERB queries
+    # per bed) found recall@10 monotone INCREASING in this weight —
+    # erb10k 0.58 (w=0) → 0.64 (w=6), erb50k 0.47 → 0.56, medium 0.23 →
+    # 0.40 — with zero gold evictions at any weight. The #138 H10q
+    # gold-eviction fear did not reproduce on enterprise-class queries.
+    # 4.0 stands; the raise-to-6.0 decision is deferred to the #205
+    # per-class retrieval profiles (w=6 may become the semantic-class
+    # value rather than a global default). ``0.0`` flips dense
+    # additively-off without disabling the dense write path or RRF
+    # participation.
     dense_additive_weight: float = 4.0
     # Tier-0 review fix (2026-05-16): noise floor for the additive-mode
     # dense merge. A dense hit whose cosine is below this does not

--- a/scripts/bench_chain/erb500k_scored.py
+++ b/scripts/bench_chain/erb500k_scored.py
@@ -1,0 +1,679 @@
+r"""erb500k_scored.py -- ERB 500-question scored run for the G2 prose gate
+(issue #93). Chain stage S4 helper.
+
+Runs the EnterpriseRAG-Bench 500-question set against the sharded 500K fixture
+and scores it with the goal-gates trinary judge protocol
+(docs/specs/2026-07-01-goal-gates-hallucination-visibility.md sec.4 area +
+docs/specs/2026-07-01-abstain-search-escalation.md sec.4).
+
+Per question:
+  (a) POST /context/packet -> RECORD the know / miss block verbatim.
+  (b) Generate an answer with Claude Sonnet (claude -p, packet context +
+      question), context injected as an appended system prompt.
+  (c) Judge with the trinary protocol: reference-guided single-answer grading,
+      CORRECT / INCORRECT / ABSTAINED, judge = Sonnet.
+  (d) Sample ~10% of judged items for a second-opinion AUDIT with Opus.
+
+Grounding (all read on the rig, file:line in the chain report):
+  * ERB question schema + gold resolution + prefix-tolerant delivered-path
+    matching: benchmarks/bench_enterprise_rag.py load_needles / helix_context /
+    make_gold_index / match_delivered_to_gold (worktree copy; fields:
+    q["question"], q.get("gold_answer"), q.get("expected_doc_ids"), mapped via
+    generated_data/uuid_index.json -> generated_data/sources/<rel>).
+  * claude -p convention: scripts/bench_claude_matrix.py (json output,
+    --max-budget-usd cap, short model aliases sonnet/opus) and
+    bench_enterprise_rag.run_claude (--append-system-prompt-file to dodge the
+    32K arg-line limit + an empty --mcp-config).
+  * /context/packet contract: helix_context/server/routes_context.py:546 --
+    body {query, task_type, max_genes}; top-level "know" {found, confidence,
+    gene_id_match, ...} XOR "miss" {reason, escalate_to|refresh_targets, ...}.
+    Evidence lists are verified / stale_risk / contradictions of ContextItem
+    (schemas.py:239-275; item body is `content`, path is `source_id`).
+  * Sharded fixture is served by the caller (.ps1) with HELIX_USE_SHARDS=1 and
+    HELIX_GENOME_PATH pointing at .../enterprise_rag_500k/main.genome.db
+    (helix_context/sharding.open_read_source detects the basename).
+
+RESUMABLE: the output JSONL is append-only, one line per finished question,
+keyed by question id. On restart, ids already present are skipped. 500 questions
+x several LLM calls each WILL be interrupted at least once.
+
+Published baselines for comparison (from the goal-gates spec):
+  BM25 68.8 / Vector 51.4 / Onyx+GPT-4 72.4.
+
+Stdlib + repo-adjacent imports + httpx only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+# Published prose baselines (goal-gates spec sec. "Accuracy source of truth").
+BASELINES = {"BM25": 68.8, "Vector": 51.4, "Onyx_GPT4": 72.4}
+
+
+# ---------------------------------------------------------------------------
+# ERB question loading (schema per benchmarks/bench_enterprise_rag.load_needles)
+# ---------------------------------------------------------------------------
+
+def load_needles(erb_root, max_questions=None, types=None):
+    """Parse questions.jsonl defensively and resolve gold dsids to paths.
+
+    Field names confirmed from bench_enterprise_rag.load_needles:
+      q["question"], q.get("gold_answer",""), q.get("expected_doc_ids",[]),
+      q.get("question_type"), q["question_id"].
+    Everything is accessed with .get() and skipped if malformed so a single
+    bad row cannot abort a 500-question run.
+    """
+    questions_path = erb_root / "questions.jsonl"
+    uuid_index_path = erb_root / "generated_data" / "uuid_index.json"
+    corpus_root = erb_root / "generated_data" / "sources"
+
+    uuid_index = {}
+    if uuid_index_path.is_file():
+        try:
+            uuid_index = json.loads(
+                uuid_index_path.read_text(encoding="utf-8", errors="replace"))
+        except Exception:
+            uuid_index = {}
+
+    needles = []
+    if not questions_path.is_file():
+        return needles
+    with questions_path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                q = json.loads(line)
+            except Exception:
+                continue
+            qid = q.get("question_id") or q.get("id")
+            qtext = q.get("question")
+            if not qid or not qtext:
+                continue
+            qtype = q.get("question_type") or q.get("type") or "unknown"
+            if types and qtype not in types:
+                continue
+            gold_paths = []
+            for dsid in q.get("expected_doc_ids") or []:
+                rel = uuid_index.get(str(dsid))
+                if rel:
+                    gold_paths.append(str(corpus_root / rel))
+            needles.append({
+                "id": str(qid),
+                "type": qtype,
+                "question": str(qtext),
+                "gold_answer": q.get("gold_answer", "") or q.get("answer", "") or "",
+                "expected_doc_ids": q.get("expected_doc_ids", []) or [],
+                "gold_paths": gold_paths,
+            })
+    if max_questions is not None:
+        needles = needles[:max_questions]
+    return needles
+
+
+# ---------------------------------------------------------------------------
+# Prefix-tolerant delivered-path -> gold matching
+# (copied from bench_enterprise_rag: the <GENE src> prefix-strip bug fix)
+# ---------------------------------------------------------------------------
+
+def _rel_after_sources(p):
+    n = str(p).replace("\\", "/")
+    if "/sources/" in n:
+        return n.split("/sources/", 1)[1]
+    if n.startswith("sources/"):
+        return n[len("sources/"):]
+    return n
+
+
+def make_gold_index(gold_paths):
+    canonicals = set()
+    index = {}
+    for p in gold_paths or ():
+        canonical = _rel_after_sources(p)
+        if not canonical:
+            continue
+        canonicals.add(canonical)
+        index[canonical] = canonical
+        first_slash = canonical.find("/")
+        if first_slash > 0:
+            index.setdefault(canonical[first_slash + 1:], canonical)
+    return index, canonicals
+
+
+def match_delivered(delivered_path, gold_index, gold_canonicals):
+    if not delivered_path:
+        return None
+    rel = _rel_after_sources(delivered_path)
+    if not rel:
+        return None
+    if rel in gold_canonicals:
+        return rel
+    return gold_index.get(rel)
+
+
+# ---------------------------------------------------------------------------
+# /context/packet -- record know/miss verbatim + assemble injectable context
+# ---------------------------------------------------------------------------
+
+def fetch_packet(helix_url, query, max_genes, timeout_s=40.0):
+    """POST /context/packet. Returns the full packet dict (know/miss verbatim)
+    plus a derived {context_text, delivered_paths} for answer injection.
+
+    The packet carries evidence items (freshness-labeled). We build a compact
+    context blob from the ContextItem bodies (`content`) across the
+    verified / stale_risk / contradictions lists; if none are present (packet
+    is navigation-first) we fall back to /context content.
+    """
+    out = {"status": "ok", "know": None, "miss": None,
+           "context_text": "", "delivered_paths": [], "raw_keys": []}
+    try:
+        resp = httpx.post(
+            helix_url + "/context/packet",
+            json={"query": query, "task_type": "explain",
+                  "max_genes": max_genes, "include_raw": True},
+            timeout=timeout_s,
+        )
+    except Exception as exc:
+        out["status"] = "error:{}".format(exc)
+        return out
+    if resp.status_code != 200:
+        out["status"] = "http_{}".format(resp.status_code)
+        return out
+    try:
+        packet = resp.json()
+    except Exception as exc:
+        out["status"] = "json_error:{}".format(exc)
+        return out
+
+    out["raw_keys"] = sorted(list(packet.keys())) if isinstance(packet, dict) else []
+    if isinstance(packet, dict):
+        out["know"] = packet.get("know")
+        out["miss"] = packet.get("miss")
+        # ContextPacket carries evidence as verified / stale_risk /
+        # contradictions lists of ContextItem (schemas.py:265-275; item body is
+        # `content`, path is `source_id`). Extra keys are harmless supersets.
+        pieces = []
+        paths = []
+        for key in ("verified", "stale_risk", "contradictions",
+                    "items", "evidence", "genes"):
+            arr = packet.get(key)
+            if isinstance(arr, list):
+                for it in arr:
+                    if not isinstance(it, dict):
+                        continue
+                    src = (it.get("source_id") or it.get("source")
+                           or it.get("path") or it.get("title") or "")
+                    body = (it.get("content") or it.get("body")
+                            or it.get("text") or it.get("raw") or "")
+                    if src:
+                        paths.append(str(src).replace("\\", "/"))
+                    if body:
+                        pieces.append("[{}]\n{}".format(src, body))
+        out["delivered_paths"] = paths
+        out["context_text"] = "\n\n".join(pieces)[:12000]
+
+    # Fallback: if the packet gave us no usable context body, pull /context.
+    if not out["context_text"]:
+        try:
+            r2 = httpx.post(helix_url + "/context",
+                            json={"query": query, "decoder_mode": "none"},
+                            timeout=timeout_s)
+            if r2.status_code == 200:
+                raw = r2.json()
+                d = raw[0] if isinstance(raw, list) and raw else (
+                    raw if isinstance(raw, dict) else {})
+                ctx = d.get("content", "") or ""
+                out["context_text"] = ctx[:12000]
+                for m in re.finditer(r'<GENE\s+src="([^"]+)"', ctx):
+                    out["delivered_paths"].append(m.group(1).replace("\\", "/"))
+        except Exception:
+            pass
+    return out
+
+
+# ---------------------------------------------------------------------------
+# claude -p (answer + judge + audit)
+# ---------------------------------------------------------------------------
+
+_ANSWER_SYS = (
+    "You are answering a single factual question about an internal company "
+    "knowledge base. Use ONLY the context provided below to answer. If the "
+    "answer is not in the context, say exactly: I don't know.\n\n"
+    "<CONTEXT>\n{ctx}\n</CONTEXT>"
+)
+_ANSWER_SYS_COLD = (
+    "You are answering a single factual question about an internal company "
+    "knowledge base. If you don't have the specific information being asked "
+    "for, say exactly: I don't know. Do not make up details."
+)
+
+
+def _claude(prompt, model, max_usd, system_text="", timeout_s=180):
+    """One claude -p call. json output, cost-capped, no local MCP.
+
+    system_text (when given) is written to a temp file and passed via
+    --append-system-prompt-file to dodge the 32K arg-line limit (the
+    bench_enterprise_rag pattern).
+    """
+    clean_cwd = Path(tempfile.gettempdir()) / "helix-bench-clean-cwd"
+    clean_cwd.mkdir(parents=True, exist_ok=True)
+    empty_cfg = clean_cwd / "_empty_mcp.json"
+    if not empty_cfg.exists():
+        empty_cfg.write_text('{"mcpServers":{}}', encoding="utf-8")
+
+    sp_name = None
+    cmd = [
+        "claude", "-p",
+        "--model", model,
+        "--tools", "",
+        "--strict-mcp-config",
+        "--mcp-config", str(empty_cfg),
+        "--max-budget-usd", str(max_usd),
+        "--output-format", "json",
+    ]
+    try:
+        if system_text:
+            sp = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".txt", delete=False, encoding="utf-8")
+            sp.write(system_text)
+            sp.close()
+            sp_name = sp.name
+            cmd += ["--append-system-prompt-file", sp_name]
+        cmd += ["--", prompt]
+
+        t0 = time.perf_counter()
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, encoding="utf-8",
+                errors="replace", cwd=str(clean_cwd),
+                timeout=timeout_s, creationflags=NO_WINDOW,
+            )
+        except subprocess.TimeoutExpired:
+            return {"status": "timeout", "text": "", "cost_usd": None,
+                    "elapsed_s": timeout_s}
+        elapsed = time.perf_counter() - t0
+        if proc.returncode != 0:
+            return {"status": "exit_nonzero", "rc": proc.returncode,
+                    "stderr": (proc.stderr or "")[-300:], "text": "",
+                    "cost_usd": None, "elapsed_s": elapsed}
+        try:
+            data = json.loads(proc.stdout)
+        except Exception:
+            return {"status": "json_error",
+                    "stdout_tail": (proc.stdout or "")[-300:], "text": "",
+                    "cost_usd": None, "elapsed_s": elapsed}
+        return {"status": "ok", "text": data.get("result", "") or "",
+                "cost_usd": float(data.get("total_cost_usd", 0) or 0),
+                "elapsed_s": elapsed}
+    finally:
+        if sp_name:
+            try:
+                os.unlink(sp_name)
+            except Exception:
+                pass
+
+
+def generate_answer(question, ctx_text, model, max_usd):
+    system_text = (_ANSWER_SYS.format(ctx=ctx_text) if ctx_text
+                   else _ANSWER_SYS_COLD)
+    return _claude(question, model, max_usd, system_text=system_text)
+
+
+# ---- Judge protocol (goal-gates spec sec.4) --------------------------------
+
+_JUDGE_INSTRUCTIONS = (
+    "You are a strict grader for a retrieval-augmented QA system. You will be "
+    "given a QUESTION, a REFERENCE answer (ground truth), and a candidate "
+    "ANSWER. Grade the candidate ANSWER using single-answer reference-guided "
+    "grading. Output EXACTLY one token on the first line, one of:\n"
+    "  CORRECT   - the answer conveys the same key fact(s) as the reference\n"
+    "  INCORRECT - the answer states something that conflicts with, or is "
+    "absent from, the reference (a confident wrong answer)\n"
+    "  ABSTAINED - the answer declines to answer (e.g. says it does not know, "
+    "or that the context lacks the information)\n"
+    "Judge ONLY factual agreement with the reference; ignore style and length. "
+    "After the verdict token, you may add one short line of justification."
+)
+
+
+def _judge_prompt(question, reference, answer):
+    return (
+        "QUESTION:\n{}\n\n".format(question)
+        + "REFERENCE (ground truth):\n{}\n\n".format(
+            reference or "(no reference provided)")
+        + "CANDIDATE ANSWER:\n{}\n\n".format(answer)
+        + "Verdict (CORRECT / INCORRECT / ABSTAINED) then one line why:"
+    )
+
+
+_VERDICT_RE = re.compile(r"\b(CORRECT|INCORRECT|ABSTAINED)\b", re.IGNORECASE)
+
+
+def parse_verdict(text):
+    """Extract the trinary verdict; default ABSTAINED if unparseable so an
+    unreadable judge output never counts as a hallucination."""
+    if not text:
+        return "ABSTAINED"
+    m = _VERDICT_RE.search(text)
+    if not m:
+        return "ABSTAINED"
+    return m.group(1).upper()
+
+
+def judge_answer(question, reference, answer, model, max_usd):
+    r = _claude(_judge_prompt(question, reference, answer), model, max_usd,
+                system_text=_JUDGE_INSTRUCTIONS)
+    verdict = parse_verdict(r.get("text", "")) if r.get("status") == "ok" else "ERROR"
+    return {"verdict": verdict, "raw": r.get("text", "")[:400],
+            "status": r.get("status"), "cost_usd": r.get("cost_usd"),
+            "elapsed_s": r.get("elapsed_s")}
+
+
+# ---------------------------------------------------------------------------
+# Resume: read completed ids from the output jsonl
+# ---------------------------------------------------------------------------
+
+def load_done_ids(out_path):
+    done = set()
+    if not out_path.is_file():
+        return done
+    with out_path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            qid = rec.get("id")
+            if qid:
+                done.add(str(qid))
+    return done
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--erb-root", default=os.environ.get(
+        "ERB_ROOT", r"F:\Projects\EnterpriseRAG-Bench-main"))
+    ap.add_argument("--helix-url", default=os.environ.get(
+        "HELIX_URL", "http://127.0.0.1:11437"))
+    ap.add_argument("--out", required=True, help="Per-question output JSONL.")
+    ap.add_argument("--summary-out", required=True, help="Summary JSON path.")
+    ap.add_argument("--answer-model", default="sonnet",
+                    help="claude -p model for answer + judge (Sonnet class).")
+    ap.add_argument("--audit-model", default="opus",
+                    help="claude -p model for the 10 pct audit rung (Opus class).")
+    ap.add_argument("--answer-max-usd", type=float, default=0.20)
+    ap.add_argument("--judge-max-usd", type=float, default=0.10)
+    ap.add_argument("--audit-max-usd", type=float, default=0.40)
+    ap.add_argument("--audit-fraction", type=float, default=0.10)
+    ap.add_argument("--max-genes", type=int, default=8)
+    ap.add_argument("--max-questions", type=int, default=None,
+                    help="Cap questions (smoke). Default: all 500.")
+    ap.add_argument("--types", default="",
+                    help="Comma-separated question_type filter.")
+    ap.add_argument("--seed", type=int, default=93,
+                    help="RNG seed for the deterministic audit subsample.")
+    args = ap.parse_args(argv)
+
+    erb_root = Path(args.erb_root)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path = Path(args.summary_out)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    types = [t.strip() for t in args.types.split(",") if t.strip()] or None
+    needles = load_needles(erb_root, max_questions=args.max_questions, types=types)
+    if not needles:
+        summary_path.write_text(json.dumps({
+            "benchmark": "erb500k_scored", "issue": "#93",
+            "error": ("no questions loaded from {} -- check --erb-root exists "
+                      "on the rig".format(erb_root / "questions.jsonl")),
+            "baselines": BASELINES,
+        }, indent=2), encoding="utf-8")
+        print("ERROR: no questions from {}".format(erb_root), file=sys.stderr)
+        return 2
+
+    # Deterministic audit subsample by id (stable across resumes).
+    rng = random.Random(args.seed)
+    ids = [nd["id"] for nd in needles]
+    k_audit = max(1, int(round(len(ids) * args.audit_fraction)))
+    audit_ids = set(rng.sample(ids, min(k_audit, len(ids))))
+
+    done = load_done_ids(out_path)
+    print("[erb500k] {} questions; {} already done; audit subsample={}".format(
+        len(needles), len(done), len(audit_ids)))
+
+    # Health check (fail fast if the sharded server isn't up / genes=0).
+    try:
+        h = httpx.get(args.helix_url + "/health", timeout=10).json()
+        genes = h.get("genes") or h.get("document_count")
+        print("[erb500k] helix health: genes={} pid={}".format(
+            genes, h.get("pid")))
+        if genes is not None and int(genes) == 0:
+            print("[erb500k] WARN: server reports genes=0 -- sharded fixture "
+                  "may not be mounted (HELIX_USE_SHARDS?)", file=sys.stderr)
+    except Exception as exc:
+        summary_path.write_text(json.dumps({
+            "benchmark": "erb500k_scored", "issue": "#93",
+            "error": "helix /health unreachable at {}: {}".format(
+                args.helix_url, exc),
+            "baselines": BASELINES,
+        }, indent=2), encoding="utf-8")
+        print("ERROR: helix unreachable: {}".format(exc), file=sys.stderr)
+        return 2
+
+    processed = 0
+    with out_path.open("a", encoding="utf-8") as ofh:
+        for i, nd in enumerate(needles, 1):
+            qid = nd["id"]
+            if qid in done:
+                continue
+
+            # (a) packet + verbatim know/miss
+            packet = fetch_packet(args.helix_url, nd["question"], args.max_genes)
+            gold_index, gold_canon = make_gold_index(nd["gold_paths"])
+            gold_delivered = any(
+                match_delivered(p, gold_index, gold_canon) is not None
+                for p in packet.get("delivered_paths", [])
+            )
+            know_block = packet.get("know")
+            miss_block = packet.get("miss")
+            emitted = ("know" if know_block is not None
+                       else "miss" if miss_block is not None else "neither")
+
+            # (b) answer with Sonnet
+            ans = generate_answer(nd["question"], packet.get("context_text", ""),
+                                  args.answer_model, args.answer_max_usd)
+            answer_text = ans.get("text", "")
+
+            # (c) judge with Sonnet (trinary, reference-guided)
+            jr = judge_answer(nd["question"], nd["gold_answer"], answer_text,
+                              args.answer_model, args.judge_max_usd)
+            verdict = jr["verdict"]
+
+            # (d) 10% audit with Opus
+            audit = None
+            if qid in audit_ids:
+                ar = judge_answer(nd["question"], nd["gold_answer"], answer_text,
+                                  args.audit_model, args.audit_max_usd)
+                audit = {"verdict": ar["verdict"], "raw": ar["raw"],
+                         "status": ar["status"], "model": args.audit_model,
+                         "cost_usd": ar["cost_usd"]}
+
+            rec = {
+                "id": qid,
+                "type": nd["type"],
+                "question": nd["question"][:500],
+                "gold_answer": (nd["gold_answer"] or "")[:400],
+                "expected_doc_ids": nd["expected_doc_ids"],
+                "packet": {
+                    "status": packet.get("status"),
+                    "emitted": emitted,
+                    "know": know_block,   # verbatim
+                    "miss": miss_block,   # verbatim
+                    "gold_delivered": gold_delivered,
+                    "n_delivered": len(packet.get("delivered_paths", [])),
+                    "raw_keys": packet.get("raw_keys"),
+                },
+                "answer": {
+                    "text": answer_text[:2000],
+                    "status": ans.get("status"),
+                    "cost_usd": ans.get("cost_usd"),
+                    "elapsed_s": round(ans.get("elapsed_s", 0), 2),
+                },
+                "judge": {
+                    "verdict": verdict,
+                    "raw": jr["raw"],
+                    "model": args.answer_model,
+                    "status": jr["status"],
+                    "cost_usd": jr["cost_usd"],
+                },
+                "audit": audit,
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+            ofh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            ofh.flush()
+            processed += 1
+            if processed % 10 == 0:
+                print("[erb500k] +{} (idx {}/{}) last: emitted={} verdict={}".format(
+                    processed, i, len(needles), emitted, verdict))
+
+    # ------------------------------------------------------------------
+    # Summarize from the full jsonl (all rows, including prior-run rows).
+    # ------------------------------------------------------------------
+    summ = summarize(out_path, audit_ids)
+    summ.update({
+        "benchmark": "erb500k_scored",
+        "issue": "#93",
+        "fixture": "genomes/bench/matrix-sharded/enterprise_rag_500k",
+        "helix_url": args.helix_url,
+        "answer_model": args.answer_model,
+        "audit_model": args.audit_model,
+        "n_questions_total": len(needles),
+        "audit_fraction": args.audit_fraction,
+        "baselines": BASELINES,
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+    })
+    summary_path.write_text(json.dumps(summ, indent=2), encoding="utf-8")
+    print("=" * 60)
+    print("[erb500k] rows={} answered={} correctness_among_answered={} "
+          "hallucination_rate={} coverage={}".format(
+              summ["n_rows"], summ["answered"],
+              summ["correctness_among_answered"],
+              summ["hallucination_rate"], summ["coverage"]))
+    print("[erb500k] know-vs-judged agreement={}".format(
+        summ["know_vs_judged_agreement"]))
+    print("-> {}".format(out_path))
+    print("-> {}".format(summary_path))
+    return 0
+
+
+def summarize(out_path, audit_ids):
+    """Compute the gate metrics from the per-question jsonl.
+
+    Metrics (goal-gates spec sec.4):
+      correctness among answered = CORRECT / (CORRECT + INCORRECT)
+      hallucination rate         = INCORRECT / (CORRECT + INCORRECT)
+      coverage                   = answered / total   (abstains -> coverage loss)
+      know-vs-judged agreement   = fraction of rows where (packet emitted 'know')
+                                   agrees with (judge said CORRECT) -- the
+                                   calibration signal: know should predict correct.
+      audit agreement            = fraction of audited rows where the Opus audit
+                                   verdict == the Sonnet judge verdict.
+    """
+    n_rows = 0
+    correct = incorrect = abstained = judge_err = 0
+    know_emitted = 0
+    know_and_correct = 0
+    know_rows = 0            # rows where packet emitted 'know'
+    judged_rows = 0          # rows with a parseable trinary verdict
+    agree_cells = 0          # know<->correct agreement over judged rows
+    audit_n = audit_agree = 0
+
+    if out_path.is_file():
+        with out_path.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                n_rows += 1
+                emitted = (rec.get("packet") or {}).get("emitted")
+                is_know = (emitted == "know")
+                if is_know:
+                    know_emitted += 1
+                v = (rec.get("judge") or {}).get("verdict")
+                if v == "CORRECT":
+                    correct += 1
+                elif v == "INCORRECT":
+                    incorrect += 1
+                elif v == "ABSTAINED":
+                    abstained += 1
+                else:
+                    judge_err += 1
+
+                if v in ("CORRECT", "INCORRECT", "ABSTAINED"):
+                    judged_rows += 1
+                    judged_correct = (v == "CORRECT")
+                    if is_know:
+                        know_rows += 1
+                        if judged_correct:
+                            know_and_correct += 1
+                    if (is_know and judged_correct) or (
+                            not is_know and not judged_correct):
+                        agree_cells += 1
+
+                au = rec.get("audit")
+                if isinstance(au, dict) and au.get("verdict") in (
+                        "CORRECT", "INCORRECT", "ABSTAINED"):
+                    audit_n += 1
+                    if au["verdict"] == v:
+                        audit_agree += 1
+
+    answered = correct + incorrect
+    result = {
+        "n_rows": n_rows,
+        "correct": correct,
+        "incorrect": incorrect,
+        "abstained": abstained,
+        "judge_error": judge_err,
+        "answered": answered,
+        "know_emitted": know_emitted,
+        "correctness_among_answered": round(correct / answered, 4) if answered else 0.0,
+        "hallucination_rate": round(incorrect / answered, 4) if answered else 0.0,
+        "coverage": round(answered / n_rows, 4) if n_rows else 0.0,
+        "know_precision_correct": round(know_and_correct / know_rows, 4) if know_rows else 0.0,
+        "know_vs_judged_agreement": round(agree_cells / judged_rows, 4) if judged_rows else 0.0,
+        "audit_n": audit_n,
+        "audit_agreement": round(audit_agree / audit_n, 4) if audit_n else 0.0,
+        "audit_agreement_target": 0.80,
+    }
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_chain/erb_to_sweep_queries.py
+++ b/scripts/bench_chain/erb_to_sweep_queries.py
@@ -1,0 +1,118 @@
+"""Convert ERB questions.jsonl -> sweep_dense_additive_weight --queries JSON.
+
+The sweep expects a JSON LIST of {"query": str, "gold_ids": [gene_id]} where
+gold_ids are gene_ids IN THE TARGET GENOME. ERB ships JSONL with
+expected_doc_ids (uuids) resolved to relative source paths via
+generated_data/uuid_index.json. This adapter resolves uuid -> rel path ->
+gene_id by suffix-matching the genome's source_id column (path-separator
+tolerant). Questions with zero resolvable golds in the target genome are
+dropped (correct per-bed subset for the 10K/50K fixtures) and counted.
+
+Usage:
+  python erb_to_sweep_queries.py --genome <db> --erb-root <dir> --out <json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+
+
+def norm(p: str) -> str:
+    return p.replace("\\", "/").lower().lstrip("/")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--genome", required=True)
+    ap.add_argument("--erb-root", default=r"F:\Projects\EnterpriseRAG-Bench-main")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--limit", type=int, default=0, help="0 = all questions")
+    args = ap.parse_args()
+
+    root = args.erb_root.rstrip("\\/")
+    # uuid -> relative source path (fixture-matrix doc: uuid_index.json lives
+    # in generated_data/ root). Tolerate both root and generated_data layouts.
+    idx = None
+    for cand in (f"{root}\\generated_data\\uuid_index.json",
+                 f"{root}\\uuid_index.json"):
+        try:
+            idx = json.load(open(cand, encoding="utf-8"))
+            break
+        except OSError:
+            continue
+    if idx is None:
+        print("ERROR: uuid_index.json not found under", root, file=sys.stderr)
+        return 2
+    uuid_to_rel = {}
+    for k, v in idx.items():
+        if isinstance(v, str):
+            uuid_to_rel[k] = norm(v)
+        elif isinstance(v, dict):
+            for key in ("path", "file", "relative_path", "source"):
+                if isinstance(v.get(key), str):
+                    uuid_to_rel[k] = norm(v[key])
+                    break
+
+    # Genome source_id -> gene_id (suffix match table).
+    conn = sqlite3.connect(f"file:{args.genome}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT gene_id, source_id FROM genes WHERE source_id IS NOT NULL"
+    ).fetchall()
+    conn.close()
+    by_src = [(norm(r["source_id"]), r["gene_id"]) for r in rows if r["source_id"]]
+
+    def golds_for(rel: str) -> list[str]:
+        out = []
+        for src, gid in by_src:
+            if src.endswith(rel):
+                out.append(gid)
+        return out
+
+    qpath = None
+    for cand in (f"{root}\\questions.jsonl",
+                 f"{root}\\generated_data\\questions.jsonl"):
+        try:
+            open(cand, encoding="utf-8").close()
+            qpath = cand
+            break
+        except OSError:
+            continue
+    if qpath is None:
+        print("ERROR: questions.jsonl not found under", root, file=sys.stderr)
+        return 2
+
+    queries, dropped, total = [], 0, 0
+    for line in open(qpath, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            q = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        total += 1
+        text = q.get("question") or q.get("query") or ""
+        gold_ids: list[str] = []
+        for doc_id in q.get("expected_doc_ids") or []:
+            rel = uuid_to_rel.get(str(doc_id))
+            if rel:
+                gold_ids.extend(golds_for(rel))
+        gold_ids = sorted(set(gold_ids))
+        if text and gold_ids:
+            queries.append({"query": text, "gold_ids": gold_ids})
+        else:
+            dropped += 1
+        if args.limit and len(queries) >= args.limit:
+            break
+
+    json.dump(queries, open(args.out, "w", encoding="utf-8"), indent=1)
+    print(f"wrote {len(queries)} queries ({dropped} dropped of {total} total) "
+          f"-> {args.out}")
+    return 0 if queries else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_chain/run_chain.ps1
+++ b/scripts/bench_chain/run_chain.ps1
@@ -1,0 +1,38 @@
+# Bench chain 2026-07-01 - serial stages per goal-gates run discipline.
+# S1 3-arm ContextBench -> S2 SIKE bed-sweep (#221) -> S3 dense sweep (#203)
+# -> S4 ERB 500-q scored @ June-11 500K fixture (#93).
+# Every stage logs to benchmarks/logs and updates chain_status.json.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$chain = "$repo\scripts\bench_chain"
+$logs = "$repo\benchmarks\logs"
+New-Item -ItemType Directory -Force -Path $logs | Out-Null
+"chain started $(Get-Date -Format o) pid=$PID" | Set-Content "$logs\chain_runner.log"
+$PID | Set-Content "$logs\chain.pid"
+
+# Load annotation (method-notes discipline): record rig load at chain start.
+try {
+    $gpu = nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu --format=csv,noheader
+    $cpu = (Get-CimInstance Win32_Processor).LoadPercentage
+    "load at start: GPU $gpu / CPU $cpu pct" | Add-Content "$logs\chain_runner.log"
+} catch {}
+
+function Run-Stage {
+    param([string]$name, [string]$script)
+    if (-not (Test-Path $script)) {
+        "SKIP $name - $script not found $(Get-Date -Format o)" | Add-Content "$logs\chain_runner.log"
+        return
+    }
+    "START $name $(Get-Date -Format o)" | Add-Content "$logs\chain_runner.log"
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $script
+    "END $name exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\chain_runner.log"
+}
+
+Run-Stage -name 's1_3arm' -script "$chain\s1_contextbench_3arm.ps1"
+Run-Stage -name 's2_sike_beds' -script "$chain\s2_sike_bed_sweep.ps1"
+Run-Stage -name 's3_203_sweep' -script "$chain\s3_dense_weight_sweep.ps1"
+Run-Stage -name 's4_erb500k' -script "$chain\s4_erb500k_scored.ps1"
+
+"chain complete $(Get-Date -Format o)" | Add-Content "$logs\chain_runner.log"
+$done = @{stage='chain'; state='COMPLETE'; at=(Get-Date -Format o)} | ConvertTo-Json
+$done | Set-Content "$logs\chain_status.json"

--- a/scripts/bench_chain/run_sike_203.ps1
+++ b/scripts/bench_chain/run_sike_203.ps1
@@ -1,0 +1,56 @@
+# SIKE + #203 sequencer (2026-07-03). ERB-500q scored run SKIPPED per Max
+# (resource requirements). Serial: S2' SIKE bed-sweep (fixed: force-fresh
+# copies + checkpoint + gene-count gate) -> S3b' ERB dense-weight sweeps
+# (n=100 seeded sample, weights 0,2,4,6 -- real queries run ~25s each, the
+# full 470x6 grid would be ~23h/bed).
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$ts = Get-Date -Format 'yyyy-MM-dd_HHmm'
+$env:HELIX_OTEL_ENABLED = '1'
+$env:HELIX_OTEL_ENDPOINT = 'localhost:4317'
+cd $repo
+"sike+203 sequencer started $(Get-Date -Format o) pid=$PID" | Set-Content "$logs\sike203_runner.log"
+$PID | Set-Content "$logs\sike203.pid"
+
+function Set-Status {
+    param([string]$stage, [string]$state)
+    @{stage=$stage; state=$state; at=(Get-Date -Format o)} | ConvertTo-Json |
+        Set-Content "$repo\benchmarks\logs\chain_status.json"
+}
+
+# ---- Stage A: SIKE bed-sweep (repaired) ------------------------------------
+"START s2_sike $(Get-Date -Format o)" | Add-Content "$logs\sike203_runner.log"
+& powershell -NoProfile -ExecutionPolicy Bypass -File "$repo\scripts\bench_chain\s2_sike_bed_sweep.ps1"
+"END s2_sike exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\sike203_runner.log"
+
+# ---- Stage B: #203 sweeps, sampled -----------------------------------------
+$weights = '0,2,4,6'
+foreach ($bed in @(
+    @('erb10k', 'genomes\bench\matrix\enterprise_rag_10k_batched.db'),
+    @('erb50k', 'genomes\bench\matrix\enterprise_rag_50k_batched.db')
+)) {
+    $name = $bed[0]; $db = $bed[1]
+    Set-Status 's3b_203' "adapt-$name"
+    $qfull = "$repo\benchmarks\results\erb_sweep_queries_$name.json"
+    $qsample = "$repo\benchmarks\results\erb_sweep_queries_${name}_n100.json"
+    if (-not (Test-Path $qfull)) {
+        python scripts\bench_chain\erb_to_sweep_queries.py --genome $db `
+            --out $qfull *> "$logs\s3b_adapt_${name}_$ts.log"
+        if ($LASTEXITCODE -ne 0) {
+            "adapter FAILED for $name" | Add-Content "$logs\sike203_runner.log"
+            continue
+        }
+    }
+    python -c "import json,random,sys; qs=json.load(open(sys.argv[1],encoding='utf-8')); random.Random(0).shuffle(qs); json.dump(qs[:100], open(sys.argv[2],'w',encoding='utf-8'))" $qfull $qsample
+    Set-Status 's3b_203' "sweep-$name-n100"
+    "START sweep $name $(Get-Date -Format o)" | Add-Content "$logs\sike203_runner.log"
+    python benchmarks\sweep_dense_additive_weight.py `
+        --genome $db --queries $qsample --weights $weights `
+        --out benchmarks\results\sweep_w_${name}_realq_n100_$ts.json `
+        *> "$logs\s3b_${name}_n100_$ts.log"
+    "END sweep $name exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\sike203_runner.log"
+}
+
+Set-Status 'chain' 'COMPLETE-SIKE-203 (erb500k skipped per Max)'
+"sequencer complete $(Get-Date -Format o)" | Add-Content "$logs\sike203_runner.log"

--- a/scripts/bench_chain/s1_contextbench_3arm.ps1
+++ b/scripts/bench_chain/s1_contextbench_3arm.ps1
@@ -1,0 +1,73 @@
+# Stage 1 — 3-arm ContextBench (council plan step 2 / run plan 2026-07-01)
+# Arm A: BM25 foil = frozen baseline (0.484 packet line recall, stored)
+# Arm B: master (cAST default-on) with the committed lexical probe config
+# Arm C: ws3 worktree code (WS2+WS3, rebased on master) + symbol_graph=true
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$ts = Get-Date -Format 'yyyy-MM-dd_HHmm'
+New-Item -ItemType Directory -Force -Path $logs | Out-Null
+$env:HELIX_OTEL_ENABLED = '1'
+$env:HELIX_OTEL_ENDPOINT = 'localhost:4317'
+
+function Set-Status($stage, $state) {
+    @{stage=$stage; state=$state; at=(Get-Date -Format o)} | ConvertTo-Json |
+        Set-Content "$repo\benchmarks\logs\chain_status.json"
+}
+
+Set-Status 's1_3arm' 'building-armC-config'
+# Build arm-C toml: lexical probe + symbol knobs (python keeps TOML valid).
+$py = @'
+import io, tomllib
+src = r"F:\Projects\helix-context\docs\benchmarks\helix_probe_lexical.toml"
+dst = r"F:\Projects\helix-context\docs\benchmarks\helix_probe_symbol.toml"
+t = io.open(src, encoding="utf-8").read()
+def set_key(t, section, line):
+    hdr = f"[{section}]"
+    if hdr in t:
+        return t.replace(hdr, hdr + "\n" + line, 1)
+    return t + f"\n{hdr}\n{line}\n"
+t = set_key(t, "ingestion", "symbol_graph = true")
+t = set_key(t, "retrieval", "symbol_expansion_cap = 8")
+io.open(dst, "w", encoding="utf-8").write(t)
+tomllib.load(open(dst, "rb"))
+print("arm-C toml ok")
+'@
+$py | Set-Content "$env:TEMP\mk_symbol_toml.py" -Encoding UTF8
+python "$env:TEMP\mk_symbol_toml.py"
+if ($LASTEXITCODE -ne 0) { Set-Status 's1_3arm' 'FAILED-armC-config'; exit 1 }
+
+cd $repo
+# ── Arm B: master code ───────────────────────────────────────────────
+Set-Status 's1_3arm' 'armB-running'
+Remove-Item Env:\PYTHONPATH -ErrorAction SilentlyContinue
+python benchmarks\cb_helix_pred.py --tag armB_cast_master_$ts `
+    --config docs\benchmarks\helix_probe_lexical.toml --workers 3 `
+    *> "$logs\s1_armB_$ts.log"
+$armB_exit = $LASTEXITCODE
+
+# ── Arm C: ws3 worktree code (WS2+WS3) + symbol config ──────────────
+Set-Status 's1_3arm' 'armC-running'
+$env:PYTHONPATH = 'F:\Projects\helix-context\.worktrees\ws3-pagerank'
+python benchmarks\cb_helix_pred.py --tag armC_symbol_ws3_$ts `
+    --config docs\benchmarks\helix_probe_symbol.toml --workers 3 `
+    *> "$logs\s1_armC_$ts.log"
+$armC_exit = $LASTEXITCODE
+Remove-Item Env:\PYTHONPATH -ErrorAction SilentlyContinue
+
+# ── AST-path assertion (run-plan gap #2): chunk_regex must be 0 ─────
+Set-Status 's1_3arm' 'ast-assertion'
+$regexHits = (Select-String -Path "$logs\s1_armB_$ts.log","$logs\s1_armC_$ts.log" `
+    -Pattern 'chunking path: regex|fell back to regex' -ErrorAction SilentlyContinue |
+    Measure-Object).Count
+"AST assertion: chunk_regex log lines = $regexHits (must be 0 for code corpora)" |
+    Add-Content "$logs\s1_summary_$ts.log"
+
+# ── Score both arms with the cb-step0 venv ──────────────────────────
+Set-Status 's1_3arm' 'scoring'
+$scorer = 'F:\Projects\_venvs\cb-step0\Scripts\python.exe'
+& $scorer benchmarks\cb_score_all.py *> "$logs\s1_score_$ts.log"
+
+"armB_exit=$armB_exit armC_exit=$armC_exit" | Add-Content "$logs\s1_summary_$ts.log"
+if ($armB_exit -eq 0 -and $armC_exit -eq 0) { Set-Status 's1_3arm' 'DONE' }
+else { Set-Status 's1_3arm' "DONE-WITH-ERRORS(B=$armB_exit,C=$armC_exit)" }

--- a/scripts/bench_chain/s2_rerun_after_203.ps1
+++ b/scripts/bench_chain/s2_rerun_after_203.ps1
@@ -1,0 +1,25 @@
+# Watcher (2026-07-03): waits for the SIKE+203 sequencer to finish its
+# #203 sweeps, then reruns the FIXED S2 bed-sweep (lexical-config serving,
+# no GPU contention with the ollama ladder). Final state: COMPLETE-FINAL.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$status = "$logs\chain_status.json"
+"s2-after-203 watcher started $(Get-Date -Format o) pid=$PID" | Set-Content "$logs\s2after203_watcher.log"
+$PID | Set-Content "$logs\s2after203.pid"
+
+while ($true) {
+    Start-Sleep -Seconds 120
+    try { $s = Get-Content $status -Raw | ConvertFrom-Json } catch { continue }
+    if ($s.state -like 'COMPLETE-SIKE-203*') { break }
+}
+"203 done; rerunning fixed S2 $(Get-Date -Format o)" | Add-Content "$logs\s2after203_watcher.log"
+$run = @{stage='s2_rerun2'; state='starting'; at=(Get-Date -Format o)} | ConvertTo-Json
+$run | Set-Content $status
+
+& powershell -NoProfile -ExecutionPolicy Bypass -File "$repo\scripts\bench_chain\s2_sike_bed_sweep.ps1"
+"s2 rerun2 exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\s2after203_watcher.log"
+
+$done = @{stage='chain'; state='COMPLETE-FINAL (SIKE fixed + 203 n100; erb500k skipped)'; at=(Get-Date -Format o)} | ConvertTo-Json
+$done | Set-Content $status
+"watcher done $(Get-Date -Format o)" | Add-Content "$logs\s2after203_watcher.log"

--- a/scripts/bench_chain/s2_rerun_watcher.ps1
+++ b/scripts/bench_chain/s2_rerun_watcher.ps1
@@ -1,0 +1,30 @@
+# Waits for the main chain to COMPLETE, then re-runs the repaired S2
+# (SIKE bed-sweep) that was killed after the 2026-07-02 ollama-list hang.
+# Serial discipline: never runs S2 while S3/S4 own the rig.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$status = "$logs\chain_status.json"
+"s2 rerun watcher started $(Get-Date -Format o) pid=$PID" | Set-Content "$logs\s2_watcher.log"
+$PID | Set-Content "$logs\s2_watcher.pid"
+
+while ($true) {
+    Start-Sleep -Seconds 60
+    if (-not (Test-Path $status)) { continue }
+    try { $s = Get-Content $status -Raw | ConvertFrom-Json } catch { continue }
+    if ($s.state -eq 'COMPLETE') { break }
+}
+
+"chain COMPLETE detected; starting repaired S2 $(Get-Date -Format o)" | Add-Content "$logs\s2_watcher.log"
+$run = @{stage='s2_rerun'; state='starting'; at=(Get-Date -Format o)} | ConvertTo-Json
+$run | Set-Content $status
+
+& powershell -NoProfile -ExecutionPolicy Bypass -File "$repo\scripts\bench_chain\s2_sike_bed_sweep.ps1"
+"s2 rerun exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\s2_watcher.log"
+
+& powershell -NoProfile -ExecutionPolicy Bypass -File "$repo\scripts\bench_chain\s3b_erb_sweep_rerun.ps1"
+"s3b erb sweep rerun exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\s2_watcher.log"
+
+$done = @{stage='chain'; state='COMPLETE-ALL(s2+s3b-rerun-done)'; at=(Get-Date -Format o)} | ConvertTo-Json
+$done | Set-Content $status
+"watcher done $(Get-Date -Format o)" | Add-Content "$logs\s2_watcher.log"

--- a/scripts/bench_chain/s2_sike_bed_sweep.ps1
+++ b/scripts/bench_chain/s2_sike_bed_sweep.ps1
@@ -1,0 +1,232 @@
+# Stage 2 - issue #221: fixed SIKE curated needle set swept across distractor beds.
+# Beds: xl.db (own-code mixed) + enterprise_rag_10k_batched + enterprise_rag_50k_batched.
+# Per bed: copy to genomes/bench/sike_beds/<name>.db (resume-safe: skip if present),
+#          ingest the SIKE gold docs into the copy (bench_needle does NOT self-ingest),
+#          start a blob-mode uvicorn on that copy, run the needle battery across a
+#          local ollama ladder (auto-discovered) + one Claude Sonnet rung (cost-capped),
+#          write results to benchmarks/results/sike_bedsweep_<bed>_<ts>.json.
+# On a per-bed failure: log and continue to the next bed. Never exit on one step.
+# Pure ASCII, PowerShell 5.1-safe.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$results = "$repo\benchmarks\results"
+$bedsDir = "$repo\genomes\bench\sike_beds"
+$ts = Get-Date -Format 'yyyy-MM-dd_HHmm'
+New-Item -ItemType Directory -Force -Path $logs | Out-Null
+New-Item -ItemType Directory -Force -Path $results | Out-Null
+New-Item -ItemType Directory -Force -Path $bedsDir | Out-Null
+$env:HELIX_OTEL_ENABLED = '1'
+$env:HELIX_OTEL_ENDPOINT = 'localhost:4317'
+$env:PYTHONHASHSEED = '0'
+$port = 11437
+$helixUrl = "http://127.0.0.1:$port"
+cd $repo
+
+function Set-Status {
+    param([string]$stage, [string]$state)
+    @{stage=$stage; state=$state; at=(Get-Date -Format o)} | ConvertTo-Json |
+        Set-Content "$repo\benchmarks\logs\chain_status.json"
+}
+
+# ---- Server lifecycle helpers (mirror bench_orchestrator conventions) -------
+
+function Wait-PortFree {
+    param([int]$p, [int]$timeoutSec = 20)
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        $inUse = $false
+        try {
+            $c = New-Object System.Net.Sockets.TcpClient
+            $iar = $c.BeginConnect('127.0.0.1', $p, $null, $null)
+            if ($iar.AsyncWaitHandle.WaitOne(500)) {
+                try { $c.EndConnect($iar); $inUse = $true } catch { $inUse = $false }
+            }
+            $c.Close()
+        } catch { $inUse = $false }
+        if (-not $inUse) { return $true }
+        Start-Sleep -Milliseconds 300
+    }
+    return $false
+}
+
+function Wait-Healthy {
+    param([string]$url, [int]$timeoutSec = 90)
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $h = Invoke-RestMethod -Uri "$url/health" -TimeoutSec 5 -ErrorAction Stop
+            if ($h) { return $true }
+        } catch { Start-Sleep -Milliseconds 500 }
+    }
+    return $false
+}
+
+function Start-HelixOnBed {
+    # Start uvicorn (blob mode) pointed at $bedPath via HELIX_GENOME_PATH.
+    # Returns the process object, or $null on failure.
+    param([string]$bedPath, [string]$srvLog)
+    $env:HELIX_GENOME_PATH = $bedPath
+    # 2026-07-03 fix: serve beds with the LEXICAL probe config (dense OFF).
+    # Master's default has dense_embedding_enabled=true, which put BGE-M3
+    # on the same 12GB GPU the ollama 26b/31b consumers were using -->
+    # 30-60s/query --> the runner's httpx calls ALL hit ReadTimeout and
+    # every needle scored zero delivery. SIKE needles are lexical-designed;
+    # the CPU-only lexical config removes the contention entirely.
+    $env:HELIX_CONFIG = "$repo\docs\benchmarks\helix_probe_lexical.toml"
+    # 2026-07-05 fix: the proxy's default upstream_timeout (180s,
+    # helix_context/config.py) fired mid-generation for the CPU-offloaded
+    # gemma4 26b-a4b/31b/26b rungs -- ~25-30% of their needles came back
+    # as httpx.ReadTimeout -> http_error rows at ~181s elapsed, deflating
+    # coverage to 0.66-0.78. 600s gives slow local generations room; the
+    # runner's client timeout is 660s so the server side still decides.
+    $env:HELIX_SERVER_UPSTREAM_TIMEOUT = '600'
+    Remove-Item Env:\HELIX_USE_SHARDS -ErrorAction SilentlyContinue
+    if (-not (Wait-PortFree -p $port -timeoutSec 20)) {
+        "  port $port still occupied; cannot start server" | Add-Content $srvLog
+        return $null
+    }
+    $srvArgs = @('-m', 'uvicorn', 'helix_context._asgi:app',
+                 '--host', '127.0.0.1', '--port', "$port")
+    $proc = Start-Process -FilePath 'python' -ArgumentList $srvArgs `
+        -RedirectStandardOutput $srvLog -RedirectStandardError "$srvLog.err" `
+        -WindowStyle Hidden -PassThru
+    if (-not (Wait-Healthy -url $helixUrl -timeoutSec 90)) {
+        "  server did not become healthy" | Add-Content $srvLog
+        Stop-HelixTree -proc $proc
+        return $null
+    }
+    return $proc
+}
+
+function Stop-HelixTree {
+    param($proc)
+    if ($null -eq $proc) { return }
+    try { taskkill /T /F /PID $proc.Id 2>&1 | Out-Null } catch {}
+    Start-Sleep -Seconds 1
+    Wait-PortFree -p $port -timeoutSec 15 | Out-Null
+}
+
+# ---- Discover local ollama models (the local ladder rungs) ------------------
+
+Set-Status 's2_sike_beds' 'discover-ollama'
+# 2026-07-02 hang fix: `ollama list` blocked forever in the hidden shell
+# (chain stalled 8.5h at this exact step). Discovery now runs in a job
+# with a hard 30s timeout and uses the HTTP API (no console semantics);
+# on timeout/empty the ladder degrades to the Sonnet rung only.
+$ollamaModels = ''
+$job = Start-Job -ScriptBlock {
+    try {
+        $r = Invoke-RestMethod -Uri 'http://localhost:11434/api/tags' -TimeoutSec 20
+        ($r.models | ForEach-Object { $_.name }) -join ','
+    } catch { '' }
+}
+if (Wait-Job $job -Timeout 30) {
+    $ollamaModels = (Receive-Job $job)
+} else {
+    Stop-Job $job -ErrorAction SilentlyContinue
+}
+Remove-Job $job -Force -ErrorAction SilentlyContinue
+if ($ollamaModels) {
+    "ollama models discovered: $ollamaModels" | Add-Content "$logs\s2_summary_$ts.log"
+} else {
+    "ollama discovery timed out or empty - proceeding with Sonnet rung only" |
+        Add-Content "$logs\s2_summary_$ts.log"
+}
+if (-not $ollamaModels) {
+    "WARN: no ollama models discovered; local ladder will be empty (Claude rung still runs)" |
+        Add-Content "$logs\s2_summary_$ts.log"
+}
+
+# ---- Bed table (source -> copy) --------------------------------------------
+
+$beds = @(
+    @{ name = 'xl';           src = "$repo\genomes\bench\matrix\xl.db" },
+    @{ name = 'enterprise_rag_10k'; src = "$repo\genomes\bench\matrix\enterprise_rag_10k_batched.db" },
+    @{ name = 'enterprise_rag_50k'; src = "$repo\genomes\bench\matrix\enterprise_rag_50k_batched.db" }
+)
+
+foreach ($bed in $beds) {
+    $name = $bed.name
+    $src = $bed.src
+    $copy = "$bedsDir\$name.db"
+    Set-Status 's2_sike_beds' "bed:$name"
+    "=== BED $name $(Get-Date -Format o) ===" | Add-Content "$logs\s2_summary_$ts.log"
+
+    # 1. FORCE-FRESH copy (2026-07-03 fix). The resume-safe skip kept a
+    # 132-gene stub db (auto-created by an earlier aborted attempt) as the
+    # xl bed forever, and WAL-pending gold writes were invisible to the
+    # server. Always delete + recopy, then verify below.
+    try {
+        if (-not (Test-Path $src)) {
+            "  SOURCE MISSING: $src -- skipping bed $name" | Add-Content "$logs\s2_summary_$ts.log"
+            continue
+        }
+        Remove-Item -Path $copy, "$copy-wal", "$copy-shm" -Force -ErrorAction SilentlyContinue
+        "  fresh copy $src -> $copy" | Add-Content "$logs\s2_summary_$ts.log"
+        Copy-Item -Path $src -Destination $copy -Force -ErrorAction Stop
+        foreach ($side in @("$src-wal", "$src-shm")) {
+            if (Test-Path $side) { Copy-Item -Path $side -Destination ($side -replace [regex]::Escape($src), $copy) -Force }
+        }
+    } catch {
+        "  COPY FAILED for ${name}: $_ -- skipping" | Add-Content "$logs\s2_summary_$ts.log"
+        continue
+    }
+
+    # 2. Ingest SIKE gold docs into the copy (bench_needle scores against them).
+    $ingLog = "$logs\s2_${name}_ingest_$ts.log"
+    python scripts\bench_chain\sike_bed_ingest.py --genome $copy --json `
+        *> $ingLog
+    $ingExit = $LASTEXITCODE
+    "  gold-ingest exit=$ingExit (log: $ingLog)" | Add-Content "$logs\s2_summary_$ts.log"
+    if ($ingExit -ne 0) {
+        "  WARN: gold ingest returned $ingExit for $name; recall may read 0 -- continuing anyway" |
+            Add-Content "$logs\s2_summary_$ts.log"
+    }
+
+    # 2b (2026-07-03): checkpoint the WAL so the server sees every gold,
+    # then VERIFY the bed is a real corpus before serving. A bed with
+    # fewer than 1000 genes means the copy/ingest went wrong -- skip it
+    # loudly instead of producing all-zero results.
+    $verify = python -c "import sqlite3,sys; c=sqlite3.connect(sys.argv[1], timeout=60); c.execute('PRAGMA wal_checkpoint(TRUNCATE)'); n=c.execute('SELECT COUNT(*) FROM genes').fetchone()[0]; c.close(); print(n)" $copy
+    "  bed verify: $verify genes in $copy" | Add-Content "$logs\s2_summary_$ts.log"
+    if ([int]$verify -lt 1000) {
+        "  BED INVALID ($verify genes) -- skipping $name" | Add-Content "$logs\s2_summary_$ts.log"
+        continue
+    }
+
+    # 3. Start a blob-mode server on the bed copy.
+    $srvLog = "$logs\s2_${name}_server_$ts.log"
+    $proc = Start-HelixOnBed -bedPath $copy -srvLog $srvLog
+    if ($null -eq $proc) {
+        "  SERVER START FAILED for $name -- skipping bed" | Add-Content "$logs\s2_summary_$ts.log"
+        continue
+    }
+    "  server pid=$($proc.Id) serving $copy" | Add-Content "$logs\s2_summary_$ts.log"
+
+    # 4. Run the needle battery across the ollama ladder + Claude Sonnet rung.
+    $outJson = "$results\sike_bedsweep_${name}_$ts.json"
+    $runLog = "$logs\s2_${name}_run_$ts.log"
+    $claudeArgs = @('scripts\bench_chain\s2_sike_bedsweep_run.py',
+                    '--bed', $name,
+                    '--helix-url', $helixUrl,
+                    '--claude-model', 'sonnet',
+                    '--claude-max-usd', '0.15',
+                    '--out', $outJson)
+    # The Claude Sonnet rung always runs (cost-capped). The local ollama
+    # ladder is appended only when models were discovered; if none, the run
+    # proceeds with the Claude rung alone.
+    if ($ollamaModels) { $claudeArgs += @('--ollama-models', $ollamaModels) }
+
+    python @claudeArgs *> $runLog
+    $runExit = $LASTEXITCODE
+    "  run exit=$runExit out=$outJson (log: $runLog)" | Add-Content "$logs\s2_summary_$ts.log"
+
+    # 5. Tear down the server before the next bed.
+    Stop-HelixTree -proc $proc
+    "  server stopped for $name" | Add-Content "$logs\s2_summary_$ts.log"
+}
+
+Remove-Item Env:\HELIX_GENOME_PATH, Env:\HELIX_SERVER_UPSTREAM_TIMEOUT, Env:\HELIX_CONFIG -ErrorAction SilentlyContinue
+Set-Status 's2_sike_beds' 'DONE'
+"s2 complete $(Get-Date -Format o)" | Add-Content "$logs\s2_summary_$ts.log"

--- a/scripts/bench_chain/s2_sike_bedsweep_run.py
+++ b/scripts/bench_chain/s2_sike_bedsweep_run.py
@@ -1,0 +1,475 @@
+r"""s2_sike_bedsweep_run.py -- run the fixed SIKE curated needle set against
+one DISTRACTOR bed, across a local ollama ladder + one Claude Sonnet rung.
+Issue #221 (chain stage S2 helper).
+
+Design is grounded in three existing harnesses:
+  * benchmarks/bench_needle.py -- the SIKE needle list (NEEDLES) and the
+    load-bearing gold-delivery scorer (check_gold_delivery / find_needle).
+    We import and reuse its retrieval scoring verbatim so recall numbers are
+    directly comparable to the standalone harness. bench_needle drives its
+    answer model via the HELIX_MODEL env var and hits HELIX_URL /context +
+    /v1/chat/completions -- so an ollama rung is just "set HELIX_MODEL and run
+    find_needle".
+  * scripts/bench_claude_matrix.py -- the claude -p convention: json output,
+    per-question --max-budget-usd cost cap, sonnet default. We reuse
+    score_answer's {-1,0,+1} trinary and the ABSTAIN markers.
+  * benchmarks/bench_orchestrator.py -- NOT imported here (the .ps1 owns the
+    BenchServer lifecycle so a bed failure can't wedge the whole sweep); this
+    script assumes a server is already serving the bed at --helix-url and just
+    runs the needle battery.
+
+Consumers (rungs):
+  * local ollama models discovered at runtime (`ollama list`), passed in via
+    --ollama-models (comma-separated). Each is driven THROUGH helix's proxy
+    (/v1/chat/completions) exactly as bench_needle does, so the context the
+    local model sees is helix-assembled.
+  * one Claude rung using Sonnet via `claude -p` (retrieval context injected
+    as a system prompt the same way bench_enterprise_rag does), hard-capped at
+    --claude-max-usd per query.
+
+Retrieval recall is measured ONCE per bed (model-independent: it is a property
+of /context, not of the answering model) using bench_needle.find_needle's
+gold-delivery fields. Per-consumer correctness is measured by re-answering each
+needle with that consumer and word-boundary accept-matching.
+
+OUTPUT (single JSON, relocatable by the .ps1):
+  benchmarks/results/sike_bedsweep_<bed>_<ts>.json
+
+Stdlib + repo imports + httpx (already a repo dep, used by bench_needle).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+_BENCH_DIR = _REPO_ROOT / "benchmarks"
+if str(_BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCH_DIR))
+
+import httpx  # noqa: E402  (repo dependency; bench_needle imports it too)
+
+# Reuse the canonical needle list + retrieval scorer.
+import bench_needle  # noqa: E402
+
+NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+# Abstain markers + trinary scorer copied from scripts/bench_claude_matrix.py
+# so Claude-rung scoring matches the existing matrix runner exactly.
+_ABSTAIN_MARKERS = [
+    r"\bi (?:don't|cannot|can't|am unable to|do not) (?:find|know|determine)\b",
+    r"\bno (?:relevant )?information\b",
+    r"\bnot (?:available|found|present)\b",
+    r"\binsufficient (?:context|information|data)\b",
+    r"\bunable to (?:find|determine|answer)\b",
+    r"\bcouldn't find\b",
+    r"\bi don't know\b",
+]
+_ABSTAIN_RE = re.compile("|".join(_ABSTAIN_MARKERS), re.IGNORECASE)
+
+
+def _score_answer(answer_text: str, accept) -> dict:
+    """{-1,0,+1} trinary, identical policy to bench_claude_matrix.score_answer."""
+    text = (answer_text or "").strip()
+    if not text:
+        return {"score": 0, "reason": "empty"}
+    for a in accept:
+        if re.search(rf"\b{re.escape(a)}\b", text, re.IGNORECASE):
+            return {"score": 1, "reason": f"accept-match:{a}", "matched_token": a}
+    if _ABSTAIN_RE.search(text):
+        return {"score": 0, "reason": "abstain"}
+    return {"score": -1, "reason": "no-match-and-confident"}
+
+
+# ---------------------------------------------------------------------------
+# Claude rung (Sonnet) -- context-injected, cost-capped
+# ---------------------------------------------------------------------------
+
+_SYS_INJECTED = (
+    "You are answering a single factual question about an internal knowledge "
+    "base. Use ONLY the context provided below. If the answer is not in the "
+    "context, say exactly: I don't know.\n\n<CONTEXT>\n{ctx}\n</CONTEXT>"
+)
+
+
+def _fetch_context(helix_url: str, query: str,
+                   timeout_s: float = 30.0) -> tuple[str, bool]:
+    """Fetch helix /context text for a query (decoder off, retrieval only).
+
+    Returns (context_text, fetch_ok). fetch_ok=False distinguishes a
+    fetch failure from a genuinely-empty retrieval so Claude-rung rows
+    don't score infrastructure failures as abstentions (review
+    2026-07-05). ignore_delivered matches bench_needle.find_needle.
+    """
+    try:
+        resp = httpx.post(
+            f"{helix_url}/context",
+            json={"query": query, "decoder_mode": "none",
+                  "ignore_delivered": True},
+            timeout=timeout_s,
+        )
+    except Exception:
+        return "", False
+    if resp.status_code != 200:
+        return "", False
+    raw = resp.json()
+    data = raw[0] if isinstance(raw, list) and raw else (
+        raw if isinstance(raw, dict) else {}
+    )
+    ctx = data.get("content", "") or data.get("context", "") or ""
+    return ctx[:12000], True
+
+
+def _run_claude_sonnet(query: str, ctx_text: str, model: str,
+                       max_usd: float, timeout_s: int = 180) -> dict:
+    """claude -p, Sonnet, context as an appended system prompt, cost-capped.
+
+    Mirrors scripts/bench_claude_matrix.run_claude (json output, budget cap)
+    and bench_enterprise_rag.run_claude (context via --append-system-prompt-file
+    + an empty --mcp-config so no local MCP is consulted).
+    """
+    clean_cwd = Path(tempfile.gettempdir()) / "helix-bench-clean-cwd"
+    clean_cwd.mkdir(parents=True, exist_ok=True)
+    empty_cfg = clean_cwd / "_empty_mcp.json"
+    if not empty_cfg.exists():
+        empty_cfg.write_text('{"mcpServers":{}}', encoding="utf-8")
+
+    sys_prompt = _SYS_INJECTED.format(ctx=ctx_text) if ctx_text else (
+        "You are answering a single factual question about an internal "
+        "knowledge base. If you don't have the specific information, say "
+        "exactly: I don't know. Do not make up details."
+    )
+    sp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False, encoding="utf-8")
+    sp.write(sys_prompt)
+    sp.close()
+    try:
+        cmd = [
+            "claude", "-p",
+            "--model", model,
+            "--tools", "",
+            "--strict-mcp-config",
+            "--mcp-config", str(empty_cfg),
+            "--append-system-prompt-file", sp.name,
+            "--max-budget-usd", str(max_usd),
+            "--output-format", "json",
+            "--", query,
+        ]
+        t0 = time.perf_counter()
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, encoding="utf-8",
+                errors="replace", cwd=str(clean_cwd),
+                timeout=timeout_s, creationflags=NO_WINDOW,
+            )
+        except subprocess.TimeoutExpired:
+            return {"status": "timeout", "answer": "", "elapsed_s": timeout_s,
+                    "cost_usd": None}
+        elapsed = time.perf_counter() - t0
+        if proc.returncode != 0:
+            return {"status": "exit_nonzero", "rc": proc.returncode,
+                    "stderr": (proc.stderr or "")[-300:], "answer": "",
+                    "elapsed_s": elapsed, "cost_usd": None}
+        try:
+            data = json.loads(proc.stdout)
+        except Exception:
+            return {"status": "json_error",
+                    "stdout_tail": (proc.stdout or "")[-300:],
+                    "answer": "", "elapsed_s": elapsed, "cost_usd": None}
+        return {
+            "status": "ok",
+            "answer": data.get("result", "") or "",
+            "cost_usd": float(data.get("total_cost_usd", 0) or 0),
+            "elapsed_s": elapsed,
+        }
+    finally:
+        try:
+            os.unlink(sp.name)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Ollama rung -- driven THROUGH the helix proxy, exactly like bench_needle
+# ---------------------------------------------------------------------------
+
+def _run_ollama_via_proxy(helix_url: str, query: str, model: str,
+                          timeout_s: float = 660.0) -> dict:
+    """Answer via helix /v1/chat/completions with the given ollama model.
+
+    This is the same call bench_needle.find_needle makes for answer accuracy
+    (HELIX_MODEL) -- context is helix-assembled and injected by the proxy.
+
+    timeout_s must exceed the proxy's upstream timeout (600s via
+    HELIX_SERVER_UPSTREAM_TIMEOUT in s2_sike_bed_sweep.ps1) so the server
+    side decides and the bench records a real HTTP status instead of a
+    client-side ReadTimeout (2026-07-05: the 180s default upstream
+    timeout censored ~25-30 percent of the big-gemma needles as http_error).
+    """
+    t0 = time.perf_counter()
+    try:
+        resp = httpx.post(
+            f"{helix_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": query}],
+                "stream": False,
+                "options": {"temperature": 0, "num_predict": 256},
+            },
+            timeout=timeout_s,
+        )
+    except Exception as exc:
+        return {"status": "error", "error": str(exc), "answer": "",
+                "elapsed_s": time.perf_counter() - t0}
+    elapsed = time.perf_counter() - t0
+    if resp.status_code != 200:
+        return {"status": "http_error", "http": resp.status_code,
+                "error": (resp.text or "")[:200],
+                "answer": "", "elapsed_s": elapsed}
+    choices = resp.json().get("choices", [])
+    answer = choices[0].get("message", {}).get("content", "") if choices else ""
+    return {"status": "ok", "answer": answer, "elapsed_s": elapsed,
+            "cost_usd": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--bed", required=True,
+                    help="Bed label for the output filename, e.g. 'xl'.")
+    ap.add_argument("--helix-url", default=os.environ.get(
+        "HELIX_URL", "http://127.0.0.1:11437"))
+    ap.add_argument("--ollama-models", default="",
+                    help="Comma-separated ollama model tags (local ladder).")
+    ap.add_argument("--claude-model", default="sonnet",
+                    help="claude -p --model for the Claude rung (Sonnet class).")
+    ap.add_argument("--claude-max-usd", type=float, default=0.15,
+                    help="Hard per-query cost cap for the Claude rung.")
+    ap.add_argument("--skip-claude", action="store_true",
+                    help="Skip the Claude rung (local ladder only).")
+    ap.add_argument("--out", required=True, help="Output JSON path.")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Cap needles (0 = all; smoke only).")
+    args = ap.parse_args(argv)
+
+    ollama_models = [m.strip() for m in args.ollama_models.split(",") if m.strip()]
+    needles = list(bench_needle.NEEDLES)
+    if args.limit:
+        needles = needles[: args.limit]
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    result: dict = {
+        "benchmark": "sike_bedsweep",
+        "issue": "#221",
+        "bed": args.bed,
+        "helix_url": args.helix_url,
+        "timestamp": ts,
+        "n_needles": len(needles),
+        "consumers": {"ollama": ollama_models,
+                      "claude": (None if args.skip_claude else args.claude_model)},
+        "retrieval": {},
+        "per_consumer": {},
+        "errors": [],
+    }
+
+    # Server sanity + gene count.
+    bench_needle.HELIX_URL = args.helix_url  # so find_needle hits this server
+    try:
+        stats = httpx.get(f"{args.helix_url}/stats", timeout=15).json()
+        result["genome_genes"] = stats.get("total_genes")
+        result["compression_ratio"] = stats.get("compression_ratio")
+    except Exception as exc:
+        result["errors"].append(f"/stats unreachable: {exc}")
+        _write(result, args.out)
+        return 2
+
+    # Pass-1 client timeout must exceed the proxy's upstream timeout
+    # (600s via HELIX_SERVER_UPSTREAM_TIMEOUT in the .ps1): find_needle's
+    # answer step drives a local model through the proxy, and a client
+    # that fires first turns a slow generation into a dropped recall row
+    # (silent denominator shrink — review 2026-07-05).
+    client = httpx.Client(timeout=660)
+
+    # ------------------------------------------------------------------
+    # Pass 1: retrieval recall (model-independent) via find_needle. This
+    # also captures the default-model answer accuracy as a free byproduct,
+    # but we only keep the retrieval fields here.
+    # ------------------------------------------------------------------
+    recall_rows = []
+    ks = (1, 3, 5)
+    recall_counts = {f"recall@{k}": 0 for k in ks}
+    gold_delivered = 0
+    body_has_answer = 0
+    for nd in needles:
+        try:
+            r = bench_needle.find_needle(client, nd)
+        except Exception as exc:
+            result["errors"].append(f"find_needle({nd['name']}): {exc}")
+            continue
+        # find_needle exposes gold_delivered (gold source in delivered top-K)
+        # and found_in_context (a delivered body carries the answer). We do
+        # not have a per-rank position from find_needle, so recall@k here
+        # collapses to gold_delivered within the harness's delivered set
+        # (max_genes cap). Report it as recall@K_delivered for honesty.
+        gd = bool(r.get("gold_delivered"))
+        bh = bool(r.get("found_in_context"))
+        if gd:
+            gold_delivered += 1
+            for k in ks:
+                recall_counts[f"recall@{k}"] += 1
+        if bh:
+            body_has_answer += 1
+        recall_rows.append({
+            "name": r.get("name"),
+            "gold_delivered": gd,
+            "body_has_answer": bh,
+            "n_gold_blocks": r.get("n_gold_blocks"),
+            "n_delivered_blocks": r.get("n_delivered_blocks"),
+            "resolution_confidence": r.get("resolution_confidence"),
+            "context_latency_s": r.get("context_latency_s"),
+        })
+
+    n = max(len(recall_rows), 1)
+    result["retrieval"] = {
+        "note": ("recall@k here == gold_source_in_delivered_topK; find_needle "
+                 "does not expose per-rank position, so k<=max_genes collapse. "
+                 "gold_delivered_rate is the primary retrieval metric."),
+        "gold_delivered": gold_delivered,
+        "gold_delivered_rate": round(gold_delivered / n, 4),
+        "body_has_answer": body_has_answer,
+        "body_has_answer_rate": round(body_has_answer / n, 4),
+        "per_needle": recall_rows,
+    }
+    for k in ks:
+        result["retrieval"][f"recall@{k}_rate"] = round(
+            recall_counts[f"recall@{k}"] / n, 4)
+
+    # ------------------------------------------------------------------
+    # Pass 2: per-consumer correctness. Each consumer re-answers every
+    # needle; retrieval is identical (same bed), so this isolates the
+    # answering model.
+    # ------------------------------------------------------------------
+    def _run_consumer(kind: str, model: str) -> dict:
+        rows = []
+        correct = abstain = wrong = errors = 0
+        cost = 0.0
+        consecutive_errors = 0
+        rung_aborted = False
+        for nd in needles:
+            accept = nd.get("accept", [nd.get("expected", "")])
+            q = nd["query"]
+            if kind == "ollama":
+                a = _run_ollama_via_proxy(args.helix_url, q, model)
+            else:  # claude
+                ctx, ctx_ok = _fetch_context(args.helix_url, q)
+                a = _run_claude_sonnet(q, ctx, model, args.claude_max_usd)
+                a["ctx_chars"] = len(ctx)
+                if not ctx_ok:
+                    a["ctx_fetch_failed"] = True
+            ans = a.get("answer", "")
+            sc = _score_answer(ans, accept)
+            if a.get("status") != "ok":
+                errors += 1
+                consecutive_errors += 1
+            else:
+                consecutive_errors = 0
+                if sc["score"] == 1:
+                    correct += 1
+                elif sc["score"] == 0:
+                    abstain += 1
+                else:
+                    wrong += 1
+            c = a.get("cost_usd")
+            if isinstance(c, (int, float)):
+                cost += c
+            row = {
+                "name": nd["name"], "status": a.get("status"),
+                "score": sc["score"], "score_reason": sc["reason"],
+                "answer_preview": ans[:200],
+                "cost_usd": c, "elapsed_s": round(a.get("elapsed_s", 0), 2),
+            }
+            # Diagnostic fields for non-ok rows (2026-07-05: the 180s
+            # upstream-timeout diagnosis needed the HTTP code; it was
+            # captured by _run_ollama_via_proxy but never persisted).
+            # Claude-rung failures carry rc/stderr/stdout_tail instead.
+            for k in ("http", "rc", "ctx_chars"):
+                if a.get(k) is not None:
+                    row[k] = a.get(k)
+            for k in ("error", "stderr", "stdout_tail"):
+                if a.get(k):
+                    row[k] = str(a.get(k))[:200]
+            if a.get("ctx_fetch_failed"):
+                row["ctx_fetch_failed"] = True
+            rows.append(row)
+            # Circuit breaker (review 2026-07-05): a wedged rung at the
+            # 600s upstream timeout would otherwise burn 50 x ~600s =
+            # ~8.3h producing identical error rows. Coverage already
+            # penalizes the skipped needles (denominator is all needles).
+            if consecutive_errors >= 5:
+                rung_aborted = True
+                break
+        answered = correct + wrong
+        summary = {
+            "model": model,
+            "correct": correct, "abstain": abstain, "wrong": wrong,
+            "errors": errors,
+            "answered": answered,
+            "correctness_among_answered": round(correct / answered, 4)
+            if answered else 0.0,
+            "hallucination_rate": round(wrong / answered, 4) if answered else 0.0,
+            # Denominator is the FULL needle set, not len(recall_rows):
+            # Pass-1 drops must not inflate Pass-2 coverage (review
+            # 2026-07-05; coverage could previously exceed 1.0).
+            "coverage": round(answered / max(len(needles), 1), 4),
+            "total_cost_usd": round(cost, 4),
+            "per_needle": rows,
+        }
+        if rung_aborted:
+            summary["rung_aborted"] = True
+            summary["rung_aborted_after"] = len(rows)
+        return summary
+
+    for m in ollama_models:
+        try:
+            result["per_consumer"][f"ollama:{m}"] = _run_consumer("ollama", m)
+        except Exception as exc:
+            result["errors"].append(f"ollama consumer {m} failed: {exc}")
+
+    if not args.skip_claude:
+        try:
+            result["per_consumer"][f"claude:{args.claude_model}"] = _run_consumer(
+                "claude", args.claude_model)
+        except Exception as exc:
+            result["errors"].append(f"claude consumer failed: {exc}")
+
+    client.close()
+    _write(result, args.out)
+    print("bed={} genes={} gold_delivered_rate={} consumers={}".format(
+        args.bed, result.get("genome_genes"),
+        result["retrieval"].get("gold_delivered_rate"),
+        list(result["per_consumer"].keys())))
+    return 0
+
+
+def _write(result: dict, out_path: str) -> None:
+    p = Path(out_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print("-> {}".format(p))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_chain/s3_dense_weight_sweep.ps1
+++ b/scripts/bench_chain/s3_dense_weight_sweep.ps1
@@ -1,0 +1,43 @@
+# Stage 3 — issue #203: dense_additive_weight sweep with REAL ERB questions
+# Arms: ERB-10K, ERB-50K (prose) + medium.db with SIKE-style content queries (code side)
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$ts = Get-Date -Format 'yyyy-MM-dd_HHmm'
+$env:HELIX_OTEL_ENABLED = '1'
+$env:HELIX_OTEL_ENDPOINT = 'localhost:4317'
+cd $repo
+
+function Set-Status($stage, $state) {
+    @{stage=$stage; state=$state; at=(Get-Date -Format o)} | ConvertTo-Json |
+        Set-Content "$repo\benchmarks\logs\chain_status.json"
+}
+
+$questions = 'F:\Projects\EnterpriseRAG-Bench-main\questions.jsonl'
+$weights = '0,1,2,3,4,6'
+
+Set-Status 's3_203_sweep' 'erb10k'
+python benchmarks\sweep_dense_additive_weight.py `
+    --genome genomes\bench\matrix\enterprise_rag_10k_batched.db `
+    --queries $questions --weights $weights `
+    --out benchmarks\results\sweep_w_erb10k_realq_$ts.json `
+    *> "$logs\s3_erb10k_$ts.log"
+"erb10k exit=$LASTEXITCODE" | Add-Content "$logs\s3_summary_$ts.log"
+
+Set-Status 's3_203_sweep' 'erb50k'
+python benchmarks\sweep_dense_additive_weight.py `
+    --genome genomes\bench\matrix\enterprise_rag_50k_batched.db `
+    --queries $questions --weights $weights `
+    --out benchmarks\results\sweep_w_erb50k_realq_$ts.json `
+    *> "$logs\s3_erb50k_$ts.log"
+"erb50k exit=$LASTEXITCODE" | Add-Content "$logs\s3_summary_$ts.log"
+
+Set-Status 's3_203_sweep' 'code-arm-medium'
+python benchmarks\sweep_dense_additive_weight.py `
+    --genome genomes\bench\matrix\medium.db `
+    --weights $weights `
+    --out benchmarks\results\sweep_w_medium_code_$ts.json `
+    *> "$logs\s3_medium_$ts.log"
+"medium exit=$LASTEXITCODE" | Add-Content "$logs\s3_summary_$ts.log"
+
+Set-Status 's3_203_sweep' 'DONE'

--- a/scripts/bench_chain/s3b_erb_sweep_rerun.ps1
+++ b/scripts/bench_chain/s3b_erb_sweep_rerun.ps1
@@ -1,0 +1,40 @@
+# S3b - rerun of the two ERB dense-weight sweep steps that failed on
+# 2026-07-02 (sweep expects a JSON LIST of {query, gold_ids}; ERB ships
+# JSONL with uuid golds). erb_to_sweep_queries.py adapts per bed genome.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$ts = Get-Date -Format 'yyyy-MM-dd_HHmm'
+$env:HELIX_OTEL_ENABLED = '1'
+$env:HELIX_OTEL_ENDPOINT = 'localhost:4317'
+cd $repo
+
+function Set-Status {
+    param([string]$stage, [string]$state)
+    @{stage=$stage; state=$state; at=(Get-Date -Format o)} | ConvertTo-Json |
+        Set-Content "$repo\benchmarks\logs\chain_status.json"
+}
+
+$weights = '0,1,2,3,4,6'
+
+foreach ($bed in @(
+    @('erb10k', 'genomes\bench\matrix\enterprise_rag_10k_batched.db'),
+    @('erb50k', 'genomes\bench\matrix\enterprise_rag_50k_batched.db')
+)) {
+    $name = $bed[0]; $db = $bed[1]
+    Set-Status 's3b_erb_sweep' "adapt-$name"
+    $qfile = "$repo\benchmarks\results\erb_sweep_queries_$name.json"
+    python scripts\bench_chain\erb_to_sweep_queries.py --genome $db `
+        --out $qfile *> "$logs\s3b_adapt_${name}_$ts.log"
+    if ($LASTEXITCODE -ne 0) {
+        "adapter FAILED for ${name}: see s3b_adapt log" | Add-Content "$logs\s3b_summary_$ts.log"
+        continue
+    }
+    Set-Status 's3b_erb_sweep' "sweep-$name"
+    python benchmarks\sweep_dense_additive_weight.py `
+        --genome $db --queries $qfile --weights $weights `
+        --out benchmarks\results\sweep_w_${name}_realq_$ts.json `
+        *> "$logs\s3b_${name}_$ts.log"
+    "$name exit=$LASTEXITCODE" | Add-Content "$logs\s3b_summary_$ts.log"
+}
+Set-Status 's3b_erb_sweep' 'DONE'

--- a/scripts/bench_chain/s4_erb500k_scored.ps1
+++ b/scripts/bench_chain/s4_erb500k_scored.ps1
@@ -1,0 +1,191 @@
+# Stage 4 - issue #93 / G2 prose gate: ERB 500-question scored run against the
+# sharded 500K fixture (genomes/bench/matrix-sharded/enterprise_rag_500k).
+# Per question: /context/packet (know/miss recorded verbatim) -> Claude Sonnet
+# answer -> Sonnet trinary judge (CORRECT/INCORRECT/ABSTAINED, reference-guided)
+# -> 10% Opus second-opinion audit. Outputs a per-question JSONL + a summary
+# JSON with correctness/hallucination/coverage/know-vs-judged agreement and the
+# published baselines (BM25 68.8 / Vector 51.4 / Onyx+GPT-4 72.4).
+# RESUMABLE: the python helper skips question ids already in the output jsonl,
+# so a mid-run interruption is recovered by re-running (the chain may restart it).
+# Pure ASCII, PowerShell 5.1-safe. Never exits on a single-step failure.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$results = "$repo\benchmarks\results"
+$ts = Get-Date -Format 'yyyy-MM-dd_HHmm'
+New-Item -ItemType Directory -Force -Path $logs | Out-Null
+New-Item -ItemType Directory -Force -Path $results | Out-Null
+$env:HELIX_OTEL_ENABLED = '1'
+$env:HELIX_OTEL_ENDPOINT = 'localhost:4317'
+$env:PYTHONHASHSEED = '0'
+$port = 11437
+$helixUrl = "http://127.0.0.1:$port"
+# 2026-07-02 repoint (Max): use the BLOB-mode ERB fixture instead of the
+# sharded routing DB. F:\tmp\erb_blob.db = 829,131 genes over 499,997 ERB
+# source docs, dense_v2 97.6% populated, finished 2026-06-16, WAL
+# checkpointed clean. Blob mode = every retrieval feature live (the
+# sharded path skips WS2/WS3 + several blob-only tiers).
+$fixture = "F:\tmp\erb_blob.db"
+$erbRoot = 'F:\Projects\EnterpriseRAG-Bench-main'
+cd $repo
+
+function Set-Status {
+    param([string]$stage, [string]$state)
+    @{stage=$stage; state=$state; at=(Get-Date -Format o)} | ConvertTo-Json |
+        Set-Content "$repo\benchmarks\logs\chain_status.json"
+}
+
+function Wait-PortFree {
+    param([int]$p, [int]$timeoutSec = 20)
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        $inUse = $false
+        try {
+            $c = New-Object System.Net.Sockets.TcpClient
+            $iar = $c.BeginConnect('127.0.0.1', $p, $null, $null)
+            if ($iar.AsyncWaitHandle.WaitOne(500)) {
+                try { $c.EndConnect($iar); $inUse = $true } catch { $inUse = $false }
+            }
+            $c.Close()
+        } catch { $inUse = $false }
+        if (-not $inUse) { return $true }
+        Start-Sleep -Milliseconds 300
+    }
+    return $false
+}
+
+function Wait-Healthy {
+    param([string]$url, [int]$timeoutSec = 120)
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $h = Invoke-RestMethod -Uri "$url/health" -TimeoutSec 5 -ErrorAction Stop
+            if ($h) { return $true }
+        } catch { Start-Sleep -Milliseconds 500 }
+    }
+    return $false
+}
+
+function Stop-HelixTree {
+    param($proc)
+    if ($null -eq $proc) { return }
+    try { taskkill /T /F /PID $proc.Id 2>&1 | Out-Null } catch {}
+    Start-Sleep -Seconds 1
+    Wait-PortFree -p $port -timeoutSec 15 | Out-Null
+}
+
+Set-Status 's4_erb500k' 'preflight'
+
+# Preflight 0 (2026-07-02): claude auth probe. The first S4 attempt burned
+# 74 minutes producing 500x judge_error rows because every claude -p call
+# hit 401. Fail fast instead.
+$authProbe = & claude -p --model sonnet --tools "" --max-budget-usd 0.02 `
+    --output-format json -- "Reply with exactly: OK" 2>$null
+$authOk = $false
+try {
+    $aj = $authProbe | ConvertFrom-Json
+    if (-not $aj.is_error) { $authOk = $true }
+} catch {}
+if (-not $authOk) {
+    "CLAUDE AUTH FAILED (401?) -- run 'claude login' or set a valid " +
+    "ANTHROPIC_API_KEY, then rerun this stage" |
+        Add-Content "$logs\s4_summary_$ts.log"
+    Set-Status 's4_erb500k' 'SKIPPED-claude-auth'
+    return
+}
+
+# Preflight: fixture + question set must exist. If not, log clearly and mark
+# the stage skipped -- do not crash the chain.
+if (-not (Test-Path $fixture)) {
+    "FIXTURE MISSING: $fixture -- cannot run ERB 500K scored run" |
+        Add-Content "$logs\s4_summary_$ts.log"
+    Set-Status 's4_erb500k' 'SKIPPED-no-fixture'
+    return
+}
+if (-not (Test-Path "$erbRoot\questions.jsonl")) {
+    "QUESTIONS MISSING: $erbRoot\questions.jsonl -- cannot run" |
+        Add-Content "$logs\s4_summary_$ts.log"
+    Set-Status 's4_erb500k' 'SKIPPED-no-questions'
+    return
+}
+"preflight ok: fixture + questions present" | Add-Content "$logs\s4_summary_$ts.log"
+
+# Start uvicorn in BLOB mode pointed at erb_blob.db (2026-07-02 repoint).
+# No HELIX_USE_SHARDS: a plain genome path loads the standard KnowledgeStore
+# with the full blob-mode tier stack.
+Set-Status 's4_erb500k' 'starting-server'
+Remove-Item Env:\HELIX_USE_SHARDS -ErrorAction SilentlyContinue
+$env:HELIX_GENOME_PATH = $fixture
+$srvLog = "$logs\s4_server_$ts.log"
+$proc = $null
+if (Wait-PortFree -p $port -timeoutSec 20) {
+    $srvArgs = @('-m', 'uvicorn', 'helix_context._asgi:app',
+                 '--host', '127.0.0.1', '--port', "$port")
+    $proc = Start-Process -FilePath 'python' -ArgumentList $srvArgs `
+        -RedirectStandardOutput $srvLog -RedirectStandardError "$srvLog.err" `
+        -WindowStyle Hidden -PassThru
+    if (-not (Wait-Healthy -url $helixUrl -timeoutSec 120)) {
+        "SERVER did not become healthy (sharded 500K) -- see $srvLog" |
+            Add-Content "$logs\s4_summary_$ts.log"
+        Stop-HelixTree -proc $proc
+        Remove-Item Env:\HELIX_USE_SHARDS -ErrorAction SilentlyContinue
+        Remove-Item Env:\HELIX_GENOME_PATH -ErrorAction SilentlyContinue
+        Set-Status 's4_erb500k' 'FAILED-server-start'
+        return
+    }
+} else {
+    "PORT $port occupied; cannot start sharded server" |
+        Add-Content "$logs\s4_summary_$ts.log"
+    Set-Status 's4_erb500k' 'FAILED-port-busy'
+    return
+}
+"server pid=$($proc.Id) serving BLOB ERB fixture (erb_blob.db, 829K genes)" |
+    Add-Content "$logs\s4_summary_$ts.log"
+
+# Run the scored harness (resumable). Fixed output paths per-run so a restart
+# of THIS ps1 within the same minute resumes the same jsonl; a later chain run
+# gets a new $ts. To make the run resumable ACROSS chain restarts on different
+# minutes, we use a stable (non-timestamped) jsonl name so re-invocation always
+# finds prior progress; the summary is timestamped.
+Set-Status 's4_erb500k' 'scoring'
+# 2026-07-02: blob-specific output name so the resume logic never skips
+# rows from the failed sharded attempt (archived separately).
+$outJsonl = "$results\erb500k_blob_scored.jsonl"  # stable name -> resume across restarts
+$summaryJson = "$results\erb500k_blob_scored_summary_$ts.json"
+$runLog = "$logs\s4_run_$ts.log"
+
+python scripts\bench_chain\erb500k_scored.py `
+    --erb-root $erbRoot `
+    --helix-url $helixUrl `
+    --out $outJsonl `
+    --summary-out $summaryJson `
+    --answer-model sonnet `
+    --audit-model opus `
+    --answer-max-usd 0.20 `
+    --judge-max-usd 0.10 `
+    --audit-max-usd 0.40 `
+    --audit-fraction 0.10 `
+    --max-genes 8 `
+    *> $runLog
+$runExit = $LASTEXITCODE
+"scored-run exit=$runExit out=$outJsonl summary=$summaryJson (log: $runLog)" |
+    Add-Content "$logs\s4_summary_$ts.log"
+
+# Also drop a per-run timestamped copy of the jsonl so the run is archivable
+# alongside its summary (the stable jsonl keeps accumulating for resume).
+try {
+    if (Test-Path $outJsonl) {
+        Copy-Item -Path $outJsonl -Destination "$results\erb500k_blob_scored_$ts.jsonl" -Force
+    }
+} catch {
+    "archive copy failed: $_" | Add-Content "$logs\s4_summary_$ts.log"
+}
+
+# Tear down the server.
+Stop-HelixTree -proc $proc
+Remove-Item Env:\HELIX_USE_SHARDS -ErrorAction SilentlyContinue
+Remove-Item Env:\HELIX_GENOME_PATH -ErrorAction SilentlyContinue
+"server stopped" | Add-Content "$logs\s4_summary_$ts.log"
+
+if ($runExit -eq 0) { Set-Status 's4_erb500k' 'DONE' }
+else { Set-Status 's4_erb500k' "DONE-WITH-ERRORS(exit=$runExit)" }

--- a/scripts/bench_chain/s4blob_watcher.ps1
+++ b/scripts/bench_chain/s4blob_watcher.ps1
@@ -1,0 +1,51 @@
+# Final-stage watcher (2026-07-02): waits until BOTH conditions hold, then
+# runs the repointed S4 (ERB 500-q scored on the BLOB fixture F:\tmp\erb_blob.db):
+#   1. chain_status.json state == COMPLETE-ALL(s2+s3b-rerun-done)
+#      (i.e. the s2/s3b rerun watcher has finished and the rig is free)
+#   2. claude auth works (probe succeeds) -- the first S4 attempt burned
+#      74 min on 401s; this watcher self-resumes the moment Max re-auths.
+$ErrorActionPreference = 'Continue'
+$repo = 'F:\Projects\helix-context'
+$logs = "$repo\benchmarks\logs"
+$status = "$logs\chain_status.json"
+"s4blob watcher started $(Get-Date -Format o) pid=$PID" | Set-Content "$logs\s4blob_watcher.log"
+$PID | Set-Content "$logs\s4blob_watcher.pid"
+
+function Test-ClaudeAuth {
+    try {
+        $probe = & claude -p --model sonnet --tools "" --max-budget-usd 0.02 `
+            --output-format json -- "Reply with exactly: OK" 2>$null
+        $aj = $probe | ConvertFrom-Json
+        return (-not $aj.is_error)
+    } catch { return $false }
+}
+
+$rigFree = $false
+$authOk = $false
+while (-not ($rigFree -and $authOk)) {
+    Start-Sleep -Seconds 120
+    if (-not $rigFree) {
+        try {
+            $s = Get-Content $status -Raw | ConvertFrom-Json
+            if ($s.state -like 'COMPLETE-ALL*') { $rigFree = $true;
+                "rig free at $(Get-Date -Format o)" | Add-Content "$logs\s4blob_watcher.log" }
+        } catch {}
+    }
+    if ($rigFree -and -not $authOk) {
+        $authOk = Test-ClaudeAuth
+        if (-not $authOk) {
+            $w = @{stage='s4_blob'; state='WAITING-claude-auth'; at=(Get-Date -Format o)} | ConvertTo-Json
+            $w | Set-Content $status
+        } else {
+            "claude auth OK at $(Get-Date -Format o)" | Add-Content "$logs\s4blob_watcher.log"
+        }
+    }
+}
+
+"launching blob S4 $(Get-Date -Format o)" | Add-Content "$logs\s4blob_watcher.log"
+& powershell -NoProfile -ExecutionPolicy Bypass -File "$repo\scripts\bench_chain\s4_erb500k_scored.ps1"
+"s4 blob exit=$LASTEXITCODE $(Get-Date -Format o)" | Add-Content "$logs\s4blob_watcher.log"
+
+$done = @{stage='chain'; state='COMPLETE-FINAL(all-stages+blob-s4)'; at=(Get-Date -Format o)} | ConvertTo-Json
+$done | Set-Content $status
+"s4blob watcher done $(Get-Date -Format o)" | Add-Content "$logs\s4blob_watcher.log"

--- a/scripts/bench_chain/sike_bed_ingest.py
+++ b/scripts/bench_chain/sike_bed_ingest.py
@@ -1,0 +1,304 @@
+r"""sike_bed_ingest.py -- inject the SIKE curated-needle gold docs into a
+distractor-bed genome copy (issue #221 bed-sweep, chain stage S2 helper).
+
+WHY
+---
+``benchmarks/bench_needle.py`` does NOT self-ingest its needles. It queries
+``/context`` and scores whether each needle's ``gold_source`` file shows up in
+the delivered ``<GENE src="...">`` set (and whether the block body carries the
+answer). So for a fixed SIKE question set swept across arbitrary DISTRACTOR
+beds, the gold source *files* must be present in the bed we serve -- otherwise
+every needle is a guaranteed miss and the sweep measures nothing.
+
+This helper reads the canonical needle list straight out of
+``benchmarks/bench_needle.py`` (``NEEDLES``), collects every distinct
+``gold_source`` path substring, resolves each to a real file on disk under a
+set of project roots (default ``F:\Projects``), and ingests those files into
+the target bed copy with ``source_id`` set to the on-disk path -- exactly the
+provenance shape ``helix ingest`` uses (``metadata={"path":..,
+"source_id":..}``, see helix_context/cli/cmd_ingest.py) so bench_needle's
+bidirectional-substring gold match fires.
+
+Ingest goes through a read-write ``KnowledgeStore`` opened directly on the bed
+copy (no server round-trip): faster, and it matches how the beds were built
+(scripts/build_bench_genomes.py). content_type is inferred from the extension
+(code vs text) the same way the CLI does (#224), so code golds get the code
+chunker path.
+
+IDEMPOTENT / RESUME-SAFE
+------------------------
+``KnowledgeStore.upsert_doc`` is keyed on a deterministic gene_id derived from
+content, so re-running against a bed that already has the golds is a no-op
+rewrite (no duplication). A ``--probe-only`` mode reports how many gold
+source files are already resolvable + already present without writing.
+
+CLI
+---
+  python scripts/bench_chain/sike_bed_ingest.py --genome <bed.db> \
+      [--roots F:\Projects] [--json] [--probe-only]
+
+Exit codes: 0 ok (>=1 gold file ingested or already present), 2 hard failure
+(no needle list, no resolvable gold files, genome open failure). Stdlib + repo
+imports only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Repo root is scripts/bench_chain/ -> parents[2].
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+# benchmarks/ must be importable to read the canonical NEEDLES list.
+_BENCH_DIR = _REPO_ROOT / "benchmarks"
+if str(_BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCH_DIR))
+
+
+# Extension -> content_type, mirroring cli/cmd_ingest._content_type_for (#224).
+_CODE_EXTS = frozenset({
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".java", ".c",
+    ".h", ".cc", ".cpp", ".hpp", ".hh", ".cs", ".rb", ".php", ".lua",
+    ".scala", ".kt", ".kts", ".swift", ".sh", ".bash", ".sql", ".m", ".mm",
+    ".toml", ".yaml", ".yml", ".json", ".ini", ".cfg", ".bat", ".ps1",
+})
+_MAX_FILE_BYTES = 400_000  # generous: SIKE golds are small config/doc files.
+
+
+def _content_type_for(path: Path) -> str:
+    return "code" if path.suffix.lower() in _CODE_EXTS else "text"
+
+
+def _load_gold_sources() -> list[str]:
+    """Return the distinct ``gold_source`` path substrings across all needles.
+
+    Reads ``benchmarks/bench_needle.py``'s NEEDLES so the sweep never drifts
+    from the harness's own gold list. We DELIBERATELY skip pure-directory
+    entries (e.g. ``helix-context/docs``) and the bench answer-key doc -- a
+    directory can't be ingested as a single file and the answer-key would
+    inflate recall circularly (the harness's own DO-NOT-ADD rule).
+    """
+    try:
+        import bench_needle  # type: ignore
+    except Exception as exc:  # pragma: no cover - reported by caller
+        raise RuntimeError(
+            "could not import benchmarks/bench_needle.py to read NEEDLES: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    needles = getattr(bench_needle, "NEEDLES", None)
+    if not needles:
+        raise RuntimeError("bench_needle.NEEDLES is empty or missing")
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for nd in needles:
+        for gs in nd.get("gold_source", []) or []:
+            g = str(gs).replace("\\", "/").strip()
+            if not g or g in seen:
+                continue
+            # Skip bare-directory gold hints (no file extension in the last
+            # segment) -- not individually ingestable.
+            last = g.rsplit("/", 1)[-1]
+            if "." not in last:
+                continue
+            # Never ingest the bench answer-key (circular recall).
+            if "benchmarks/benchmarks.md" in g.lower():
+                continue
+            seen.add(g)
+            out.append(g)
+    return out
+
+
+def _resolve(gold_substr: str, roots: list[Path]) -> Path | None:
+    """Resolve a project-relative gold substring to a real file on disk.
+
+    ``gold_source`` entries are project-relative like
+    ``helix-context/helix.toml`` or ``Education/CLAUDE.md``. Try each root as a
+    prefix; the sibling repos (Education, BookKeeper, two-brain-audit, ...)
+    live directly under a projects root on the rig, and the substring already
+    carries the repo dir as its first segment.
+    """
+    rel = gold_substr.replace("/", os.sep)
+    for root in roots:
+        cand = root / rel
+        if cand.is_file():
+            return cand
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--genome", required=True,
+                    help="Path to the bed genome copy to ingest golds into.")
+    ap.add_argument(
+        "--roots", default=os.environ.get("SIKE_GOLD_ROOTS", r"F:\Projects"),
+        help="os.pathsep-separated project roots to resolve gold paths under "
+             r"(default F:\Projects).",
+    )
+    ap.add_argument("--json", action="store_true",
+                    help="Emit a machine-readable JSON summary on stdout.")
+    ap.add_argument("--probe-only", action="store_true",
+                    help="Report resolvable/present golds; do not write.")
+    args = ap.parse_args(argv)
+
+    roots = [Path(r) for r in str(args.roots).split(os.pathsep) if r.strip()]
+    summary: dict = {
+        "genome": args.genome,
+        "roots": [str(r) for r in roots],
+        "gold_sources_total": 0,
+        "resolved_files": 0,
+        "unresolved": [],
+        "ingested_files": 0,
+        "genes_written": 0,
+        "already_present_files": 0,
+        "errors": [],
+    }
+
+    # 1. Collect gold source substrings from the canonical needle list.
+    try:
+        gold_sources = _load_gold_sources()
+    except Exception as exc:
+        summary["errors"].append(str(exc))
+        _emit(summary, args.json)
+        return 2
+    summary["gold_sources_total"] = len(gold_sources)
+
+    # 2. Resolve each to a real file (de-dup by resolved path).
+    resolved: dict[str, Path] = {}
+    for gs in gold_sources:
+        f = _resolve(gs, roots)
+        if f is None:
+            summary["unresolved"].append(gs)
+        else:
+            resolved[str(f)] = f
+    summary["resolved_files"] = len(resolved)
+
+    if not resolved:
+        summary["errors"].append(
+            "no gold source files resolvable under roots "
+            f"{summary['roots']}; bench_needle would score 0/N on this bed"
+        )
+        _emit(summary, args.json)
+        return 2
+
+    if args.probe_only:
+        _emit(summary, args.json)
+        return 0
+
+    # 3. Open the bed copy read-write and ingest each gold file.
+    try:
+        from helix_context.knowledge_store import KnowledgeStore
+        from helix_context.codons import CodonChunker
+        from helix_context.tagger import CpuTagger
+    except Exception as exc:
+        summary["errors"].append(
+            f"repo import failed: {type(exc).__name__}: {exc}"
+        )
+        _emit(summary, args.json)
+        return 2
+
+    try:
+        ks = KnowledgeStore(path=args.genome)
+    except Exception as exc:
+        summary["errors"].append(
+            f"could not open genome {args.genome}: "
+            f"{type(exc).__name__}: {exc}"
+        )
+        _emit(summary, args.json)
+        return 2
+
+    chunker = CodonChunker()
+    tagger = CpuTagger()
+
+    try:
+        for src_path, f in sorted(resolved.items()):
+            try:
+                size = f.stat().st_size
+                if size == 0 or size > _MAX_FILE_BYTES:
+                    summary["errors"].append(
+                        f"skip {src_path} (size {size} out of bounds)"
+                    )
+                    continue
+                content = f.read_text(encoding="utf-8", errors="replace")
+                if not content.strip():
+                    continue
+                ct = _content_type_for(f)
+                # Detect prior presence: is any gene already carrying this
+                # source_id? (resume-safe accounting; ingest itself is a
+                # deterministic-id no-op rewrite regardless.)
+                try:
+                    row = ks.conn.execute(
+                        "SELECT COUNT(*) FROM genes WHERE source_id = ?",
+                        (src_path,),
+                    ).fetchone()
+                    if row and int(row[0]) > 0:
+                        summary["already_present_files"] += 1
+                except Exception:
+                    pass
+
+                strands = chunker.chunk(content, content_type=ct)
+                n_written = 0
+                for i, strand in enumerate(strands):
+                    gene = tagger.pack(
+                        strand.content,
+                        content_type=ct,
+                        source_id=src_path,
+                        sequence_index=i,
+                    )
+                    gene.is_fragment = strand.is_fragment
+                    ks.upsert_doc(gene, apply_gate=False)
+                    n_written += 1
+                summary["ingested_files"] += 1
+                summary["genes_written"] += n_written
+            except Exception as exc:
+                summary["errors"].append(
+                    f"ingest {src_path} failed: {type(exc).__name__}: {exc}"
+                )
+    finally:
+        try:
+            ks.close()
+        except Exception:
+            pass
+
+    _emit(summary, args.json)
+    # Success if we ingested at least one gold file (or all were already
+    # present). Hard failure only if nothing usable happened.
+    if summary["ingested_files"] > 0 or summary["already_present_files"] > 0:
+        return 0
+    return 2
+
+
+def _emit(summary: dict, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(summary, indent=2))
+        return
+    print("=" * 60)
+    print("SIKE gold ingest -> {}".format(summary["genome"]))
+    print("  gold sources in needle list : {}".format(
+        summary["gold_sources_total"]))
+    print("  resolved to files on disk   : {}".format(
+        summary["resolved_files"]))
+    print("  ingested files              : {}".format(
+        summary["ingested_files"]))
+    print("  genes written               : {}".format(
+        summary["genes_written"]))
+    print("  already present (resume)    : {}".format(
+        summary["already_present_files"]))
+    if summary["unresolved"]:
+        print("  UNRESOLVED ({}) -- not on disk under roots:".format(
+            len(summary["unresolved"])))
+        for u in summary["unresolved"][:20]:
+            print("      {}".format(u))
+    if summary["errors"]:
+        print("  errors ({}):".format(len(summary["errors"])))
+        for e in summary["errors"][:20]:
+            print("      {}".format(e))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_citations.py
+++ b/tests/test_bench_citations.py
@@ -235,3 +235,298 @@ def test_legacy_block_bodies_fallback():
 def test_empty_block_bodies_no_crash():
     assert cit.extract_block_bodies([]) == []
     assert cit.extract_block_bodies({}) == []
+
+
+# ─── Realistic live shapes: <expressed_context> wrapper (2026-07-04) ────
+#
+# The live renderer ships ``window.expressed_context`` == the WRAPPED
+# string (context_manager.py builds ``<expressed_context>\n...\n
+# </expressed_context>``). The fixtures above omit the wrapper, which is
+# why the old tests stayed green while every real /context response
+# failed body pairing: the wrapper glues to the first block, the header
+# regex (anchored via .match) misses it, the first body is dropped, and
+# every citation→body pairing shifts by one. Observed as
+# body_has_answer_rate ∈ {0.0, 0.02} across ALL sike_bedsweep runs.
+
+
+def _wrapped_response(with_headers: bool = True) -> list[dict]:
+    """The live /context response shape: wrapper + optional headers.
+
+    ``with_headers=False`` mirrors bench configs that set
+    ``legibility_enabled = false`` (e.g. docs/benchmarks/
+    helix_probe_lexical.toml): parts are bare spliced text.
+    """
+    if with_headers:
+        content = (
+            "<expressed_context>\n"
+            "[gene=aaaa11112222 ◆ fired=harmonic:2.3,lex_anchor:1.1 1200→320c]\n"
+            "The helix proxy listens on port 11437.\n"
+            "---\n"
+            "[gene=bbbb33334444 ◇ fired=sema_boost:1.8 180c]\n"
+            "Six-step expression pipeline.\n"
+            "</expressed_context>"
+        )
+    else:
+        content = (
+            "<expressed_context>\n"
+            "The helix proxy listens on port 11437.\n"
+            "---\n"
+            "Six-step expression pipeline.\n"
+            "</expressed_context>"
+        )
+    return [{
+        "name": "Helix Genome Context",
+        "content": content,
+        "agent": {
+            "citations": [
+                {"gene_id": "aaaa11112222aaaa", "source": "helix-context/helix.toml"},
+                {"gene_id": "bbbb33334444bbbb", "source": "helix-context/README.md"},
+            ],
+        },
+    }]
+
+
+def test_wrapped_content_first_block_body_not_lost():
+    """Regression: the <expressed_context> wrapper must not swallow the
+    first block. Before the fix, blocks[0] body was '' and pairing
+    shifted by one."""
+    blocks = cit.extract_block_bodies(_wrapped_response())
+    assert len(blocks) == 2
+    assert blocks[0][0] == "helix-context/helix.toml"
+    assert "port 11437" in blocks[0][2]
+    assert blocks[1][0] == "helix-context/README.md"
+    assert "Six-step" in blocks[1][2]
+
+
+def test_wrapped_content_close_tag_not_in_last_body():
+    blocks = cit.extract_block_bodies(_wrapped_response())
+    for _, _, body in blocks:
+        assert "</expressed_context>" not in body
+
+
+def test_headerless_content_pairs_positionally():
+    """legibility_enabled=false configs emit no [gene=...] headers.
+    Bodies must still pair positionally (citations are written in
+    delivery order, 1:1 with content blocks) instead of all-empty."""
+    blocks = cit.extract_block_bodies(_wrapped_response(with_headers=False))
+    assert len(blocks) == 2
+    assert "port 11437" in blocks[0][2]
+    assert "Six-step" in blocks[1][2]
+
+
+def test_dropped_citation_does_not_shift_pairing():
+    """routes_context skips a citation when its row lookup fails
+    (``continue`` at the row_map miss), so citations can be FEWER than
+    content blocks. Header short-ids (gene_id[:12]) are prefixes of the
+    full citation gene_id — pairing must join on that, not position."""
+    payload = [{
+        "content": (
+            "<expressed_context>\n"
+            "[gene=aaaa11112222 ◆ fired=lex:1.0 100c]\n"
+            "body of gene A\n"
+            "---\n"
+            "[gene=bbbb33334444 ◇ fired=lex:0.9 90c]\n"
+            "body of gene B (citation row was dropped)\n"
+            "---\n"
+            "[gene=cccc55556666 ⬦ fired=lex:0.8 80c]\n"
+            "body of gene C\n"
+            "</expressed_context>"
+        ),
+        "agent": {
+            "citations": [
+                {"gene_id": "aaaa11112222aaaa", "source": "a.py"},
+                # gene bbbb... citation dropped by the server
+                {"gene_id": "cccc55556666cccc", "source": "c.py"},
+            ],
+        },
+    }]
+    blocks = cit.extract_block_bodies(payload)
+    assert len(blocks) == 2
+    assert blocks[0][0] == "a.py"
+    assert "body of gene A" in blocks[0][2]
+    assert blocks[1][0] == "c.py"
+    assert "body of gene C" in blocks[1][2]
+
+
+def test_elision_stub_body_is_empty():
+    """Session-delivery elision stubs share the [gene={id[:12]} ...]
+    shape and must pair with their citation — but their body must be ''
+    so accept-matching can never fire on stub text. (Review 2026-07-05:
+    'delivered 16 queries ago' word-boundary matches numeric accepts
+    like '16'; '1' matches the age string '1.2h'.)"""
+    payload = [{
+        "content": (
+            "<expressed_context>\n"
+            "[gene=aaaa11112222 ↻ delivered 3 queries ago / 45s — see earlier response]\n"
+            "---\n"
+            "[gene=bbbb33334444 ◆ fired=lex:1.2 200→90c]\n"
+            "fresh body text\n"
+            "</expressed_context>"
+        ),
+        "agent": {
+            "citations": [
+                {"gene_id": "aaaa11112222aaaa", "source": "elided.py"},
+                {"gene_id": "bbbb33334444bbbb", "source": "fresh.py"},
+            ],
+        },
+    }]
+    blocks = cit.extract_block_bodies(payload)
+    assert blocks[0][0] == "elided.py"
+    assert blocks[0][2] == ""
+    assert blocks[1][0] == "fresh.py"
+    assert "fresh body text" in blocks[1][2]
+
+
+def test_elision_stub_numeric_accept_does_not_inflate_metrics():
+    """The real collision: helix_subpackages_count accepts '16', and a
+    stub reading 'delivered 16 queries ago' must NOT count as
+    body_has_answer/gold_has_answer."""
+    import bench_needle
+
+    payload = [{
+        "content": (
+            "<expressed_context>\n"
+            "[gene=aaaa11112222 ↻ delivered 16 queries ago / 1.2h — see earlier response]\n"
+            "</expressed_context>"
+        ),
+        "agent": {
+            "citations": [
+                {"gene_id": "aaaa11112222aaaa", "source": "helix-context/CLAUDE.md"},
+            ],
+        },
+    }]
+    gold = bench_needle.check_gold_delivery(
+        "", ["helix-context/CLAUDE.md"], ["16", "1"], response=payload,
+    )
+    assert gold["gold_delivered"] is True   # citation still counts
+    assert gold["gold_has_answer"] is False
+    assert gold["body_has_answer"] is False
+
+
+def test_headerless_count_mismatch_fails_closed():
+    """Headerless (legibility off) pairing is positional and only safe
+    when blocks and citations are 1:1. A dropped citation (server
+    row-lookup miss) must yield empty bodies, not shifted ones."""
+    payload = [{
+        "content": (
+            "<expressed_context>\n"
+            "body of gene X\n"
+            "---\n"
+            "body of gene Y\n"
+            "</expressed_context>"
+        ),
+        "agent": {
+            # X's citation was dropped by the server; naive positional
+            # pairing would hand Y gene X's body.
+            "citations": [{"gene_id": "yyyy77778888yyyy", "source": "y.py"}],
+        },
+    }]
+    blocks = cit.extract_block_bodies(payload)
+    assert len(blocks) == 1
+    assert blocks[0][0] == "y.py"
+    assert blocks[0][2] == ""  # fail closed, never X's body
+
+
+def test_headerless_markdown_hr_inflation_fails_closed():
+    """A headerless body containing a Markdown horizontal rule splits
+    into extra blocks (2,318/46,777 xl genes contain '\\n---\\n').
+    Count mismatch must fail closed rather than shift pairings."""
+    payload = [{
+        "content": (
+            "<expressed_context>\n"
+            "intro text\n"
+            "---\n"
+            "conclusion of doc one\n"
+            "---\n"
+            "body of doc two\n"
+            "</expressed_context>"
+        ),
+        "agent": {
+            "citations": [
+                {"gene_id": "aaaa11112222aaaa", "source": "one.md"},
+                {"gene_id": "bbbb33334444bbbb", "source": "two.md"},
+            ],
+        },
+    }]
+    blocks = cit.extract_block_bodies(payload)
+    assert len(blocks) == 2
+    # 3 raw blocks vs 2 citations: pairing is ambiguous — bodies empty.
+    assert blocks[0][2] == ""
+    assert blocks[1][2] == ""
+
+
+def test_mixed_mode_headerless_fallback_requires_count_match():
+    """When SOME blocks id-matched (e.g. an elision stub) the remaining
+    headerless blocks are handed out positionally ONLY if their count
+    equals the unmatched-citation count."""
+    base_citations = [
+        {"gene_id": "aaaa11112222aaaa", "source": "stub.py"},
+        {"gene_id": "bbbb33334444bbbb", "source": "b.py"},
+        {"gene_id": "cccc55556666cccc", "source": "c.py"},
+    ]
+    content_3blocks = (
+        "<expressed_context>\n"
+        "[gene=aaaa11112222 ↻ delivered 2 queries ago / 30s — see earlier response]\n"
+        "---\n"
+        "headerless body B\n"
+        "---\n"
+        "headerless body C\n"
+        "</expressed_context>"
+    )
+    # Counts align (2 unmatched citations, 2 headerless blocks) → pair.
+    ok = cit.extract_block_bodies([{
+        "content": content_3blocks,
+        "agent": {"citations": base_citations},
+    }])
+    assert ok[1][2] == "headerless body B"
+    assert ok[2][2] == "headerless body C"
+
+    # Drop citation B: 1 unmatched citation vs 2 headerless blocks →
+    # ambiguous → fail closed.
+    dropped = cit.extract_block_bodies([{
+        "content": content_3blocks,
+        "agent": {"citations": [base_citations[0], base_citations[2]]},
+    }])
+    assert dropped[0][0] == "stub.py"
+    assert dropped[1][0] == "c.py"
+    assert dropped[1][2] == ""
+
+
+def test_non_hex_bracket_prefix_treated_as_headerless():
+    """A block that merely STARTS with bracketed text that is not a
+    hex gene-id header (e.g. a quoted doc example like '[gene=WHAT ...]')
+    must be treated as headerless, not stripped/misparsed."""
+    payload = [{
+        "content": (
+            "<expressed_context>\n"
+            "[gene=EXAMPLE-NOT-HEX ◆ fired=doc:1.0 10c] is the header shape\n"
+            "and this line documents it.\n"
+            "</expressed_context>"
+        ),
+        "agent": {
+            "citations": [
+                {"gene_id": "aaaa11112222aaaa", "source": "docs/api.md"},
+            ],
+        },
+    }]
+    blocks = cit.extract_block_bodies(payload)
+    assert len(blocks) == 1
+    # 1 headerless block, 1 citation → positional pairing keeps the
+    # FULL text including the bracketed example.
+    assert "[gene=EXAMPLE-NOT-HEX" in blocks[0][2]
+    assert "documents it" in blocks[0][2]
+
+
+def test_check_gold_delivery_body_has_answer_on_live_shape():
+    """End-to-end regression for the dead body_has_answer metric: a
+    realistic wrapped+headered response whose gold block contains the
+    accept token must score body_has_answer=True."""
+    import bench_needle
+
+    gold = bench_needle.check_gold_delivery(
+        "", ["helix-context/helix.toml"], ["11437"],
+        response=_wrapped_response(),
+    )
+    assert gold["gold_delivered"] is True
+    assert gold["gold_has_answer"] is True
+    assert gold["body_has_answer"] is True

--- a/tests/test_bench_needles.py
+++ b/tests/test_bench_needles.py
@@ -216,3 +216,86 @@ def test_bench_answer_key_doc_never_in_gold_source():
                 f"{n['name']}: gold_source contains the bench answer-key "
                 f"file {gs!r}; remove it (see docs/benchmarks/MULTI_VALID_GOLD.md)"
             )
+
+
+# ─── find_needle robustness (review 2026-07-05) ───────────────────────
+#
+# Pass-1 of the sike bedsweep runs find_needle with a 300s-class client
+# while the answer step (Step 2, /v1/chat/completions) can legitimately
+# run up to the server's upstream timeout. A Step-2 exception must NOT
+# destroy the Step-1 retrieval fields — dropping the row silently
+# shrinks the gold_delivered_rate denominator.
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else [{}]
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    """Captures /context POST bodies; raises on the answer step."""
+
+    def __init__(self):
+        self.posts = []
+
+    def post(self, url, json=None, **kwargs):
+        self.posts.append((url, json))
+        if url.endswith("/context"):
+            return _FakeResponse(200, [{
+                "content": (
+                    "<expressed_context>\n"
+                    "[gene=aaaa11112222 ◆ fired=lex:1.0 100c]\n"
+                    "The helix proxy listens on port 11437.\n"
+                    "</expressed_context>"
+                ),
+                "context_health": {"status": "aligned", "ellipticity": 0.1},
+                "agent": {"citations": [
+                    {"gene_id": "aaaa11112222aaaa",
+                     "source": "helix-context/helix.toml"},
+                ]},
+            }])
+        raise TimeoutError("simulated answer-step ReadTimeout")
+
+
+def test_find_needle_survives_answer_step_failure():
+    """A Step-2 (answer accuracy) exception must not lose Step-1
+    retrieval results: gold_delivered stays True, answer_correct is
+    False, and no exception escapes."""
+    import bench_needle
+
+    client = _FakeClient()
+    needle = {
+        "name": "helix_port",
+        "query": "what port does the helix proxy listen on",
+        "expected": "11437",
+        "accept": ["11437"],
+        "gold_source": ["helix-context/helix.toml"],
+    }
+    r = bench_needle.find_needle(client, needle)
+    assert r["gold_delivered"] is True
+    assert r["found_in_context"] is True
+    assert r["answer_correct"] is False
+
+
+def test_find_needle_passes_ignore_delivered():
+    """Bench queries must set ignore_delivered so session-delivery
+    elision (default-on in production configs) can't replace gold
+    bodies with stubs mid-battery (CLAUDE.md bench guidance)."""
+    import bench_needle
+
+    client = _FakeClient()
+    needle = {
+        "name": "helix_port",
+        "query": "what port does the helix proxy listen on",
+        "expected": "11437",
+        "accept": ["11437"],
+        "gold_source": ["helix-context/helix.toml"],
+    }
+    bench_needle.find_needle(client, needle)
+    ctx_posts = [j for (u, j) in client.posts if u.endswith("/context")]
+    assert ctx_posts, "find_needle must POST /context"
+    assert ctx_posts[0].get("ignore_delivered") is True


### PR DESCRIPTION
## Summary

Root-causes and fixes the two anomalies in the valid `2026-07-03_1556` sike_bedsweep results, hardened by an adversarial multi-agent review of the fixes themselves. Also lands the untracked `scripts/bench_chain/` harness (ROADMAP merge-queue item 3) and the bench-validity plan.

**Full detail + numbers:** `docs/benchmarks/2026-07-05-sike-bedsweep-issue-resolutions.md`

### Anomaly 1 — `body_has_answer_rate = 0.0` (metric dead in every run ever, 0.0–0.02)

Two stacked root causes in `benchmarks/_citations.py::extract_block_bodies`:
1. Live `/context` content is wrapped in `<expressed_context>` tags (`context_manager.py:2722`); the parser required each `\n---\n` block to *start* with a `[gene=...]` header, so the wrapper glued to block 1 → first body (top-ranked doc) silently dropped, all citation→body pairs shifted by one. The old test fixture omitted the wrapper — green tests, broken production.
2. Bench configs with `legibility_enabled=false` (the lexical probe used for this sweep) emit no headers at all → every body empty.

**Fix:** wrapper stripped; blocks id-joined to citations via the `gene_id[:12]` hex header prefix; count-guarded positional fallback for headerless configs (fail closed to empty bodies on any mismatch — dropped citation, Markdown `\n---\n` inside a body); elision stubs pair by id but yield `body=""` (their "delivered 16 queries ago" text word-boundary-matches numeric accepts); non-hex bracketed doc examples treated as body. `find_needle` now guards its Step-2 answer call (retrieval fields survive answer failures) and posts `ignore_delivered: true`.

### Anomaly 2 — gemma4 26b-a4b/31b/26b rungs censored (11–16 `http_error` rows/bed at ~181 s)

Proxy default `upstream_timeout = 180 s` (`config.py:197`) < CPU-offloaded 26b-class generation time; server-side `httpx.ReadTimeout` → 5xx. ~25–30 % of those rungs' samples were censored, deflating coverage to 0.66–0.78 and biasing their correctness stats.

**Fix:** `HELIX_SERVER_UPSTREAM_TIMEOUT=600` per bed in the sweep; runner client timeouts 660 s (server side decides); `http`/`error`/`rc`/`stderr`/`stdout_tail`/`ctx_chars` diagnostics persisted per row; 5-consecutive-error circuit breaker (a wedged rung previously risked ~8.3 h of identical errors); Pass-2 coverage denominator fixed to the full needle set (could exceed 1.0 before).

### Review methodology

First-pass fixes were adversarially reviewed by a 21-agent workflow (3 review dimensions → per-finding refutation panels → 4 data-grounded gap analysts over the result JSONs). 11 defects confirmed — all fixed here with failing-tests-first. The 28 wider gaps (bed contamination: 260 echo genes + 43 worktree-dupe genes in xl; probe-TOML no-op keys incl. the arm-C `symbol_graph` keys that don't exist on master; FTS5 pool starvation; inverted know-confidence AUC 0.35–0.44) are triaged in the new doc + ROADMAP Phase 1b — they gate README re-admission of the #221 numbers.

## Test plan

- [x] 14 new regression tests on the real wrapped response shape (`tests/test_bench_citations.py`, `tests/test_bench_needles.py`) — each watched fail before the fix
- [x] Full non-live suite: 2701 passed; the 10 failures + 2 errors are pre-existing on master (verified via stash)
- [x] PowerShell/py syntax checks on the harness scripts
- [ ] Run 1 (clean-baseline sweep) after merge — expected: xl gold_delivered 0.64 → ≥0.75, body_has_answer nonzero, recall n=50/bed, big-gemma errors ≈ 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)